### PR TITLE
feat: anchor persistence — reuse full-scan snapshots across restarts

### DIFF
--- a/devlog/src.md
+++ b/devlog/src.md
@@ -1,0 +1,16 @@
+## 2026-06-21: Anchor 持久化 — 跨重启复用全量扫描快照
+
+- **文件:** `src/shared/collector.js`
+- **原因:** PR #23 审查反馈 #1/#4 — 启动时复用 anchor 避免全量 month/allTime 扫描，配置绑定防止使用过期 baseline
+- **决策:**
+  - Anchor 持久化到 `sharedDataDir()/collector-anchor.json`，全量扫描后写入，启动时读取
+  - 配置绑定通过 `configFingerprint(clients, allTimeSince)` 实现，配置变化时 anchor 自动失效
+  - Interval loop 在 anchor 有效时使用 `todayOnly`，避免每次都做 3 次全量扫描
+  - Dir-skip 不做（作者建议 "drop the skip entirely"）
+  - WSL 部分不动（上游 main 已经正确）
+- **影响范围:** `src/shared/collector.js` — `configFingerprint` 新函数，`startCollector` 中 anchor 读写，`loop` 的 todayOnly 优化
+- **安全分析:**
+  - dateKey 校验确保跨日不用旧 anchor
+  - fingerprint 校验确保配置变化时触发全量扫描
+  - 文件写入失败时 try-catch 吞掉，内存 anchor 仍在，下次启动重新全量扫描
+  - 文件损坏/不存在时 `readJson` 返回 null，降级为全量扫描

--- a/devlog/tests.md
+++ b/devlog/tests.md
@@ -1,0 +1,7 @@
+## 2026-06-21: 为 Anchor 持久化添加测试
+
+- **文件:** `tests/shared/collectorAnchorPersistence.test.js`
+- **测试覆盖:**
+  - configFingerprint 函数：标准化 whitespace、不同输入产生不同输出
+  - configFingerprint 边界：undefined/empty 输入
+  - Anchored tick 使用 todayOnly 并正确推导 month/allTime

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -518,6 +518,12 @@ function deriveClientStatus(clientsCsv, allTimePeriod) {
   return statusFromSignals(clients, clientDataDirPresence(clientsCsv), allTimePeriod?.clients || {});
 }
 
