### PR TITLE
fix(collector): detect Antigravity CLI data roots

### DIFF
--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -315,9 +315,9 @@ async function maybeSyncCursor(clientsCsv, logger) {
   }
 }
 
-// tokscale's antigravity sync reads the IDE's native session roots under
-// ~/.gemini/; when none exist there is nothing to sync, so don't spawn at all.
-const ANTIGRAVITY_DATA_ROOTS = ['antigravity', 'antigravity-ide', 'antigravity-backup'];
+// tokscale's antigravity sync reads both the IDE and CLI native data roots
+// under ~/.gemini/; when none exist there is nothing to sync, so don't spawn.
+const ANTIGRAVITY_DATA_ROOTS = ['antigravity', 'antigravity-cli', 'antigravity-ide', 'antigravity-backup'];
 
 function antigravityDataPresent(home) {
   return ANTIGRAVITY_DATA_ROOTS.some((name) => dirExists(path.join(home, '.gemini', name)));

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -374,6 +374,31 @@ test('antigravity sync runs at most once per throttle window across ticks', asyn
   }
 });
 
+test('collectUsageOnce syncs antigravity when only the CLI data root exists', async () => {
+  const tmp = withTmpHome([path.join('.gemini', 'antigravity-cli')]);
+  const childProcess = require('node:child_process');
+  const originalSpawn = childProcess.spawn;
+  const calls = [];
+  childProcess.spawn = recordingSpawn(calls);
+  try {
+    const { collectUsageOnce } = freshCollector();
+    await collectUsageOnce({
+      clients: 'antigravity',
+      allTimeSince: '2024-01-01',
+      commandTimeoutMs: 1000,
+      deviceId: 'test-device',
+      agentVersion: 'test',
+      limitsEnabled: false,
+      homeDir: tmp
+    });
+    assert.equal(calls.filter((args) => args.includes('sync')).length, 1);
+  } finally {
+    childProcess.spawn = originalSpawn;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test('cursor sync runs at most once per throttle window across ticks', async () => {
   const childProcess = require('node:child_process');
   const originalSpawn = childProcess.spawn;


### PR DESCRIPTION
﻿## Summary

Token Monitor now treats `~/.gemini/antigravity-cli` as a valid Antigravity data root when deciding whether to run `tokscale antigravity sync`.

Previously, the collector only recognized the IDE roots (`~/.gemini/antigravity`, `antigravity-ide`, `antigravity-backup`). When a user only had Antigravity CLI activity, `maybeSyncAntigravity()` returned early, the tokscale cache was not refreshed, and Antigravity CLI token usage could be missing from the monitor.

This change also adds a regression test covering the CLI-only `~/.gemini/antigravity-cli` layout.

## Verification

Ran:

- `node --test tests/shared/collectorLoadGuards.test.js --test-name-pattern "antigravity|Antigravity"`

Results:

- the new CLI-only Antigravity regression test passes
- there is also a pre-existing unrelated Hermes failure in the same test file:
  `watchIgnoreMatcher prunes the Hermes runtime but keeps the state.db family and the watch root`

I did not claim `npm run verify` passed, because that would be inaccurate with the existing unrelated failure still present.

## Related

- fixes missing Antigravity CLI token sync behavior in `src/shared/collector.js`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Token Monitor now detects the Antigravity CLI data root and runs sync when only `~/.gemini/antigravity-cli` exists. This ensures CLI token usage is included in the cache.

- **Bug Fixes**
  - Added `antigravity-cli` to `ANTIGRAVITY_DATA_ROOTS` so `tokscale antigravity sync` runs without IDE roots.
  - Added a regression test for the CLI-only `~/.gemini/antigravity-cli` layout.

<sup>Written for commit 82c1dd39a265fa82633723dc62da7362ef5980e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

