### PR TITLE
fix: bump tokscale to 4.0.11 for OMP and ZCode fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "koffi": "^3.0.2",
         "semver": "^7.8.1",
         "tar": "^7.5.15",
-        "tokscale": "^4.0.9"
+        "tokscale": "^4.0.11"
       },
       "devDependencies": {
         "@eslint/compat": "^2.1.0",
@@ -1515,28 +1515,28 @@
       "license": "MIT"
     },
     "node_modules/@tokscale/cli": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli/-/cli-4.0.9.tgz",
-      "integrity": "sha512-efXRD/7QQrh+vzOXyg2HHyFJ2jMc0TChCgZK7/LM0fyn/JvTuDQPXO3hWOwmVje9AhmxA0rSqFhNdMqxj1TTNQ==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli/-/cli-4.0.11.tgz",
+      "integrity": "sha512-pbvRdbbNP+XiGqsKxx7X/xovRQHhzuX4RbH2MJbSlu469ttJF12FrfhxfkJCKZhfjBZZUeeTh8JJGqQ/5B1joA==",
       "license": "MIT",
       "bin": {
         "tokscale": "bin.js"
       },
       "optionalDependencies": {
-        "@tokscale/cli-darwin-arm64": "4.0.9",
-        "@tokscale/cli-darwin-x64": "4.0.9",
-        "@tokscale/cli-linux-arm64-gnu": "4.0.9",
-        "@tokscale/cli-linux-arm64-musl": "4.0.9",
-        "@tokscale/cli-linux-x64-gnu": "4.0.9",
-        "@tokscale/cli-linux-x64-musl": "4.0.9",
-        "@tokscale/cli-win32-arm64-msvc": "4.0.9",
-        "@tokscale/cli-win32-x64-msvc": "4.0.9"
+        "@tokscale/cli-darwin-arm64": "4.0.11",
+        "@tokscale/cli-darwin-x64": "4.0.11",
+        "@tokscale/cli-linux-arm64-gnu": "4.0.11",
+        "@tokscale/cli-linux-arm64-musl": "4.0.11",
+        "@tokscale/cli-linux-x64-gnu": "4.0.11",
+        "@tokscale/cli-linux-x64-musl": "4.0.11",
+        "@tokscale/cli-win32-arm64-msvc": "4.0.11",
+        "@tokscale/cli-win32-x64-msvc": "4.0.11"
       }
     },
     "node_modules/@tokscale/cli-darwin-arm64": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-arm64/-/cli-darwin-arm64-4.0.9.tgz",
-      "integrity": "sha512-ZwNQvaYMcjjzvaE/Y0Q9QqYeK+Q+Kvql6MGH3JK1XXhgZketQK3d91jUWnr6+brPxztF2S3GkN9++0/LMhcRsA==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-arm64/-/cli-darwin-arm64-4.0.11.tgz",
+      "integrity": "sha512-8odO8EClzKPCF8Agsc91g2Z3fxXW7p6DpPkX1yPpE3U+/qJI9V+DPqMV7Kx/lY79Fqs0fkXwWGOcUn0mH4dFIg==",
       "cpu": [
         "arm64"
       ],
@@ -1547,9 +1547,9 @@
       ]
     },
     "node_modules/@tokscale/cli-darwin-x64": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-x64/-/cli-darwin-x64-4.0.9.tgz",
-      "integrity": "sha512-V+AxGnugJabCNgwANKmhVnmmNpB8zkdaEcB09E+AXYTZ6JXU+FXQZciCQfBya1LBQ5TMBj1UngDWg86BwpThrQ==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-x64/-/cli-darwin-x64-4.0.11.tgz",
+      "integrity": "sha512-9Dxr5k/aAx6Y/GUTwnWvNqIVygrRrNg8OVW8KSxJCONa3MZfIu6g6MnCmzoT8hP5lw+cLmcMllDXvqEQu0rcVg==",
       "cpu": [
         "x64"
       ],
@@ -1560,9 +1560,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-arm64-gnu": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-4.0.9.tgz",
-      "integrity": "sha512-7pTyY8YAI+f/pOiBviLEWa5/HaL9Hag4iyai56dbN+hcofZSttpBYkIAefd9kFkIidMde2SJ3kkxVf1GnbUauQ==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-4.0.11.tgz",
+      "integrity": "sha512-NZb7/YG569FjbOHMqrjrizGX7JT2dof2nCL4zviYVuXK7aEnILTj0aqNitCqm6/vwkEqcdHHt6A5Ywdab2LScQ==",
       "cpu": [
         "arm64"
       ],
