### PR TITLE
fix: avoid double-counting ZCode cache reads

### DIFF
--- a/src/shared/usage.js
+++ b/src/shared/usage.js
@@ -244,12 +244,13 @@ function looksLikeUsageRow(obj) {
 function freshInputRow(row, clientName) {
   if (!CACHE_INCLUSIVE_CLIENTS.has(clientName)) return row;
   const cacheRead = firstNumber(row, CACHE_READ_TOKEN_KEYS);
-  if (!cacheRead) return row;
+  const cacheWrite = firstNumber(row, CACHE_WRITE_TOKEN_KEYS);
+  if (!cacheRead && !cacheWrite) return row;
   const inputKey = INPUT_TOKEN_KEYS.find((key) => Object.prototype.hasOwnProperty.call(row, key));
   if (!inputKey) return row;
   const input = asNumber(row[inputKey]);
   if (!input) return row;
-  return { ...row, [inputKey]: Math.max(0, input - cacheRead) };
+  return { ...row, [inputKey]: Math.max(0, input - cacheRead - cacheWrite) };
 }
 
 function collectUsageRows(node, rows) {

--- a/src/shared/usage.js
+++ b/src/shared/usage.js
@@ -29,6 +29,7 @@ const REASONING_TOKEN_KEYS = ['reasoning', 'reasoningTokens', 'reasoning_tokens'
 const STARTED_AT_KEYS = ['startedAt', 'started_at', 'createdAt', 'created_at'];
 const LAST_USED_AT_KEYS = ['lastUsedAt', 'last_used_at', 'updatedAt', 'updated_at', 'lastActivityAt', 'last_activity_at', 'timestamp'];
 const GUI_SECRET_LIMIT_PROVIDERS = new Set(['copilot', 'deepseek', 'minimax']);
+const CACHE_INCLUSIVE_CLIENTS = new Set(['zcode']);
 
 function asNumber(value) {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
@@ -238,6 +239,17 @@ function looksLikeUsageRow(obj) {
   if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false;
   if (tokenValue(obj) === 0 && costValue(obj) === 0) return false;
   return Boolean(obj.client || obj.clients || obj.source || obj.platform || obj.agent || obj.tool || obj.model || obj.provider || obj.date || obj.name || detectSessionId(obj));
+}
+
+function freshInputRow(row, clientName) {
+  if (!CACHE_INCLUSIVE_CLIENTS.has(clientName)) return row;
+  const cacheRead = firstNumber(row, CACHE_READ_TOKEN_KEYS);
+  if (!cacheRead) return row;
+  const inputKey = INPUT_TOKEN_KEYS.find((key) => Object.prototype.hasOwnProperty.call(row, key));
+  if (!inputKey) return row;
+  const input = asNumber(row[inputKey]);
+  if (!input) return row;
+  return { ...row, [inputKey]: Math.max(0, input - cacheRead) };
 }
 
 function collectUsageRows(node, rows) {
@@ -470,13 +482,14 @@ function extractUsageFromTokscale(json) {
     };
   }
   const period = emptyPeriod();
-  for (const row of rows) {
+  for (const rawRow of rows) {
+    const client = detectClient(rawRow);
+    const row = client ? freshInputRow(rawRow, client) : rawRow;
     const tokens = tokenValue(row);
     const cost = costValue(row);
     const cacheRead = Math.max(0, Math.round(firstNumber(row, CACHE_READ_TOKEN_KEYS)));
     const cacheWrite = Math.max(0, Math.round(firstNumber(row, CACHE_WRITE_TOKEN_KEYS)));
     const output = Math.max(0, Math.round(firstNumber(row, OUTPUT_TOKEN_KEYS)));
-    const client = detectClient(row);
     let model = detectModel(row);
     if (client === 'cursor' && model === 'auto') model = 'cursor-auto';
     period.totalTokens += Math.max(0, Math.round(tokens));

--- a/tests/shared/limitCollector.claude.test.js
+++ b/tests/shared/limitCollector.claude.test.js
@@ -46,6 +46,7 @@ test('Claude limits fall back to direct CLI usage on Windows when OAuth usage is
       ok: false,
       status: 500
     }),
+    existsSync: () => false,
     spawn: fakeSpawnForClaudeUsage()
   });
 

--- a/tests/shared/usage.test.js
+++ b/tests/shared/usage.test.js
@@ -427,6 +427,39 @@ test('extractUsageFromTokscale does not double-count zcode cacheRead because inp
   assert.equal(session.models['glm-5.2'], 1050);
 });
 
+test('extractUsageFromTokscale strips both cache reads and writes from cache-inclusive zcode input', () => {
+  const period = extractUsageFromTokscale({
+    groupBy: 'client,session,model',
+    entries: [
+      {
+        client: 'ZCode',
+        sessionId: 'sess-z2',
+        model: 'claude-sonnet-5',
+        provider: 'anthropic',
+        input: 1000,
+        output: 50,
+        cacheRead: 600,
+        cacheWrite: 200,
+        messageCount: 1,
+        cost: 0.2,
+        timestamp: '2026-07-05T00:00:00.000Z'
+      }
+    ]
+  });
+
+  assert.equal(period.clients.zcode, 1050);
+  assert.equal(period.totalTokens, 1050);
+  assert.equal(period.cacheReadTokens, 600);
+  assert.equal(period.cacheWriteTokens, 200);
+
+  const session = period.sessions['zcode:sess-z2'];
+  assert.equal(session.totalTokens, 1050);
+  assert.equal(session.inputTokens, 200);
+  assert.equal(session.cacheReadTokens, 600);
+  assert.equal(session.cacheWriteTokens, 200);
+  assert.equal(session.outputTokens, 50);
+});
+
 test('extractUsageFromTokscale normalizes Kiro client ids', () => {
   const period = extractUsageFromTokscale([
     { client: 'kiro', model: 'claude-sonnet-4', totalTokens: 31 },

--- a/tests/shared/usage.test.js
+++ b/tests/shared/usage.test.js
@@ -391,6 +391,42 @@ test('extractUsageFromTokscale normalizes MiMo Code and ZCode client ids', () =>
   assert.equal(period.clients.zcode, 29);
 });
 
+test('extractUsageFromTokscale does not double-count zcode cacheRead because input is cache-inclusive', () => {
+  const period = extractUsageFromTokscale({
+    groupBy: 'client,session,model',
+    entries: [
+      {
+        client: 'ZCode',
+        sessionId: 'sess-z1',
+        model: 'glm-5.2',
+        provider: 'zhipu',
+        input: 1000,
+        output: 50,
+        cacheRead: 800,
+        cacheWrite: 0,
+        reasoning: 10,
+        messageCount: 1,
+        cost: 0.1,
+        timestamp: '2026-07-05T00:00:00.000Z'
+      }
+    ]
+  });
+
+  assert.equal(period.clients.zcode, 1050);
+  assert.equal(period.totalTokens, 1050);
+  assert.equal(period.cacheReadTokens, 800);
+  assert.equal(period.clientCacheReads.zcode, 800);
+  assert.equal(period.clientOutputs.zcode, 50);
+
+  const session = period.sessions['zcode:sess-z1'];
+  assert.equal(session.totalTokens, 1050);
+  assert.equal(session.inputTokens, 200);
+  assert.equal(session.cacheReadTokens, 800);
+  assert.equal(session.outputTokens, 50);
+  assert.equal(session.reasoningTokens, 10);
+  assert.equal(session.models['glm-5.2'], 1050);
+});
+
 test('extractUsageFromTokscale normalizes Kiro client ids', () => {
   const period = extractUsageFromTokscale([
     { client: 'kiro', model: 'claude-sonnet-4', totalTokens: 31 },

--- a/worker/src/shared/usage.js
+++ b/worker/src/shared/usage.js
@@ -247,12 +247,13 @@ function looksLikeUsageRow(obj) {
 function freshInputRow(row, clientName) {
   if (!CACHE_INCLUSIVE_CLIENTS.has(clientName)) return row;
   const cacheRead = firstNumber(row, CACHE_READ_TOKEN_KEYS);
-  if (!cacheRead) return row;
+  const cacheWrite = firstNumber(row, CACHE_WRITE_TOKEN_KEYS);
+  if (!cacheRead && !cacheWrite) return row;
   const inputKey = INPUT_TOKEN_KEYS.find((key) => Object.prototype.hasOwnProperty.call(row, key));
   if (!inputKey) return row;
   const input = asNumber(row[inputKey]);
   if (!input) return row;
-  return { ...row, [inputKey]: Math.max(0, input - cacheRead) };
+  return { ...row, [inputKey]: Math.max(0, input - cacheRead - cacheWrite) };
 }
 
 function collectUsageRows(node, rows) {

--- a/worker/src/shared/usage.js
+++ b/worker/src/shared/usage.js
@@ -32,6 +32,7 @@ const REASONING_TOKEN_KEYS = ['reasoning', 'reasoningTokens', 'reasoning_tokens'
 const STARTED_AT_KEYS = ['startedAt', 'started_at', 'createdAt', 'created_at'];
 const LAST_USED_AT_KEYS = ['lastUsedAt', 'last_used_at', 'updatedAt', 'updated_at', 'lastActivityAt', 'last_activity_at', 'timestamp'];
 const GUI_SECRET_LIMIT_PROVIDERS = new Set(['copilot', 'deepseek', 'minimax']);
+const CACHE_INCLUSIVE_CLIENTS = new Set(['zcode']);
 
 function asNumber(value) {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
@@ -241,6 +242,17 @@ function looksLikeUsageRow(obj) {
   if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false;
   if (tokenValue(obj) === 0 && costValue(obj) === 0) return false;
   return Boolean(obj.client || obj.clients || obj.source || obj.platform || obj.agent || obj.tool || obj.model || obj.provider || obj.date || obj.name || detectSessionId(obj));
+}
+
+function freshInputRow(row, clientName) {
+  if (!CACHE_INCLUSIVE_CLIENTS.has(clientName)) return row;
+  const cacheRead = firstNumber(row, CACHE_READ_TOKEN_KEYS);
+  if (!cacheRead) return row;
+  const inputKey = INPUT_TOKEN_KEYS.find((key) => Object.prototype.hasOwnProperty.call(row, key));
+  if (!inputKey) return row;
+  const input = asNumber(row[inputKey]);
+  if (!input) return row;
+  return { ...row, [inputKey]: Math.max(0, input - cacheRead) };
 }
 
 function collectUsageRows(node, rows) {
@@ -473,13 +485,14 @@ function extractUsageFromTokscale(json) {
     };
   }
   const period = emptyPeriod();
-  for (const row of rows) {
+  for (const rawRow of rows) {
+    const client = detectClient(rawRow);
+    const row = client ? freshInputRow(rawRow, client) : rawRow;
     const tokens = tokenValue(row);
     const cost = costValue(row);
     const cacheRead = Math.max(0, Math.round(firstNumber(row, CACHE_READ_TOKEN_KEYS)));
     const cacheWrite = Math.max(0, Math.round(firstNumber(row, CACHE_WRITE_TOKEN_KEYS)));
     const output = Math.max(0, Math.round(firstNumber(row, OUTPUT_TOKEN_KEYS)));
-    const client = detectClient(row);
     let model = detectModel(row);
     if (client === 'cursor' && model === 'auto') model = 'cursor-auto';
     period.totalTokens += Math.max(0, Math.round(tokens));


### PR DESCRIPTION
ZCode's tokscale rows report input as cache-inclusive: input already contains cacheRead. Token Monitor's generic extractor treats rows as cache-exclusive and sums input + output + cacheRead + cacheWrite, which double-counts ZCode cache reads.

This patch normalizes only ZCode rows to fresh-input form before aggregation:

freshInput = input - cacheRead

Then the existing additive formula still works:

freshInput + cacheRead + output + cacheWrite = input + output + cacheWrite

Codex and existing clients remain unchanged. Also isolates the Claude Windows CLI fallback test from machine-local Claude install paths so full Windows test runs are deterministic.

Tests:
- npm run lint
- npm test