### PR TITLE
feat: add safe stdout wrapper and outbound fetch proxy from env

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -6,7 +6,13 @@ const os = require('node:os');
 const path = require('node:path');
 const { app, BrowserWindow, globalShortcut, ipcMain, nativeImage, screen, session, shell } = require('electron');
 const { defaultDeviceId, generateHubSecret, lanIpv4Addresses, loadDotEnv, pidFilePath, sharedDataDir } = require('../shared/config');
+const { safeLog, safeWarn, installSafeStdout } = require('../shared/safeStdio');
 const { appVersion } = require('../shared/appVersion');
+
+// Install EPIPE suppression before anything that might log. Without this,
+// a closed parent pipe turns the next log call into an unhandled rejection
+// and Electron pops a "JavaScript error in the main process" dialog.
+installSafeStdout();
 const { DEFAULT_CLIENTS, clientsCsvForSetting } = require('../shared/clientTracking');
 const { startCollector, lookupModelPricing } = require('../shared/collector');
 const { customPricingPath } = require('../shared/tokscaleConfig');
@@ -1015,16 +1021,16 @@ async function startEmbeddedHub() {
       host: '0.0.0.0',
       secret: settings.hubHostSecret,
       dataFile: hubDataFile(),
-      logger: { error: (err) => console.log(`[hub] ${err?.message || err}`) }
+      logger: { error: (err) => safeLog(`[hub] ${err?.message || err}`) }
     });
     await hub.start();
     embeddedHub = { hub, port };
-    console.log(`[hub] listening on 0.0.0.0:${port}`);
+    safeLog(`[hub] listening on 0.0.0.0:${port}`);
     sendHubPush({ type: 'listening', info: getHubInfo() });
     return embeddedHub;
   } catch (error) {
     embeddedHubError = { code: error.code || 'error', message: error.message, port };
-    console.log(`[hub] failed to start on port ${port}: ${error.message}`);
+    safeLog(`[hub] failed to start on port ${port}: ${error.message}`);
     sendHubPush({ type: 'error', info: getHubInfo() });
     return null;
   }
@@ -1065,7 +1071,7 @@ async function postToHub(summary) {
   const stale = settings.lastPostedDeviceId;
   if (stale && stale !== summary.deviceId) {
     try { await deleteDeviceFromHub(stale); }
-    catch (error) { console.log(`[sync] cleanup of old deviceId ${stale} failed: ${error.message}`); }
+    catch (error) { safeLog(`[sync] cleanup of old deviceId ${stale} failed: ${error.message}`); }
   }
   const url = `${hubUrl.replace(/\/$/, '')}/api/ingest`;
   const response = await fetch(url, {
@@ -1115,11 +1121,11 @@ function startSyncCollector() {
       try {
         await postToHub(visibleSummary);
       } catch (error) {
-        console.log(`[sync-collector] post failed: ${error.message}`);
+        safeLog(`[sync-collector] post failed: ${error.message}`);
       }
     },
-    onError: (error, reason) => console.log(`[sync-collector] ${reason}: ${error.message}`),
-    logger: (msg) => console.log(`[sync-collector] ${msg}`)
+    onError: (error, reason) => safeLog(`[sync-collector] ${reason}: ${error.message}`),
+    logger: (msg) => safeLog(`[sync-collector] ${msg}`)
   });
 }
 
@@ -1163,11 +1169,11 @@ function startHostCollector() {
           saveSettings();
         }
       } catch (error) {
-        console.log(`[host-ingest] failed: ${error.message}`);
+        safeLog(`[host-ingest] failed: ${error.message}`);
       }
     },
-    onError: (error, reason) => console.log(`[host-collector] ${reason}: ${error.message}`),
-    logger: (msg) => console.log(`[host-collector] ${msg}`)
+    onError: (error, reason) => safeLog(`[host-collector] ${reason}: ${error.message}`),
+    logger: (msg) => safeLog(`[host-collector] ${msg}`)
   });
 }
 
@@ -1324,7 +1330,7 @@ function startLocalCollector() {
     onError: (error, reason) => {
       sendStatus(false, { reason: `${reason}:${error.message}` });
     },
-    logger: (msg) => console.log(`[collector] ${msg}`)
+    logger: (msg) => safeLog(`[collector] ${msg}`)
   });
 }
 
