### PR TITLE
feat: add safe stdout wrapper to suppress EPIPE dialogs

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -6,12 +6,12 @@ const os = require('node:os');
 const path = require('node:path');
 const { app, BrowserWindow, globalShortcut, ipcMain, nativeImage, screen, session, shell } = require('electron');
 const { defaultDeviceId, generateHubSecret, lanIpv4Addresses, loadDotEnv, pidFilePath, sharedDataDir } = require('../shared/config');
-const { safeLog, safeWarn, installSafeStdout } = require('../shared/safeStdio');
+const { installSafeStdout } = require('../shared/safeStdio');
 const { appVersion } = require('../shared/appVersion');
 
 // Install EPIPE suppression before anything that might log. Without this,
-// a closed parent pipe turns the next log call into an unhandled rejection
-// and Electron pops a "JavaScript error in the main process" dialog.
+// a closed parent pipe turns the next log call into an unhandled 'error'
+// event and Electron pops a "JavaScript error in the main process" dialog.
 installSafeStdout();
 const { DEFAULT_CLIENTS, clientsCsvForSetting } = require('../shared/clientTracking');
 const { startCollector, lookupModelPricing } = require('../shared/collector');
@@ -1021,16 +1021,16 @@ async function startEmbeddedHub() {
       host: '0.0.0.0',
       secret: settings.hubHostSecret,
       dataFile: hubDataFile(),
-      logger: { error: (err) => safeLog(`[hub] ${err?.message || err}`) }
+      logger: { error: (err) => console.log(`[hub] ${err?.message || err}`) }
     });
     await hub.start();
     embeddedHub = { hub, port };
-    safeLog(`[hub] listening on 0.0.0.0:${port}`);
+    console.log(`[hub] listening on 0.0.0.0:${port}`);
     sendHubPush({ type: 'listening', info: getHubInfo() });
     return embeddedHub;
   } catch (error) {
     embeddedHubError = { code: error.code || 'error', message: error.message, port };
-    safeLog(`[hub] failed to start on port ${port}: ${error.message}`);
+    console.log(`[hub] failed to start on port ${port}: ${error.message}`);
     sendHubPush({ type: 'error', info: getHubInfo() });
     return null;
   }
@@ -1071,7 +1071,7 @@ async function postToHub(summary) {
   const stale = settings.lastPostedDeviceId;
   if (stale && stale !== summary.deviceId) {
     try { await deleteDeviceFromHub(stale); }
-    catch (error) { safeLog(`[sync] cleanup of old deviceId ${stale} failed: ${error.message}`); }
+    catch (error) { console.log(`[sync] cleanup of old deviceId ${stale} failed: ${error.message}`); }
   }
   const url = `${hubUrl.replace(/\/$/, '')}/api/ingest`;
   const response = await fetch(url, {
@@ -1121,11 +1121,11 @@ function startSyncCollector() {
       try {
         await postToHub(visibleSummary);
       } catch (error) {
-        safeLog(`[sync-collector] post failed: ${error.message}`);
+        console.log(`[sync-collector] post failed: ${error.message}`);
       }
     },
-    onError: (error, reason) => safeLog(`[sync-collector] ${reason}: ${error.message}`),
-    logger: (msg) => safeLog(`[sync-collector] ${msg}`)
+    onError: (error, reason) => console.log(`[sync-collector] ${reason}: ${error.message}`),
+    logger: (msg) => console.log(`[sync-collector] ${msg}`)
   });
 }
 
@@ -1169,11 +1169,11 @@ function startHostCollector() {
           saveSettings();
         }
       } catch (error) {
-        safeLog(`[host-ingest] failed: ${error.message}`);
+        console.log(`[host-ingest] failed: ${error.message}`);
       }
     },
-    onError: (error, reason) => safeLog(`[host-collector] ${reason}: ${error.message}`),
-    logger: (msg) => safeLog(`[host-collector] ${msg}`)
+    onError: (error, reason) => console.log(`[host-collector] ${reason}: ${error.message}`),
+    logger: (msg) => console.log(`[host-collector] ${msg}`)
   });
 }
 
@@ -1330,7 +1330,7 @@ function startLocalCollector() {
     onError: (error, reason) => {
       sendStatus(false, { reason: `${reason}:${error.message}` });
     },
-    logger: (msg) => safeLog(`[collector] ${msg}`)
+    logger: (msg) => console.log(`[collector] ${msg}`)
   });
 }
 
