### PR TITLE
feat(macos): add launchd helpers for dev auto-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ npm install
 npm start
 ```
 
+**macOS dev auto-start (optional):** register a login LaunchAgent so a source checkout starts hidden on sign-in:
+
+```bash
+npm run launchd:install   # install LaunchAgent
+npm run launchd:status    # check status
+npm run launchd:uninstall # remove
+```
+
+Uses `scripts/launch-token-monitor.sh` and unsets `ELECTRON_RUN_AS_NODE`. Set `TOKEN_MONITOR_APP=/Applications/Token Monitor.app` to launch a packaged build instead.
+
 ### Multi-device sync
 
 Pick ONE hub backend that all your devices (and any headless agents) connect to. On each device, open the widget and pick a mode under Settings → Multi-device Sync. The widget contributes this device's usage automatically; run `npm run agent` only on machines without a widget.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "dist:mac": "electron-builder --mac --arm64",
     "dist:win": "electron-builder --win --x64",
     "lint": "eslint .",
-    "verify": "npm run lint && npm test"
+    "verify": "npm run lint && npm test",
+    "launchd:install": "bash scripts/launchd-install.sh",
+    "launchd:uninstall": "bash scripts/launchd-uninstall.sh",
+    "launchd:status": "bash scripts/launchd-status.sh"
   },
   "build": {
     "appId": "com.javis.tokenmonitor",

--- a/scripts/launch-token-monitor.sh
+++ b/scripts/launch-token-monitor.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+unset ELECTRON_RUN_AS_NODE
+
+if [[ -n "${TOKEN_MONITOR_APP:-}" && -d "$TOKEN_MONITOR_APP" ]]; then
+  exec open -a "$TOKEN_MONITOR_APP" --args --hidden
+fi
+
+if [[ -x "$ROOT/node_modules/.bin/electron" ]]; then
+  exec "$ROOT/node_modules/.bin/electron" .
+fi
+
+exec npm start

--- a/scripts/launchd-install.sh
+++ b/scripts/launchd-install.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LABEL="com.javis.tokenmonitor"
+PLIST_NAME="${LABEL}.plist"
+LAUNCHER="$ROOT/scripts/launch-token-monitor.sh"
+AGENTS_DIR="$HOME/Library/LaunchAgents"
+PLIST_PATH="$AGENTS_DIR/$PLIST_NAME"
+LOG_DIR="$HOME/Library/Logs/Token Monitor"
+UID_NUM="$(id -u)"
+DOMAIN="gui/${UID_NUM}"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "launchd install is macOS only." >&2
+  exit 1
+fi
+
+chmod +x "$LAUNCHER"
+mkdir -p "$LOG_DIR" "$AGENTS_DIR"
+
+cat > "$PLIST_PATH" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${LAUNCHER}</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${ROOT}</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+  <key>StandardOutPath</key>
+  <string>${LOG_DIR}/launchd.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>${LOG_DIR}/launchd.err.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+</dict>
+</plist>
+EOF
+
+if launchctl print "${DOMAIN}/${LABEL}" >/dev/null 2>&1; then
+  launchctl bootout "${DOMAIN}" "$PLIST_PATH" >/dev/null 2>&1 || true
+fi
+
+launchctl bootstrap "${DOMAIN}" "$PLIST_PATH"
+launchctl enable "${DOMAIN}/${LABEL}" >/dev/null 2>&1 || true
+launchctl kickstart -k "${DOMAIN}/${LABEL}" >/dev/null 2>&1 || true
+
+echo "Installed LaunchAgent: ${PLIST_PATH}"
+echo "Logs: ${LOG_DIR}/launchd.{out,err}.log"
+echo "Status: launchctl print ${DOMAIN}/${LABEL}"

--- a/scripts/launchd-status.sh
+++ b/scripts/launchd-status.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+LABEL="com.javis.tokenmonitor"
+PLIST_PATH="$HOME/Library/LaunchAgents/${LABEL}.plist"
+UID_NUM="$(id -u)"
+DOMAIN="gui/${UID_NUM}"
+
+if [[ ! -f "$PLIST_PATH" ]]; then
+  echo "Not installed: ${PLIST_PATH}"
+  exit 1
+fi
+
+echo "Plist: ${PLIST_PATH}"
+launchctl print "${DOMAIN}/${LABEL}" 2>/dev/null || {
+  echo "Registered plist exists but job is not loaded."
+  exit 1
+}

--- a/scripts/launchd-uninstall.sh
+++ b/scripts/launchd-uninstall.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+LABEL="com.javis.tokenmonitor"
+PLIST_NAME="${LABEL}.plist"
+AGENTS_DIR="$HOME/Library/LaunchAgents"
+PLIST_PATH="$AGENTS_DIR/$PLIST_NAME"
+UID_NUM="$(id -u)"
+DOMAIN="gui/${UID_NUM}"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "launchd uninstall is macOS only." >&2
+  exit 1
+fi
+
+if [[ -f "$PLIST_PATH" ]]; then
+  launchctl bootout "${DOMAIN}" "$PLIST_PATH" >/dev/null 2>&1 || true
+  rm -f "$PLIST_PATH"
+  echo "Removed LaunchAgent: ${PLIST_PATH}"
+else
+  echo "LaunchAgent not installed: ${PLIST_PATH}"
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/launchd-{install,uninstall,status}.sh` and `scripts/launch-token-monitor.sh` for macOS dev workflows.
- Expose npm scripts: `launchd:install`, `launchd:uninstall`, `launchd:status`.
- Document optional login auto-start in README (with `TOKEN_MONITOR_APP` override for packaged `.app` builds).

## Test plan
- [ ] macOS: `npm run launchd:install` → log in again → widget starts hidden from source checkout
- [ ] `npm run launchd:status` shows loaded job
- [ ] `npm run launchd:uninstall` removes LaunchAgent

Made with [Cursor](https://cursor.com)