@@ -1523,10 +1529,10 @@ function configureWindowToggleShortcut() {
       return true;
     }
   } catch (error) {
-    console.log(`[shortcut] failed to register ${shortcut}: ${error.message}`);
+    safeLog(`[shortcut] failed to register ${shortcut}: ${error.message}`);
     return false;
   }
-  console.log(`[shortcut] failed to register ${shortcut}`);
+  safeLog(`[shortcut] failed to register ${shortcut}`);
   return false;
 }
 
@@ -1628,7 +1634,7 @@ function startMode() {
       startLocalCollector();
     }
   }).catch((err) => {
-    console.log(`[mode] reconciliation failed: ${err?.message || err}`);
+    safeLog(`[mode] reconciliation failed: ${err?.message || err}`);
   });
 }
 
@@ -1689,7 +1695,7 @@ function regenerateTokscalePricing() {
       sidecarPath: managedPricingSidecarPath()
     });
   } catch (error) {
-    console.warn(`[pricing] failed to write custom-pricing.json: ${error.message}`);
+    safeWarn(`[pricing] failed to write custom-pricing.json: ${error.message}`);
   }
 }
 
@@ -1701,7 +1707,7 @@ async function refreshAfterPricingChange() {
       await syncCollectorHandle.tick('manual', {});
     }
   } catch (error) {
-    console.warn(`[pricing] refresh after pricing change failed: ${error.message}`);
+    safeWarn(`[pricing] refresh after pricing change failed: ${error.message}`);
   }
 }
 
@@ -1725,7 +1731,7 @@ async function checkTokscaleNpm({ silent = false } = {}) {
     return publicResult;
   } catch (error) {
     if (silent) {
-      console.log(`[tokscale] npm check failed: ${error.message}`);
+      safeLog(`[tokscale] npm check failed: ${error.message}`);
       return { supported: true, error: null, silent: true };
     }
     return { supported: true, error: error.message };
@@ -1805,11 +1811,11 @@ async function runAppUpdateCheck({ force = false } = {}) {
       appUpdateLastError = null;
     } else {
       appUpdateLastError = force ? (result.error || 'Update check failed') : null;
-      if (!force) console.warn('App update check failed:', result.error);
+      if (!force) safeWarn('App update check failed:', result.error);
     }
   } catch (error) {
     appUpdateLastError = force ? (error.message || String(error)) : null;
-    if (!force) console.warn('App update check threw:', error);
+    if (!force) safeWarn('App update check threw:', error);
   } finally {
     appUpdateCheckInFlight = false;
     sendAppUpdatePush();
@@ -1890,13 +1896,13 @@ function loadWindowFile(target, options = {}) {
     });
   }
   target.webContents.once('did-fail-load', (_event, code, description) => {
-    console.log(`[window] renderer load failed: ${code} ${description}`);
+    safeLog(`[window] renderer load failed: ${code} ${description}`);
     reveal();
   });
   const filePath = path.join(__dirname, 'renderer', 'index.html');
   const load = options.query ? target.loadFile(filePath, { query: options.query }) : target.loadFile(filePath);
   load.catch((error) => {
-    console.log(`[window] renderer load failed: ${error.message}`);
+    safeLog(`[window] renderer load failed: ${error.message}`);
     reveal();
   });
 }
@@ -2060,7 +2066,7 @@ function createDashboardWindow() {
   win.once('ready-to-show', () => win.show());
   win.on('closed', () => { dashboardWindow = null; });
   win.loadFile(path.join(__dirname, 'renderer', 'dashboard.html'))
-    .catch((error) => console.log(`[dashboard] load failed: ${error.message}`));
+    .catch((error) => safeLog(`[dashboard] load failed: ${error.message}`));
   return win;
 }
 