@@ -1529,10 +1529,10 @@ function configureWindowToggleShortcut() {
       return true;
     }
   } catch (error) {
-    safeLog(`[shortcut] failed to register ${shortcut}: ${error.message}`);
+    console.log(`[shortcut] failed to register ${shortcut}: ${error.message}`);
     return false;
   }
-  safeLog(`[shortcut] failed to register ${shortcut}`);
+  console.log(`[shortcut] failed to register ${shortcut}`);
   return false;
 }
 
@@ -1634,7 +1634,7 @@ function startMode() {
       startLocalCollector();
     }
   }).catch((err) => {
-    safeLog(`[mode] reconciliation failed: ${err?.message || err}`);
+    console.log(`[mode] reconciliation failed: ${err?.message || err}`);
   });
 }
 
@@ -1695,7 +1695,7 @@ function regenerateTokscalePricing() {
       sidecarPath: managedPricingSidecarPath()
     });
   } catch (error) {
-    safeWarn(`[pricing] failed to write custom-pricing.json: ${error.message}`);
+    console.warn(`[pricing] failed to write custom-pricing.json: ${error.message}`);
   }
 }
 
@@ -1707,7 +1707,7 @@ async function refreshAfterPricingChange() {
       await syncCollectorHandle.tick('manual', {});
     }
   } catch (error) {
-    safeWarn(`[pricing] refresh after pricing change failed: ${error.message}`);
+    console.warn(`[pricing] refresh after pricing change failed: ${error.message}`);
   }
 }
 
@@ -1731,7 +1731,7 @@ async function checkTokscaleNpm({ silent = false } = {}) {
     return publicResult;
   } catch (error) {
     if (silent) {
-      safeLog(`[tokscale] npm check failed: ${error.message}`);
+      console.log(`[tokscale] npm check failed: ${error.message}`);
       return { supported: true, error: null, silent: true };
     }
     return { supported: true, error: error.message };
@@ -1811,11 +1811,11 @@ async function runAppUpdateCheck({ force = false } = {}) {
       appUpdateLastError = null;
     } else {
       appUpdateLastError = force ? (result.error || 'Update check failed') : null;
-      if (!force) safeWarn('App update check failed:', result.error);
+      if (!force) console.warn('App update check failed:', result.error);
     }
   } catch (error) {
     appUpdateLastError = force ? (error.message || String(error)) : null;
-    if (!force) safeWarn('App update check threw:', error);
+    if (!force) console.warn('App update check threw:', error);
   } finally {
     appUpdateCheckInFlight = false;
     sendAppUpdatePush();
@@ -1896,13 +1896,13 @@ function loadWindowFile(target, options = {}) {
     });
   }
   target.webContents.once('did-fail-load', (_event, code, description) => {
-    safeLog(`[window] renderer load failed: ${code} ${description}`);
+    console.log(`[window] renderer load failed: ${code} ${description}`);
     reveal();
   });
   const filePath = path.join(__dirname, 'renderer', 'index.html');
   const load = options.query ? target.loadFile(filePath, { query: options.query }) : target.loadFile(filePath);
   load.catch((error) => {
-    safeLog(`[window] renderer load failed: ${error.message}`);
+    console.log(`[window] renderer load failed: ${error.message}`);
     reveal();
   });
 }
@@ -2066,7 +2066,7 @@ function createDashboardWindow() {
   win.once('ready-to-show', () => win.show());
   win.on('closed', () => { dashboardWindow = null; });
   win.loadFile(path.join(__dirname, 'renderer', 'dashboard.html'))
-    .catch((error) => safeLog(`[dashboard] load failed: ${error.message}`));
+    .catch((error) => console.log(`[dashboard] load failed: ${error.message}`));
   return win;
 }
 
