### PR TITLE
fix(collector): include Hermes profile databases in tokscale scans

### DIFF
--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -12,6 +12,7 @@ const { normalizeClientsCsv } = require('./clientTracking');
 const { tokscalePackageNameForPlatform, tokscalePlatformKey } = require('./tokscalePlatform');
 const { applyPeriodDelta, emptyPeriod, extractUsageFromTokscale, mergePeriods } = require('./usage');
 const { collectWslUsage: collectWslUsageImpl, emptyWslBundle, probeWslState: probeWslStateImpl } = require('./wslUsage');
+const { hermesProfileWatchDirs, resolveHermesHome, tokscaleEnvFromSpawnArgs } = require('./hermesProfiles');
 const { parseGraphResult, normalizeHistory } = require('./history');
 const { collectLimitsOnce, createLimitsCollector } = require('./limitCollector');
 const cursorAuth = require('./cursorAuth');
@@ -109,10 +110,14 @@ function parseJsonOutput(stdout) {
   throw new Error(`Could not parse tokscale JSON output: ${text.slice(0, 300)}`);
 }
 
-function spawnTokscaleJson(userArgs, commandTimeoutMs) {
+function spawnTokscaleJson(userArgs, commandTimeoutMs, spawnOpts = {}) {
   const { bin, prefixArgs, env } = tokscaleCommand();
+  const childEnv = tokscaleEnvFromSpawnArgs(env, userArgs, {
+    env,
+    homeDir: spawnOpts.homeDir || os.homedir()
+  });
   return new Promise((resolve, reject) => {
-    const child = spawn(bin, [...prefixArgs, ...userArgs], { env, windowsHide: true });
+    const child = spawn(bin, [...prefixArgs, ...userArgs], { env: childEnv, windowsHide: true });
     let stdout = '';
     let stderr = '';
     const timeout = setTimeout(() => { child.kill('SIGTERM'); reject(new Error(`tokscale timed out after ${commandTimeoutMs}ms`)); }, commandTimeoutMs);
@@ -534,7 +539,8 @@ function clientWatchCandidates(clientsCsv) {
   const add = (client, ...dirs) => { if (enabled.has(client)) byClient[client] = dirs; };
   add('claude', path.join(home, '.claude', 'projects'), path.join(home, '.claude', 'transcripts'));
   add('codex', path.join(home, '.codex', 'sessions'));
-  add('hermes', process.env.HERMES_HOME || path.join(home, '.hermes'));
+  const hermesHome = resolveHermesHome({ env: process.env, homeDir: home });
+  add('hermes', hermesHome, ...hermesProfileWatchDirs(hermesHome));
   add('opencode', path.join(home, '.local', 'share', 'opencode'));
   add('openclaw', path.join(home, '.openclaw', 'agents'));
   add('cursor', path.join(home, '.config', 'tokscale', 'cursor-cache'));

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -640,10 +640,15 @@ const HERMES_DB_FILES = new Set(['state.db', 'state.db-wal', 'state.db-shm']);
 function watchIgnoreMatcher(clientsCsv) {
   const roots = (clientWatchCandidates(clientsCsv).hermes || []).map((dir) => path.resolve(dir));
   if (roots.length === 0) return undefined;
+  const rootSet = new Set(roots);
   return (target) => {
     const resolved = path.resolve(target);
+    // Every explicit watch root stays watched — the home dir AND each profile
+    // dir. A profile dir lives under the home root, so the child-prune below
+    // would otherwise ignore it (basename isn't a db file) before we recognise
+    // it as a watch root in its own right, silencing profile-db change events.
+    if (rootSet.has(resolved)) return false;
     for (const root of roots) {
-      if (resolved === root) return false; // the watch root itself must stay watched
       if (resolved.startsWith(root + path.sep)) return !HERMES_DB_FILES.has(path.basename(resolved));
     }
     return false; // non-Hermes paths are never ignored

--- a/src/shared/hermesProfiles.js
+++ b/src/shared/hermesProfiles.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function resolveHermesHome({ env = process.env, homeDir, platform = process.platform, existsSync = fs.existsSync } = {}) {
+  const home = homeDir || require('node:os').homedir();
+  const fromEnv = String(env.HERMES_HOME || '').trim();
+  if (fromEnv) return fromEnv;
+
+  if (platform === 'win32') {
+    const localAppData = String(env.LOCALAPPDATA || '').trim() || path.join(home, 'AppData', 'Local');
+    const winNative = path.join(localAppData, 'hermes');
+    if (existsSync(path.join(winNative, 'state.db'))) return winNative;
+  }
+
+  return path.join(home, '.hermes');
+}
+
+function discoverHermesProfileScanPaths(hermesHome, deps = {}) {
+  const existsSync = deps.existsSync || fs.existsSync;
+  const readdirSync = deps.readdirSync || fs.readdirSync;
+  const root = String(hermesHome || '').trim();
+  if (!root) return [];
+
+  const profilesDir = path.join(root, 'profiles');
+  if (!existsSync(profilesDir)) return [];
+
+  const paths = [];
+  let entries = [];
+  try {
+    entries = readdirSync(profilesDir, { withFileTypes: true });
+  } catch (_) {
+    return [];
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const profileDir = path.join(profilesDir, entry.name);
+    if (existsSync(path.join(profileDir, 'state.db'))) paths.push(profileDir);
+  }
+
+  return paths.sort((a, b) => a.localeCompare(b));
+}
+
+function hermesProfileWatchDirs(hermesHome, deps = {}) {
+  return discoverHermesProfileScanPaths(hermesHome, deps);
+}
+
+function clientsCsvIncludesHermes(clientsCsv) {
+  return String(clientsCsv || '')
+    .split(',')
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean)
+    .includes('hermes');
+}
+
+function mergeTokscaleExtraDirs(env, additions) {
+  const base = env && typeof env === 'object' ? { ...env } : {};
+  const extra = (additions || []).filter(Boolean);
+  if (extra.length === 0) return base;
+
+  const existing = String(base.TOKSCALE_EXTRA_DIRS || '').trim();
+  const merged = existing
+    ? `${existing},${extra.join(',')}`
+    : extra.join(',');
+  base.TOKSCALE_EXTRA_DIRS = merged;
+  return base;
+}
+
+function tokscaleEnvWithHermesProfiles(env, clientsCsv, opts = {}) {
+  if (!clientsCsvIncludesHermes(clientsCsv)) return env;
+  const hermesHome = resolveHermesHome(opts);
+  const profileDirs = discoverHermesProfileScanPaths(hermesHome, opts);
+  if (profileDirs.length === 0) return env;
+  const additions = profileDirs.map((dir) => `hermes:${dir}`);
+  return mergeTokscaleExtraDirs(env, additions);
+}
+
+function tokscaleEnvFromSpawnArgs(env, userArgs, opts = {}) {
+  const args = Array.isArray(userArgs) ? userArgs : [];
+  const clientIndex = args.indexOf('--client');
+  if (clientIndex < 0 || clientIndex >= args.length - 1) return env;
+  return tokscaleEnvWithHermesProfiles(env, args[clientIndex + 1], opts);
+}
+
+module.exports = {
+  clientsCsvIncludesHermes,
+  discoverHermesProfileScanPaths,
+  hermesProfileWatchDirs,
+  mergeTokscaleExtraDirs,
+  resolveHermesHome,
+  tokscaleEnvFromSpawnArgs,
+  tokscaleEnvWithHermesProfiles
+};

--- a/src/shared/hermesProfiles.js
+++ b/src/shared/hermesProfiles.js
@@ -8,13 +8,18 @@ function resolveHermesHome({ env = process.env, homeDir, platform = process.plat
   const fromEnv = String(env.HERMES_HOME || '').trim();
   if (fromEnv) return fromEnv;
 
+  const dotHermes = path.join(home, '.hermes');
+  if (existsSync(path.join(dotHermes, 'state.db'))) return dotHermes;
+
+  // Windows native installs often land in %LOCALAPPDATA%\hermes instead of
+  // ~/.hermes. Resolve via the active home dir so mocked homedirs in tests do
+  // not leak the developer machine's real AppData path.
   if (platform === 'win32') {
-    const localAppData = String(env.LOCALAPPDATA || '').trim() || path.join(home, 'AppData', 'Local');
-    const winNative = path.join(localAppData, 'hermes');
+    const winNative = path.join(home, 'AppData', 'Local', 'hermes');
     if (existsSync(path.join(winNative, 'state.db'))) return winNative;
   }
 
-  return path.join(home, '.hermes');
+  return dotHermes;
 }
 
 function discoverHermesProfileScanPaths(hermesHome, deps = {}) {

--- a/src/shared/hermesProfiles.js
+++ b/src/shared/hermesProfiles.js
@@ -32,7 +32,7 @@ function discoverHermesProfileScanPaths(hermesHome, deps = {}) {
   if (!existsSync(profilesDir)) return [];
 
   const paths = [];
-  let entries = [];
+  let entries;
   try {
     entries = readdirSync(profilesDir, { withFileTypes: true });
   } catch (_) {

--- a/src/shared/hermesProfiles.js
+++ b/src/shared/hermesProfiles.js
@@ -1,10 +1,11 @@
 'use strict';
 
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 function resolveHermesHome({ env = process.env, homeDir, platform = process.platform, existsSync = fs.existsSync } = {}) {
-  const home = homeDir || require('node:os').homedir();
+  const home = homeDir || os.homedir();
   const fromEnv = String(env.HERMES_HOME || '').trim();
   if (fromEnv) return fromEnv;
 
@@ -12,10 +13,11 @@ function resolveHermesHome({ env = process.env, homeDir, platform = process.plat
   if (existsSync(path.join(dotHermes, 'state.db'))) return dotHermes;
 
   // Windows native installs often land in %LOCALAPPDATA%\hermes instead of
-  // ~/.hermes. Resolve via the active home dir so mocked homedirs in tests do
-  // not leak the developer machine's real AppData path.
+  // ~/.hermes. Prefer the real LOCALAPPDATA, falling back to the active home
+  // dir so mocked homedirs in tests do not leak the developer machine's AppData.
   if (platform === 'win32') {
-    const winNative = path.join(home, 'AppData', 'Local', 'hermes');
+    const localAppData = env.LOCALAPPDATA || path.join(home, 'AppData', 'Local');
+    const winNative = path.join(localAppData, 'hermes');
     if (existsSync(path.join(winNative, 'state.db'))) return winNative;
   }
 
@@ -84,6 +86,10 @@ function tokscaleEnvWithHermesProfiles(env, clientsCsv, opts = {}) {
 
 function tokscaleEnvFromSpawnArgs(env, userArgs, opts = {}) {
   const args = Array.isArray(userArgs) ? userArgs : [];
+  // A `--home` scan (WSL) disables tokscale's env roots, so it ignores
+  // TOKSCALE_EXTRA_DIRS entirely — injecting host profile dirs there is dead
+  // work and would point at host paths that don't exist under that home.
+  if (args.includes('--home')) return env;
   const clientIndex = args.indexOf('--client');
   if (clientIndex < 0 || clientIndex >= args.length - 1) return env;
   return tokscaleEnvWithHermesProfiles(env, args[clientIndex + 1], opts);

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -173,6 +173,31 @@ test('watchPathsForClients watches Pi (incl. Oh My Pi), Zed (incl. native macOS)
   }
 });
 
+test('watchPathsForClients watches Hermes profile dirs alongside the home root', () => {
+  const tmp = withTmpHome([path.join('.hermes', 'hermes-agent', 'node_modules')]);
+  const hermesRoot = path.join(tmp, '.hermes');
+  fs.writeFileSync(path.join(hermesRoot, 'state.db'), '');
+  const profileDir = path.join(hermesRoot, 'profiles', 'research');
+  fs.mkdirSync(profileDir, { recursive: true });
+  fs.writeFileSync(path.join(profileDir, 'state.db'), '');
+  const originalHomedir = os.homedir;
+  const previousHermesHome = process.env.HERMES_HOME;
+  os.homedir = () => tmp;
+  try {
+    delete process.env.HERMES_HOME;
+    const { clientDataDirPresence, watchPathsForClients } = freshCollector();
+    const dirs = watchPathsForClients('hermes');
+    assert.deepEqual(dirs, [hermesRoot, profileDir]);
+    assert.deepEqual(clientDataDirPresence('hermes'), { hermes: true });
+  } finally {
+    os.homedir = originalHomedir;
+    if (previousHermesHome === undefined) delete process.env.HERMES_HOME;
+    else process.env.HERMES_HOME = previousHermesHome;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test('watchPathsForClients watches the Hermes home dir so new state.db sidecars are picked up', () => {
   // Hermes keeps usage in a single SQLite db at the root of HERMES_HOME, but that
   // dir also holds the Desktop App runtime (hermes-agent/node_modules/venv: GBs /

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -255,6 +255,40 @@ test('watchIgnoreMatcher prunes the Hermes runtime but keeps the state.db family
   }
 });
 
+test('watchIgnoreMatcher keeps profile dirs and their db family so profile changes still fire', () => {
+  // A profile dir lives under the Hermes home root, so the child-prune must not
+  // ignore it just because its basename isn't a db file — chokidar would then
+  // refuse to watch the explicit profile watch root and profile-db edits would
+  // only surface on the next interval scan, not the promised 3-5 s refresh.
+  const tmp = withTmpHome([path.join('.hermes', 'hermes-agent', 'node_modules')]);
+  const hermesRoot = path.join(tmp, '.hermes');
+  fs.writeFileSync(path.join(hermesRoot, 'state.db'), '');
+  const profileDir = path.join(hermesRoot, 'profiles', 'research');
+  fs.mkdirSync(profileDir, { recursive: true });
+  fs.writeFileSync(path.join(profileDir, 'state.db'), '');
+  const originalHomedir = os.homedir;
+  const previousHermesHome = process.env.HERMES_HOME;
+  os.homedir = () => tmp;
+  try {
+    delete process.env.HERMES_HOME;
+    const { watchIgnoreMatcher } = freshCollector();
+    const ignored = watchIgnoreMatcher('hermes');
+    // The profile dir (an explicit watch root) and its db family stay watched.
+    assert.equal(ignored(profileDir), false);
+    assert.equal(ignored(path.join(profileDir, 'state.db')), false);
+    assert.equal(ignored(path.join(profileDir, 'state.db-wal')), false);
+    assert.equal(ignored(path.join(profileDir, 'state.db-shm')), false);
+    // Junk inside a profile dir is still pruned.
+    assert.equal(ignored(path.join(profileDir, 'logs')), true);
+  } finally {
+    os.homedir = originalHomedir;
+    if (previousHermesHome === undefined) delete process.env.HERMES_HOME;
+    else process.env.HERMES_HOME = previousHermesHome;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test('watchIgnoreMatcher honors HERMES_HOME and is absent when Hermes is not tracked', () => {
   const tmp = withTmpHome([]);
   const hermesHome = path.join(tmp, 'custom-hermes');

--- a/tests/shared/hermesProfiles.test.js
+++ b/tests/shared/hermesProfiles.test.js
@@ -19,17 +19,33 @@ test('resolveHermesHome prefers HERMES_HOME when set', () => {
   );
 });
 
-test('resolveHermesHome falls back to Windows LocalAppData when native state.db exists', () => {
+test('resolveHermesHome prefers home-relative .hermes before Windows LocalAppData', () => {
   const homeDir = 'C:\\Users\\u';
-  const localAppData = 'C:\\Users\\u\\AppData\\Local';
+  const dotHermes = path.join(homeDir, '.hermes');
+  const winNative = path.join(homeDir, 'AppData', 'Local', 'hermes');
   assert.equal(
     resolveHermesHome({
-      env: { LOCALAPPDATA: localAppData },
+      env: {},
       homeDir,
       platform: 'win32',
-      existsSync: (target) => target === path.join(localAppData, 'hermes', 'state.db')
+      existsSync: (target) => target === path.join(dotHermes, 'state.db')
+        || target === path.join(winNative, 'state.db')
     }),
-    path.join(localAppData, 'hermes')
+    dotHermes
+  );
+});
+
+test('resolveHermesHome falls back to Windows LocalAppData when native state.db exists', () => {
+  const homeDir = 'C:\\Users\\u';
+  const winNative = path.join(homeDir, 'AppData', 'Local', 'hermes');
+  assert.equal(
+    resolveHermesHome({
+      env: {},
+      homeDir,
+      platform: 'win32',
+      existsSync: (target) => target === path.join(winNative, 'state.db')
+    }),
+    winNative
   );
 });
 

--- a/tests/shared/hermesProfiles.test.js
+++ b/tests/shared/hermesProfiles.test.js
@@ -93,11 +93,9 @@ test('tokscaleEnvWithHermesProfiles injects hermes profile dirs into TOKSCALE_EX
     }
   );
 
+  const profileDir = path.join(hermesHome, 'profiles', 'lab-a');
   assert.equal(env.FOO, 'bar');
-  assert.match(
-    env.TOKSCALE_EXTRA_DIRS,
-    /codex:C:\\extra,hermes:C:\\Users\\u\\AppData\\Local\\hermes\\profiles\\lab-a/
-  );
+  assert.equal(env.TOKSCALE_EXTRA_DIRS, `codex:C:\\extra,hermes:${profileDir}`);
 });
 
 test('tokscaleEnvWithHermesProfiles leaves env untouched when hermes is not enabled', () => {

--- a/tests/shared/hermesProfiles.test.js
+++ b/tests/shared/hermesProfiles.test.js
@@ -125,6 +125,24 @@ test('tokscaleEnvFromSpawnArgs reads --client from tokscale argv', () => {
   assert.equal(env.TOKSCALE_EXTRA_DIRS, `hermes:${profileDir}`);
 });
 
+test('tokscaleEnvFromSpawnArgs skips injection for --home scans (tokscale ignores extra dirs there)', () => {
+  const base = { FOO: 'bar' };
+  const env = tokscaleEnvFromSpawnArgs(
+    base,
+    ['--json', '--client', 'hermes', '--group-by', 'client,model', '--home', '\\\\wsl$\\Ubuntu\\home\\u'],
+    {
+      env: { HERMES_HOME: path.join('/home/u', '.hermes') },
+      homeDir: '/home/u',
+      platform: 'linux',
+      existsSync: () => true,
+      readdirSync: () => [{ name: 'research', isDirectory: () => true }]
+    }
+  );
+
+  assert.equal(env, base);
+  assert.equal(env.TOKSCALE_EXTRA_DIRS, undefined);
+});
+
 test('mergeTokscaleExtraDirs appends without duplicating the env object fields', () => {
   const env = mergeTokscaleExtraDirs({ A: '1' }, ['hermes:/tmp/p1', 'hermes:/tmp/p2']);
   assert.equal(env.A, '1');

--- a/tests/shared/hermesProfiles.test.js
+++ b/tests/shared/hermesProfiles.test.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  discoverHermesProfileScanPaths,
+  mergeTokscaleExtraDirs,
+  resolveHermesHome,
+  tokscaleEnvFromSpawnArgs,
+  tokscaleEnvWithHermesProfiles
+} = require('../../src/shared/hermesProfiles');
+
+test('resolveHermesHome prefers HERMES_HOME when set', () => {
+  assert.equal(
+    resolveHermesHome({ env: { HERMES_HOME: 'C:\\hermes-root' }, homeDir: 'C:\\Users\\u', platform: 'win32' }),
+    'C:\\hermes-root'
+  );
+});
+
+test('resolveHermesHome falls back to Windows LocalAppData when native state.db exists', () => {
+  const homeDir = 'C:\\Users\\u';
+  const localAppData = 'C:\\Users\\u\\AppData\\Local';
+  assert.equal(
+    resolveHermesHome({
+      env: { LOCALAPPDATA: localAppData },
+      homeDir,
+      platform: 'win32',
+      existsSync: (target) => target === path.join(localAppData, 'hermes', 'state.db')
+    }),
+    path.join(localAppData, 'hermes')
+  );
+});
+
+test('resolveHermesHome falls back to ~/.hermes on other platforms', () => {
+  assert.equal(
+    resolveHermesHome({ env: {}, homeDir: '/home/u', platform: 'linux' }),
+    path.join('/home/u', '.hermes')
+  );
+});
+
+test('discoverHermesProfileScanPaths returns profile dirs that contain state.db', () => {
+  const hermesHome = '/home/u/.hermes';
+  const paths = discoverHermesProfileScanPaths(hermesHome, {
+    existsSync: (target) => {
+      if (target === path.join(hermesHome, 'profiles')) return true;
+      return target.endsWith(`${path.sep}02${path.sep}state.db`)
+        || target.endsWith(`${path.sep}wiki-sys${path.sep}state.db`);
+    },
+    readdirSync: () => [
+      { name: '02', isDirectory: () => true },
+      { name: 'empty', isDirectory: () => true },
+      { name: 'notes.txt', isDirectory: () => false },
+      { name: 'wiki-sys', isDirectory: () => true }
+    ]
+  });
+
+  assert.deepEqual(paths, [
+    path.join(hermesHome, 'profiles', '02'),
+    path.join(hermesHome, 'profiles', 'wiki-sys')
+  ]);
+});
+
+test('tokscaleEnvWithHermesProfiles injects hermes profile dirs into TOKSCALE_EXTRA_DIRS', () => {
+  const hermesHome = 'C:\\Users\\u\\AppData\\Local\\hermes';
+  const env = tokscaleEnvWithHermesProfiles(
+    { FOO: 'bar', TOKSCALE_EXTRA_DIRS: 'codex:C:\\extra' },
+    'claude,hermes',
+    {
+      env: { HERMES_HOME: hermesHome },
+      homeDir: 'C:\\Users\\u',
+      platform: 'win32',
+      existsSync: (target) => target.endsWith(`${path.sep}profiles`)
+        || target.endsWith(`${path.sep}02${path.sep}state.db`),
+      readdirSync: () => [{ name: '02', isDirectory: () => true }]
+    }
+  );
+
+  assert.equal(env.FOO, 'bar');
+  assert.match(
+    env.TOKSCALE_EXTRA_DIRS,
+    /codex:C:\\extra,hermes:C:\\Users\\u\\AppData\\Local\\hermes\\profiles\\02/
+  );
+});
+
+test('tokscaleEnvWithHermesProfiles leaves env untouched when hermes is not enabled', () => {
+  const base = { FOO: 'bar' };
+  assert.equal(
+    tokscaleEnvWithHermesProfiles(base, 'claude,codex', { env: {}, homeDir: '/home/u', platform: 'linux' }),
+    base
+  );
+});
+
+test('tokscaleEnvFromSpawnArgs reads --client from tokscale argv', () => {
+  const hermesHome = path.join('/home/u', '.hermes');
+  const profileDir = path.join(hermesHome, 'profiles', 'research');
+  const env = tokscaleEnvFromSpawnArgs(
+    {},
+    ['--json', '--client', 'hermes', '--group-by', 'client,session,model'],
+    {
+      env: { HERMES_HOME: hermesHome },
+      homeDir: '/home/u',
+      platform: 'linux',
+      existsSync: (target) => target === path.join(hermesHome, 'profiles')
+        || target === path.join(profileDir, 'state.db'),
+      readdirSync: () => [{ name: 'research', isDirectory: () => true }]
+    }
+  );
+
+  assert.equal(env.TOKSCALE_EXTRA_DIRS, `hermes:${profileDir}`);
+});
+
+test('mergeTokscaleExtraDirs appends without duplicating the env object fields', () => {
+  const env = mergeTokscaleExtraDirs({ A: '1' }, ['hermes:/tmp/p1', 'hermes:/tmp/p2']);
+  assert.equal(env.A, '1');
+  assert.equal(env.TOKSCALE_EXTRA_DIRS, 'hermes:/tmp/p1,hermes:/tmp/p2');
+});

--- a/tests/shared/hermesProfiles.test.js
+++ b/tests/shared/hermesProfiles.test.js
@@ -61,20 +61,20 @@ test('discoverHermesProfileScanPaths returns profile dirs that contain state.db'
   const paths = discoverHermesProfileScanPaths(hermesHome, {
     existsSync: (target) => {
       if (target === path.join(hermesHome, 'profiles')) return true;
-      return target.endsWith(`${path.sep}02${path.sep}state.db`)
-        || target.endsWith(`${path.sep}wiki-sys${path.sep}state.db`);
+      return target.endsWith(`${path.sep}lab-a${path.sep}state.db`)
+        || target.endsWith(`${path.sep}research${path.sep}state.db`);
     },
     readdirSync: () => [
-      { name: '02', isDirectory: () => true },
+      { name: 'lab-a', isDirectory: () => true },
       { name: 'empty', isDirectory: () => true },
       { name: 'notes.txt', isDirectory: () => false },
-      { name: 'wiki-sys', isDirectory: () => true }
+      { name: 'research', isDirectory: () => true }
     ]
   });
 
   assert.deepEqual(paths, [
-    path.join(hermesHome, 'profiles', '02'),
-    path.join(hermesHome, 'profiles', 'wiki-sys')
+    path.join(hermesHome, 'profiles', 'lab-a'),
+    path.join(hermesHome, 'profiles', 'research')
   ]);
 });
 
@@ -88,15 +88,15 @@ test('tokscaleEnvWithHermesProfiles injects hermes profile dirs into TOKSCALE_EX
       homeDir: 'C:\\Users\\u',
       platform: 'win32',
       existsSync: (target) => target.endsWith(`${path.sep}profiles`)
-        || target.endsWith(`${path.sep}02${path.sep}state.db`),
-      readdirSync: () => [{ name: '02', isDirectory: () => true }]
+        || target.endsWith(`${path.sep}lab-a${path.sep}state.db`),
+      readdirSync: () => [{ name: 'lab-a', isDirectory: () => true }]
     }
   );
 
   assert.equal(env.FOO, 'bar');
   assert.match(
     env.TOKSCALE_EXTRA_DIRS,
-    /codex:C:\\extra,hermes:C:\\Users\\u\\AppData\\Local\\hermes\\profiles\\02/
+    /codex:C:\\extra,hermes:C:\\Users\\u\\AppData\\Local\\hermes\\profiles\\lab-a/
   );
 });
 


### PR DESCRIPTION
## Summary

Hermes Agent stores each profile in its own SQLite database under `$HERMES_HOME/profiles/*/state.db`. Tokscale only scans the default `state.db`, so Token Monitor under-counts Hermes when users run multiple profiles.

This PR teaches the collector to:

- Resolve the real Hermes home (`HERMES_HOME`, Windows `%LOCALAPPDATA%\hermes`, or `~/.hermes`)
- Discover every profile directory that contains a `state.db`
- Inject those paths into `TOKSCALE_EXTRA_DIRS` whenever tokscale is spawned with `--client … hermes …`
- Watch profile directories for filesystem changes so refreshes stay timely

No tokscale fork or manual `settings.json` editing required.

## Evidence

On a machine with one main Hermes DB plus multiple profile DBs, `collectUsageOnce({ clients: 'hermes' })` matches the SQL sum across all discovered profile databases (not just the main `state.db`).

## Test plan

- [x] `npm run lint`
- [x] `node --test tests/shared/hermesProfiles.test.js`
- [x] Manual `collectUsageOnce({ clients: 'hermes' })` matches main + profile SQL totals