### PR TITLE
fix(limits): detect quoted Antigravity CLI paths

### DIFF
--- a/src/shared/antigravityProbe.js
+++ b/src/shared/antigravityProbe.js
@@ -45,8 +45,8 @@ function isAntigravityCommand(lowerCommand) {
 // different process name. Path-anchor the match so unrelated binaries/arguments
 // (e.g. `/opt/imagytool/...`, `legacy-agent`) do not match.
 function isAntigravityCliCommand(lowerCommand) {
-  if (/(^|[/\\])(antigravity-cli|antigravity_cli)([\s/\\]|$)/.test(lowerCommand)) return true;
-  if (/(^|[/\\])agy(\.exe)?(\s|$)/.test(lowerCommand)) return true;
+  if (/(^|[/\\])(antigravity-cli|antigravity_cli)(\.exe)?(["'\s/\\]|$)/.test(lowerCommand)) return true;
+  if (/(^|[/\\])agy(\.exe)?(["'\s]|$)/.test(lowerCommand)) return true;
   return false;
 }
 

--- a/tests/shared/antigravityProbe.test.js
+++ b/tests/shared/antigravityProbe.test.js
@@ -61,6 +61,13 @@ test('parseProcessLine matches agy.exe on win32 cmdlines', () => {
   assert.equal(info.kind, 'cli');
 });
 
+test('parseProcessLine matches a quoted agy.exe path with regular CLI args on win32', () => {
+  const info = probe._parseProcessLine('35144 "C:\\Users\\Cx\\AppData\\Local\\agy\\bin\\agy.exe" --print hello --print-timeout 30s');
+  assert.equal(info.pid, 35144);
+  assert.equal(info.kind, 'cli');
+  assert.equal(info.csrfToken, '');
+});
+
 test('parseProcessLine does not match agy embedded in an unrelated path', () => {
   assert.equal(probe._parseProcessLine('700 /opt/imagytool/bin/run --serve'), null);
   assert.equal(probe._parseProcessLine('701 /usr/local/bin/legacy-agent start'), null);
@@ -128,6 +135,14 @@ test('detectProcessInfo (win32) finds the agy.exe CLI when no IDE LS is running'
   const stdout = '9001 C:\\Users\\j\\.antigravity\\agy.exe language-server\n';
   const info = await probe.detectProcessInfo({ platform: 'win32', spawn: fakeSpawn(stdout) });
   assert.equal(info.pid, 9001);
+  assert.equal(info.kind, 'cli');
+  assert.equal(info.csrfToken, '');
+});
+
+test('detectProcessInfo (win32) finds a quoted agy.exe CLI command line', async () => {
+  const stdout = '35144 "C:\\Users\\Cx\\AppData\\Local\\agy\\bin\\agy.exe" --print hello --print-timeout 30s\n';
+  const info = await probe.detectProcessInfo({ platform: 'win32', spawn: fakeSpawn(stdout) });
+  assert.equal(info.pid, 35144);
   assert.equal(info.kind, 'cli');
   assert.equal(info.csrfToken, '');
 });


### PR DESCRIPTION
## Summary
Fix Antigravity CLI detection on Windows when the running `agy.exe` path is quoted in the process command line.

## Root cause
Token Monitor only recognized `agy` / `antigravity-cli` commands when the executable name was followed immediately by whitespace, a path separator, or end-of-string. The real Windows CLI command line is emitted as a quoted executable path, for example `"C:\Users\...\agy.exe" --print ...`, so the trailing quote prevented the CLI process from being classified as Antigravity.

## What changed
- allow `agy(.exe)` and `antigravity-cli(.exe)` matches to terminate on a quote as well as whitespace/path boundaries
- add regression tests for quoted Windows `agy.exe` command lines in both `_parseProcessLine()` and `detectProcessInfo()`

## Validation
- `npm run lint`
- `node --test tests/shared/antigravityProbe.test.js tests/shared/antigravityLimits.test.js tests/shared/limitPlanLabels.test.js`
- local repro on Windows by starting `agy --print hello --print-timeout 30s` and confirming `src/shared/antigravityProbe.detectProcessInfo()` now returns the CLI pid and listening ports

## Notes
`npm test` still reports one unrelated existing failure in `tests/shared/collectorLoadGuards.test.js` (`watchIgnoreMatcher prunes the Hermes runtime but keeps the state.db family and the watch root`). I left that out of this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Antigravity CLI detection on Windows when the executable path is quoted (e.g., "C:\...\agy.exe"), so CLI processes are correctly identified and limits checks run as expected.

- **Bug Fixes**
  - Updated CLI regex to accept quotes as terminators and support `.exe` for `antigravity-cli` and `agy`.
  - Added regression tests for quoted `agy.exe` in `_parseProcessLine()` and `detectProcessInfo()`.

<sup>Written for commit 83888b1ad131c74a8f3af674f4b770d603bbaf9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