@@ -2147,7 +2147,7 @@ app.whenReady().then(() => {
   createWindow();
   syncLoginItemSettingFromOs();
   configureWindowToggleShortcut();
-  cleanupStaleStaging().catch((error) => safeLog(`[tokscale] staging cleanup failed: ${error.message}`));
+  cleanupStaleStaging().catch((error) => console.log(`[tokscale] staging cleanup failed: ${error.message}`));
   ensureTray();
   if (settings.trayMode) enterTrayMode();
   regenerateTokscalePricing();

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -6,7 +6,13 @@ const os = require('node:os');
 const path = require('node:path');
 const { app, BrowserWindow, globalShortcut, ipcMain, nativeImage, screen, session, shell } = require('electron');
 const { defaultDeviceId, generateHubSecret, lanIpv4Addresses, loadDotEnv, pidFilePath, sharedDataDir } = require('../shared/config');
+const { safeLog, safeWarn, installSafeStdout } = require('../shared/safeStdio');
 const { appVersion } = require('../shared/appVersion');
+
+// Install EPIPE suppression before anything that might log. Without this,
+// a closed parent pipe turns the next log call into an unhandled rejection
+// and Electron pops a "JavaScript error in the main process" dialog.
+installSafeStdout();
 const { DEFAULT_CLIENTS, clientsCsvForSetting } = require('../shared/clientTracking');
 const { startCollector, lookupModelPricing } = require('../shared/collector');
 const { customPricingPath } = require('../shared/tokscaleConfig');
@@ -1015,16 +1021,16 @@ async function startEmbeddedHub() {
       host: '0.0.0.0',
       secret: settings.hubHostSecret,
       dataFile: hubDataFile(),
-      logger: { error: (err) => console.log(`[hub] ${err?.message || err}`) }
+      logger: { error: (err) => safeLog(`[hub] ${err?.message || err}`) }
     });
     await hub.start();
     embeddedHub = { hub, port };
-    console.log(`[hub] listening on 0.0.0.0:${port}`);
+    safeLog(`[hub] listening on 0.0.0.0:${port}`);
     sendHubPush({ type: 'listening', info: getHubInfo() });
     return embeddedHub;
   } catch (error) {
     embeddedHubError = { code: error.code || 'error', message: error.message, port };
-    console.log(`[hub] failed to start on port ${port}: ${error.message}`);
+    safeLog(`[hub] failed to start on port ${port}: ${error.message}`);
     sendHubPush({ type: 'error', info: getHubInfo() });
     return null;
   }
@@ -1065,7 +1071,7 @@ async function postToHub(summary) {
   const stale = settings.lastPostedDeviceId;
   if (stale && stale !== summary.deviceId) {
     try { await deleteDeviceFromHub(stale); }
-    catch (error) { console.log(`[sync] cleanup of old deviceId ${stale} failed: ${error.message}`); }
+    catch (error) { safeLog(`[sync] cleanup of old deviceId ${stale} failed: ${error.message}`); }
   }
   const url = `${hubUrl.replace(/\/$/, '')}/api/ingest`;
   const response = await fetch(url, {
@@ -1115,11 +1121,11 @@ function startSyncCollector() {
       try {
         await postToHub(visibleSummary);
       } catch (error) {
-        console.log(`[sync-collector] post failed: ${error.message}`);
+        safeLog(`[sync-collector] post failed: ${error.message}`);
       }
     },
-    onError: (error, reason) => console.log(`[sync-collector] ${reason}: ${error.message}`),
-    logger: (msg) => console.log(`[sync-collector] ${msg}`)
+    onError: (error, reason) => safeLog(`[sync-collector] ${reason}: ${error.message}`),
+    logger: (msg) => safeLog(`[sync-collector] ${msg}`)
   });
 }
 
@@ -1163,11 +1169,11 @@ function startHostCollector() {
           saveSettings();
         }
       } catch (error) {
-        console.log(`[host-ingest] failed: ${error.message}`);
+        safeLog(`[host-ingest] failed: ${error.message}`);
       }
     },
-    onError: (error, reason) => console.log(`[host-collector] ${reason}: ${error.message}`),
-    logger: (msg) => console.log(`[host-collector] ${msg}`)
+    onError: (error, reason) => safeLog(`[host-collector] ${reason}: ${error.message}`),
+    logger: (msg) => safeLog(`[host-collector] ${msg}`)
   });
 }
 
@@ -1324,7 +1330,7 @@ function startLocalCollector() {
     onError: (error, reason) => {
       sendStatus(false, { reason: `${reason}:${error.message}` });
     },
-    logger: (msg) => console.log(`[collector] ${msg}`)
+    logger: (msg) => safeLog(`[collector] ${msg}`)
   });
 }
 