+function configFingerprint(clientsCsv, allTimeSince) {
+  // Deterministic string that captures the config inputs anchor correctness
+  // depends on. When this changes, the persisted anchor is invalidated.
+  return `${normalizeClientsCsv(clientsCsv)}|${allTimeSince}`;
+}
+
 function startCollector(options) {
   const {
     clients, allTimeSince, commandTimeoutMs, deviceId, agentVersion, agentRuntime,
@@ -542,6 +548,22 @@ function startCollector(options) {
   let intervalTimer = null;
   let stopped = false;
   const watchers = [];
+
+  // On-disk anchor: persist full-scan snapshots so the collector can reuse
+  // month/allTime across restarts. On the first interval tick the anchor is
+  // valid for today and configFingerprint matches, only --today is scanned
+  // and month/allTime are derived via applyPeriodDelta.
+  const anchorPath = path.join(sharedDataDir(), 'collector-anchor.json');
+  try {
+    const saved = readJson(anchorPath, null);
+    if (saved && saved.dateKey === localTodayKey()) {
+      const fp = configFingerprint(clients, allTimeSince);
+      if (saved.configFingerprint === fp) {
+        anchor = { dateKey: saved.dateKey, today: saved.today, month: saved.month, allTime: saved.allTime };
+        wslAnchor = saved.wslBundle || null;
+      }
+    }
+  } catch (_) {}
 
   function resolvePendingWaiters() {
     const waiters = pendingWaiters;
@@ -575,6 +597,17 @@ function startCollector(options) {
       if (!anchored && captured) {
         anchor = { dateKey: todayKey, today: captured.windowsPeriods.today, month: captured.windowsPeriods.month, allTime: captured.windowsPeriods.allTime };
         wslAnchor = captured.wslBundle;
+        try {
+          fs.mkdirSync(path.dirname(anchorPath), { recursive: true });
+          fs.writeFileSync(anchorPath, JSON.stringify({
+            dateKey: anchor.dateKey,
+            today: anchor.today,
+            month: anchor.month,
+            allTime: anchor.allTime,
+            wslBundle: wslAnchor,
+            configFingerprint: configFingerprint(clients, allTimeSince)
+          }));
+        } catch (_) {}
       }
       await onUpdate?.(summary, reason);
     } catch (error) {
@@ -646,7 +679,8 @@ function startCollector(options) {
 
   function loop() {
     if (stopped) return;
-    runTick('interval').finally(() => {
+    const anchorToday = Boolean(anchor && anchor.dateKey === localTodayKey());
+    runTick('interval', anchorToday ? { todayOnly: true } : {}).finally(() => {
       if (stopped) return;
       intervalTimer = setTimeout(loop, intervalMs);
     });
@@ -674,6 +708,7 @@ module.exports = {
   collectHistoryOnce,
   collectUsageOnce,
   clientDataDirPresence,
+  configFingerprint,
   deriveClientStatus,
   statusFromSignals,
   decideResolver,

--- a/tests/shared/collectorAnchorPersistence.test.js
+++ b/tests/shared/collectorAnchorPersistence.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  configFingerprint,
+  collectUsageOnce,
+  localTodayKey
+} = require('../../src/shared/collector');
+const { emptyPeriod } = require('../../src/shared/usage');
+
+test('configFingerprint normalizes clients and includes allTimeSince', () => {
+  const a = configFingerprint('claude, codex', '2024-01-01');
+  const b = configFingerprint('claude,codex', '2024-01-01');
+  // whitespace-normalised to the same value
+  assert.equal(a, b, 'whitespace should be normalized');
+  assert.match(a, /^claude,codex\|2024-01-01$/);
+
+  const c = configFingerprint('claude', '2024-01-01');
+  assert.notEqual(a, c, 'different clients should differ');
+
+  const d = configFingerprint('claude,codex', '2024-06-01');
+  assert.notEqual(a, d, 'different allTimeSince should differ');
+});
+
+test('configFingerprint handles undefined and empty clients', () => {
+  const a = configFingerprint(undefined, '2024-01-01');
+  assert.equal(a, '|2024-01-01', 'undefined clients should produce empty string before pipe');
+
+  const b = configFingerprint('', '2024-01-01');
+  assert.equal(b, '|2024-01-01', 'empty clients should produce same as undefined');
+
+  const c = configFingerprint('claude', undefined);
+  assert.match(c, /\|undefined$/, 'undefined allTimeSince produces string "undefined"');
+});
+
+test('anchored tick with valid anchor runs todayOnly scan and derives month/allTime', async () => {
+  const dateKey = localTodayKey();
+
+  // Establish a baseline anchor from a "previous full scan"
+  const anchorToday = emptyPeriod();
+  anchorToday.totalTokens = 50;
+  anchorToday.clients = { claude: 50 };
+
+  const anchorMonth = emptyPeriod();
+  anchorMonth.totalTokens = 500;
+  anchorMonth.clients = { claude: 500 };
+
+  const anchorAllTime = emptyPeriod();
+  anchorAllTime.totalTokens = 5000;
+  anchorAllTime.clients = { claude: 5000 };
+
+  const anchor = { dateKey, today: anchorToday, month: anchorMonth, allTime: anchorAllTime };
+
+  // Stub tokscale to return a delta: today jumped from 50 to 130
+  let tokscaleCalls = 0;
+  async function stubTokscale() {
+    tokscaleCalls += 1;
+    return { entries: [{ client: 'claude', sessionId: 's1', model: 'claude-opus', input: 80, output: 0, cost: 0 }] };
+  }
+
+  const summary = await collectUsageOnce({
+    clients: 'claude',
+    allTimeSince: '2024-01-01',
+    commandTimeoutMs: 1000,
+    deviceId: 'dev1',
+    limitsEnabled: false,
+    historyEnabled: false,
+    todayOnlyAnchor: anchor,
+    wslAnchor: emptyWslBundle(),
+    runTokscale: stubTokscale,
+    collectWslUsage: async () => emptyWslBundle()
+  });
+
+  // Only one tokscale call (--today), not three
+  assert.equal(tokscaleCalls, 1, 'anchored tick must only run one tokscale scan');
+
+  // today = 80 (from stub; anchor was 50)
+  assert.equal(summary.today.totalTokens, 80, 'today should come from fresh scan');
+
+  // month = anchor month 500 + (today 80 - anchor today 50) = 530
+  assert.equal(summary.month.totalTokens, 530, 'month should be derived via applyPeriodDelta');
+
+  // allTime = anchor allTime 5000 + (today 80 - anchor today 50) = 5030
+  assert.equal(summary.allTime.totalTokens, 5030, 'allTime should be derived via applyPeriodDelta');
+});
+
+function emptyWslBundle() {
+  return { today: emptyPeriod(), month: emptyPeriod(), allTime: emptyPeriod() };
+}


### PR DESCRIPTION
## Summary

Persist the collector's full-scan anchor to disk so that after a restart the first interval tick can reuse the cached month/allTime snapshots instead of running three serial tokscale scans. This saves approximately 2/3 of the startup scan time.

This is the anchor-persistence portion split from the original PR #23. The progressive loading fix was already submitted separately in PR #27.

### Changes

**src/shared/collector.js** (+39 lines)

1. **configFingerprint helper** — Deterministic string from `normalizeClientsCsv(clients)` and `allTimeSince`. Used to invalidate the persisted anchor when the tracked clients or start date change.

2. **Anchor loading on startup** — After `startCollector` initialises, `readJson` loads `collector-anchor.json` from `sharedDataDir`. The anchor is accepted only when its `dateKey` matches today and its `configFingerprint` matches the current settings. On mismatch (different day, changed config, or missing/corrupt file) the anchor stays null and a full scan runs as normal.

3. **Anchor saving after full scan** — When a non-anchored tick completes and `onAnchorComputed` fires, the Windows-only anchor, `wslBundle`, and current fingerprint are written to disk. Errors are silently caught — the in-memory anchor is unaffected, and the next restart falls back to a fresh full scan.

4. **Interval-loop anchor reuse** — `loop()` checks whether the in-memory anchor is valid for today. When it is, `runTick` passes `{ todayOnly: true }` so only `--today` is scanned and `applyPeriodDelta` derives month/allTime from the anchor. On date change or config change the anchor becomes invalid and the next interval tick does a full scan.

### Prior review items addressed

| # | Issue | Status |
|---|-------|--------|
| 1 | Dir-skip directory depth | **Not included** — per review suggestion ("just keep the persisted anchor and drop the skip entirely") |
| 2 | WSL anchor isolation | **Already correct in upstream/main** — Windows-only anchor + separate wslAnchor |
| 3 | Progressive loading null keys | PR #27 (already submitted) |
| 4 | Anchor not tied to config | **Fixed** — configFingerprint invalidates anchor on any settings change |
| 5 | Tests | **Added** — 3 tests: configFingerprint correctness, edge cases, anchored tick delta derivation |

### Tests

`tests/shared/collectorAnchorPersistence.test.js` (3 tests):

| Test | What it covers |
|------|---------------|
| configFingerprint normalises clients | Whitespace case, different clients, different allTimeSince |
| configFingerprint handles undefined/empty | Edge cases for both inputs |
| Anchored tick with valid anchor | Single --today scan, correct applyPeriodDelta derivation |
