### PR TITLE
fix(worker): document Cloudflare deploy setup

### DIFF
--- a/worker/.dev.vars.example
+++ b/worker/.dev.vars.example
@@ -1,0 +1,16 @@
+# Secrets for the Token Monitor hub Worker.
+#
+# This file exists so the "Deploy to Cloudflare" button prompts for these
+# values during setup (Cloudflare reads secret names from .dev.vars.example).
+# For local dev, copy it to `.dev.vars` (git-ignored) and fill in real values.
+# To set them on an already-deployed Worker, use `wrangler secret put <NAME>`
+# or the dashboard: Settings → Variables and Secrets → Add → Secret.
+
+# Required. Shared secret every agent, widget, and API request must present.
+# Generate a long random string, e.g. `openssl rand -hex 32`.
+# While unset, all data endpoints return 503 secret_required.
+TOKEN_MONITOR_SECRET=
+
+# Optional. Set to 1 to expose the unauthenticated GET /api/public/stats
+# endpoint (device records and account identifiers are stripped). Blank = off.
+PUBLIC_STATS_ENABLED=

--- a/worker/.dev.vars.example
+++ b/worker/.dev.vars.example
@@ -6,9 +6,11 @@
 # To set them on an already-deployed Worker, use `wrangler secret put <NAME>`
 # or the dashboard: Settings → Variables and Secrets → Add → Secret.
 
-# Required. Shared secret every agent, widget, and API request must present.
+# Required. Shared secret for protected hub routes.
+# Agents, widgets, and API clients must present it when posting or reading
+# private stats.
 # Generate a long random string, e.g. `openssl rand -hex 32`.
-# While unset, all data endpoints return 503 secret_required.
+# While unset, protected data endpoints return 503 secret_required.
 TOKEN_MONITOR_SECRET=
 
 # Optional. Set to 1 to expose the unauthenticated GET /api/public/stats

--- a/worker/README.md
+++ b/worker/README.md
@@ -25,6 +25,11 @@ Why use this instead of the Node hub:
 
 ## Deploy
 
+Deploy Button note: if a one-click deploy leaves the Worker responding with
+plain `Hello world`, Cloudflare hit a known intermittent import failure and
+created a repo without the Worker source. Use the manual deploy steps below, or
+reconnect Workers Builds to a repo that contains the full `worker/` directory.
+
 ```bash
 cd worker
 npm install

--- a/worker/README.zh-CN.md
+++ b/worker/README.zh-CN.md
@@ -21,6 +21,10 @@
 
 ## 部署
 
+Deploy Button 提醒：如果一键部署后的 Worker 只返回纯文本 `Hello world`，
+说明踩中了 Cloudflare 的已知间歇性导入故障，生成的仓库没有 Worker 源码。
+可以改用下面的手动部署，或把 Workers Builds 重新连到包含完整 `worker/` 目录的仓库。
+
 ```bash
 cd worker
 npm install

--- a/worker/README.zh-TW.md
+++ b/worker/README.zh-TW.md
@@ -21,6 +21,10 @@
 
 ## 部署
 
+Deploy Button 提醒：如果一鍵部署後的 Worker 只回傳純文字 `Hello world`，
+代表踩中了 Cloudflare 的已知間歇性匯入故障，產生的倉庫沒有 Worker 原始碼。
+可以改用下面的手動部署，或把 Workers Builds 重新連到包含完整 `worker/` 目錄的倉庫。
+
 ```bash
 cd worker
 npm install

--- a/worker/package.json
+++ b/worker/package.json
@@ -10,6 +10,16 @@
     "tail": "wrangler tail",
     "secret:put": "wrangler secret put TOKEN_MONITOR_SECRET"
   },
+  "cloudflare": {
+    "bindings": {
+      "TOKEN_MONITOR_SECRET": {
+        "description": "Required. Shared secret every agent, widget, and API request must present. Generate a long random string, e.g. `openssl rand -hex 32`."
+      },
+      "PUBLIC_STATS_ENABLED": {
+        "description": "Optional. Set to 1 to expose the unauthenticated GET /api/public/stats endpoint. Leave blank to keep it off."
+      }
+    }
+  },
   "author": "Javis",
   "license": "MIT",
   "repository": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -13,7 +13,7 @@
   "cloudflare": {
     "bindings": {
       "TOKEN_MONITOR_SECRET": {
-        "description": "Required. Shared secret every agent, widget, and API request must present. Generate a long random string, e.g. `openssl rand -hex 32`."
+        "description": "Required. Shared secret for protected hub routes. Agents, widgets, and API clients must present it when posting or reading private stats. Generate a long random string, e.g. `openssl rand -hex 32`."
       },
       "PUBLIC_STATS_ENABLED": {
         "description": "Optional. Set to 1 to expose the unauthenticated GET /api/public/stats endpoint. Leave blank to keep it off."


### PR DESCRIPTION
## Summary

- Add `worker/.dev.vars.example` so the Cloudflare Deploy Button can discover `TOKEN_MONITOR_SECRET` and `PUBLIC_STATS_ENABLED`.
- Add `cloudflare.bindings` descriptions for those values in `worker/package.json`, matching Cloudflare's Deploy Button guidance.
- Document the known intermittent Cloudflare Deploy Button `Hello world` import failure in the Worker README locales.
- Keep this scoped to the actionable repo-side follow-up from #67. The intermittent source import failure remains a Cloudflare-side issue.
- Credit @freefrank for the original investigation and split-out follow-up.

## Test Plan

- `npm run verify`

Refs #67.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Cloudflare Deploy Button setup for the Worker. Adds `worker/.dev.vars.example` to prompt for `TOKEN_MONITOR_SECRET` and `PUBLIC_STATS_ENABLED`, tightens deploy‑secret wording and sets `cloudflare.bindings` descriptions in `worker/package.json`, and documents the intermittent one‑click deploy "Hello world" import failure.

<sup>Written for commit 5b3ad4c6efec95e51111b7bc0f6c0de6389c18d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