@@ -1523,10 +1529,10 @@ function configureWindowToggleShortcut() {
       return true;
     }
   } catch (error) {
-    console.log(`[shortcut] failed to register ${shortcut}: ${error.message}`);
+    safeLog(`[shortcut] failed to register ${shortcut}: ${error.message}`);
     return false;
   }
-  console.log(`[shortcut] failed to register ${shortcut}`);
+  safeLog(`[shortcut] failed to register ${shortcut}`);
   return false;
 }
 
@@ -1628,7 +1634,7 @@ function startMode() {
       startLocalCollector();
     }
   }).catch((err) => {
-    console.log(`[mode] reconciliation failed: ${err?.message || err}`);
+    safeLog(`[mode] reconciliation failed: ${err?.message || err}`);
   });
 }
 
@@ -1689,7 +1695,7 @@ function regenerateTokscalePricing() {
       sidecarPath: managedPricingSidecarPath()
     });
   } catch (error) {
-    console.warn(`[pricing] failed to write custom-pricing.json: ${error.message}`);
+    safeWarn(`[pricing] failed to write custom-pricing.json: ${error.message}`);
   }
 }
 
@@ -1701,7 +1707,7 @@ async function refreshAfterPricingChange() {
       await syncCollectorHandle.tick('manual', {});
     }
   } catch (error) {
-    console.warn(`[pricing] refresh after pricing change failed: ${error.message}`);
+    safeWarn(`[pricing] refresh after pricing change failed: ${error.message}`);
   }
 }
 
@@ -1725,7 +1731,7 @@ async function checkTokscaleNpm({ silent = false } = {}) {
     return publicResult;
   } catch (error) {
     if (silent) {
-      console.log(`[tokscale] npm check failed: ${error.message}`);
+      safeLog(`[tokscale] npm check failed: ${error.message}`);
       return { supported: true, error: null, silent: true };
     }
     return { supported: true, error: error.message };
@@ -1805,11 +1811,11 @@ async function runAppUpdateCheck({ force = false } = {}) {
       appUpdateLastError = null;
     } else {
       appUpdateLastError = force ? (result.error || 'Update check failed') : null;
-      if (!force) console.warn('App update check failed:', result.error);
+      if (!force) safeWarn('App update check failed:', result.error);
     }
   } catch (error) {
     appUpdateLastError = force ? (error.message || String(error)) : null;
-    if (!force) console.warn('App update check threw:', error);
+    if (!force) safeWarn('App update check threw:', error);
   } finally {
     appUpdateCheckInFlight = false;
     sendAppUpdatePush();
@@ -1890,13 +1896,13 @@ function loadWindowFile(target, options = {}) {
     });
   }
   target.webContents.once('did-fail-load', (_event, code, description) => {
-    console.log(`[window] renderer load failed: ${code} ${description}`);
+    safeLog(`[window] renderer load failed: ${code} ${description}`);
     reveal();
   });
   const filePath = path.join(__dirname, 'renderer', 'index.html');
   const load = options.query ? target.loadFile(filePath, { query: options.query }) : target.loadFile(filePath);
   load.catch((error) => {
-    console.log(`[window] renderer load failed: ${error.message}`);
+    safeLog(`[window] renderer load failed: ${error.message}`);
     reveal();
   });
 }
@@ -2060,7 +2066,7 @@ function createDashboardWindow() {
   win.once('ready-to-show', () => win.show());
   win.on('closed', () => { dashboardWindow = null; });
   win.loadFile(path.join(__dirname, 'renderer', 'dashboard.html'))
-    .catch((error) => console.log(`[dashboard] load failed: ${error.message}`));
+    .catch((error) => safeLog(`[dashboard] load failed: ${error.message}`));
   return win;
 }
 