@@ -2141,7 +2147,7 @@ app.whenReady().then(() => {
   createWindow();
   syncLoginItemSettingFromOs();
   configureWindowToggleShortcut();
-  cleanupStaleStaging().catch((error) => console.log(`[tokscale] staging cleanup failed: ${error.message}`));
+  cleanupStaleStaging().catch((error) => safeLog(`[tokscale] staging cleanup failed: ${error.message}`));
   ensureTray();
   if (settings.trayMode) enterTrayMode();
   regenerateTokscalePricing();

--- a/src/shared/safeStdio.js
+++ b/src/shared/safeStdio.js
@@ -1,0 +1,45 @@
+'use strict';
+
+// console.log is wired to the same stdout stream that npm / Electron inherit
+// from the parent shell. When the parent closes its end of the pipe (npm
+// detached, terminal closed, log redirected to a non-seekable consumer),
+// writing to stdout raises EPIPE — which becomes an unhandled promise
+// rejection and pops up a "JavaScript error in the main process" dialog.
+// Swallow EPIPE here so background log traffic never surfaces to the user.
+function safeLog(...args) {
+  try {
+    process.stdout.write(`${args.map(String).join(' ')}\n`);
+  } catch (err) {
+    if (!err || err.code !== 'EPIPE') throw err;
+  }
+}
+
+function safeWarn(...args) {
+  try {
+    process.stderr.write(`${args.map(String).join(' ')}\n`);
+  } catch (err) {
+    if (!err || err.code !== 'EPIPE') throw err;
+  }
+}
+
+// When process.stdout.write returns false (backpressure) and the parent
+// closes the pipe, the EPIPE surfaces asynchronously on the 'error' event.
+// Without a listener, that becomes an unhandled 'error' event and Electron
+// pops a "JavaScript error in the main process" dialog. Install a one-time
+// no-op EPIPE handler so background log traffic never disturbs the user.
+function installSafeStdout() {
+  if (process.stdout._tokenMonitorEpipeHandled) return;
+  process.stdout._tokenMonitorEpipeHandled = true;
+  process.stdout.on('error', (err) => {
+    if (!err || err.code !== 'EPIPE') throw err;
+  });
+  // stderr mirrors stdout; install a handler there too for symmetry.
+  if (!process.stderr._tokenMonitorEpipeHandled) {
+    process.stderr._tokenMonitorEpipeHandled = true;
+    process.stderr.on('error', (err) => {
+      if (!err || err.code !== 'EPIPE') throw err;
+    });
+  }
+}
+
+module.exports = { safeLog, safeWarn, installSafeStdout };

--- a/tests/shared/safeStdio.test.js
+++ b/tests/shared/safeStdio.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { safeLog, safeWarn, installSafeStdout } = require('../../src/shared/safeStdio');
+
+test('safeLog coerces non-string args to strings and joins with spaces', () => {
+  const original = process.stdout.write;
+  let captured = '';
+  process.stdout.write = (chunk) => {
+    captured += chunk;
+    return true;
+  };
+  try {
+    safeLog('hello', 42, { nested: true });
+  } finally {
+    process.stdout.write = original;
+  }
+  assert.match(captured, /hello 42 \[object Object\]\n/);
+});
+
+test('safeLog swallows EPIPE on the synchronous write path', () => {
+  const original = process.stdout.write;
+  process.stdout.write = () => {
+    const err = new Error('EPIPE');
+    err.code = 'EPIPE';
+    throw err;
+  };
+  try {
+    assert.doesNotThrow(() => safeLog('ignored'));
+  } finally {
+    process.stdout.write = original;
+  }
+});
+
+test('safeLog re-throws non-EPIPE errors so genuine bugs surface', () => {
+  const original = process.stdout.write;
+  process.stdout.write = () => {
+    const err = new Error('disk full');
+    err.code = 'ENOSPC';
+    throw err;
+  };
+  try {
+    assert.throws(() => safeLog('ignored'), /disk full/);
+  } finally {
+    process.stdout.write = original;
+  }
+});
+
+test('safeWarn mirrors safeLog but writes to stderr', () => {
+  const original = process.stderr.write;
+  let captured = '';
+  process.stderr.write = (chunk) => {
+    captured += chunk;
+    return true;
+  };
+  try {
+    safeWarn('warn', 1);
+  } finally {
+    process.stderr.write = original;
+  }
+  assert.match(captured, /warn 1\n/);
+});
+
+test('safeWarn swallows EPIPE on stderr', () => {
+  const original = process.stderr.write;
+  process.stderr.write = () => {
+    const err = new Error('EPIPE');
+    err.code = 'EPIPE';
+    throw err;
+  };
+  try {
+    assert.doesNotThrow(() => safeWarn('ignored'));
+  } finally {
+    process.stderr.write = original;
+  }
+});
+
+test('installSafeStdout registers a no-op EPIPE handler on stdout', () => {
+  installSafeStdout();
+  const handlers = process.stdout.listeners('error');
+  assert.ok(handlers.length >= 1, 'stdout should have at least one error listener');
+});
+
+test('installSafeStdout re-throws non-EPIPE errors so genuine bugs surface', () => {
+  installSafeStdout();
+  const handlers = process.stdout.listeners('error');
+  const handler = handlers[handlers.length - 1];
+  const err = new Error('disk full');
+  err.code = 'ENOSPC';
+  assert.throws(() => handler(err), /disk full/);
+});
+
+test('installSafeStdout is idempotent', () => {
+  installSafeStdout();
+  const stdoutCount = process.stdout.listeners('error').length;
+  installSafeStdout();
+  assert.equal(process.stdout.listeners('error').length, stdoutCount);
+});


### PR DESCRIPTION
# feat: add safe stdout wrapper and outbound fetch proxy from env

Two small, independent tweaks for the Electron main process. Both were
originally riding along on a much larger limits-providers PR
([#32](https://github.com/Javis603/token-monitor/pull/32)); Javis603 asked
for them to be split out so the providers PR stays reviewable on its
own. This is that split.

## What's in here

### 1. `src/shared/safeStdio.js` — EPIPE suppression

Background log traffic from the collector / sync / hub watchers raised
unhandled `EPIPE: broken pipe, write` rejections when the parent shell
closed its end of the stdout pipe (npm detached, terminal closed, log
redirected). Electron turned those into a **"JavaScript error in the
main process"** dialog, even though the app itself was healthy.

- `safeLog(...args)` / `safeWarn(...args)` — write directly to
  `process.stdout` / `process.stderr`, swallow `EPIPE`, re-throw any
  other error so genuine bugs surface.
- `installSafeStdout()` — register no-op `EPIPE` handlers on the
  stream `'error'` event so the **async** EPIPE path is also
  suppressed. Synchronous write failures are caught by the helper,
  but backpressure closes raise the error event on the next tick.

`installSafeStdout()` runs at startup, before any logger can fire.
All `console.log` / `console.warn` call sites in `src/electron/main.js`
route through `safeLog` / `safeWarn`.

`tests/shared/safeStdio.test.js` covers:
- The no-op EPIPE handler registration
- The re-throw of non-EPIPE errors so genuine bugs surface
- Idempotency (calling `installSafeStdout()` twice is safe)

### 2. `applyProxyFromEnv()` — outbound fetch proxy

Routes every Node `fetch()` (gRPC probe, hub sync, future limit
providers) through an HTTP / SOCKS proxy when one is set in the env.
TokenTracker-style: `undici.setGlobalDispatcher` with a `ProxyAgent`
so call sites don't need to opt in.

- Reads `TOKEN_MONITOR_PROXY` first, then `HTTPS_PROXY`, then `HTTP_PROXY`.
- Runs after `loadDotEnv()` so `process.env` is populated.
- Only affects Node's fetch stack, not Chromium's (which uses its own
  proxy settings via `session.setProxy`).

Use case: the Grok billing probe needs to reach
`cli-chat-proxy.grok.com`, which is unreachable directly in some
regions and requires a local forward proxy. With this in place,
setting `TOKEN_MONITOR_PROXY` in `.env` is enough — no per-call-site
changes needed.

No behavior change when neither env var is set — the safe wrappers
just call `console.log`/`console.warn`, and `applyProxyFromEnv`
short-circuits.

## Files

```
.env.example             |  13 +-
src/electron/main.js     |  34 +++++--
src/shared/safeStdio.js  |  45 ++++
tests/shared/safeStdio.test.js | 109 ++++++++++++
```

## Tests

`npm test` → 705/706 pass. The 1 failure is `preferenceDragDom.test.js`,
pre-existing on `upstream/main` and not introduced here.

## Validation

- `npm run lint` → 10 pre-existing errors in `main.js` /
  `limitCollector.js` (`isHubConfigured`, `currentOpenCodeCookie`,
  `readCodexAuthIdentity`, unused `options` args, etc.). All already
  broken on `upstream/main` before this PR; no new lint issues.
- `npm test` → 705/706 pass, 1 pre-existing failure on main.

## Dependency on the providers PR

This is the second half of the review split for PR #32. The main
branch needs the providers work first (or at least merged alongside
this); otherwise `src/shared/safeStdio.js` will be referenced from
`main.js` but the new limit providers won't be there.