@@ -1573,9 +1573,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-arm64-musl": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-musl/-/cli-linux-arm64-musl-4.0.9.tgz",
-      "integrity": "sha512-THsVJAwHilI3ZtXHN9LiGRSX8fvgsLZ3by2m+61dLd0MbMkwl+iW4MO5UXK7BDzXUgodS/eZFrWY7QYNOSNxfQ==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-musl/-/cli-linux-arm64-musl-4.0.11.tgz",
+      "integrity": "sha512-T+MzC6BrtzOBNrnzZEApx7xVVdcdIskMGbPM+2AOCYQMhjGKlxoJM/4O4ajvHOWcYqkbRmaefpKp6o59ugUVeg==",
       "cpu": [
         "arm64"
       ],
@@ -1586,9 +1586,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-x64-gnu": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-gnu/-/cli-linux-x64-gnu-4.0.9.tgz",
-      "integrity": "sha512-bnOExZh19qtuKGaW4bLVDLVjVuVAJv5ax5xEkMT1sw91O/z/ZAQ6BngC3cUYt58Z6h6vcMabeBMMTCivpUU51Q==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-gnu/-/cli-linux-x64-gnu-4.0.11.tgz",
+      "integrity": "sha512-PQGeDd4jYxXFz8EhmplZrPZd9PbC4DItzOsJ++lWpjWI6Y6siJsQNahit+onza7/+4rWnmrC/fAIVYTHgMsvuA==",
       "cpu": [
         "x64"
       ],
@@ -1599,9 +1599,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-x64-musl": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-musl/-/cli-linux-x64-musl-4.0.9.tgz",
-      "integrity": "sha512-YPgAADPPhW2doeelQWp8Yy4/HwnnHdR5O8h7WUJBxZ25BmDpX2mN6mGglqvIPjRnHwy+7aNdo3GBR8FR+7Um8Q==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-musl/-/cli-linux-x64-musl-4.0.11.tgz",
+      "integrity": "sha512-v+IBo0APtkJE4I5PyNTik2LAi7Wa5GUFwmTD72kC8Jf/qTvTvSzfQF2KBt3ogZlvwh41HDigcDpP6OfKtPxPBQ==",
       "cpu": [
         "x64"
       ],
@@ -1612,9 +1612,9 @@
       ]
     },
     "node_modules/@tokscale/cli-win32-arm64-msvc": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-4.0.9.tgz",
-      "integrity": "sha512-tyZX2KLY5TwsH4fasv7qIfBZaLalJSUhIsLpDtUn7ZHOSML20J31JQAY4/Tnbzm7H7A5VBTPPZwMJ+21r4Et1g==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-4.0.11.tgz",
+      "integrity": "sha512-EkeUy/AV3x1bb07FUZRzBliKSFRIIYmVpNpq2cFo4g+2QnuVWKFtMajxVYP5DGyOYsY12WA64/BsB9orXLUVFA==",
       "cpu": [
         "arm64"
       ],
@@ -1625,9 +1625,9 @@
       ]
     },
     "node_modules/@tokscale/cli-win32-x64-msvc": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-x64-msvc/-/cli-win32-x64-msvc-4.0.9.tgz",
-      "integrity": "sha512-5+7UAQPfCcop/y+u1Wr30vcKrXiV2kqXLAuKDwlvMfr1jvTRi9bUQQxIsDC5Sn0KGrZBUWTKrFjQ8G26j2mkyg==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-x64-msvc/-/cli-win32-x64-msvc-4.0.11.tgz",
+      "integrity": "sha512-S6TBtfe8mUON/Zj3xclRwMgvpeeAzumlLKfRRXttTcCr7RThxrECBLUq9o3mWTJJdDUat6tWeoh8kTkSX096VA==",
       "cpu": [
         "x64"
       ],
@@ -7411,12 +7411,12 @@
       }
     },
     "node_modules/tokscale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/tokscale/-/tokscale-4.0.9.tgz",
