### PR TITLE
feat: add hover details to home activity heatmap

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -2626,6 +2626,20 @@ function setupHomeActivityHover(scroller) {
   });
   scroller.addEventListener('pointerleave', hide);
   scroller.addEventListener('scroll', hide);
+  // The tooltip lives on document.body and is only dismissed by handlers on this
+  // scroller, which renderHome() throws away on every rebuild. Expose the latest
+  // hide() so renderHome/render can clear it — DOM removal fires no pointerleave.
+  state.homeActivityHoverTeardown = hide;
+}
+
+// Dismiss the body-level activity tooltip + spotlight from outside the scroller's own
+// pointer handlers (Home rerender, or switching away from Home while a cell is hovered).
+// Clearing the ref after teardown drops the last hold on the old hide() closure, so a
+// discarded scroller + its SVG can be collected when the trends module goes away and no
+// fresh setupHomeActivityHover reassigns it. setup always re-registers before any hover.
+function hideHomeActivityTooltip() {
+  state.homeActivityHoverTeardown?.();
+  state.homeActivityHoverTeardown = null;
 }
 
 function renderHomeTrendsModule() {
@@ -2713,7 +2727,9 @@ function renderHomeTrendsModule() {
 function renderHome() {
   if (!els.homePanel) return;
   // The previous scroller (and its ResizeObserver) is about to be replaced; drop the
-  // observer so at most one is live and it is gone if the trends module disappears.
+  // observer so at most one is live and it is gone if the trends module disappears,
+  // and hide any open activity tooltip before its owning scroller is discarded.
+  hideHomeActivityTooltip();
   state.homeActivityResizeObserver?.disconnect();
   state.homeActivityResizeObserver = null;
   const period = state.stats.periods?.[state.period] || { totalTokens: 0, costUsd: 0, clients: {} };
@@ -2774,6 +2790,9 @@ function render() {
   if (!state.refreshBusy && !state.refreshFeedbackTimer) setRefreshButtonState('idle');
   els.shell.classList.toggle('session-mode', state.breakdown === 'session');
   els.shell.classList.toggle('home-mode', state.breakdown === 'home');
+  // Leaving Home only CSS-hides the panel, so its heatmap scroller never sees a
+  // pointerleave — dismiss the body-level tooltip here (renderHome covers rerenders).
+  if (state.breakdown !== 'home') hideHomeActivityTooltip();
   if (state.breakdown === 'status') ensureServiceStatusTicker(); else stopServiceStatusTicker();
   if (state.breakdown === 'home') {
     els.breakdown.classList.add('hidden');

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -2492,6 +2492,142 @@ function setupHomeActivityScroller(scroller) {
   applyHomeActivityScroll(scroller);
 }
 
+function homeActivityTooltipEl() {
+  let tooltip = document.querySelector('.home-activity-tooltip');
+  if (tooltip) return tooltip;
+  tooltip = document.createElement('div');
+  tooltip.className = 'home-activity-tooltip';
+  tooltip.setAttribute('role', 'tooltip');
+  tooltip.setAttribute('aria-hidden', 'true');
+
+  const count = document.createElement('span');
+  count.className = 'home-activity-tooltip-count';
+  count.dataset.homeActivityTooltipCount = 'true';
+
+  const label = document.createElement('span');
+  label.className = 'home-activity-tooltip-label';
+  label.textContent = 'tokens';
+
+  const date = document.createElement('span');
+  date.className = 'home-activity-tooltip-date';
+  date.dataset.homeActivityTooltipDate = 'true';
+
+  const row = document.createElement('span');
+  row.className = 'home-activity-tooltip-row';
+  row.append(count, label);
+  tooltip.append(row, date);
+  document.body.append(tooltip);
+  return tooltip;
+}
+
+function moveHomeActivityTooltip(tooltip, cell) {
+  const cellRect = cell.getBoundingClientRect();
+  const tooltipRect = tooltip.getBoundingClientRect();
+  const gap = 9;
+  const pad = 6;
+  const desiredX = cellRect.left + cellRect.width / 2;
+  const x = Math.max(pad + tooltipRect.width / 2, Math.min(window.innerWidth - pad - tooltipRect.width / 2, desiredX));
+  const aboveY = cellRect.top - tooltipRect.height - gap;
+  const belowY = cellRect.bottom + gap;
+  const y = aboveY >= pad ? aboveY : Math.min(window.innerHeight - pad - tooltipRect.height, belowY);
+  tooltip.style.transform = `translate(${x}px, ${y}px) translate(-50%, 0)`;
+}
+
+function setupHomeActivityHover(scroller) {
+  const canvas = scroller.querySelector('.home-activity-canvas');
+  const svg = canvas?.querySelector('.dash-heatmap');
+  const gradient = svg?.querySelector('#homeActivitySpotlightGradient');
+  const tooltip = homeActivityTooltipEl();
+  let activeCell = null;
+  let spotlightFrame = 0;
+  let spotlightVisible = false;
+  const spotlightTarget = { x: -200, y: -200 };
+  const spotlightCurrent = { x: -200, y: -200 };
+
+  const setSpotlight = (point) => {
+    gradient?.setAttribute('cx', String(Math.round(point.x * 10) / 10));
+    gradient?.setAttribute('cy', String(Math.round(point.y * 10) / 10));
+  };
+
+  const scheduleSpotlight = () => {
+    if (spotlightFrame || !gradient) return;
+    spotlightFrame = requestAnimationFrame(() => {
+      spotlightFrame = 0;
+      const dx = spotlightTarget.x - spotlightCurrent.x;
+      const dy = spotlightTarget.y - spotlightCurrent.y;
+      if (Math.abs(dx) < 0.12 && Math.abs(dy) < 0.12) {
+        spotlightCurrent.x = spotlightTarget.x;
+        spotlightCurrent.y = spotlightTarget.y;
+      } else {
+        spotlightCurrent.x += dx * 0.32;
+        spotlightCurrent.y += dy * 0.32;
+        scheduleSpotlight();
+      }
+      setSpotlight(spotlightCurrent);
+    });
+  };
+
+  const moveSpotlight = (x, y) => {
+    spotlightTarget.x = x;
+    spotlightTarget.y = y;
+    if (!spotlightVisible) {
+      spotlightVisible = true;
+      spotlightCurrent.x = x;
+      spotlightCurrent.y = y;
+      setSpotlight(spotlightCurrent);
+      return;
+    }
+    scheduleSpotlight();
+  };
+
+  const hide = () => {
+    tooltip.dataset.visible = 'false';
+    tooltip.setAttribute('aria-hidden', 'true');
+    tooltip.style.transform = 'translate(-9999px, -9999px)';
+    if (spotlightFrame) cancelAnimationFrame(spotlightFrame);
+    spotlightFrame = 0;
+    spotlightVisible = false;
+    spotlightTarget.x = -200;
+    spotlightTarget.y = -200;
+    spotlightCurrent.x = -200;
+    spotlightCurrent.y = -200;
+    setSpotlight(spotlightCurrent);
+    if (activeCell) activeCell.removeAttribute('data-active');
+    activeCell = null;
+  };
+
+  scroller.addEventListener('pointermove', (event) => {
+    if (!svg || scroller.classList.contains('is-dragging')) {
+      hide();
+      return;
+    }
+    const rect = svg.getBoundingClientRect();
+    const view = svg.viewBox.baseVal;
+    const x = view.x + (event.clientX - rect.left) * view.width / Math.max(1, rect.width);
+    const y = view.y + (event.clientY - rect.top) * view.height / Math.max(1, rect.height);
+    moveSpotlight(x, y);
+
+    const target = event.target instanceof Element ? event.target.closest('.heat[data-d]') : null;
+    const cell = target && canvas.contains(target) ? target : null;
+    if (!cell) {
+      hide();
+      return;
+    }
+    if (activeCell !== cell) {
+      activeCell?.removeAttribute('data-active');
+      activeCell = cell;
+      activeCell.setAttribute('data-active', 'true');
+      tooltip.querySelector('[data-home-activity-tooltip-count]').textContent = formatCompact(Number(cell.dataset.t || 0));
+      tooltip.querySelector('[data-home-activity-tooltip-date]').textContent = cell.dataset.d || '';
+    }
+    tooltip.dataset.visible = 'true';
+    tooltip.setAttribute('aria-hidden', 'false');
+    moveHomeActivityTooltip(tooltip, cell);
+  });
+  scroller.addEventListener('pointerleave', hide);
+  scroller.addEventListener('scroll', hide);
+}
+
 function renderHomeTrendsModule() {
   const charts = window.TokenMonitorUsageCharts;
   const historyEnabled = state.settings?.historyEnabled !== false;
@@ -2537,10 +2673,14 @@ function renderHomeTrendsModule() {
   activityCanvas.className = 'home-activity-canvas';
   activityCanvas.innerHTML = charts.heatmapSvg(activity, {
     monthLabel: (month) => compactMonthLabel(month.label),
-    radius: activityLayout.radius
+    radius: activityLayout.radius,
+    glowFilterId: 'homeActivityHeatGlow',
+    spotlightId: 'homeActivitySpotlight',
+    spotlightRadius: 82
   });
   activityScroll.append(activityCanvas);
   setupHomeActivityScroller(activityScroll);
+  setupHomeActivityHover(activityScroll);
   const linePoints = charts.clampDaily(points, 45);
   const summary = homeOverviewApi.homeTrendSummary(linePoints);
   const trendHead = document.createElement('div');

--- a/src/electron/renderer/styles.css
+++ b/src/electron/renderer/styles.css
@@ -1969,11 +1969,33 @@ body.floating-bubble-collapsed-right .floating-bubble-tab {
 }
 .home-activity-canvas .dash-heatmap {
   display: block;
+  overflow: visible;
+}
+.home-activity-canvas .heat-base-layer .heat {
+  transform-box: fill-box;
+  transform-origin: center;
 }
 .home-activity-canvas .heat {
   fill: rgba(var(--overlay-rgb), 0.03);
   stroke: none;
   stroke-width: 0;
+  transition: fill 140ms ease, stroke 140ms ease, transform 140ms ease;
+}
+.home-activity-canvas .heat[data-active="true"],
+.home-activity-canvas .heat:hover {
+  filter: url("#homeActivityHeatGlow");
+  stroke: rgba(var(--line-rgb), 0.9);
+  stroke-width: 1;
+  transform: scale(1.28);
+}
+.home-activity-canvas .heat-bright-layer {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 180ms ease;
+}
+.home-activity-scroll:hover .heat-bright-layer,
+.home-activity-scroll:focus-within .heat-bright-layer {
+  opacity: 1;
 }
 .home-activity-canvas .heat.lvl-1 {
   fill: rgba(90, 170, 255, 0.18);
@@ -1987,8 +2009,68 @@ body.floating-bubble-collapsed-right .floating-bubble-tab {
 .home-activity-canvas .heat.lvl-4 {
   fill: rgba(180, 230, 255, 1);
 }
+.home-activity-canvas .heat-bright {
+  fill: rgba(var(--overlay-rgb), 0.12);
+}
+.home-activity-canvas .heat-bright.lvl-1 {
+  fill: rgba(99, 183, 255, 0.38);
+}
+.home-activity-canvas .heat-bright.lvl-2 {
+  fill: rgba(112, 196, 255, 0.66);
+}
+.home-activity-canvas .heat-bright.lvl-3 {
+  fill: rgba(146, 216, 255, 0.9);
+}
+.home-activity-canvas .heat-bright.lvl-4 {
+  fill: rgb(200, 238, 255);
+}
 .home-activity-canvas .heat-month {
   fill: rgba(var(--line-rgb), 0.5);
+  font-size: 9px;
+}
+.home-activity-tooltip {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  min-width: 72px;
+  padding: 6px 9px;
+  border: 1px solid rgba(var(--line-rgb), 0.16);
+  border-radius: 8px;
+  background: rgba(var(--panel-rgb), 0.94);
+  color: var(--text);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.26), 0 0 18px rgba(var(--blue-rgb), 0.22);
+  font-size: 10px;
+  line-height: 1.1;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-9999px, -9999px);
+  transition: opacity 130ms ease;
+  white-space: nowrap;
+}
+.home-activity-tooltip[data-visible="true"] {
+  opacity: 1;
+}
+.home-activity-tooltip-row {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  font-weight: 700;
+}
+.home-activity-tooltip-count {
+  color: var(--number);
+  font-variant-numeric: tabular-nums;
+}
+.home-activity-tooltip-label,
+.home-activity-tooltip-date {
+  color: var(--muted);
+  font-weight: 500;
+}
+.home-activity-tooltip-date {
   font-size: 9px;
 }
 .home-module-empty {

--- a/src/electron/renderer/usageCharts.js
+++ b/src/electron/renderer/usageCharts.js
@@ -148,6 +148,7 @@
   function contribHeatmap(daily, options) {
     const o = Object.assign({ cell: 11, gap: 2, startDate: null, endDate: null }, options || {});
     const intensities = new Map();
+    const values = new Map();
     // startDate/endDate, when given, fix the window (e.g. a rolling year) so the grid
     // spans the whole range even where there are no records; otherwise it hugs the data.
     let minDate = o.startDate ? String(o.startDate).slice(0, 10) : null;
@@ -155,6 +156,7 @@
     for (const d of (Array.isArray(daily) ? daily : [])) {
       const key = String(d.date).slice(0, 10);
       intensities.set(key, n(d.intensity));
+      values.set(key, { tokens: n(d.tokens), cost: n(d.cost) });
       if (!o.startDate && (!minDate || key < minDate)) minDate = key;
       if (!o.endDate && (!maxDate || key > maxDate)) maxDate = key;
     }
@@ -172,7 +174,8 @@
       // Label the column that contains the 1st of a month — this puts the first
       // month flush at the left edge (the leading week always spans a month's 1st).
       if (key.slice(8, 10) === '01') monthLabels.push({ col, label: key.slice(0, 7) });
-      cells.push({ date: key, intensity: intensities.get(key) || 0, col, row, x: col * (o.cell + o.gap), y: row * (o.cell + o.gap), size: o.cell });
+      const value = values.get(key) || { tokens: 0, cost: 0 };
+      cells.push({ date: key, intensity: intensities.get(key) || 0, tokens: value.tokens, cost: value.cost, col, row, x: col * (o.cell + o.gap), y: row * (o.cell + o.gap), size: o.cell });
     }
     const weeks = cells.length ? cells[cells.length - 1].col + 1 : 0;
     return {
@@ -446,12 +449,34 @@
   }
 
   function heatmapSvg(model, options) {
-    const o = Object.assign({ titleOf: () => '', monthLabel: (m) => m.label, radius: 3 }, options || {});
+    const o = Object.assign({ titleOf: () => '', monthLabel: (m) => m.label, radius: 3, glowFilterId: '', spotlightId: '', spotlightRadius: 86 }, options || {});
     const botPad = 16;
     const pitch = (model.cell || 11) + (model.gap || 2);
+    const glowFilterId = String(o.glowFilterId || '');
+    const spotlightId = String(o.spotlightId || '');
+    const spotlightGradientId = spotlightId ? `${spotlightId}Gradient` : '';
+    const spotlightMaskId = spotlightId ? `${spotlightId}Mask` : '';
+    const radius = svgRound(Math.max(1, Number(o.spotlightRadius) || 86));
+    const defsParts = [];
+    if (glowFilterId) {
+      defsParts.push(`<filter id="${escapeXml(glowFilterId)}" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB"><feDropShadow dx="0" dy="0" stdDeviation="2.1" flood-color="rgb(120, 190, 255)" flood-opacity="0.95"></feDropShadow><feDropShadow dx="0" dy="0" stdDeviation="4.2" flood-color="rgb(120, 190, 255)" flood-opacity="0.42"></feDropShadow></filter>`);
+    }
+    if (spotlightId) {
+      defsParts.push(`<radialGradient id="${escapeXml(spotlightGradientId)}" gradientUnits="userSpaceOnUse" cx="-200" cy="-200" r="${radius}"><stop offset="0" stop-color="white" stop-opacity="1"></stop><stop offset="0.35" stop-color="white" stop-opacity="0.62"></stop><stop offset="0.75" stop-color="white" stop-opacity="0"></stop></radialGradient><mask id="${escapeXml(spotlightMaskId)}"><rect x="0" y="0" width="${svgRound(model.width)}" height="${svgRound(model.height)}" fill="url(#${escapeXml(spotlightGradientId)})"></rect></mask>`);
+    }
+    const defs = defsParts.length ? `<defs>${defsParts.join('')}</defs>` : '';
+    const cellAttrs = (c) => `class="heat lvl-${c.intensity}" data-d="${escapeXml(c.date)}" data-t="${svgRound(c.tokens || 0)}" data-cost="${svgRound(c.cost || 0)}" x="${svgRound(c.x)}" y="${svgRound(c.y)}" width="${svgRound(c.size)}" height="${svgRound(c.size)}" rx="${svgRound(Math.max(0, Number(o.radius) || 0))}"`;
     const cells = (model.cells || []).map((c) =>
-      `<rect class="heat lvl-${c.intensity}" data-d="${c.date}" x="${svgRound(c.x)}" y="${svgRound(c.y)}" width="${svgRound(c.size)}" height="${svgRound(c.size)}" rx="${svgRound(Math.max(0, Number(o.radius) || 0))}">${o.titleOf(c) ? `<title>${escapeXml(o.titleOf(c))}</title>` : ''}</rect>`
+      `<rect ${cellAttrs(c)}>${o.titleOf(c) ? `<title>${escapeXml(o.titleOf(c))}</title>` : ''}</rect>`
     ).join('');
+    const brightCells = spotlightId
+      ? (model.cells || []).map((c) =>
+        `<rect class="heat heat-bright lvl-${c.intensity}" x="${svgRound(c.x)}" y="${svgRound(c.y)}" width="${svgRound(c.size)}" height="${svgRound(c.size)}" rx="${svgRound(Math.max(0, Number(o.radius) || 0))}"></rect>`
+      ).join('')
+      : '';
+    const brightLayer = spotlightId
+      ? `<g class="heat-bright-layer" mask="url(#${escapeXml(spotlightMaskId)})" aria-hidden="true">${brightCells}</g>`
+      : '';
     // Month labels sit BELOW the grid, left-anchored at the column where each month
     // starts — so the current month naturally lands on whichever column its 1st falls in
     // (no special-casing), and the first month sits flush at the left edge.
@@ -459,7 +484,7 @@
     const months = (model.monthLabels || []).map((m) =>
       `<text class="heat-month" x="${svgRound(m.col * pitch)}" y="${svgRound(labelY)}" text-anchor="start">${escapeXml(o.monthLabel(m))}</text>`
     ).join('');
-    return `<svg class="dash-heatmap" viewBox="0 0 ${model.width} ${model.height + botPad}" width="${model.width}" height="${model.height + botPad}">${cells}${months}</svg>`;
+    return `<svg class="dash-heatmap" viewBox="0 0 ${model.width} ${model.height + botPad}" width="${model.width}" height="${model.height + botPad}">${defs}<g class="heat-base-layer">${cells}</g>${brightLayer}${months}</svg>`;
   }
 
   function statsCardsHtml(cards, options) {

--- a/tests/electron/homeOverview.test.js
+++ b/tests/electron/homeOverview.test.js
@@ -48,6 +48,8 @@ test('Home activity heatmap is a scaled copy of the dashboard heatmap', () => {
     assert.equal(fill(css, homeSelector), fill(dashboardCss, dashboardSelector));
   }
   assert.doesNotMatch(rule(css, '.home-activity-scroll'), /padding-block/);
+  assert.match(rule(css, '.home-activity-canvas .heat-bright-layer'), /pointer-events:\s*none/);
+  assert.match(rule(css, '.home-activity-tooltip'), /position:\s*fixed/);
   assert.match(rule(css, '.home-activity-canvas .heat-month'), /fill:\s*rgba\(var\(--line-rgb\), 0\.5\)/);
 });
 
@@ -59,6 +61,15 @@ test('Home module selection is independent from main view preferences', () => {
   assert.match(match[1], /hiddenHomeModuleSet|orderedHomeModules|HOME_MODULE_OPTIONS/);
   assert.match(rendererSource, /function renderHomeToolModule/);
   assert.match(rendererSource, /function renderHomeDeviceModule/);
+});
+
+test('Home activity uses a custom spotlight hover instead of native SVG titles', () => {
+  const rendererSource = fs.readFileSync(path.join(__dirname, '../../src/electron/renderer/app.js'), 'utf8');
+  const match = rendererSource.match(/function renderHomeTrendsModule\(\) \{([\s\S]*?)\n\}\n\nfunction renderHome/);
+  assert.ok(match, 'renderHomeTrendsModule exists');
+  assert.match(match[1], /setupHomeActivityHover\(activityScroll\)/);
+  assert.match(match[1], /spotlightId:\s*'homeActivitySpotlight'/);
+  assert.doesNotMatch(match[1], /titleOf:/);
 });
 
 test('Home device rows keep only the local badge and mute stale devices without status text', () => {

--- a/tests/electron/homeOverview.test.js
+++ b/tests/electron/homeOverview.test.js
@@ -72,6 +72,26 @@ test('Home activity uses a custom spotlight hover instead of native SVG titles',
   assert.doesNotMatch(match[1], /titleOf:/);
 });
 
+test('Home activity tooltip is dismissed on Home rerender and when the view leaves Home', () => {
+  const rendererSource = fs.readFileSync(path.join(__dirname, '../../src/electron/renderer/app.js'), 'utf8');
+  // The body-level tooltip only has scroller-local pointer handlers; DOM removal fires
+  // no pointerleave, so the hover setup must expose a teardown other code can invoke.
+  assert.match(rendererSource, /state\.homeActivityHoverTeardown\s*=\s*hide/);
+  // Clearing the ref after teardown lets a discarded scroller closure be collected.
+  const hideFn = rendererSource.match(/function hideHomeActivityTooltip\(\) \{([\s\S]*?)\n\}/);
+  assert.ok(hideFn, 'hideHomeActivityTooltip exists');
+  assert.match(hideFn[1], /state\.homeActivityHoverTeardown\s*=\s*null/);
+  // renderHome replaces the scroller that owns those handlers — it must hide the tooltip
+  // before rebuilding, or a cell hovered across a stats refresh leaves a stale tooltip.
+  const renderHome = rendererSource.match(/function renderHome\(\) \{([\s\S]*?)\n\}\n\nfunction render\(\)/);
+  assert.ok(renderHome, 'renderHome exists');
+  assert.match(renderHome[1], /hideHomeActivityTooltip\(\)/);
+  // Leaving Home for another view must also dismiss it (the panel is only CSS-hidden).
+  const render = rendererSource.match(/function render\(\) \{([\s\S]*?)\n\}\n\nfunction setStatus/);
+  assert.ok(render, 'render exists');
+  assert.match(render[1], /breakdown !== 'home'[\s\S]*?hideHomeActivityTooltip\(\)/);
+});
+
 test('Home device rows keep only the local badge and mute stale devices without status text', () => {
   const rendererSource = fs.readFileSync(path.join(__dirname, '../../src/electron/renderer/app.js'), 'utf8');
   const match = rendererSource.match(/function renderHomeDeviceModule\(\) \{([\s\S]*?)\n\}\n\nfunction dailyWithHeatIntensity/);

--- a/tests/electron/usageCharts.test.js
+++ b/tests/electron/usageCharts.test.js
@@ -108,6 +108,7 @@ test('contribHeatmap lays days on a Sunday-started week grid, filling gaps with 
   assert.equal(byDate['2026-05-31'].row, 0);     // grid starts on the prior Sunday
   assert.equal(byDate['2026-06-07'].col, 1);
   assert.equal(byDate['2026-06-07'].row, 0);
+  assert.equal(byDate['2026-06-07'].tokens, 0);
   assert.equal(byDate['2026-06-08'].col, 1);
   assert.equal(byDate['2026-06-08'].x, 13);
   assert.equal(byDate['2026-06-03'].intensity, 0); // gap day filled with 0
@@ -116,6 +117,13 @@ test('contribHeatmap lays days on a Sunday-started week grid, filling gaps with 
   assert.deepEqual(h.monthLabels, [{ col: 0, label: '2026-06' }]);
   assert.equal(h.cell, 11);
   assert.equal(h.gap, 2);
+});
+
+test('contribHeatmap carries daily token values for hover titles', () => {
+  const h = contribHeatmap([{ date: '2026-06-01', intensity: 4, tokens: 1234, cost: 0.5 }], { cell: 11, gap: 2 });
+  const cell = h.cells.find((c) => c.date === '2026-06-01');
+  assert.equal(cell.tokens, 1234);
+  assert.equal(cell.cost, 0.5);
 });
 
 test('contribHeatmap tolerates empty input', () => {
@@ -135,6 +143,51 @@ test('heatmapSvg scales its corner radius for compact variants', () => {
   }, { radius: 2 });
 
   assert.match(svg, /rx="2"/);
+});
+
+test('heatmapSvg embeds escaped per-cell titles when supplied', () => {
+  const svg = heatmapSvg({
+    width: 9,
+    height: 9,
+    cell: 9,
+    gap: 3,
+    cells: [{ date: '2026-06-22', intensity: 4, tokens: 1234, x: 0, y: 0, size: 9 }],
+    monthLabels: []
+  }, { titleOf: (cell) => `${cell.date} < ${cell.tokens}` });
+
+  assert.match(svg, /<title>2026-06-22 &lt; 1234<\/title>/);
+});
+
+test('heatmapSvg can include a glow filter for hovered cells', () => {
+  const svg = heatmapSvg({
+    width: 9,
+    height: 9,
+    cell: 9,
+    gap: 3,
+    cells: [{ date: '2026-06-22', intensity: 4, tokens: 1234, x: 0, y: 0, size: 9 }],
+    monthLabels: []
+  }, { glowFilterId: 'homeActivityHeatGlow' });
+
+  assert.match(svg, /<defs><filter id="homeActivityHeatGlow"/);
+  assert.match(svg, /<feDropShadow/);
+});
+
+test('heatmapSvg can include a spotlight layer with cell data attributes', () => {
+  const svg = heatmapSvg({
+    width: 9,
+    height: 9,
+    cell: 9,
+    gap: 3,
+    cells: [{ date: '2026-06-22', intensity: 4, tokens: 1234, cost: 0.25, x: 0, y: 0, size: 9 }],
+    monthLabels: []
+  }, { spotlightId: 'homeActivitySpotlight' });
+
+  assert.match(svg, /id="homeActivitySpotlightGradient"/);
+  assert.match(svg, /id="homeActivitySpotlightMask"/);
+  assert.match(svg, /class="heat-base-layer"/);
+  assert.match(svg, /class="heat-bright-layer"/);
+  assert.match(svg, /data-d="2026-06-22"/);
+  assert.match(svg, /data-t="1234"/);
 });
 
 test('statsCards returns ordered descriptors with kinds and coerced values', () => {


### PR DESCRIPTION
## Summary
- add per-day token/cost data to Home activity heatmap cells
- show an immediate custom tooltip with date and token usage on hover
- add a smooth spotlight/highlight effect for hovered activity cells

Closes #75

## Tests
- npm run lint
- npm test -- tests/electron/usageCharts.test.js tests/electron/homeOverview.test.js