### PR TITLE
feat: progressive loading — push partial results during full scan

### DIFF
--- a/devlog/src.md
+++ b/devlog/src.md
@@ -1,0 +1,9 @@
+## 2026-06-21 14:00: 实现渐进推送 onProgress 回调
+- **文件:**
+  - `src/shared/collector.js`
+- **原因:** PR #23 审查反馈 — 需要将渐进推送拆分为独立 PR，并修复 null key 问题
+- **决策:**
+  - 在完整扫描路径（3 次 tokscale 调用）中，每次 period 完成后通过 `onProgress` 推送中间结果
+  - 部分摘要中**省略** `history` 和 `limits` key（而非设为 null），让 `carryDeviceHistory` 正常延续前值
+  - 锚点 tick（watch 触发）不触发 onProgress，因为单次 --today 扫描已经很快
+- **影响范围:** `src/shared/collector.js` — `collectUsageOnce` 新增 onProgress 调用点，`performTick` 新增 onProgress handler

--- a/devlog/tests.md
+++ b/devlog/tests.md
@@ -1,0 +1,8 @@
+## 2026-06-21 14:00: 为渐进推送添加测试
+- **文件:**
+  - `tests/shared/collectorProgressiveLoading.test.js`
+- **原因:** 新增渐进推送功能需要测试覆盖
+- **测试覆盖:**
+  - 完整扫描时 onProgress 在 today 和 month 阶段各触发一次
+  - 部分数据不含 history/limits key
+  - 锚点 tick 不触发 onProgress

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -379,10 +379,12 @@ async function collectUsageOnce(options) {
       // Serial on purpose: concurrent scans triple the peak CPU/IO load, which
       // is what let the issue #15 self-trigger loop spike tokscale past 500% CPU.
       const todayJson = await runTokscaleFn({ clients: normalizedClients, flags: ['--today'], commandTimeoutMs });
-      const monthJson = await runTokscaleFn({ clients: normalizedClients, flags: ['--month'], commandTimeoutMs });
-      const allTimeJson = await runTokscaleFn({ clients: normalizedClients, flags: ['--since', allTimeSince], commandTimeoutMs });
       today = extractUsageFromTokscale(todayJson);
+      if (typeof options.onProgress === 'function') options.onProgress({ today, updatedAt: new Date().toISOString() });
+      const monthJson = await runTokscaleFn({ clients: normalizedClients, flags: ['--month'], commandTimeoutMs });
       month = extractUsageFromTokscale(monthJson);
+      if (typeof options.onProgress === 'function') options.onProgress({ today, month, updatedAt: new Date().toISOString() });
+      const allTimeJson = await runTokscaleFn({ clients: normalizedClients, flags: ['--since', allTimeSince], commandTimeoutMs });
       allTime = extractUsageFromTokscale(allTimeJson);
     }
     applySessionTimestamps({ today, month, allTime }, options.homeDir || os.homedir());