-      "integrity": "sha512-oQEZaWhWthjPcc8Ylkzf3tbo6TO62PCxRTl4xrLKdu0+xrgamecQ9IfwG/8NnjiBrfnCezrBjbrjj3Lg5i/9fw==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/tokscale/-/tokscale-4.0.11.tgz",
+      "integrity": "sha512-BCTFx3Tyxa9z1hrHCGEA6mB6Z5SwQ1N6uRNMAx4M8b/Kk1ttoB9MuU7jTCCOXkMtxbQYIXKknx3913/gmVL5Uw==",
       "license": "MIT",
       "dependencies": {
-        "@tokscale/cli": "4.0.9"
+        "@tokscale/cli": "4.0.11"
       },
       "bin": {
         "tokscale": "bin.js"

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "koffi": "^3.0.2",
     "semver": "^7.8.1",
     "tar": "^7.5.15",
-    "tokscale": "^4.0.9"
+    "tokscale": "^4.0.11"
   },
   "devDependencies": {
     "@eslint/compat": "^2.1.0",

--- a/src/shared/usage.js
+++ b/src/shared/usage.js
@@ -29,7 +29,6 @@ const REASONING_TOKEN_KEYS = ['reasoning', 'reasoningTokens', 'reasoning_tokens'
 const STARTED_AT_KEYS = ['startedAt', 'started_at', 'createdAt', 'created_at'];
 const LAST_USED_AT_KEYS = ['lastUsedAt', 'last_used_at', 'updatedAt', 'updated_at', 'lastActivityAt', 'last_activity_at', 'timestamp'];
 const GUI_SECRET_LIMIT_PROVIDERS = new Set(['copilot', 'deepseek', 'minimax']);
-const CACHE_INCLUSIVE_CLIENTS = new Set(['zcode']);
 
 function asNumber(value) {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
@@ -239,18 +238,6 @@ function looksLikeUsageRow(obj) {
   if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false;
   if (tokenValue(obj) === 0 && costValue(obj) === 0) return false;
   return Boolean(obj.client || obj.clients || obj.source || obj.platform || obj.agent || obj.tool || obj.model || obj.provider || obj.date || obj.name || detectSessionId(obj));
-}
-
-function freshInputRow(row, clientName) {
-  if (!CACHE_INCLUSIVE_CLIENTS.has(clientName)) return row;
-  const cacheRead = firstNumber(row, CACHE_READ_TOKEN_KEYS);
-  const cacheWrite = firstNumber(row, CACHE_WRITE_TOKEN_KEYS);
-  if (!cacheRead && !cacheWrite) return row;
-  const inputKey = INPUT_TOKEN_KEYS.find((key) => Object.prototype.hasOwnProperty.call(row, key));
-  if (!inputKey) return row;
-  const input = asNumber(row[inputKey]);
-  if (!input) return row;
-  return { ...row, [inputKey]: Math.max(0, input - cacheRead - cacheWrite) };
 }
 
 function collectUsageRows(node, rows) {
@@ -483,9 +470,8 @@ function extractUsageFromTokscale(json) {
     };
   }
   const period = emptyPeriod();
-  for (const rawRow of rows) {
-    const client = detectClient(rawRow);
-    const row = client ? freshInputRow(rawRow, client) : rawRow;
+  for (const row of rows) {
+    const client = detectClient(row);
     const tokens = tokenValue(row);
     const cost = costValue(row);
     const cacheRead = Math.max(0, Math.round(firstNumber(row, CACHE_READ_TOKEN_KEYS)));

--- a/tests/shared/usage.test.js
+++ b/tests/shared/usage.test.js
@@ -391,7 +391,11 @@ test('extractUsageFromTokscale normalizes MiMo Code and ZCode client ids', () =>
   assert.equal(period.clients.zcode, 29);
 });
 
-test('extractUsageFromTokscale does not double-count zcode cacheRead because input is cache-inclusive', () => {
+test('extractUsageFromTokscale passes zcode input straight through (tokscale normalizes cache upstream)', () => {
+  // tokscale >= 4.0.11 emits zcode rows whose `input` already excludes cache
+  // overlap (junhoyeo/tokscale#825), so zcode is aggregated like any other
+  // client with no local subtraction. If the removed workaround still ran it
+  // would subtract cache a second time (200 - 800 clamped to 0) and under-count.
   const period = extractUsageFromTokscale({
     groupBy: 'client,session,model',
     entries: [
@@ -400,7 +404,7 @@ test('extractUsageFromTokscale does not double-count zcode cacheRead because inp
         sessionId: 'sess-z1',
         model: 'glm-5.2',
         provider: 'zhipu',
-        input: 1000,
+        input: 200,
         output: 50,
         cacheRead: 800,
         cacheWrite: 0,
@@ -425,39 +429,6 @@ test('extractUsageFromTokscale does not double-count zcode cacheRead because inp
   assert.equal(session.outputTokens, 50);
   assert.equal(session.reasoningTokens, 10);
   assert.equal(session.models['glm-5.2'], 1050);
-});
-
-test('extractUsageFromTokscale strips both cache reads and writes from cache-inclusive zcode input', () => {
-  const period = extractUsageFromTokscale({
-    groupBy: 'client,session,model',
-    entries: [
-      {
-        client: 'ZCode',
-        sessionId: 'sess-z2',
-        model: 'claude-sonnet-5',
-        provider: 'anthropic',
-        input: 1000,
-        output: 50,
-        cacheRead: 600,
-        cacheWrite: 200,
-        messageCount: 1,
-        cost: 0.2,
-        timestamp: '2026-07-05T00:00:00.000Z'
-      }
-    ]
-  });
-
-  assert.equal(period.clients.zcode, 1050);
-  assert.equal(period.totalTokens, 1050);
-  assert.equal(period.cacheReadTokens, 600);
-  assert.equal(period.cacheWriteTokens, 200);
-
-  const session = period.sessions['zcode:sess-z2'];
-  assert.equal(session.totalTokens, 1050);
-  assert.equal(session.inputTokens, 200);
-  assert.equal(session.cacheReadTokens, 600);
-  assert.equal(session.cacheWriteTokens, 200);
-  assert.equal(session.outputTokens, 50);
 });
 
 test('extractUsageFromTokscale normalizes Kiro client ids', () => {

--- a/worker/src/shared/usage.js
+++ b/worker/src/shared/usage.js
@@ -32,7 +32,6 @@ const REASONING_TOKEN_KEYS = ['reasoning', 'reasoningTokens', 'reasoning_tokens'
 const STARTED_AT_KEYS = ['startedAt', 'started_at', 'createdAt', 'created_at'];
 const LAST_USED_AT_KEYS = ['lastUsedAt', 'last_used_at', 'updatedAt', 'updated_at', 'lastActivityAt', 'last_activity_at', 'timestamp'];
 const GUI_SECRET_LIMIT_PROVIDERS = new Set(['copilot', 'deepseek', 'minimax']);
-const CACHE_INCLUSIVE_CLIENTS = new Set(['zcode']);
 
 function asNumber(value) {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
@@ -242,18 +241,6 @@ function looksLikeUsageRow(obj) {
   if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false;
   if (tokenValue(obj) === 0 && costValue(obj) === 0) return false;
   return Boolean(obj.client || obj.clients || obj.source || obj.platform || obj.agent || obj.tool || obj.model || obj.provider || obj.date || obj.name || detectSessionId(obj));
-}
-
-function freshInputRow(row, clientName) {
-  if (!CACHE_INCLUSIVE_CLIENTS.has(clientName)) return row;
-  const cacheRead = firstNumber(row, CACHE_READ_TOKEN_KEYS);
-  const cacheWrite = firstNumber(row, CACHE_WRITE_TOKEN_KEYS);
-  if (!cacheRead && !cacheWrite) return row;
-  const inputKey = INPUT_TOKEN_KEYS.find((key) => Object.prototype.hasOwnProperty.call(row, key));
-  if (!inputKey) return row;
-  const input = asNumber(row[inputKey]);
-  if (!input) return row;
-  return { ...row, [inputKey]: Math.max(0, input - cacheRead - cacheWrite) };
 }
 
 function collectUsageRows(node, rows) {
@@ -486,9 +473,8 @@ function extractUsageFromTokscale(json) {
     };
   }
   const period = emptyPeriod();
-  for (const rawRow of rows) {
-    const client = detectClient(rawRow);
-    const row = client ? freshInputRow(rawRow, client) : rawRow;
+  for (const row of rows) {
+    const client = detectClient(row);
     const tokens = tokenValue(row);
     const cost = costValue(row);
     const cacheRead = Math.max(0, Math.round(firstNumber(row, CACHE_READ_TOKEN_KEYS)));


### PR DESCRIPTION
## What

Bumps tokscale 4.0.9 → 4.0.11 and drops the now-redundant local ZCode workaround.

- **OMP usage (#46):** junhoyeo/tokscale#807 fixes the Oh My Pi session parser, which was dropping records whose JSONL starts with a `title` line before the `session` header. OMP usage under `~/.omp/agent/sessions/` already flows through the existing `pi` client and watch path, so no wiring change is needed — the bump alone makes it count (under the Pi client).
- **ZCode double-count (#73):** junhoyeo/tokscale#825 now subtracts the cache/reasoning overlap from ZCode `input`/`output` at parse, and fixes its cost. That makes the local `CACHE_INCLUSIVE_CLIENTS` / `freshInputRow` patch redundant — keeping it would double-subtract and under-count — so this removes it. ZCode cost is correct upstream now too.

## Changes

- `package.json` / `package-lock.json`: tokscale 4.0.9 → 4.0.11.
- `src/shared/usage.js`: drop `CACHE_INCLUSIVE_CLIENTS`, `freshInputRow`, and its call site.
- `worker/src/shared/usage.js`: regenerated via `npm run sync:worker` (a `@generated` copy).
- `tests/shared/usage.test.js`: replace the two workaround tests with one asserting ZCode passes tokscale's already-normalized numbers straight through.

## Verification

`npm run verify` (lint + 937 tests) passes.

Closes #46
Closes #73
