### PR TITLE
fix(limits): prefer fresh synced provider states

### DIFF
--- a/src/shared/limits.js
+++ b/src/shared/limits.js
@@ -339,16 +339,22 @@ function aggregateLimits(devices, staleAfterMs = 0, nowMs = Date.now()) {
   const aggregate = { updatedAt: new Date(nowMs).toISOString(), providers: [] };
   const byKey = new Map();
   const providersWithConfiguredAccounts = new Set();
+  const providersWithFreshConfiguredAccounts = new Set();
+  const providersWithFreshObservations = new Set();
 
   for (const device of devices || []) {
     const summary = normalizeLimitsSummary(device?.limits);
     for (const provider of summary.providers) {
-      if (isConfiguredProvider(provider)) providersWithConfiguredAccounts.add(provider.provider);
       const candidate = {
         ...provider,
         sourceDeviceId: String(device?.deviceId || ''),
         stale: isProviderStale(provider, summary, device, staleAfterMs, nowMs)
       };
+      if (isConfiguredProvider(provider)) providersWithConfiguredAccounts.add(provider.provider);
+      if (!candidate.stale) {
+        providersWithFreshObservations.add(provider.provider);
+        if (isConfiguredProvider(provider)) providersWithFreshConfiguredAccounts.add(provider.provider);
+      }
       const key = providerAggregateKey(provider);
       byKey.set(key, pickBetterProvider(byKey.get(key), candidate));
     }
@@ -360,7 +366,12 @@ function aggregateLimits(devices, staleAfterMs = 0, nowMs = Date.now()) {
   // Map.set() would arbitrarily overwrite the fresh one with the stale one.
   const byProvider = new Map();
   for (const candidate of byKey.values()) {
-    if (!isConfiguredProvider(candidate) && providersWithConfiguredAccounts.has(candidate.provider)) continue;
+    const hasFreshObservation = providersWithFreshObservations.has(candidate.provider);
+    if (candidate.stale && hasFreshObservation) continue;
+    const configuredProviders = hasFreshObservation
+      ? providersWithFreshConfiguredAccounts
+      : providersWithConfiguredAccounts;
+    if (!isConfiguredProvider(candidate) && configuredProviders.has(candidate.provider)) continue;
     const collapseKey = providerCollapseKey(candidate);
     byProvider.set(collapseKey, pickBetterProvider(byProvider.get(collapseKey), candidate));
   }

--- a/tests/shared/limits.test.js
+++ b/tests/shared/limits.test.js
@@ -119,6 +119,68 @@ test('aggregateLimits keeps Codex quota windows over a newer empty transient sna
   assert.equal(accountA.windows[0].remainingPercent, 50);
 });
 
+test('aggregateLimits prefers a fresh notConfigured state over stale configured Codex quota', () => {
+  const staleProvider = codexProvider(
+    'sha256:codex-a',
+    'a@example.com',
+    41,
+    '2026-07-08T13:04:49.000Z'
+  );
+  const aggregate = aggregateLimits([
+    {
+      deviceId: 'old-device-id',
+      stale: true,
+      limits: {
+        updatedAt: '2026-07-08T13:04:49.000Z',
+        providers: [staleProvider]
+      }
+    },
+    {
+      deviceId: 'current-device-id',
+      stale: false,
+      limits: {
+        updatedAt: '2026-07-10T02:55:17.000Z',
+        providers: [{
+          provider: 'codex',
+          status: 'notConfigured',
+          updatedAt: '2026-07-10T02:55:17.000Z',
+          windows: []
+        }]
+      }
+    }
+  ], 10 * 60 * 1000, Date.parse('2026-07-10T03:00:00.000Z'));
+
+  const codexProviders = aggregate.providers.filter((provider) => provider.provider === 'codex');
+  assert.equal(codexProviders.length, 1);
+  assert.equal(codexProviders[0].status, 'notConfigured');
+  assert.equal(codexProviders[0].sourceDeviceId, 'current-device-id');
+  assert.equal(codexProviders[0].stale, false);
+  assert.deepEqual(codexProviders[0].windows, []);
+});
+
+test('aggregateLimits still exposes stale configured Codex quota when no fresh observation exists', () => {
+  const aggregate = aggregateLimits([
+    {
+      deviceId: 'offline-device',
+      stale: true,
+      limits: {
+        updatedAt: '2026-07-08T13:04:49.000Z',
+        providers: [codexProvider(
+          'sha256:codex-a',
+          'a@example.com',
+          41,
+          '2026-07-08T13:04:49.000Z'
+        )]
+      }
+    }
+  ], 10 * 60 * 1000, Date.parse('2026-07-10T03:00:00.000Z'));
+
+  assert.equal(aggregate.providers.length, 1);
+  assert.equal(aggregate.providers[0].status, 'ok');
+  assert.equal(aggregate.providers[0].stale, true);
+  assert.equal(aggregate.providers[0].windows[0].remainingPercent, 41);
+});
+
 test('mergeCodexTransientWindows keeps recent Codex windows when the same account reads empty', () => {
   const previous = {
     updatedAt: '2026-06-14T10:00:00.000Z',

--- a/tests/shared/usage.test.js
+++ b/tests/shared/usage.test.js
@@ -65,6 +65,58 @@ test('mergeDeviceRecord allows explicit empty limits to clear stale provider sta
   assert.deepEqual(merged.limits.providers, []);
 });
 
+test('aggregateDevices does not let an orphaned stale device id override the current limits state', () => {
+  const oldDevice = recordWithLimits({
+    deviceId: 'old-device-id',
+    updatedAt: '2026-07-08T13:08:54.000Z',
+    receivedAt: '2026-07-08T13:08:54.000Z',
+    limits: {
+      updatedAt: '2026-07-08T13:04:49.000Z',
+      refreshMs: 300000,
+      providers: [{
+        provider: 'codex',
+        accountKey: 'sha256:old-codex',
+        status: 'ok',
+        source: 'rpc',
+        updatedAt: '2026-07-08T13:04:49.000Z',
+        windows: [
+          { kind: 'session', usedPercent: 59, resetsAt: '2026-07-08T15:37:24.000Z', windowMinutes: 300 },
+          { kind: 'weekly', usedPercent: 54, resetsAt: '2026-07-14T04:16:57.000Z', windowMinutes: 10080 }
+        ]
+      }]
+    }
+  });
+  const currentDevice = recordWithLimits({
+    deviceId: 'current-device-id',
+    updatedAt: '2026-07-10T02:58:40.000Z',
+    receivedAt: '2026-07-10T02:58:41.000Z',
+    limits: {
+      updatedAt: '2026-07-10T02:55:17.000Z',
+      refreshMs: 300000,
+      providers: [{
+        provider: 'codex',
+        status: 'notConfigured',
+        updatedAt: '2026-07-10T02:55:17.000Z',
+        windows: []
+      }]
+    }
+  });
+
+  const aggregate = aggregateDevices(
+    [oldDevice, currentDevice],
+    10 * 60 * 1000,
+    Date.parse('2026-07-10T03:00:00.000Z')
+  );
+
+  assert.equal(aggregate.devices.find((device) => device.deviceId === 'old-device-id').stale, true);
+  assert.equal(aggregate.devices.find((device) => device.deviceId === 'current-device-id').stale, false);
+  assert.equal(aggregate.limits.providers.length, 1);
+  assert.equal(aggregate.limits.providers[0].provider, 'codex');
+  assert.equal(aggregate.limits.providers[0].status, 'notConfigured');
+  assert.equal(aggregate.limits.providers[0].sourceDeviceId, 'current-device-id');
+  assert.deepEqual(aggregate.limits.providers[0].windows, []);
+});
+
 test('mergeDeviceRecord supports limitsOnly updates without wiping usage periods', () => {
   const existing = recordWithLimits();
   const incoming = {

--- a/worker/src/shared/limits.js
+++ b/worker/src/shared/limits.js
@@ -342,16 +342,22 @@ function aggregateLimits(devices, staleAfterMs = 0, nowMs = Date.now()) {
   const aggregate = { updatedAt: new Date(nowMs).toISOString(), providers: [] };
   const byKey = new Map();
   const providersWithConfiguredAccounts = new Set();
+  const providersWithFreshConfiguredAccounts = new Set();
+  const providersWithFreshObservations = new Set();
 
   for (const device of devices || []) {
     const summary = normalizeLimitsSummary(device?.limits);
     for (const provider of summary.providers) {
-      if (isConfiguredProvider(provider)) providersWithConfiguredAccounts.add(provider.provider);
       const candidate = {
         ...provider,
         sourceDeviceId: String(device?.deviceId || ''),
         stale: isProviderStale(provider, summary, device, staleAfterMs, nowMs)
       };
+      if (isConfiguredProvider(provider)) providersWithConfiguredAccounts.add(provider.provider);
+      if (!candidate.stale) {
+        providersWithFreshObservations.add(provider.provider);
+        if (isConfiguredProvider(provider)) providersWithFreshConfiguredAccounts.add(provider.provider);
+      }
       const key = providerAggregateKey(provider);
       byKey.set(key, pickBetterProvider(byKey.get(key), candidate));
     }
@@ -363,7 +369,12 @@ function aggregateLimits(devices, staleAfterMs = 0, nowMs = Date.now()) {
   // Map.set() would arbitrarily overwrite the fresh one with the stale one.
   const byProvider = new Map();
   for (const candidate of byKey.values()) {
-    if (!isConfiguredProvider(candidate) && providersWithConfiguredAccounts.has(candidate.provider)) continue;
+    const hasFreshObservation = providersWithFreshObservations.has(candidate.provider);
+    if (candidate.stale && hasFreshObservation) continue;
+    const configuredProviders = hasFreshObservation
+      ? providersWithFreshConfiguredAccounts
+      : providersWithConfiguredAccounts;
+    if (!isConfiguredProvider(candidate) && configuredProviders.has(candidate.provider)) continue;
     const collapseKey = providerCollapseKey(candidate);
     byProvider.set(collapseKey, pickBetterProvider(byProvider.get(collapseKey), candidate));
   }


### PR DESCRIPTION
## Summary

- prefer fresh provider observations over stale records from old or renamed devices
- keep stale quota data visible only when no fresh observation for that provider exists
- apply the same aggregation behavior in the Node hub and generated Worker copy

## Root cause

Configured accounts and unconfigured provider states can have different aggregation keys. An orphaned stale device could therefore keep a configured quota candidate while the current device reported a fresh `notConfigured` state, and the later provider collapse could select the stale quota instead of the current observation.

The aggregation pass now records which providers have fresh observations and excludes stale candidates whenever a current observation exists. If every observation is stale, the most useful stale quota remains visible as before.

## Impact

Synced dashboards reflect the current device/provider state instead of showing quota data left behind by a stale device id.

## Validation

- `npm run verify` (lint + 1028 tests)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer fresh provider states during limits aggregation so stale data from old or renamed devices can’t override the current state. Dashboards now reflect the current device/provider status.

- Bug Fixes
  - Ignore stale candidates when a fresh observation for that provider exists.
  - If fresh data exists, only consider configured accounts from fresh devices; otherwise keep the most useful stale configured quota.
  - Apply the same logic in `src/shared/limits.js` and `worker/src/shared/limits.js`, with tests covering these cases.

<sup>Written for commit 05a60acc764c60985ec0012134bb9283948f3abe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