@@ -2141,7 +2147,7 @@ app.whenReady().then(() => {
   createWindow();
   syncLoginItemSettingFromOs();
   configureWindowToggleShortcut();
-  cleanupStaleStaging().catch((error) => console.log(`[tokscale] staging cleanup failed: ${error.message}`));
+  cleanupStaleStaging().catch((error) => safeLog(`[tokscale] staging cleanup failed: ${error.message}`));
   ensureTray();
   if (settings.trayMode) enterTrayMode();
   regenerateTokscalePricing();

--- a/src/shared/safeStdio.js
+++ b/src/shared/safeStdio.js
@@ -2,31 +2,12 @@
 
 // console.log is wired to the same stdout stream that npm / Electron inherit
 // from the parent shell. When the parent closes its end of the pipe (npm
-// detached, terminal closed, log redirected to a non-seekable consumer),
-// writing to stdout raises EPIPE — which becomes an unhandled promise
-// rejection and pops up a "JavaScript error in the main process" dialog.
-// Swallow EPIPE here so background log traffic never surfaces to the user.
-function safeLog(...args) {
-  try {
-    process.stdout.write(`${args.map(String).join(' ')}\n`);
-  } catch (err) {
-    if (!err || err.code !== 'EPIPE') throw err;
-  }
-}
-
-function safeWarn(...args) {
-  try {
-    process.stderr.write(`${args.map(String).join(' ')}\n`);
-  } catch (err) {
-    if (!err || err.code !== 'EPIPE') throw err;
-  }
-}
-
-// When process.stdout.write returns false (backpressure) and the parent
-// closes the pipe, the EPIPE surfaces asynchronously on the 'error' event.
-// Without a listener, that becomes an unhandled 'error' event and Electron
-// pops a "JavaScript error in the main process" dialog. Install a one-time
-// no-op EPIPE handler so background log traffic never disturbs the user.
+// detached, terminal closed, log redirected to a non-seekable consumer), the
+// next write raises EPIPE asynchronously on the stream's 'error' event. With
+// no listener that becomes an unhandled 'error' and Electron pops a
+// "JavaScript error in the main process" dialog, even though the app is fine.
+// Install a one-time no-op EPIPE handler so background log traffic never
+// disturbs the user; re-throw anything else so genuine bugs still surface.
 function installSafeStdout() {
   if (process.stdout._tokenMonitorEpipeHandled) return;
   process.stdout._tokenMonitorEpipeHandled = true;
@@ -42,4 +23,4 @@ function installSafeStdout() {
   }
 }
 
-module.exports = { safeLog, safeWarn, installSafeStdout };
+module.exports = { installSafeStdout };

--- a/src/shared/safeStdio.js
+++ b/src/shared/safeStdio.js
@@ -1,0 +1,45 @@
+'use strict';
+
+// console.log is wired to the same stdout stream that npm / Electron inherit
+// from the parent shell. When the parent closes its end of the pipe (npm
+// detached, terminal closed, log redirected to a non-seekable consumer),
+// writing to stdout raises EPIPE — which becomes an unhandled promise
+// rejection and pops up a "JavaScript error in the main process" dialog.
+// Swallow EPIPE here so background log traffic never surfaces to the user.
+function safeLog(...args) {
+  try {
+    process.stdout.write(`${args.map(String).join(' ')}\n`);
+  } catch (err) {
+    if (!err || err.code !== 'EPIPE') throw err;
+  }
+}
+
+function safeWarn(...args) {
+  try {
+    process.stderr.write(`${args.map(String).join(' ')}\n`);
+  } catch (err) {
+    if (!err || err.code !== 'EPIPE') throw err;
+  }
+}
+
+// When process.stdout.write returns false (backpressure) and the parent
+// closes the pipe, the EPIPE surfaces asynchronously on the 'error' event.
+// Without a listener, that becomes an unhandled 'error' event and Electron
+// pops a "JavaScript error in the main process" dialog. Install a one-time
+// no-op EPIPE handler so background log traffic never disturbs the user.
+function installSafeStdout() {
+  if (process.stdout._tokenMonitorEpipeHandled) return;
+  process.stdout._tokenMonitorEpipeHandled = true;
+  process.stdout.on('error', (err) => {
+    if (!err || err.code !== 'EPIPE') throw err;
+  });
+  // stderr mirrors stdout; install a handler there too for symmetry.
+  if (!process.stderr._tokenMonitorEpipeHandled) {
+    process.stderr._tokenMonitorEpipeHandled = true;
+    process.stderr.on('error', (err) => {
+      if (!err || err.code !== 'EPIPE') throw err;
+    });
+  }
+}
+
+module.exports = { safeLog, safeWarn, installSafeStdout };

--- a/tests/shared/safeStdio.test.js
+++ b/tests/shared/safeStdio.test.js
@@ -3,87 +3,24 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 
-const { safeLog, safeWarn, installSafeStdout } = require('../../src/shared/safeStdio');
+const { installSafeStdout } = require('../../src/shared/safeStdio');
 
-test('safeLog coerces non-string args to strings and joins with spaces', () => {
-  const original = process.stdout.write;
-  let captured = '';
-  process.stdout.write = (chunk) => {
-    captured += chunk;
-    return true;
-  };
-  try {
-    safeLog('hello', 42, { nested: true });
-  } finally {
-    process.stdout.write = original;
-  }
-  assert.match(captured, /hello 42 \[object Object\]\n/);
+test('installSafeStdout registers a no-op EPIPE handler on stdout and stderr', () => {
+  installSafeStdout();
+  assert.ok(process.stdout.listeners('error').length >= 1, 'stdout should have an error listener');
+  assert.ok(process.stderr.listeners('error').length >= 1, 'stderr should have an error listener');
 });
 
-test('safeLog swallows EPIPE on the synchronous write path', () => {
-  const original = process.stdout.write;
-  process.stdout.write = () => {
-    const err = new Error('EPIPE');
-    err.code = 'EPIPE';
-    throw err;
-  };
-  try {
-    assert.doesNotThrow(() => safeLog('ignored'));
-  } finally {
-    process.stdout.write = original;
-  }
-});
-
-test('safeLog re-throws non-EPIPE errors so genuine bugs surface', () => {
-  const original = process.stdout.write;
-  process.stdout.write = () => {
-    const err = new Error('disk full');
-    err.code = 'ENOSPC';
-    throw err;
-  };
-  try {
-    assert.throws(() => safeLog('ignored'), /disk full/);
-  } finally {
-    process.stdout.write = original;
-  }
-});
-
-test('safeWarn mirrors safeLog but writes to stderr', () => {
-  const original = process.stderr.write;
-  let captured = '';
-  process.stderr.write = (chunk) => {
-    captured += chunk;
-    return true;
-  };
-  try {
-    safeWarn('warn', 1);
-  } finally {
-    process.stderr.write = original;
-  }
-  assert.match(captured, /warn 1\n/);
-});
-
-test('safeWarn swallows EPIPE on stderr', () => {
-  const original = process.stderr.write;
-  process.stderr.write = () => {
-    const err = new Error('EPIPE');
-    err.code = 'EPIPE';
-    throw err;
-  };
-  try {
-    assert.doesNotThrow(() => safeWarn('ignored'));
-  } finally {
-    process.stderr.write = original;
-  }
-});
-
-test('installSafeStdout registers a no-op EPIPE handler on stdout', () => {
+test('the installed handler swallows EPIPE', () => {
   installSafeStdout();
   const handlers = process.stdout.listeners('error');
-  assert.ok(handlers.length >= 1, 'stdout should have at least one error listener');
+  const handler = handlers[handlers.length - 1];
+  const err = new Error('EPIPE');
+  err.code = 'EPIPE';
+  assert.doesNotThrow(() => handler(err));
 });
 
-test('installSafeStdout re-throws non-EPIPE errors so genuine bugs surface', () => {
+test('the installed handler re-throws non-EPIPE errors so genuine bugs surface', () => {
   installSafeStdout();
   const handlers = process.stdout.listeners('error');
   const handler = handlers[handlers.length - 1];
@@ -95,6 +32,8 @@ test('installSafeStdout re-throws non-EPIPE errors so genuine bugs surface', () 
 test('installSafeStdout is idempotent', () => {
   installSafeStdout();
   const stdoutCount = process.stdout.listeners('error').length;
+  const stderrCount = process.stderr.listeners('error').length;
   installSafeStdout();
   assert.equal(process.stdout.listeners('error').length, stdoutCount);
+  assert.equal(process.stderr.listeners('error').length, stderrCount);
 });

--- a/tests/shared/safeStdio.test.js
+++ b/tests/shared/safeStdio.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { safeLog, safeWarn, installSafeStdout } = require('../../src/shared/safeStdio');
+
+test('safeLog coerces non-string args to strings and joins with spaces', () => {
+  const original = process.stdout.write;
+  let captured = '';
+  process.stdout.write = (chunk) => {
+    captured += chunk;
+    return true;
+  };
+  try {
+    safeLog('hello', 42, { nested: true });
+  } finally {
+    process.stdout.write = original;
+  }
+  assert.match(captured, /hello 42 \[object Object\]\n/);
+});
+
+test('safeLog swallows EPIPE on the synchronous write path', () => {
+  const original = process.stdout.write;
+  process.stdout.write = () => {
+    const err = new Error('EPIPE');
+    err.code = 'EPIPE';
+    throw err;
+  };
+  try {
+    assert.doesNotThrow(() => safeLog('ignored'));
+  } finally {
+    process.stdout.write = original;
+  }
+});
+
+test('safeLog re-throws non-EPIPE errors so genuine bugs surface', () => {
+  const original = process.stdout.write;
+  process.stdout.write = () => {
+    const err = new Error('disk full');
+    err.code = 'ENOSPC';
+    throw err;
+  };
+  try {
+    assert.throws(() => safeLog('ignored'), /disk full/);
+  } finally {
+    process.stdout.write = original;
+  }
+});
+
+test('safeWarn mirrors safeLog but writes to stderr', () => {
+  const original = process.stderr.write;
+  let captured = '';
+  process.stderr.write = (chunk) => {
+    captured += chunk;
+    return true;
+  };
+  try {
+    safeWarn('warn', 1);
+  } finally {
+    process.stderr.write = original;
+  }
+  assert.match(captured, /warn 1\n/);
+});
+
+test('safeWarn swallows EPIPE on stderr', () => {
+  const original = process.stderr.write;
+  process.stderr.write = () => {
+    const err = new Error('EPIPE');
+    err.code = 'EPIPE';
+    throw err;
+  };
+  try {
+    assert.doesNotThrow(() => safeWarn('ignored'));
+  } finally {
+    process.stderr.write = original;
+  }
+});
+
+test('installSafeStdout registers a no-op EPIPE handler on stdout', () => {
+  installSafeStdout();
+  const handlers = process.stdout.listeners('error');
+  assert.ok(handlers.length >= 1, 'stdout should have at least one error listener');
+});
+
+test('installSafeStdout re-throws non-EPIPE errors so genuine bugs surface', () => {
+  installSafeStdout();
+  const handlers = process.stdout.listeners('error');
+  const handler = handlers[handlers.length - 1];
+  const err = new Error('disk full');
+  err.code = 'ENOSPC';
+  assert.throws(() => handler(err), /disk full/);
+});
+
+test('installSafeStdout is idempotent', () => {
+  installSafeStdout();
+  const stdoutCount = process.stdout.listeners('error').length;
+  installSafeStdout();
+  assert.equal(process.stdout.listeners('error').length, stdoutCount);
+});


### PR DESCRIPTION
# feat: add safe stdout wrapper to suppress EPIPE dialogs

Standalone fix for an Electron main-process issue: background log traffic
from the collector / sync / hub watchers raises unhandled `EPIPE: broken
pipe, write` rejections when the parent shell closes its end of the
stdout pipe (npm detached, terminal closed, log redirected to a
non-seekable consumer). Electron turns those into a **"JavaScript error
in the main process"** dialog, even though the app itself is healthy.

## What's in here

`src/shared/safeStdio.js` exposes:

- `safeLog(...args)` / `safeWarn(...args)` — write directly to
  `process.stdout` / `process.stderr`, swallow `EPIPE`, re-throw any
  other error so genuine bugs surface.
- `installSafeStdout()` — register no-op `EPIPE` handlers on the
  stream `'error'` event so the **async** EPIPE path is also
  suppressed. Synchronous write failures are caught by `safeLog` /
  `safeWarn`, but backpressure closes raise the error event on the
  next tick.

`installSafeStdout()` runs at startup, before any logger can fire. All
`console.log` / `console.warn` call sites in `src/electron/main.js`
route through `safeLog` / `safeWarn`.

`tests/shared/safeStdio.test.js` covers:
- `safeLog` / `safeWarn` arg coercion (non-string args join with spaces)
- Sync EPIPE suppression
- Re-throw of non-EPIPE errors so genuine bugs surface
- Idempotency of `installSafeStdout`

## Files

```
src/electron/main.js           |  52 +++++++++++----------
src/shared/safeStdio.js        |  45 +++
tests/shared/safeStdio.test.js | 100 +++++++++++++++++++++++++++++++++++++
```

## Origin

Split out from a larger limits-providers PR
([#32](https://github.com/Javis603/token-monitor/pull/32)) per the
maintainer's request. Originally that PR also proposed routing Node
`fetch()` through a `TOKEN_MONITOR_PROXY` env var; that's been dropped
from this branch at the maintainer's direction (the proxy change is
app-wide network behavior and not appropriate for a focused
providers PR).