### PR TITLE
fix: add OMP (Oh My Pi) session path to tokscaler scan

### DIFF
--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -93,8 +93,15 @@ function resolvePlatformBinary() {
 function tokscaleCommand() {
   const resolved = resolvePlatformBinary();
   const useDirect = Boolean(resolved && resolved.source !== 'shim');
-  if (useDirect) return { bin: resolved.path, prefixArgs: [], env: process.env };
-  return { bin: process.execPath, prefixArgs: [TOKSCALE_BIN_JS], env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' } };
+  const env = { ...process.env };
+  // OMP (Oh My Pi) stores sessions at ~/.omp/agent/sessions — tokscaler only
+  // knows about ~/.pi/agent/sessions. Pass the extra dir so both are scanned.
+  if (!env.TOKSCALE_EXTRA_DIRS) {
+    const ompPath = path.join(os.homedir(), '.omp', 'agent', 'sessions');
+    env.TOKSCALE_EXTRA_DIRS = `pi:${ompPath}`;
+  }
+  if (useDirect) return { bin: resolved.path, prefixArgs: [], env };
+  return { bin: process.execPath, prefixArgs: [TOKSCALE_BIN_JS], env: { ...env, ELECTRON_RUN_AS_NODE: '1' } };
 }
 
 function parseJsonOutput(stdout) {


### PR DESCRIPTION
## Problem

tokscale only scans `~/.pi/agent/sessions` for the Pi client. OMP (Oh My Pi) stores sessions at `~/.omp/agent/sessions`, which was not being scanned — resulting in OMP token data not being tracked.

## Solution

Set `TOKSCALE_EXTRA_DIRS=pi:$HOME/.omp/agent/sessions` when spawning tokscale. This tells tokscale to also scan the OMP session directory in addition to the default Pi directory.

## Changes

- `src/shared/collector.js`: Add `TOKSCALE_EXTRA_DIRS` env var in `tokscaleCommand()`

## Testing

- Verified tokscale 4.0.5 supports `TOKSCALE_EXTRA_DIRS` via `parse_extra_dirs()` in scanner.rs
- Pi client is NOT in the `supports_extra_dir_scanning()` exclusion list (only Kilo, Crush, Goose are excluded)
- Existing user `TOKSCALE_EXTRA_DIRS` values are preserved (only set if not already present)
