### PR TITLE
fix: add OMP (Oh My Pi) session path to tokscaler scan

### DIFF
--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -93,8 +93,15 @@ function resolvePlatformBinary() {
 function tokscaleCommand() {
   const resolved = resolvePlatformBinary();
   const useDirect = Boolean(resolved && resolved.source !== 'shim');
-  if (useDirect) return { bin: resolved.path, prefixArgs: [], env: process.env };
-  return { bin: process.execPath, prefixArgs: [TOKSCALE_BIN_JS], env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' } };
+  const env = { ...process.env };
+  // OMP (Oh My Pi) stores sessions at ~/.omp/agent/sessions — tokscaler only
+  // knows about ~/.pi/agent/sessions. Pass the extra dir so both are scanned.
+  if (!env.TOKSCALE_EXTRA_DIRS) {
+    const ompPath = path.join(os.homedir(), '.omp', 'agent', 'sessions');
+    env.TOKSCALE_EXTRA_DIRS = `pi:${ompPath}`;
+  }
+  if (useDirect) return { bin: resolved.path, prefixArgs: [], env };
+  return { bin: process.execPath, prefixArgs: [TOKSCALE_BIN_JS], env: { ...env, ELECTRON_RUN_AS_NODE: '1' } };
 }
 
 function parseJsonOutput(stdout) {


### PR DESCRIPTION
tokscale only knows about `~/.pi/agent/sessions` for the Pi client.
OMP (Oh My Pi) stores sessions at `~/.omp/agent/sessions`, which was not being scanned.

This change sets `TOKSCALE_EXTRA_DIRS=pi:<omp_path>` so both directories are scanned.

**Changes:**
- `src/shared/collector.js`: detect OMP session path and pass it via `TOKSCALE_EXTRA_DIRS` env var to tokscaler

Resolves the issue where OMP agent token data was not being collected.