### PR TITLE
feat: 启动加速优化 — 锚点持久化/目录时间戳缓存/渐进式展示

### DIFF
--- a/devlog/src.md
+++ b/devlog/src.md
@@ -1,0 +1,15 @@
+# src 模块变更日志
+
+## 2026-06-20: 提取启动加速功能到独立分支
+- **文件:** `src/shared/collector.js`
+- **原因:** 从 develop 分支提取启动加速相关改动到 feat/startup-optimization 分支，排除贴边隐藏/OpenCode 多账号等无关代码
+- **决策:** 手动从 develop 分支的 collector.js 中识别并提取仅与启动加速相关的代码段，保持 WSL 代码完整（不属于启动加速范畴，不做删除）
+- **改动:**
+  - 锚点持久化：全量扫描结果保存到 `collector-anchor.json`，启动时加载并检查 dateKey 有效性
+  - 目录时间戳缓存：`collectDirTimestamps()` 收集各客户端数据目录 mtime，排除自同步客户端，保存到 `collector-dirts.json`；启动时对比无变化则完全跳过 tokscale
+  - 渐进式展示：`onProgress` 回调使 today 扫完即推送数据，不等 month/allTime
+  - 同步修复：`maybeSyncCursor`/`maybeSyncAntigravity` 移到 `skipTokenscan` 判断之前，始终执行
+  - 空锚点保护：`anchorHasData` 检查 `totalTokens > 0` 防止静默显示空数据
+  - `loop()` 启动首 tick 根据锚点有效性决定 `todayOnly` 模式
+  - 锚点 tick 后更新目录时间戳快照，锁定新基线
+- **影响范围:** `src/shared/collector.js` 仅启动加速功能

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -365,14 +365,22 @@ async function collectUsageOnce(options) {
   const anchor = options.todayOnlyAnchor;
   const anchorUsed = Boolean(anchor && anchor.dateKey === localTodayKey());
   if (normalizedClients) {
+    // Sync cursor/antigravity 始终执行（syncDue 内部 5 分钟限速），不受 skipTokenscan 影响
     await maybeSyncCursor(normalizedClients, options.logger);
     await maybeSyncAntigravity(normalizedClients, options.logger, options.homeDir || os.homedir());
-    if (anchorUsed) {
-      // Anchored tick (watch-triggered): every tokscale period scan costs the
-      // same full load + filter, so scan only --today and update the broader
-      // windows exactly via applyPeriodDelta — one spawn instead of three.
+
+    if (options.skipTokenscan) {
+      // 目录无变化，直接复用锚点缓存数据，完全跳过 tokscale 扫描
+      today = anchor.today;
+      month = anchor.month;
+      allTime = anchor.allTime;
+      // 立即推送缓存数据，让渲染层尽快展示
+      options.onProgress?.({ today, month, allTime, updatedAt: new Date().toISOString() });
+    } else if (anchorUsed) {
+      // Anchored tick (watch-triggered): 仅扫 --today，通过 applyPeriodDelta 推导 month/allTime
       const todayJson = await runTokscaleFn({ clients: normalizedClients, flags: ['--today'], commandTimeoutMs });
       today = extractUsageFromTokscale(todayJson);
+      options.onProgress?.({ today, month: null, allTime: null, updatedAt: new Date().toISOString() });
       month = applyPeriodDelta(anchor.month, today, anchor.today);
       allTime = applyPeriodDelta(anchor.allTime, today, anchor.today);
     } else {
@@ -382,7 +390,9 @@ async function collectUsageOnce(options) {
       const monthJson = await runTokscaleFn({ clients: normalizedClients, flags: ['--month'], commandTimeoutMs });
       const allTimeJson = await runTokscaleFn({ clients: normalizedClients, flags: ['--since', allTimeSince], commandTimeoutMs });
       today = extractUsageFromTokscale(todayJson);
+      options.onProgress?.({ today, month: null, allTime: null, updatedAt: new Date().toISOString() });
       month = extractUsageFromTokscale(monthJson);
+      options.onProgress?.({ today, month, allTime: null, updatedAt: new Date().toISOString() });
       allTime = extractUsageFromTokscale(allTimeJson);
     }
     applySessionTimestamps({ today, month, allTime }, options.homeDir || os.homedir());
@@ -394,7 +404,7 @@ async function collectUsageOnce(options) {
   // that only exists inside WSL still reports as active.
   const windowsPeriods = { today, month, allTime };
   let wslBundle = options.wslAnchor || emptyWslBundle();
-  if (normalizedClients && !anchorUsed) {
+  if (normalizedClients && !anchorUsed && !options.skipTokenscan) {
     wslBundle = await collectWsl({
       clients: normalizedClients,
       allTimeSince,
@@ -499,6 +509,27 @@ function clientDataDirPresence(clientsCsv) {
   return presence;
 }
 
+// Collect mtime of each client data directory for tokscale cache invalidation.
+function collectDirTimestamps(clientsCsv) {
+  const candidates = clientWatchCandidates(clientsCsv);
+  const ts = {};
+  for (const [client, dirs] of Object.entries(candidates)) {
+    if (SELF_SYNCED_CLIENTS.has(client)) continue; // cursor/antigravity 由自身 sync 触发，排除后避免下次启动误判
+    for (const dir of dirs) {
+      try { ts[dir] = fs.statSync(dir).mtimeMs; } catch (_) {}
+    }
+  }
+  return ts;
+}
+
+function timestampsEqual(a, b) {
+  const keys = new Set([...Object.keys(a || {}), ...Object.keys(b || {})]);
+  for (const key of keys) {
+    if (a?.[key] !== b?.[key]) return false;
+  }
+  return true;
+}
+
 // Pure detection-status derivation, given the two existing signals per client:
 // `active`  — tokscale read all-time usage for it,
 // `waiting` — its data directory exists but no usage was found,
@@ -533,10 +564,22 @@ function startCollector(options) {
   let lastHistoryAt = 0;
   // Last full-scan snapshot; lets watch ticks scan only --today and derive
   // month/allTime exactly (applyPeriodDelta). Reset by every full tick.
-  // anchor holds Windows-only periods; wslAnchor is the WSL contribution frozen
-  // between full ticks (WSL is not scanned on watch ticks).
   let anchor = null;
   let wslAnchor = null;
+  // 锚点持久化：从磁盘加载上次全量扫描结果，用于后续启动时跳过 month/allTime 扫描
+  const anchorPath = path.join(sharedDataDir(), 'collector-anchor.json');
+  try {
+    const saved = readJson(anchorPath, null);
+    if (saved && saved.dateKey && saved.today && saved.month && saved.allTime) {
+      anchor = saved;
+    }
+  } catch (_) {}
+  // 目录时间戳缓存：文件未变时完全跳过 tokscale 扫描
+  const dirTimestampsPath = path.join(sharedDataDir(), 'collector-dirts.json');
+  let savedDirTimestamps = null;
+  try {
+    savedDirTimestamps = readJson(dirTimestampsPath, null);
+  } catch (_) {}
   let pendingWaiters = [];
   let debounceTimer = null;
   let intervalTimer = null;
@@ -554,6 +597,11 @@ function startCollector(options) {
     if (includeHistory) lastHistoryAt = Date.now();
     const todayKey = localTodayKey();
     const anchored = Boolean(tickOptions.todayOnly && anchor && anchor.dateKey === todayKey);
+    // Only skip tokscale when the anchor actually has data. If all periods are
+    // zero (e.g. from a failed scan) the next relaunch must retry, not silently
+    // show empty data forever.
+    const anchorHasData = anchored && (anchor.today?.totalTokens > 0 || anchor.month?.totalTokens > 0 || anchor.allTime?.totalTokens > 0);
+    const dirsMatch = anchored && anchorHasData && savedDirTimestamps && timestampsEqual(collectDirTimestamps(clients), savedDirTimestamps);
     try {
       let captured = null;
       const summary = await collectUsageOnce({
@@ -569,12 +617,39 @@ function startCollector(options) {
         forceLimits: Boolean(tickOptions.forceLimits),
         todayOnlyAnchor: anchored ? anchor : null,
         wslAnchor: anchored ? wslAnchor : null,
+        skipTokenscan: dirsMatch,
+        onProgress: (partial) => {
+          if (!partial.today) return;
+          onUpdate?.({
+            deviceId, hostname: os.hostname(),
+            platform: `${process.platform}-${process.arch}`,
+            updatedAt: partial.updatedAt,
+            agentVersion, agentRuntime,
+            trackedClients: (clients || '').split(',').filter(Boolean),
+            clientStatus: deriveClientStatus(clients, partial.allTime || partial.month || partial.today),
+            today: partial.today,
+            month: partial.month || emptyPeriod(),
+            allTime: partial.allTime || emptyPeriod(),
+            history: null, limits: null
+          }, 'progress');
+        },
         onAnchorComputed: (x) => { captured = x; }
       });
       if (stopped) return;
       if (!anchored && captured) {
         anchor = { dateKey: todayKey, today: captured.windowsPeriods.today, month: captured.windowsPeriods.month, allTime: captured.windowsPeriods.allTime };
         wslAnchor = captured.wslBundle;
+        try {
+          fs.mkdirSync(path.dirname(anchorPath), { recursive: true });
+          fs.writeFileSync(anchorPath, JSON.stringify(anchor));
+          savedDirTimestamps = collectDirTimestamps(clients);
+          fs.writeFileSync(dirTimestampsPath, JSON.stringify(savedDirTimestamps));
+        } catch (_) {}
+      } else if (!dirsMatch && summary?.today?.totalTokens > 0) {
+        // 锚点 tick 后更新时间戳快照：目录变化已被本次扫描消化，锁定新基线
+        // 使后续 tick 可重新命中 dirsMatch → skipTokenscan
+        savedDirTimestamps = collectDirTimestamps(clients);
+        try { fs.writeFileSync(dirTimestampsPath, JSON.stringify(savedDirTimestamps)); } catch (_) {}
       }
       await onUpdate?.(summary, reason);
     } catch (error) {
@@ -646,7 +721,8 @@ function startCollector(options) {
 
   function loop() {
     if (stopped) return;
-    runTick('interval').finally(() => {
+    const anchorToday = anchor && anchor.dateKey === localTodayKey();
+    runTick('interval', anchorToday ? { todayOnly: true } : {}).finally(() => {
       if (stopped) return;
       intervalTimer = setTimeout(loop, intervalMs);
     });


### PR DESCRIPTION
## 概述

从 develop 分支提取启动加速功能到独立分支，排除贴边隐藏、OpenCode 多账号等无关代码。

## 改动内容

### `src/shared/collector.js`

1. **锚点持久化**
   - 全量扫描结果保存到 `collector-anchor.json`
   - 启动时从磁盘加载锚点，检查 `dateKey` 是否当天有效
   - 锚点有效时跳过 month/allTime 扫描，仅扫 today
   - 通过 `applyPeriodDelta(base, freshToday, anchorToday)` 推导 month/allTime
   - 空锚点保护：`anchorHasData` 检查 `totalTokens > 0`，防止静默显示空数据

2. **目录时间戳缓存**
   - `collectDirTimestamps(clientsCsv)` 收集各客户端数据目录 mtime
   - 排除 `SELF_SYNCED_CLIENTS`（cursor/antigravity）
   - 保存到 `collector-dirts.json`
   - 启动时对比 mtime 无变化时完全跳过 tokscale 扫描
   - 锚点 tick 后更新时间戳快照，锁定新基线

3. **渐进式展示**
   - `onProgress` 回调支持
   - today 扫完立刻推数据，不等 month/allTime

4. **同步修复**
   - `maybeSyncCursor`/`maybeSyncAntigravity` 移到 `skipTokenscan` 判断之前，始终执行

## 不包含

- 贴边隐藏代码
- OpenCode 多账号代码
- cacheRead 改动
- Go 定价表相关改动
- WSL 代码（保持原样）

## 测试计划

- [ ] 验证正常启动流程无报错
- [ ] 验证锚点持久化：首次全量扫描后重启，检查是否跳过 month/allTime 扫描
- [ ] 验证目录时间戳缓存：目录无变化时完全跳过 tokscale
- [ ] 验证渐进式展示：today 数据先展示，month/allTime 随后
- [ ] 验证同步修复：sync 始终不受 skipTokenscan 影响