### PR TITLE
chore(deps): upgrade tokscaler for OMP parser fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "koffi": "^3.0.2",
         "semver": "^7.8.1",
         "tar": "^7.5.15",
-        "tokscale": "^4.0.5"
+        "tokscale": "4.0.8"
       },
       "devDependencies": {
         "@eslint/compat": "^2.1.0",
@@ -1515,28 +1515,28 @@
       "license": "MIT"
     },
     "node_modules/@tokscale/cli": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli/-/cli-4.0.5.tgz",
-      "integrity": "sha512-tyJ/DS6zBH9iv+XgPsVwl8j6wzrpttLYhp8cO/SNVXZVzmudXRL0hE9zAbxnqJr8Ss/K0mGHhwhZxowd/5viYw==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli/-/cli-4.0.8.tgz",
+      "integrity": "sha512-N8HQHw6t9Res0EEu3pXMFHJq+2AFMJEJucYieKKSxbqavqu2XWHcCCmGneAOxA46V2Gwl7CPwl+dS9T5Rt+12A==",
       "license": "MIT",
       "bin": {
         "tokscale": "bin.js"
       },
       "optionalDependencies": {
-        "@tokscale/cli-darwin-arm64": "4.0.5",
-        "@tokscale/cli-darwin-x64": "4.0.5",
-        "@tokscale/cli-linux-arm64-gnu": "4.0.5",
-        "@tokscale/cli-linux-arm64-musl": "4.0.5",
-        "@tokscale/cli-linux-x64-gnu": "4.0.5",
-        "@tokscale/cli-linux-x64-musl": "4.0.5",
-        "@tokscale/cli-win32-arm64-msvc": "4.0.5",
-        "@tokscale/cli-win32-x64-msvc": "4.0.5"
+        "@tokscale/cli-darwin-arm64": "4.0.8",
+        "@tokscale/cli-darwin-x64": "4.0.8",
+        "@tokscale/cli-linux-arm64-gnu": "4.0.8",
+        "@tokscale/cli-linux-arm64-musl": "4.0.8",
+        "@tokscale/cli-linux-x64-gnu": "4.0.8",
+        "@tokscale/cli-linux-x64-musl": "4.0.8",
+        "@tokscale/cli-win32-arm64-msvc": "4.0.8",
+        "@tokscale/cli-win32-x64-msvc": "4.0.8"
       }
     },
     "node_modules/@tokscale/cli-darwin-arm64": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-arm64/-/cli-darwin-arm64-4.0.5.tgz",
-      "integrity": "sha512-TqoNt5snBNQ0rNdh9Zgpu6v9g86qQZyzCF3mLzJmaeSvN4zN65nD6n5Q9brTIAuGX97CtutnluNOHutctL/Oqg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-arm64/-/cli-darwin-arm64-4.0.8.tgz",
+      "integrity": "sha512-4aW+hcqpzZPAbFBdiOHUjH2iaLad5OJLMe9LiQv50lawBMtN4TgXQrfUJnnXb6D7PaSJpY3b7TSsFkp7N4FEUw==",
       "cpu": [
         "arm64"
       ],
@@ -1547,9 +1547,9 @@
       ]
     },
     "node_modules/@tokscale/cli-darwin-x64": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-x64/-/cli-darwin-x64-4.0.5.tgz",
-      "integrity": "sha512-cZlbz9xqgv/40gL9bRSAM0MNHlqgftXk2TGkbg9TXn1aDBdesQTmq8aNx1TevhlB+70u/Xt3idD/FjG+dURGfQ==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-x64/-/cli-darwin-x64-4.0.8.tgz",
+      "integrity": "sha512-zRtYDAmfndlgcbAy643C2odd6tKw8hty3/fFEeRFNa/lwKdWWy2EOGS5OXwla9T6Rz/NbJO8tRfBnQgPZe+YaA==",
       "cpu": [
         "x64"
       ],
@@ -1560,9 +1560,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-arm64-gnu": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-4.0.5.tgz",
-      "integrity": "sha512-DTVMdO4z9vCM+U2h71nwUc5nc1JjleZSzB2IgQENSnyt3b2dzKSdNrr6V6pyKsVpo1xFFLBntYVh9kNhiDcwrA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-4.0.8.tgz",
+      "integrity": "sha512-7JDrfl3CQcwPGr+Ic4bMpqwQ2mPXtTfAT/njwN8xLvXZYyuMfHgB5QgNM146xqJOlnPbWWxeLMlP1AEA8S8UMg==",
       "cpu": [
         "arm64"
       ],
@@ -1573,9 +1573,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-arm64-musl": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-musl/-/cli-linux-arm64-musl-4.0.5.tgz",
-      "integrity": "sha512-nTUupzb7Xrxr7Hs2AF5G56LgzkenU0cfdJj8YmafUw5IfepHIwKvtSYlykemqTCB77pcqrjpBWnDTHW5igwIig==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-musl/-/cli-linux-arm64-musl-4.0.8.tgz",
+      "integrity": "sha512-HVlmCII8UnEQY2dBZZrHVaSF+OfgGgndLZdfkJNtfDeqNFdMujRgKbN8ZBiqEk5xPoDG14PLpzrXeicAV92uEw==",
       "cpu": [
         "arm64"
       ],