@@ -569,7 +571,21 @@ function startCollector(options) {
         forceLimits: Boolean(tickOptions.forceLimits),
         todayOnlyAnchor: anchored ? anchor : null,
         wslAnchor: anchored ? wslAnchor : null,
-        onAnchorComputed: (x) => { captured = x; }
+        onAnchorComputed: (x) => { captured = x; },
+        onProgress: (partial) => {
+          if (!partial.today) return;
+          onUpdate?.({
+            deviceId, hostname: os.hostname(),
+            platform: `${process.platform}-${process.arch}`,
+            updatedAt: partial.updatedAt,
+            agentVersion, agentRuntime,
+            trackedClients: (clients || '').split(',').filter(Boolean),
+            clientStatus: deriveClientStatus(clients, partial.allTime || partial.month || partial.today),
+            today: partial.today,
+            month: partial.month || emptyPeriod(),
+            allTime: partial.allTime || emptyPeriod()
+          }, 'progress');
+        }
       });
       if (stopped) return;
       if (!anchored && captured) {

--- a/tests/shared/collectorProgressiveLoading.test.js
+++ b/tests/shared/collectorProgressiveLoading.test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { collectUsageOnce } = require('../../src/shared/collector');
+const { emptyPeriod } = require('../../src/shared/usage');
+
+// Stub tokscale so the full scan returns controlled data per period.
+let calls = 0;
+async function sequentialTokscale() {
+  calls += 1;
+  if (calls === 1) {
+    // --today
+    return { entries: [{ client: 'claude', sessionId: 's1', model: 'claude-opus-4-8', input: 100, output: 5, cost: 1 }] };
+  }
+  if (calls === 2) {
+    // --month
+    return { entries: [
+      { client: 'claude', sessionId: 's1', model: 'claude-opus-4-8', input: 500, output: 20, cost: 5 },
+      { client: 'claude', sessionId: 's2', model: 'claude-sonnet-4-8', input: 200, output: 10, cost: 1 }
+    ] };
+  }
+  // --since allTime
+  return { entries: [
+    { client: 'claude', sessionId: 's1', model: 'claude-opus-4-8', input: 2000, output: 90, cost: 20 },
+    { client: 'claude', sessionId: 's2', model: 'claude-sonnet-4-8', input: 800, output: 40, cost: 4 }
+  ] };
+}
+
+test('progressive loading fires onProgress after each period scan', async () => {
+  calls = 0;
+  const partials = [];
+  const summary = await collectUsageOnce({
+    clients: 'claude',
+    allTimeSince: '2025-01-01',
+    commandTimeoutMs: 1000,
+    deviceId: 'dev1',
+    limitsEnabled: false,
+    historyEnabled: false,
+    runTokscale: sequentialTokscale,
+    collectWslUsage: async () => emptyWslBundle(),
+    onProgress: (data) => partials.push({ ...data })
+  });
+  // First partial: today only
+  assert.equal(partials.length, 2, 'should fire onProgress twice (today, month)');
+  assert.equal(partials[0].today.totalTokens, 105, 'first partial should have today tokens');
+  assert.equal(partials[0].month, undefined, 'first partial should not yet have month');
+  assert.equal(partials[0].allTime, undefined, 'first partial should not yet have allTime');
+  // No history or limits in partials — carryDeviceHistory contract
+  assert.equal('history' in partials[0], false, 'partial must not have history key');
+  assert.equal('limits' in partials[0], false, 'partial must not have limits key');
+  // Second partial: today + month
+  assert.equal(partials[1].today.totalTokens, 105, 'second partial should still have today');
+  assert.equal(partials[1].month.totalTokens, 730, 'second partial should have month tokens');
+  assert.equal(partials[1].allTime, undefined, 'second partial should not yet have allTime');
+  assert.equal('history' in partials[1], false, 'second partial must not have history key');
+  assert.equal('limits' in partials[1], false, 'second partial must not have limits key');
+  // Final summary must include all periods
+  assert.equal(summary.today.totalTokens, 105, 'final today');
+  assert.equal(summary.month.totalTokens, 730, 'final month');
+  assert.equal(summary.allTime.totalTokens, 2930, 'final allTime');
+});
+
+test('progressive loading skips onProgress on anchored ticks', async () => {
+  calls = 0;
+  const partials = [];
+  const anchor = { dateKey: require('../../src/shared/collector').localTodayKey(), today: emptyPeriod(), month: emptyPeriod(), allTime: emptyPeriod() };
+  await collectUsageOnce({
+    clients: 'claude',
+    allTimeSince: '2025-01-01',
+    commandTimeoutMs: 1000,
+    deviceId: 'dev1',
+    limitsEnabled: false,
+    historyEnabled: false,
+    todayOnlyAnchor: anchor,
+    wslAnchor: emptyWslBundle(),
+    runTokscale: sequentialTokscale,
+    collectWslUsage: async () => emptyWslBundle(),
+    onProgress: () => partials.push('called')
+  });
+  assert.equal(partials.length, 0, 'anchored tick should not fire onProgress');
+});
+
+function emptyWslBundle() {
+  return { today: emptyPeriod(), month: emptyPeriod(), allTime: emptyPeriod() };
+}


### PR DESCRIPTION
## Summary

During a full (3-scan) collector tick, push intermediate results to the UI as each period completes, so users see data incrementally instead of waiting for all three scans.

This is split from the original PR #23 per review feedback. The anchor persistence and dir-skip optimizations will follow in a separate PR after rework.

### Changes

**src/shared/collector.js** (2 sites):

1. **collectUsageOnce** (full-scan path only): Fire onProgress after --today and --month scans, each with whatever period data is available so far.

2. **performTick**: onProgress handler constructs a partial summary (without history/limits keys) and calls onUpdate with reason='progress'.

**Key design decisions:**

- **history and limits are omitted (not null)** from the partial summary — this is the fix for review item #3. carryDeviceHistory carries forward the previous values only when the key is absent; setting it to null bypasses the contract and causes the UI to flash empty.

- **Anchored (watch) ticks** do NOT fire onProgress — they only run one --today scan so progressive loading adds no value.

- **Partial data is Windows-only** (WSL merge happens after all three scans). The final onUpdate with reason 'interval' or 'watch' has the fully merged data.

### Prior review items addressed

This PR addresses review item #3 from the original PR #23:
"Progressive updates break the carry-forward contract and tend to flash empty. onProgress explicitly passes history: null and limits: null ... Just omit those two keys on the progressive pushes."

The other four items (dir depth, WSL anchor, config binding, tests) will be addressed in a separate PR after rework.
