### PR TITLE
fix(tray): respect limit bar modes in menu bar text and icons

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -5222,19 +5222,6 @@ window.tokenMonitor.onStatsPush?.((payload) => {
   restartTimer();
 });
 
-function pickWorstProvider(stats, windowFilter) {
-  const pair = window.TokenMonitorTrayText.pickWorstBarPair(stats, windowFilter || null);
-  return pair?.provider || null;
-}
-
-function pickWorstSessionProvider(stats) {
-  return pickBarPairForTrayMode(stats, 'barsSession')?.provider || null;
-}
-
-function pickWorstWeeklyProvider(stats) {
-  return pickBarPairForTrayMode(stats, 'barsWeekly')?.provider || null;
-}
-
 function pickBarPairForTrayMode(stats, mode) {
   return window.TokenMonitorTrayText.pickBarPairForTrayMode(stats, mode);
 }
@@ -5255,14 +5242,6 @@ function roundedRectPath(ctx, x, y, w, h, r) {
 }
 
 const trayProviderImages = {};
-
-function trayBarWindowsForProvider(provider, windowFilter = null) {
-  const windows = (provider?.windows || [])
-    .filter(limitWindowEligible)
-    .filter((window) => !windowFilter || windowFilter(window))
-    .sort((a, b) => Number(a.remainingPercent) - Number(b.remainingPercent));
-  return [windows[0] || null, windows[1] || null];
-}
 
 function renderBarsIconFromPair(pick, height = 44, colors = {}, options = {}) {
   if (!pick?.firstWindow) return null;
@@ -5302,14 +5281,6 @@ function renderBarsIconFromPair(pick, height = 44, colors = {}, options = {}) {
   drawBar(layout.barsStartY, Number(pick.firstWindow.remainingPercent));
   drawBar(layout.barsStartY + layout.barHeight + layout.barGap, secondPercent);
   return canvas.toDataURL('image/png');
-}
-
-function renderBarsIcon(stats, height = 44, picker = pickWorstProvider, colors = {}, options = {}) {
-  const provider = picker(stats);
-  if (!provider) return null;
-  const [firstWindow, secondWindow] = trayBarWindowsForProvider(provider);
-  if (!firstWindow) return null;
-  return renderBarsIconFromPair({ provider, firstWindow, secondWindow }, height, colors, options);
 }
 
 function pickConfiguredSessionProviders(stats, configOrder) {
@@ -5389,12 +5360,13 @@ function trayBarColors() {
   return dark
     ? { track: 'rgba(255, 255, 255, 0.35)', fill: 'rgba(255, 255, 255, 0.95)' }
     : { track: 'rgba(0, 0, 0, 0.32)', fill: 'rgba(0, 0, 0, 1)' };
+}
 
 async function maybeUpdateBarsIcon() {
   const mode = state.settings?.trayContent;
   if (mode !== 'bars' && mode !== 'barsSession' && mode !== 'barsWeekly' && mode !== 'barsAllSessions') return;
   if (!window.tokenMonitor.setTrayIcons) return;
-  const dataUrl = barsDataUrlForMode(mode, 44);
+  const dataUrl = barsDataUrlForMode(mode, 44, trayBarColors());
   if (!dataUrl) return;
   try { await window.tokenMonitor.setTrayIcons({ [mode]: dataUrl }); } catch (_) {}
 }

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -5223,30 +5223,24 @@ window.tokenMonitor.onStatsPush?.((payload) => {
 });
 
 function pickWorstProvider(stats, windowFilter) {
-  const providers = stats?.limits?.providers || [];
-  let worstProvider = null;
-  let worstRemaining = Infinity;
-  for (const provider of providers) {
-    if (provider.status !== 'ok' || provider.stale) continue;
-    for (const window of provider.windows || []) {
-      if (windowFilter && !windowFilter(window)) continue;
-      const remaining = Number(window.remainingPercent);
-      if (!Number.isFinite(remaining)) continue;
-      if (remaining < worstRemaining) {
-        worstRemaining = remaining;
-        worstProvider = provider;
-      }
-    }
-  }
-  return worstProvider;
+  const pair = window.TokenMonitorTrayText.pickWorstBarPair(stats, windowFilter || null);
+  return pair?.provider || null;
 }
 
 function pickWorstSessionProvider(stats) {
-  return pickWorstProvider(stats, (window) => window.kind === 'session');
+  return pickBarPairForTrayMode(stats, 'barsSession')?.provider || null;
 }
 
 function pickWorstWeeklyProvider(stats) {
-  return pickWorstProvider(stats, (window) => window.kind === 'weekly');
+  return pickBarPairForTrayMode(stats, 'barsWeekly')?.provider || null;
+}
+
+function pickBarPairForTrayMode(stats, mode) {
+  return window.TokenMonitorTrayText.pickBarPairForTrayMode(stats, mode);
+}
+
+function limitWindowEligible(window) {
+  return window.TokenMonitorTrayText.limitWindowEligible(window);
 }
 
 function roundedRectPath(ctx, x, y, w, h, r) {
@@ -5262,17 +5256,21 @@ function roundedRectPath(ctx, x, y, w, h, r) {
 
 const trayProviderImages = {};
 
-function renderBarsIcon(stats, height = 44, picker = pickWorstProvider, colors = {}) {
+function trayBarWindowsForProvider(provider, windowFilter = null) {
+  const windows = (provider?.windows || [])
+    .filter(limitWindowEligible)
+    .filter((window) => !windowFilter || windowFilter(window))
+    .sort((a, b) => Number(a.remainingPercent) - Number(b.remainingPercent));
+  return [windows[0] || null, windows[1] || null];
+}
+
+function renderBarsIconFromPair(pick, height = 44, colors = {}, options = {}) {
+  if (!pick?.firstWindow) return null;
   const trackColor = colors.track || 'rgba(0, 0, 0, 0.32)';
   const fillColor = colors.fill || 'rgba(0, 0, 0, 1)';
-  const provider = picker(stats);
-  if (!provider) return null;
-  const session = (provider.windows || []).find((w) => w.kind === 'session');
-  const weekly = (provider.windows || []).find((w) => w.kind === 'weekly');
-  const billing = (provider.windows || []).find((w) => w.kind === 'billing');
-  const providerImage = trayProviderImages[provider.provider];
+  const providerImage = trayProviderImages[pick.provider.provider];
   const { trayBarFillWidth, trayBarsLayout } = window.TokenMonitorTrayBars;
-  const layout = trayBarsLayout(height);
+  const layout = trayBarsLayout(height, { contentOnly: options.contentOnly === true });
 
   const canvas = document.createElement('canvas');
   canvas.width = layout.width;
@@ -5280,7 +5278,7 @@ function renderBarsIcon(stats, height = 44, picker = pickWorstProvider, colors =
   const ctx = canvas.getContext('2d');
   ctx.clearRect(0, 0, layout.width, layout.height);
 
-  if (providerImage) {
+  if (providerImage && !options.contentOnly) {
     ctx.drawImage(providerImage, layout.padX, layout.iconY, layout.iconSize, layout.iconSize);
   }
 
@@ -5290,7 +5288,6 @@ function renderBarsIcon(stats, height = 44, picker = pickWorstProvider, colors =
     ctx.fill();
     const fillW = trayBarFillWidth(limitFillPercent(percent, undefined, Boolean(state.settings?.showLimitUsed)), layout.barsWidth);
     if (!fillW) return;
-    // Clip-to-track + flat fillRect: a rounded rect's tiny corners get lost when the icon is downscaled into the menubar.
     ctx.save();
     roundedRectPath(ctx, layout.barsX, y, layout.barsWidth, layout.barHeight, layout.radius);
     ctx.clip();
@@ -5299,16 +5296,20 @@ function renderBarsIcon(stats, height = 44, picker = pickWorstProvider, colors =
     ctx.restore();
   }
 
-  if (session || weekly) {
-    drawBar(layout.barsStartY, Number(session?.remainingPercent));
-    drawBar(layout.barsStartY + layout.barHeight + layout.barGap, Number(weekly?.remainingPercent));
-  } else if (billing) {
-    // Billing-only providers (Grok Monthly) have no session/weekly pair — draw the
-    // single monthly bar on the top track and leave the bottom track empty, instead
-    // of painting two empty bars.
-    drawBar(layout.barsStartY, Number(billing.remainingPercent));
-  }
+  const secondPercent = pick.secondWindow
+    ? Number(pick.secondWindow.remainingPercent)
+    : Number(pick.firstWindow.remainingPercent);
+  drawBar(layout.barsStartY, Number(pick.firstWindow.remainingPercent));
+  drawBar(layout.barsStartY + layout.barHeight + layout.barGap, secondPercent);
   return canvas.toDataURL('image/png');
+}
+
+function renderBarsIcon(stats, height = 44, picker = pickWorstProvider, colors = {}, options = {}) {
+  const provider = picker(stats);
+  if (!provider) return null;
+  const [firstWindow, secondWindow] = trayBarWindowsForProvider(provider);
+  if (!firstWindow) return null;
+  return renderBarsIconFromPair({ provider, firstWindow, secondWindow }, height, colors, options);
 }
 
 function pickConfiguredSessionProviders(stats, configOrder) {
@@ -5337,7 +5338,14 @@ function renderAllSessionsIcon(stats, height = 44, configOrder, colors = {}, opt
   const picks = pickConfiguredSessionProviders(stats, configOrder);
   if (picks.length === 0) return null;
   // Only one tool has session data → fall back to that tool's session+weekly view.
-  if (picks.length === 1) return renderBarsIcon(stats, height, () => picks[0].provider, colors);
+  if (picks.length === 1) {
+    const weekly = (picks[0].provider.windows || []).find((window) => window.kind === 'weekly' && limitWindowEligible(window));
+    return renderBarsIconFromPair({
+      provider: picks[0].provider,
+      firstWindow: picks[0].session,
+      secondWindow: weekly || null
+    }, height, colors, options);
+  }
 
   const { trayBarFillWidth, trayBarsLayout } = window.TokenMonitorTrayBars;
   const layout = trayBarsLayout(height, { contentOnly: options.contentOnly === true });
@@ -5371,9 +5379,16 @@ function renderAllSessionsIcon(stats, height = 44, configOrder, colors = {}, opt
 
 function barsDataUrlForMode(mode, size = 44, colors, options = {}) {
   if (mode === 'barsAllSessions') return renderAllSessionsIcon(state.stats, size, configuredLimitProviderOrder(), colors, options);
-  const pickers = { barsSession: pickWorstSessionProvider, barsWeekly: pickWorstWeeklyProvider };
-  return renderBarsIcon(state.stats, size, pickers[mode] || pickWorstProvider, colors);
+  const pick = pickBarPairForTrayMode(state.stats, mode);
+  if (!pick) return null;
+  return renderBarsIconFromPair(pick, size, colors, options);
 }
+
+function trayBarColors() {
+  const dark = Boolean(window.matchMedia?.('(prefers-color-scheme: dark)')?.matches);
+  return dark
+    ? { track: 'rgba(255, 255, 255, 0.35)', fill: 'rgba(255, 255, 255, 0.95)' }
+    : { track: 'rgba(0, 0, 0, 0.32)', fill: 'rgba(0, 0, 0, 1)' };
 
 async function maybeUpdateBarsIcon() {
   const mode = state.settings?.trayContent;

--- a/src/electron/tray.js
+++ b/src/electron/tray.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('node:path');
-const { formatTrayText, pickWorstLimit } = require('../shared/trayText');
+const { formatTrayText, pickWorstLimit, pickWorstLimitForMode } = require('../shared/trayText');
 
 const ICON_PATH = path.join(__dirname, '..', '..', 'assets', 'icon.png');
 
@@ -90,4 +90,4 @@ function popoverBounds(tray, popoverWidth, popoverHeight) {
   return { x, y, width: popoverWidth, height: popoverHeight };
 }
 
-module.exports = { createTray, formatTrayText, popoverBounds, pickWorstLimit, pickUsageTrayIconId, buildTrayIcon };
+module.exports = { createTray, formatTrayText, popoverBounds, pickWorstLimit, pickWorstLimitForMode, pickUsageTrayIconId, buildTrayIcon };

--- a/src/shared/trayText.js
+++ b/src/shared/trayText.js
@@ -18,27 +18,74 @@
     return String(n);
   }
 
-  function pickWorstLimit(stats) {
+  function providerLimitOk(provider) {
+    return Boolean(provider && provider.status === 'ok' && !provider.stale);
+  }
+
+  function limitWindowEligible(window) {
+    return Boolean(window && window.showMeter !== false && Number.isFinite(Number(window.remainingPercent)));
+  }
+
+  function pickWorstBarPair(stats, windowFilter = null) {
     const providers = stats?.limits?.providers || [];
-    let worst = null;
+    let best = null;
     for (const provider of providers) {
-      if (provider.status !== 'ok' || provider.stale) continue;
-      for (const window of provider.windows || []) {
-        const remaining = Number(window.remainingPercent);
-        if (!Number.isFinite(remaining)) continue;
-        if (!worst || remaining < worst.remaining) {
-          worst = { remaining, provider: provider.provider };
-        }
+      if (!providerLimitOk(provider)) continue;
+      const matching = (provider.windows || [])
+        .filter(limitWindowEligible)
+        .filter((window) => !windowFilter || windowFilter(window))
+        .sort((a, b) => Number(a.remainingPercent) - Number(b.remainingPercent));
+      if (!matching.length) continue;
+      const primary = matching[0];
+      if (!best || Number(primary.remainingPercent) < Number(best.firstWindow.remainingPercent)) {
+        best = {
+          provider,
+          firstWindow: matching[0],
+          secondWindow: matching[1] || null
+        };
       }
     }
-    return worst;
+    return best;
+  }
+
+  function pickBarPairForTrayMode(stats, contentMode = 'bars') {
+    if (contentMode === 'barsSession') {
+      return pickWorstBarPair(stats, (window) => window.kind === 'session')
+        || pickWorstBarPair(stats, (window) => window.kind === 'billing')
+        || pickWorstBarPair(stats, null);
+    }
+    if (contentMode === 'barsWeekly') {
+      return pickWorstBarPair(stats, (window) => window.kind === 'weekly')
+        || pickWorstBarPair(stats, null);
+    }
+    if (contentMode === 'barsAllSessions') {
+      return pickWorstBarPair(stats, (window) => window.kind === 'session');
+    }
+    if (contentMode === 'bars') {
+      return pickWorstBarPair(stats, null);
+    }
+    return null;
+  }
+
+  function pickWorstLimit(stats) {
+    return pickWorstLimitForMode(stats, 'bars');
+  }
+
+  function pickWorstLimitForMode(stats, contentMode = 'bars') {
+    const pair = pickBarPairForTrayMode(stats, contentMode);
+    if (!pair?.firstWindow) return null;
+    return {
+      remaining: Number(pair.firstWindow.remainingPercent),
+      provider: pair.provider.provider
+    };
   }
 
   function formatTrayText(stats, contentMode = 'tokens', currencyCode = 'USD') {
     if (contentMode === 'icon') return '';
     if (contentMode === 'bars' || contentMode === 'barsSession' || contentMode === 'barsWeekly' || contentMode === 'barsAllSessions') {
-      // Icon carries all the info; only show text if we have no limit data at all.
-      if (pickWorstLimit(stats)) return '';
+      const worst = pickWorstLimitForMode(stats, contentMode);
+      if (worst) return `${Math.round(worst.remaining)}%`;
+      return '—';
     }
     const today = stats?.periods?.today || {};
     const allTime = stats?.periods?.allTime || {};
@@ -50,5 +97,13 @@
     return formatCompactNumber(today.totalTokens);
   }
 
-  return { formatCompactNumber, pickWorstLimit, formatTrayText };
+  return {
+    formatCompactNumber,
+    limitWindowEligible,
+    pickWorstBarPair,
+    pickBarPairForTrayMode,
+    pickWorstLimit,
+    pickWorstLimitForMode,
+    formatTrayText
+  };
 });

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -431,16 +431,26 @@ test('Home uses explicit billing labels so Copilot Premium and Chat stay distinc
 });
 
 test('tray bars draw the billing window for a billing-only provider instead of two empty bars', () => {
-  // renderBarsIcon used to unconditionally draw session+weekly, painting two
-  // empty tracks for a Grok-only selection. It must now branch: session/weekly
-  // when present, else the single billing bar on the top track.
-  const app = readRendererFile('app.js');
-  const renderBarsIcon = functionBody(app, 'renderBarsIcon', 'renderAllSessionsIcon');
+  const { pickBarPairForTrayMode } = require('../../src/shared/trayText');
+  const stats = {
+    limits: {
+      providers: [{
+        provider: 'grok',
+        status: 'ok',
+        stale: false,
+        windows: [{ kind: 'billing', label: 'Monthly', remainingPercent: 42, showMeter: true }]
+      }]
+    }
+  };
+  const pick = pickBarPairForTrayMode(stats, 'barsSession');
+  assert.ok(pick, 'billing-only providers should still produce a tray bar pair');
+  assert.equal(pick.firstWindow.kind, 'billing');
 
-  assert.match(renderBarsIcon, /w\.kind === 'billing'/);
-  assert.match(renderBarsIcon, /if \(session \|\| weekly\)/);
-  assert.match(renderBarsIcon, /} else if \(billing\)/);
-  assert.match(renderBarsIcon, /drawBar\(layout\.barsStartY, Number\(billing\.remainingPercent\)\)/);
+  const app = readRendererFile('app.js');
+  const renderBarsIconFromPair = functionBody(app, 'renderBarsIconFromPair', 'pickConfiguredSessionProviders');
+  assert.match(renderBarsIconFromPair, /pick\.firstWindow/);
+  assert.match(renderBarsIconFromPair, /pick\.secondWindow/);
+  assert.match(renderBarsIconFromPair, /Number\(pick\.firstWindow\.remainingPercent\)/);
 });
 
 test('DeepSeek main Limits row uses a balance meter without since-tracking copy', () => {

--- a/tests/electron/tray.test.js
+++ b/tests/electron/tray.test.js
@@ -55,3 +55,66 @@ test('tray cost text uses the selected display currency', () => {
   assert.equal(formatTrayText({ periods: { today: { costUsd: 1, totalTokens: 12_000 } } }, 'cost', 'TWD'), 'NT$31.50');
   assert.equal(formatTrayText({ periods: { today: { costUsd: 1, totalTokens: 12_000 } } }, 'both', 'HKD'), '12.0K · HK$7.80');
 });
+
+const limitStats = {
+  limits: {
+    providers: [{
+      provider: 'claude',
+      status: 'ok',
+      stale: false,
+      windows: [
+        { kind: 'session', remainingPercent: 38.2 },
+        { kind: 'weekly', remainingPercent: 72.5 }
+      ]
+    }]
+  }
+};
+
+test('tray limit modes show the worst remaining percent instead of hiding text', () => {
+  assert.equal(formatTrayText(limitStats, 'bars'), '38%');
+  assert.equal(formatTrayText(limitStats, 'barsSession'), '38%');
+  assert.equal(formatTrayText(limitStats, 'barsWeekly'), '73%');
+  assert.equal(formatTrayText(limitStats, 'barsAllSessions'), '38%');
+  assert.equal(formatTrayText({ limits: { providers: [] } }, 'bars'), '—');
+});
+
+test('barsSession falls back to billing windows when session data is missing', () => {
+  const { pickBarPairForTrayMode } = require('../../src/shared/trayText');
+  const stats = {
+    limits: {
+      providers: [{
+        provider: 'cursor',
+        status: 'ok',
+        stale: false,
+        windows: [
+          { kind: 'billing', label: 'Total', remainingPercent: 46, showMeter: true },
+          { kind: 'billing', label: 'API', remainingPercent: 0, showMeter: true }
+        ]
+      }]
+    }
+  };
+  const pair = pickBarPairForTrayMode(stats, 'barsSession');
+  assert.equal(pair.firstWindow.label, 'API');
+  assert.equal(pair.secondWindow.label, 'Total');
+  assert.equal(formatTrayText(stats, 'barsSession'), '0%');
+});
+
+test('barsWeekly uses weekly windows from providers like Antigravity', () => {
+  const { pickBarPairForTrayMode } = require('../../src/shared/trayText');
+  const stats = {
+    limits: {
+      providers: [{
+        provider: 'antigravity',
+        status: 'ok',
+        stale: false,
+        windows: [
+          { kind: 'weekly', label: 'Gemini Pro', remainingPercent: 100, showMeter: true },
+          { kind: 'weekly', label: 'Gemini Flash', remainingPercent: 80, showMeter: true }
+        ]
+      }]
+    }
+  };
+  const pair = pickBarPairForTrayMode(stats, 'barsWeekly');
+  assert.equal(pair.firstWindow.label, 'Gemini Flash');
+  assert.equal(formatTrayText(stats, 'barsWeekly'), '80%');
+});


### PR DESCRIPTION
## Summary
- Show the worst remaining percent in menu bar text for `bars`, `barsSession`, `barsWeekly`, and `barsAllSessions` instead of hiding text when limit data exists.
- Route tray bar icon rendering through shared `trayText` helpers so session/weekly/billing windows fall back correctly (helps Cursor/Antigravity and billing-only providers).
- Add regression tests for tray limit text and fallback behavior.

## Test plan
- [x] `node --test tests/electron/tray.test.js`
- [ ] macOS: set tray content to Session bars / Weekly bars and confirm text + icon update for Cursor/Antigravity accounts
- [ ] macOS: confirm token/cost modes unchanged