@@ -1586,9 +1586,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-x64-gnu": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-gnu/-/cli-linux-x64-gnu-4.0.5.tgz",
-      "integrity": "sha512-t6in0VbYydLw6+WB5FCuVJwkbr7DgH2T2cyYY4QihjxnZU6zfQcHcnQPkA2GDWNMlZsIKyJYmDCKsQKgFhbw0Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-gnu/-/cli-linux-x64-gnu-4.0.8.tgz",
+      "integrity": "sha512-Ys+WKnKARZno0CCgDqrT+4uxCPUVPZMLVyJc1QpcCubIVP43Ybhy0IazgQpvJNI1iSoLzml3xYNDcbrRsXHRIw==",
       "cpu": [
         "x64"
       ],
@@ -1599,9 +1599,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-x64-musl": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-musl/-/cli-linux-x64-musl-4.0.5.tgz",
-      "integrity": "sha512-n9N5FHKqJY1BFC9xcF05EAsCmYFxftO0JgdH/HXy9O99UGrCLokvGfsispkDvObwv6bMTns0gj6+fwk8Lhnc0A==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-musl/-/cli-linux-x64-musl-4.0.8.tgz",
+      "integrity": "sha512-xhpsZLyah/L6JwKemO1pM3pAWlxmLK7pHoxIL4NbwXcnDO2viLnF/k8bdxGz1o6/UUluYdcSPw0b8S3ctn6zpQ==",
       "cpu": [
         "x64"
       ],
@@ -1612,9 +1612,9 @@
       ]
     },
     "node_modules/@tokscale/cli-win32-arm64-msvc": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-4.0.5.tgz",
-      "integrity": "sha512-56YauukuE/0A4y4QT1w799a5z1qVjoJD5ytoNlZN9mttQJnm38UqmZPc0E3mKyroqCzR1CC6VjGBNRh+vKCl2Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-4.0.8.tgz",
+      "integrity": "sha512-OYkd9R89Kz3TRnsdLik/TrEN0lSkSF7fV7OOmaE6gohSQNozm9gegy46coUgQr2O5YBDPsSYjVPAuDEAO5GAxg==",
       "cpu": [
         "arm64"
       ],
@@ -1625,9 +1625,9 @@
       ]
     },
     "node_modules/@tokscale/cli-win32-x64-msvc": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-x64-msvc/-/cli-win32-x64-msvc-4.0.5.tgz",
-      "integrity": "sha512-dtKvdyvEQLPo/ywUCyyUMStM4PyFxrUKNuDrwiUKAmQyN1IWGEjTK4eFGpQWtFg7wy67PXbluceI9rktC5PMQA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-x64-msvc/-/cli-win32-x64-msvc-4.0.8.tgz",
+      "integrity": "sha512-xkEbqxmr+OvPPcoi799wey8aMtuS7Oj03/6Vvzi0xkWxZVRqjAw72VKAp3kb/ixECzB/jd5UlnBFLBWIxb6cyA==",
       "cpu": [
         "x64"
       ],
@@ -7411,12 +7411,12 @@
       }
     },
     "node_modules/tokscale": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/tokscale/-/tokscale-4.0.5.tgz",
-      "integrity": "sha512-SgC97fgAJyJNjz00G3DPhjKjd8O0/8Iq+YkLRW5bP6YwG3fQTttnM8m1rvBQg0DXJDdja952bJHYOPiK4Uh1fQ==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/tokscale/-/tokscale-4.0.8.tgz",
+      "integrity": "sha512-1pGDG6j4HpnkmCEBppUBMR60K+R/AH97el2iHlSmRaKEyBBKxGMs+XG4n80Sxs+15A6U56i2MPSIcL+bpflE0Q==",
       "license": "MIT",
       "dependencies": {
-        "@tokscale/cli": "4.0.5"
+        "@tokscale/cli": "4.0.8"
       },
       "bin": {
         "tokscale": "bin.js"

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "koffi": "^3.0.2",
     "semver": "^7.8.1",
     "tar": "^7.5.15",
-    "tokscale": "^4.0.5"
+    "tokscale": "4.0.8"
   },
   "devDependencies": {
     "@eslint/compat": "^2.1.0",

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -93,8 +93,15 @@ function resolvePlatformBinary() {
 function tokscaleCommand() {
   const resolved = resolvePlatformBinary();
   const useDirect = Boolean(resolved && resolved.source !== 'shim');
-  if (useDirect) return { bin: resolved.path, prefixArgs: [], env: process.env };
-  return { bin: process.execPath, prefixArgs: [TOKSCALE_BIN_JS], env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' } };
+  const env = { ...process.env };
+  // OMP (Oh My Pi) stores sessions at ~/.omp/agent/sessions — tokscaler only
+  // knows about ~/.pi/agent/sessions. Pass the extra dir so both are scanned.
+  if (!env.TOKSCALE_EXTRA_DIRS) {
+    const ompPath = path.join(os.homedir(), '.omp', 'agent', 'sessions');
+    env.TOKSCALE_EXTRA_DIRS = `pi:${ompPath}`;
+  }
+  if (useDirect) return { bin: resolved.path, prefixArgs: [], env };
+  return { bin: process.execPath, prefixArgs: [TOKSCALE_BIN_JS], env: { ...env, ELECTRON_RUN_AS_NODE: '1' } };
 }
 
 function parseJsonOutput(stdout) {


### PR DESCRIPTION
Upgrade tokscaler to include the fix for Oh My Pi (OMP) session parser.

**Root Cause:**  
OMP session files start with a `title` line before the `session` header. The parser was returning empty messages on any non-"`session`" line, causing OMP sessions to be silently skipped.

**Fix:**  
Skip non-"session" lines until the actual session header is found.

**Upstream PR:** https://github.com/junhoyeo/tokscale/pull/805

**Changes:**
- `tokscale`: 4.0.5 → 4.0.8 (includes the parser fix)