### PR TITLE
fix(limits): keep Codex account refresh scoped

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -613,6 +613,7 @@ async function refreshCodexManagedAccountLimits(id) {
       ...settings,
       limitsEnabled: true,
       limitProviders: 'codex',
+      includeLiveCodexAccount: false,
       codexManagedAccounts: [account]
     }, { env: process.env });
     return {

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -1960,7 +1960,9 @@ async function fetchCodexLimits(options = {}, deps = {}) {
   const includeLiveAccount = options.includeLiveCodexAccount !== false;
   // Single live account: keep the original single-provider shape (and error
   // propagation) so a signed-out/not-configured state surfaces as before.
-  if (managedAccounts.length === 0) return fetchLiveCodexAccount(deps, nowMs);
+  if (managedAccounts.length === 0) {
+    return includeLiveAccount ? fetchLiveCodexAccount(deps, nowMs) : [];
+  }
 
   const providers = [];
   // Dedupe by account id (accountKey) first, then email — so signing in the

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -1957,6 +1957,7 @@ async function fetchCodexLimits(options = {}, deps = {}) {
   const nowMs = (deps.now || Date.now)();
   const managedAccounts = normalizeCodexManagedAccounts(options.codexManagedAccounts || deps.codexManagedAccounts)
     .filter((account) => account.enabled !== false);
+  const includeLiveAccount = options.includeLiveCodexAccount !== false;
   // Single live account: keep the original single-provider shape (and error
   // propagation) so a signed-out/not-configured state surfaces as before.
   if (managedAccounts.length === 0) return fetchLiveCodexAccount(deps, nowMs);
@@ -1977,11 +1978,13 @@ async function fetchCodexLimits(options = {}, deps = {}) {
   // stays visible alongside managed accounts — adding a managed account never
   // hides the login you are actually using. Best-effort: a signed-out/Keychain-
   // only live account just drops out, leaving the managed accounts.
-  try {
-    const live = await fetchLiveCodexAccount(deps, nowMs);
-    providers.push(live);
-    markSeen(live);
-  } catch (_) {}
+  if (includeLiveAccount) {
+    try {
+      const live = await fetchLiveCodexAccount(deps, nowMs);
+      providers.push(live);
+      markSeen(live);
+    } catch (_) {}
+  }
   for (const account of managedAccounts) {
     const provider = await fetchManagedCodexAccountLimits(account, options, deps);
     if (alreadySeen(provider)) continue;

--- a/tests/electron/cursorSettingsLayout.test.js
+++ b/tests/electron/cursorSettingsLayout.test.js
@@ -331,6 +331,7 @@ test('Codex system account switching is exposed from limits account rows', () =>
   assert.match(main, /function codexEmailDerivedAccountKey\(account, identity\)/);
   const refreshBody = functionBody(main, 'refreshCodexManagedAccountLimits', 'migrateLimitProviders');
   assert.match(refreshBody, /limitProviders: 'codex'/);
+  assert.match(refreshBody, /includeLiveCodexAccount: false/);
   assert.match(refreshBody, /codexManagedAccounts: \[account\]/);
   assert.doesNotMatch(refreshBody, /codexManagedAccountsForCollector\(\)/);
   const renderLimits = functionBody(app, 'renderLimits', 'serviceStatusLabel');

--- a/tests/shared/limitCollector.codex.test.js
+++ b/tests/shared/limitCollector.codex.test.js
@@ -281,6 +281,26 @@ test('fetchCodexLimits can refresh only the requested managed Codex account', as
   assert.equal(providers[0].sourceDetail, 'managed');
 });
 
+test('fetchCodexLimits does not fall back to live account when scoped accounts normalize away', async () => {
+  const seenHomes = [];
+  const providers = await fetchCodexLimits({
+    includeLiveCodexAccount: false,
+    codexManagedAccounts: [
+      { id: 'target', email: 'target@example.com', homePath: '' }
+    ]
+  }, {
+    now: () => Date.parse('2026-06-01T00:00:00Z'),
+    env: { PATH: '/usr/bin' },
+    readCodexRpc: async (deps) => {
+      seenHomes.push(deps.env.CODEX_HOME || '<live>');
+      return codexPayload('live@example.com', 'app');
+    }
+  });
+
+  assert.deepEqual(seenHomes, []);
+  assert.deepEqual(providers, []);
+});
+
 test('createLimitsCollector retains recent Codex quota windows across one empty refresh', async () => {
   let now = Date.parse('2026-06-01T00:00:00Z');
   let calls = 0;

--- a/tests/shared/limitCollector.codex.test.js
+++ b/tests/shared/limitCollector.codex.test.js
@@ -256,6 +256,31 @@ test('fetchCodexLimits returns one provider per managed Codex account', async ()
   assert.deepEqual(providers.map((provider) => provider.sourceDetail), ['managed', 'managed']);
 });
 
+test('fetchCodexLimits can refresh only the requested managed Codex account', async () => {
+  const seenHomes = [];
+  const providers = await fetchCodexLimits({
+    includeLiveCodexAccount: false,
+    codexManagedAccounts: [
+      { id: 'target', email: 'target@example.com', homePath: '/tmp/token-monitor-codex/target' }
+    ]
+  }, {
+    now: () => Date.parse('2026-06-01T00:00:00Z'),
+    env: { PATH: '/usr/bin' },
+    readCodexRpc: async (deps) => {
+      const home = deps.env.CODEX_HOME || '<live>';
+      seenHomes.push(home);
+      return home === '<live>'
+        ? codexPayload('live@example.com', 'app')
+        : codexPayload('target@example.com');
+    }
+  });
+
+  assert.deepEqual(seenHomes, ['/tmp/token-monitor-codex/target']);
+  assert.equal(providers.length, 1);
+  assert.equal(providers[0].accountEmail, 'target@example.com');
+  assert.equal(providers[0].sourceDetail, 'managed');
+});
+
 test('createLimitsCollector retains recent Codex quota windows across one empty refresh', async () => {
   let now = Date.parse('2026-06-01T00:00:00Z');
   let calls = 0;


### PR DESCRIPTION
## Summary
- Keep the Codex per-account refresh path scoped to the selected managed account.
- Prevent the live system account quota snapshot from being returned during a targeted managed-account refresh.
- Add regression coverage for the scoped refresh path and the Electron IPC wiring.

## Test Plan
- `node --test tests/shared/limitCollector.codex.test.js`
- `node --test tests/shared/limitCollector.codex.test.js tests/electron/cursorSettingsLayout.test.js`
- `npm run verify`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Codex managed-account refreshes to the selected account and excludes the live system account during targeted refreshes. Adds regression tests to lock this behavior and the Electron IPC wiring.

- **Bug Fixes**
  - Added `includeLiveCodexAccount` to `fetchCodexLimits`; set to false in Electron’s `refreshCodexManagedAccountLimits` to scope to `codexManagedAccounts: [account]`.
  - When scoped, do not fetch or include the live system account, even if the managed-account list is empty.
  - Added tests for scoped refresh behavior (single-account and empty-scope) and the IPC wiring.

<sup>Written for commit 5fe692f3df81b7b64d11c034174a7153f5151682. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

