### PR TITLE
fix(limits): stabilize Codex quota refreshes

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -21,6 +21,7 @@ const { customPricingPath } = require('../shared/tokscaleConfig');
 const { applyCustomPricing, normalizeCustomPricingSetting } = require('../shared/tokscaleCustomPricing');
 const { createHub } = require('../hub/server');
 const { collectLimitsOnce, deepseekToken, normalizeLimitsRefreshMs, parseBoolean, parseLimitProviders, runCodexLogin, minimaxToken, copilotToken, zaiToken, zaiRegion, zaiTeamToken, volcengineCredentials, qoderCookie, kimiToken } = require('../shared/limitCollector');
+const { mergeCodexTransientWindows } = require('../shared/limits');
 const { copilotLoginErrorMessage, isAllowedVerificationUrl, runCopilotDeviceFlowLogin } = require('../shared/copilotDeviceFlow');
 const { codexAuthIdentity, hashAccountKey } = require('../shared/codexAuth');
 const { codexLoginUrlFromOutput, isAllowedCodexLoginUrl } = require('../shared/codexLogin');
@@ -855,9 +856,10 @@ async function refreshCodexManagedAccountLimits(id) {
       includeLiveCodexAccount: false,
       codexManagedAccounts: [account]
     }, { env: process.env });
+    const stableSummary = mergeCodexTransientWindows(latestStats?.limits, summary);
     return {
       ok: true,
-      providers: (summary.providers || []).filter((provider) => provider?.provider === 'codex')
+      providers: (stableSummary.providers || []).filter((provider) => provider?.provider === 'codex')
     };
   } catch (error) {
     return { ok: false, error: `Could not refresh Codex account limits: ${error?.message || error}` };

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -1188,15 +1188,43 @@ function codexRateLimitWindowSignature(snapshot) {
   }));
 }
 
+function codexAlternatePlanType(snapshot) {
+  const value = snapshot?.planType ?? snapshot?.plan_type;
+  const normalized = String(value ?? '').trim();
+  return normalized || null;
+}
+
+function codexAlternateResetCredits(snapshot) {
+  const resetCredits = snapshot?.rateLimitResetCredits ?? snapshot?.rate_limit_reset_credits;
+  return normalizeLimitProvider({ provider: 'codex', resetCredits }).resetCredits;
+}
+
 function unambiguousAlternateCodexRateLimits(rateLimitsById) {
-  // Object key order is not a quota-selection contract. Only use an alternate
-  // id when every windowed alternate describes the same quota snapshot.
+  // Object key order is not a quota-selection contract. Keep agreed window
+  // data, but only carry optional metadata when every alternate agrees too.
   const candidates = Object.entries(rateLimitsById)
     .filter(([id, snapshot]) => id !== 'codex' && hasCodexRateLimitWindows(snapshot))
     .sort(([left], [right]) => left.localeCompare(right));
   if (candidates.length === 0) return null;
   const signatures = new Set(candidates.map(([, snapshot]) => codexRateLimitWindowSignature(snapshot)));
-  return signatures.size === 1 ? candidates[0][1] : null;
+  if (signatures.size !== 1) return null;
+
+  const snapshots = candidates.map(([, snapshot]) => snapshot);
+  const first = snapshots[0];
+  const consensus = {
+    ...(first.primary ? { primary: first.primary } : {}),
+    ...(first.secondary ? { secondary: first.secondary } : {})
+  };
+  const planTypes = snapshots.map(codexAlternatePlanType);
+  const normalizedPlanTypes = new Set(planTypes.map((value) => value?.toLowerCase() || null));
+  if (normalizedPlanTypes.size === 1 && planTypes[0]) consensus.planType = planTypes[0];
+
+  const resetCredits = snapshots.map(codexAlternateResetCredits);
+  const resetCreditSignatures = new Set(resetCredits.map((value) => JSON.stringify(value)));
+  if (resetCreditSignatures.size === 1 && resetCredits[0]) {
+    consensus.rateLimitResetCredits = resetCredits[0];
+  }
+  return consensus;
 }
 
 function codexRateLimitSnapshot(payload = {}) {

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -1175,15 +1175,37 @@ function codexDirectRateLimits(payload = {}) {
   return payload.rateLimits || payload.rate_limits || {};
 }
 
+function codexRateLimitWindowSignature(snapshot) {
+  return JSON.stringify(['primary', 'secondary'].map((key) => {
+    const window = snapshot?.[key];
+    if (!window) return null;
+    return [
+      key,
+      window.usedPercent ?? window.used_percent ?? null,
+      window.resetsAt ?? window.resets_at ?? null,
+      window.windowDurationMins ?? window.window_duration_mins ?? null
+    ];
+  }));
+}
+
+function unambiguousAlternateCodexRateLimits(rateLimitsById) {
+  // Object key order is not a quota-selection contract. Only use an alternate
+  // id when every windowed alternate describes the same quota snapshot.
+  const candidates = Object.entries(rateLimitsById)
+    .filter(([id, snapshot]) => id !== 'codex' && hasCodexRateLimitWindows(snapshot))
+    .sort(([left], [right]) => left.localeCompare(right));
+  if (candidates.length === 0) return null;
+  const signatures = new Set(candidates.map(([, snapshot]) => codexRateLimitWindowSignature(snapshot)));
+  return signatures.size === 1 ? candidates[0][1] : null;
+}
+
 function codexRateLimitSnapshot(payload = {}) {
   const rateLimitsById = codexRateLimitsById(payload);
   const direct = codexDirectRateLimits(payload);
   if (hasCodexRateLimitWindows(rateLimitsById.codex)) return rateLimitsById.codex;
   if (hasCodexRateLimitWindows(direct)) return direct;
-  for (const [id, snapshot] of Object.entries(rateLimitsById)) {
-    if (id === 'codex') continue;
-    if (hasCodexRateLimitWindows(snapshot)) return snapshot;
-  }
+  const alternate = unambiguousAlternateCodexRateLimits(rateLimitsById);
+  if (alternate) return alternate;
   return rateLimitsById.codex || direct || {};
 }
 

--- a/src/shared/limits.js
+++ b/src/shared/limits.js
@@ -397,12 +397,14 @@ function mergeCodexTransientWindows(previousInput, currentInput, nowMs = Date.no
 
   for (const provider of previous.providers) {
     if (provider.provider !== 'codex' || provider.status !== 'ok' || !hasProviderWindows(provider)) continue;
-    const providerUpdatedAt = timestampMs(provider.updatedAt || previous.updatedAt);
+    const effectiveUpdatedAt = provider.updatedAt || previous.updatedAt;
+    const providerUpdatedAt = timestampMs(effectiveUpdatedAt);
     if (!providerUpdatedAt || currentMs - providerUpdatedAt < 0 || currentMs - providerUpdatedAt > Number(retentionMs)) continue;
-    eligiblePreviousCodexProviders.push(provider);
-    for (const key of codexProviderIdentityKeys(provider)) {
+    const eligibleProvider = provider.updatedAt ? provider : { ...provider, updatedAt: effectiveUpdatedAt };
+    eligiblePreviousCodexProviders.push(eligibleProvider);
+    for (const key of codexProviderIdentityKeys(eligibleProvider)) {
       const existing = previousByIdentity.get(key);
-      if (!existing || timestampMs(provider.updatedAt) >= timestampMs(existing.updatedAt)) previousByIdentity.set(key, provider);
+      if (!existing || providerUpdatedAt >= timestampMs(existing.updatedAt)) previousByIdentity.set(key, eligibleProvider);
     }
   }
 
@@ -416,9 +418,8 @@ function mergeCodexTransientWindows(previousInput, currentInput, nowMs = Date.no
     providers: current.providers.map((provider) => {
       if (provider.provider !== 'codex') return provider;
       const identityKeys = codexProviderIdentityKeys(provider);
-      const identityMatch = identityKeys
-        .map((key) => previousByIdentity.get(key))
-        .find(Boolean);
+      const identityMatches = new Set(identityKeys.map((key) => previousByIdentity.get(key)).filter(Boolean));
+      const identityMatch = identityMatches.size === 1 ? identityMatches.values().next().value : null;
       const previousProvider = identityMatch || (
         CODEX_TRANSIENT_PROVIDER_STATUSES.has(provider.status) && identityKeys.length === 0
           ? singletonFallback

--- a/src/shared/limits.js
+++ b/src/shared/limits.js
@@ -7,6 +7,7 @@ const VALID_SOURCES = new Set(['oauth', 'cli', 'web', 'rpc', 'local', 'api']);
 const VALID_SOURCE_DETAILS = new Set(['app', 'cli', 'managed', 'unknown']);
 const WINDOW_ORDER = ['session', 'weekly', 'billing'];
 const CODEX_TRANSIENT_WINDOW_RETENTION_MS = 10 * 60 * 1000;
+const CODEX_TRANSIENT_PROVIDER_STATUSES = new Set(['unavailable', 'error', 'rateLimited', 'sourceRateLimited']);
 
 function asNumber(value) {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
@@ -351,36 +352,80 @@ function hasProviderWindows(provider) {
   return Array.isArray(provider?.windows) && provider.windows.length > 0;
 }
 
+function cloneLimitWindows(windows) {
+  return (windows || []).map((window) => ({ ...window }));
+}
+
+function retainedCodexProvider(previousProvider, currentProvider, windows) {
+  return {
+    ...previousProvider,
+    ...currentProvider,
+    accountKey: currentProvider.accountKey || previousProvider.accountKey,
+    accountLabel: currentProvider.accountLabel || previousProvider.accountLabel,
+    accountName: currentProvider.accountName || previousProvider.accountName,
+    accountEmail: currentProvider.accountEmail || previousProvider.accountEmail,
+    source: currentProvider.source || previousProvider.source,
+    sourceDetail: currentProvider.sourceDetail || previousProvider.sourceDetail,
+    status: 'ok',
+    updatedAt: previousProvider.updatedAt || currentProvider.updatedAt,
+    windows: cloneLimitWindows(windows),
+    resetCredits: currentProvider.resetCredits || previousProvider.resetCredits
+  };
+}
+
+function mergeCodexProviderSnapshot(previousProvider, currentProvider) {
+  if (CODEX_TRANSIENT_PROVIDER_STATUSES.has(currentProvider.status)) {
+    return retainedCodexProvider(previousProvider, currentProvider, previousProvider.windows);
+  }
+  if (currentProvider.status !== 'ok') return currentProvider;
+  if (!hasProviderWindows(currentProvider)) {
+    return retainedCodexProvider(previousProvider, currentProvider, previousProvider.windows);
+  }
+  // A successful non-empty snapshot is authoritative. Codex can legitimately
+  // change percentages and reset targets after a global reset or reset-credit
+  // action, so quota values are not monotonic client-side invariants.
+  return currentProvider;
+}
+
 function mergeCodexTransientWindows(previousInput, currentInput, nowMs = Date.now(), retentionMs = CODEX_TRANSIENT_WINDOW_RETENTION_MS) {
   const current = normalizeLimitsSummary(currentInput);
   if (!previousInput || !Number.isFinite(Number(retentionMs)) || Number(retentionMs) <= 0) return current;
   const previous = normalizeLimitsSummary(previousInput);
   const currentMs = Number.isFinite(Number(nowMs)) ? Number(nowMs) : Date.now();
   const previousByIdentity = new Map();
+  const eligiblePreviousCodexProviders = [];
 
   for (const provider of previous.providers) {
     if (provider.provider !== 'codex' || provider.status !== 'ok' || !hasProviderWindows(provider)) continue;
     const providerUpdatedAt = timestampMs(provider.updatedAt || previous.updatedAt);
     if (!providerUpdatedAt || currentMs - providerUpdatedAt < 0 || currentMs - providerUpdatedAt > Number(retentionMs)) continue;
+    eligiblePreviousCodexProviders.push(provider);
     for (const key of codexProviderIdentityKeys(provider)) {
       const existing = previousByIdentity.get(key);
       if (!existing || timestampMs(provider.updatedAt) >= timestampMs(existing.updatedAt)) previousByIdentity.set(key, provider);
     }
   }
 
+  const currentCodexProviders = current.providers.filter((provider) => provider.provider === 'codex');
+  const singletonFallback = currentCodexProviders.length === 1 && eligiblePreviousCodexProviders.length === 1
+    ? eligiblePreviousCodexProviders[0]
+    : null;
+
   return {
     ...current,
     providers: current.providers.map((provider) => {
-      if (provider.provider !== 'codex' || provider.status !== 'ok' || hasProviderWindows(provider)) return provider;
-      const previousProvider = codexProviderIdentityKeys(provider)
+      if (provider.provider !== 'codex') return provider;
+      const identityKeys = codexProviderIdentityKeys(provider);
+      const identityMatch = identityKeys
         .map((key) => previousByIdentity.get(key))
         .find(Boolean);
+      const previousProvider = identityMatch || (
+        CODEX_TRANSIENT_PROVIDER_STATUSES.has(provider.status) && identityKeys.length === 0
+          ? singletonFallback
+          : null
+      );
       if (!previousProvider) return provider;
-      return {
-        ...provider,
-        updatedAt: previousProvider.updatedAt || provider.updatedAt,
-        windows: previousProvider.windows.map((window) => ({ ...window }))
-      };
+      return mergeCodexProviderSnapshot(previousProvider, provider);
     })
   };
 }

--- a/tests/electron/cursorSettingsLayout.test.js
+++ b/tests/electron/cursorSettingsLayout.test.js
@@ -416,6 +416,7 @@ test('Codex system account switching is exposed from limits account rows', () =>
   assert.match(refreshBody, /limitProviders: 'codex'/);
   assert.match(refreshBody, /includeLiveCodexAccount: false/);
   assert.match(refreshBody, /codexManagedAccounts: \[account\]/);
+  assert.match(refreshBody, /mergeCodexTransientWindows\(latestStats\?\.limits, summary\)/);
   assert.doesNotMatch(refreshBody, /codexManagedAccountsForCollector\(\)/);
   const renderLimits = functionBody(app, 'renderLimits', 'serviceStatusLabel');
   assert.match(renderLimits, /id === 'codex' \? \{\s*accountTitle: true,\s*allowSystemSwitch: true\s*\} : undefined/s);

--- a/tests/shared/limitCollector.codex.test.js
+++ b/tests/shared/limitCollector.codex.test.js
@@ -173,6 +173,50 @@ test('Codex provider reads quota windows from alternate rate limit ids', () => {
   assert.equal(provider.windows[1].remainingPercent, 75);
 });
 
+test('Codex provider does not guess between conflicting alternate rate limit ids', () => {
+  const snapshots = {
+    'gpt-5.4': {
+      primary: {
+        usedPercent: 1,
+        resetsAt: '2026-06-01T05:00:00Z',
+        windowDurationMins: 300
+      },
+      secondary: {
+        usedPercent: 0,
+        resetsAt: '2026-06-08T00:00:00Z',
+        windowDurationMins: 10080
+      }
+    },
+    'gpt-5.4-mini': {
+      primary: {
+        usedPercent: 100,
+        resetsAt: '2026-06-01T02:00:00Z',
+        windowDurationMins: 300
+      },
+      secondary: {
+        usedPercent: 100,
+        resetsAt: '2026-06-03T00:00:00Z',
+        windowDurationMins: 10080
+      }
+    }
+  };
+
+  for (const entries of [Object.entries(snapshots), Object.entries(snapshots).reverse()]) {
+    const provider = mapCodexRateLimitsToProvider({
+      account: { email: 'user@example.com', planType: 'plus' },
+      rateLimits: { planType: 'plus' },
+      rateLimitsByLimitId: Object.fromEntries(entries)
+    }, {
+      source: 'rpc',
+      sourceDetail: 'app',
+      updatedAt: '2026-06-01T00:00:00Z'
+    });
+
+    assert.equal(provider.status, 'ok');
+    assert.deepEqual(provider.windows, []);
+  }
+});
+
 test('Codex provider keeps successful empty quota reads as ok', () => {
   const provider = mapCodexRateLimitsToProvider({
     account: { email: 'user@example.com', planType: 'plus' },
@@ -342,6 +386,38 @@ test('createLimitsCollector retains recent Codex quota windows across one empty 
 
   assert.equal(first.providers[0].windows.length, 1);
   assert.equal(second.providers[0].windows.length, 1);
+  assert.equal(second.providers[0].windows[0].remainingPercent, 80);
+  assert.equal(second.providers[0].updatedAt, '2026-06-01T00:00:00.000Z');
+});
+
+test('createLimitsCollector retains the only live Codex account across a transient fetch error', async () => {
+  let now = Date.parse('2026-06-01T00:00:00Z');
+  let calls = 0;
+  const collector = createLimitsCollector({
+    limitProviders: 'codex',
+    limitsRefreshMs: 60_000
+  }, {
+    now: () => now,
+    providerFetchers: {
+      codex: async () => {
+        calls += 1;
+        if (calls === 1) {
+          return codexProvider('sha256:codex-live', 'live@example.com', 80, new Date(now).toISOString());
+        }
+        throw Object.assign(new Error('temporary Codex RPC failure'), { status: 'unavailable' });
+      }
+    }
+  });
+
+  const first = await collector.snapshot(true);
+  now = Date.parse('2026-06-01T00:05:00Z');
+  const second = await collector.snapshot(true);
+
+  assert.equal(first.providers[0].windows[0].remainingPercent, 80);
+  assert.equal(second.providers[0].status, 'ok');
+  assert.equal(second.providers[0].accountKey, 'sha256:codex-live');
+  assert.equal(second.providers[0].accountEmail, 'live@example.com');
+  assert.equal(second.providers[0].source, 'rpc');
   assert.equal(second.providers[0].windows[0].remainingPercent, 80);
   assert.equal(second.providers[0].updatedAt, '2026-06-01T00:00:00.000Z');
 });

--- a/tests/shared/limitCollector.codex.test.js
+++ b/tests/shared/limitCollector.codex.test.js
@@ -217,6 +217,68 @@ test('Codex provider does not guess between conflicting alternate rate limit ids
   }
 });
 
+test('Codex provider keeps agreed alternate windows without inheriting conflicting metadata', () => {
+  const window = {
+    usedPercent: 10,
+    resetsAt: '2026-06-01T05:00:00Z',
+    windowDurationMins: 300
+  };
+  const provider = mapCodexRateLimitsToProvider({
+    account: { email: 'user@example.com' },
+    rateLimitsByLimitId: {
+      'gpt-5.4': {
+        planType: 'plus',
+        primary: window,
+        rateLimitResetCredits: { availableCount: 2 }
+      },
+      'gpt-5.4-mini': {
+        planType: 'team',
+        primary: { ...window },
+        rateLimitResetCredits: { availableCount: 3 }
+      }
+    }
+  }, {
+    source: 'rpc',
+    sourceDetail: 'app',
+    updatedAt: '2026-06-01T00:00:00Z'
+  });
+
+  assert.equal(provider.status, 'ok');
+  assert.equal(provider.windows[0].remainingPercent, 90);
+  assert.equal(provider.accountLabel, '');
+  assert.equal(provider.resetCredits, null);
+});
+
+test('Codex provider preserves alternate metadata when every bucket agrees', () => {
+  const window = {
+    usedPercent: 10,
+    resetsAt: '2026-06-01T05:00:00Z',
+    windowDurationMins: 300
+  };
+  const provider = mapCodexRateLimitsToProvider({
+    account: { email: 'user@example.com' },
+    rateLimitsByLimitId: {
+      'gpt-5.4': {
+        planType: 'Plus',
+        primary: window,
+        rateLimitResetCredits: { availableCount: 2 }
+      },
+      'gpt-5.4-mini': {
+        plan_type: 'plus',
+        primary: { ...window },
+        rate_limit_reset_credits: { available_count: 2 }
+      }
+    }
+  }, {
+    source: 'rpc',
+    sourceDetail: 'app',
+    updatedAt: '2026-06-01T00:00:00Z'
+  });
+
+  assert.equal(provider.accountLabel, 'Plus');
+  assert.equal(provider.resetCredits.availableCount, 2);
+});
+
 test('Codex provider keeps successful empty quota reads as ok', () => {
   const provider = mapCodexRateLimitsToProvider({
     account: { email: 'user@example.com', planType: 'plus' },

--- a/tests/shared/limits.test.js
+++ b/tests/shared/limits.test.js
@@ -261,6 +261,117 @@ test('mergeCodexTransientWindows keeps recent Codex windows when the same accoun
   assert.equal(merged.providers[0].updatedAt, '2026-06-14T10:00:00.000Z');
 });
 
+test('mergeCodexTransientWindows keeps recent Codex windows across a transient read error', () => {
+  const previous = {
+    updatedAt: '2026-06-14T10:00:00.000Z',
+    providers: [codexProvider('sha256:codex-a', 'a@example.com', 50, '2026-06-14T10:00:00.000Z')]
+  };
+  const current = {
+    updatedAt: '2026-06-14T10:05:00.000Z',
+    providers: [{
+      ...codexProvider('sha256:codex-a', 'a@example.com', 0, '2026-06-14T10:05:00.000Z'),
+      status: 'unavailable',
+      windows: []
+    }]
+  };
+
+  const merged = mergeCodexTransientWindows(previous, current, Date.parse('2026-06-14T10:05:00.000Z'));
+
+  assert.equal(merged.providers[0].status, 'ok');
+  assert.equal(merged.providers[0].windows[0].remainingPercent, 50);
+  assert.equal(merged.providers[0].updatedAt, '2026-06-14T10:00:00.000Z');
+});
+
+test('mergeCodexTransientWindows does not hide a real Codex sign-out', () => {
+  const previous = {
+    updatedAt: '2026-06-14T10:00:00.000Z',
+    providers: [codexProvider('sha256:codex-a', 'a@example.com', 50, '2026-06-14T10:00:00.000Z')]
+  };
+  const current = {
+    updatedAt: '2026-06-14T10:05:00.000Z',
+    providers: [{
+      ...codexProvider('sha256:codex-a', 'a@example.com', 0, '2026-06-14T10:05:00.000Z'),
+      status: 'notConfigured',
+      windows: []
+    }]
+  };
+
+  const merged = mergeCodexTransientWindows(previous, current, Date.parse('2026-06-14T10:05:00.000Z'));
+
+  assert.equal(merged.providers[0].status, 'notConfigured');
+  assert.deepEqual(merged.providers[0].windows, []);
+  assert.equal(merged.providers[0].updatedAt, '2026-06-14T10:05:00.000Z');
+});
+
+test('mergeCodexTransientWindows accepts a successful quota increase within the same reset window', () => {
+  const previousProvider = codexProvider('sha256:codex-a', 'a@example.com', 99, '2026-06-14T10:00:00.000Z');
+  const currentProvider = codexProvider('sha256:codex-a', 'a@example.com', 100, '2026-06-14T10:05:00.000Z');
+  const merged = mergeCodexTransientWindows(
+    { updatedAt: previousProvider.updatedAt, providers: [previousProvider] },
+    { updatedAt: currentProvider.updatedAt, providers: [currentProvider] },
+    Date.parse('2026-06-14T10:05:00.000Z')
+  );
+
+  assert.equal(merged.providers[0].windows[0].remainingPercent, 100);
+  assert.equal(merged.providers[0].updatedAt, '2026-06-14T10:05:00.000Z');
+});
+
+test('mergeCodexTransientWindows accepts a successful reset-target change before the previous reset', () => {
+  const previousProvider = codexProvider('sha256:codex-a', 'a@example.com', 97, '2026-06-14T10:00:00.000Z');
+  const currentProvider = codexProvider('sha256:codex-a', 'a@example.com', 0, '2026-06-14T10:05:00.000Z');
+  currentProvider.windows[0].resetsAt = '2026-06-14T10:10:00.000Z';
+  const merged = mergeCodexTransientWindows(
+    { updatedAt: previousProvider.updatedAt, providers: [previousProvider] },
+    { updatedAt: currentProvider.updatedAt, providers: [currentProvider] },
+    Date.parse('2026-06-14T10:05:00.000Z')
+  );
+
+  assert.equal(merged.providers[0].windows[0].remainingPercent, 0);
+  assert.equal(merged.providers[0].windows[0].resetsAt, '2026-06-14T10:10:00.000Z');
+  assert.equal(merged.providers[0].updatedAt, '2026-06-14T10:05:00.000Z');
+});
+
+test('mergeCodexTransientWindows does not backfill missing windows into a successful non-empty snapshot', () => {
+  const previousProvider = codexProvider('sha256:codex-a', 'a@example.com', 97, '2026-06-14T10:00:00.000Z');
+  previousProvider.windows.push({
+    kind: 'weekly',
+    usedPercent: 40,
+    remainingPercent: 60,
+    resetsAt: '2026-06-20T00:00:00.000Z',
+    windowMinutes: 10_080
+  });
+  const currentProvider = codexProvider('sha256:codex-a', 'a@example.com', 96, '2026-06-14T10:05:00.000Z');
+  const merged = mergeCodexTransientWindows(
+    { updatedAt: previousProvider.updatedAt, providers: [previousProvider] },
+    { updatedAt: currentProvider.updatedAt, providers: [currentProvider] },
+    Date.parse('2026-06-14T10:05:00.000Z')
+  );
+
+  assert.deepEqual(merged.providers[0].windows.map((window) => window.kind), ['session']);
+  assert.equal(merged.providers[0].windows[0].remainingPercent, 96);
+  assert.equal(merged.providers[0].updatedAt, '2026-06-14T10:05:00.000Z');
+});
+
+test('mergeCodexTransientWindows does not guess an identity when multiple previous Codex accounts are eligible', () => {
+  const previous = {
+    updatedAt: '2026-06-14T10:00:00.000Z',
+    providers: [
+      codexProvider('sha256:codex-a', 'a@example.com', 50, '2026-06-14T10:00:00.000Z'),
+      codexProvider('sha256:codex-b', 'b@example.com', 75, '2026-06-14T10:00:00.000Z')
+    ]
+  };
+  const current = {
+    updatedAt: '2026-06-14T10:05:00.000Z',
+    providers: [{ provider: 'codex', status: 'unavailable', updatedAt: '2026-06-14T10:05:00.000Z', windows: [] }]
+  };
+
+  const merged = mergeCodexTransientWindows(previous, current, Date.parse('2026-06-14T10:05:00.000Z'));
+
+  assert.equal(merged.providers[0].status, 'unavailable');
+  assert.equal(merged.providers[0].accountKey, '');
+  assert.deepEqual(merged.providers[0].windows, []);
+});
+
 test('mergeCodexTransientWindows stops keeping old Codex windows after retention expires', () => {
   const previous = {
     updatedAt: '2026-06-14T10:00:00.000Z',

--- a/tests/shared/limits.test.js
+++ b/tests/shared/limits.test.js
@@ -372,6 +372,63 @@ test('mergeCodexTransientWindows does not guess an identity when multiple previo
   assert.deepEqual(merged.providers[0].windows, []);
 });
 
+test('mergeCodexTransientWindows rejects conflicting account key and email matches', () => {
+  const previous = {
+    updatedAt: '2026-06-14T10:00:00.000Z',
+    providers: [
+      codexProvider('sha256:codex-a', 'a@example.com', 50, '2026-06-14T10:00:00.000Z'),
+      codexProvider('sha256:codex-b', 'b@example.com', 75, '2026-06-14T10:00:00.000Z')
+    ]
+  };
+  const current = {
+    updatedAt: '2026-06-14T10:05:00.000Z',
+    providers: [{
+      ...codexProvider('sha256:codex-a', 'b@example.com', 0, '2026-06-14T10:05:00.000Z'),
+      status: 'unavailable',
+      windows: []
+    }]
+  };
+
+  const merged = mergeCodexTransientWindows(previous, current, Date.parse('2026-06-14T10:05:00.000Z'));
+
+  assert.equal(merged.providers[0].status, 'unavailable');
+  assert.deepEqual(merged.providers[0].windows, []);
+});
+
+test('mergeCodexTransientWindows keeps the effective successful summary timestamp during retention', () => {
+  const previousProvider = codexProvider('sha256:codex-a', 'a@example.com', 50, '');
+  const first = mergeCodexTransientWindows(
+    { updatedAt: '2026-06-14T10:00:00.000Z', providers: [previousProvider] },
+    {
+      updatedAt: '2026-06-14T10:05:00.000Z',
+      providers: [{
+        ...codexProvider('sha256:codex-a', 'a@example.com', 0, '2026-06-14T10:05:00.000Z'),
+        status: 'unavailable',
+        windows: []
+      }]
+    },
+    Date.parse('2026-06-14T10:05:00.000Z')
+  );
+
+  assert.equal(first.providers[0].updatedAt, '2026-06-14T10:00:00.000Z');
+
+  const expired = mergeCodexTransientWindows(
+    first,
+    {
+      updatedAt: '2026-06-14T10:11:00.000Z',
+      providers: [{
+        ...codexProvider('sha256:codex-a', 'a@example.com', 0, '2026-06-14T10:11:00.000Z'),
+        status: 'unavailable',
+        windows: []
+      }]
+    },
+    Date.parse('2026-06-14T10:11:00.000Z')
+  );
+
+  assert.equal(expired.providers[0].status, 'unavailable');
+  assert.deepEqual(expired.providers[0].windows, []);
+});
+
 test('mergeCodexTransientWindows stops keeping old Codex windows after retention expires', () => {
   const previous = {
     updatedAt: '2026-06-14T10:00:00.000Z',

--- a/worker/src/shared/limits.js
+++ b/worker/src/shared/limits.js
@@ -10,6 +10,7 @@ const VALID_SOURCES = new Set(['oauth', 'cli', 'web', 'rpc', 'local', 'api']);
 const VALID_SOURCE_DETAILS = new Set(['app', 'cli', 'managed', 'unknown']);
 const WINDOW_ORDER = ['session', 'weekly', 'billing'];
 const CODEX_TRANSIENT_WINDOW_RETENTION_MS = 10 * 60 * 1000;
+const CODEX_TRANSIENT_PROVIDER_STATUSES = new Set(['unavailable', 'error', 'rateLimited', 'sourceRateLimited']);
 
 function asNumber(value) {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
@@ -354,36 +355,80 @@ function hasProviderWindows(provider) {
   return Array.isArray(provider?.windows) && provider.windows.length > 0;
 }
 
+function cloneLimitWindows(windows) {
+  return (windows || []).map((window) => ({ ...window }));
+}
+
+function retainedCodexProvider(previousProvider, currentProvider, windows) {
+  return {
+    ...previousProvider,
+    ...currentProvider,
+    accountKey: currentProvider.accountKey || previousProvider.accountKey,
+    accountLabel: currentProvider.accountLabel || previousProvider.accountLabel,
+    accountName: currentProvider.accountName || previousProvider.accountName,
+    accountEmail: currentProvider.accountEmail || previousProvider.accountEmail,
+    source: currentProvider.source || previousProvider.source,
+    sourceDetail: currentProvider.sourceDetail || previousProvider.sourceDetail,
+    status: 'ok',
+    updatedAt: previousProvider.updatedAt || currentProvider.updatedAt,
+    windows: cloneLimitWindows(windows),
+    resetCredits: currentProvider.resetCredits || previousProvider.resetCredits
+  };
+}
+
+function mergeCodexProviderSnapshot(previousProvider, currentProvider) {
+  if (CODEX_TRANSIENT_PROVIDER_STATUSES.has(currentProvider.status)) {
+    return retainedCodexProvider(previousProvider, currentProvider, previousProvider.windows);
+  }
+  if (currentProvider.status !== 'ok') return currentProvider;
+  if (!hasProviderWindows(currentProvider)) {
+    return retainedCodexProvider(previousProvider, currentProvider, previousProvider.windows);
+  }
+  // A successful non-empty snapshot is authoritative. Codex can legitimately
+  // change percentages and reset targets after a global reset or reset-credit
+  // action, so quota values are not monotonic client-side invariants.
+  return currentProvider;
+}
+
 function mergeCodexTransientWindows(previousInput, currentInput, nowMs = Date.now(), retentionMs = CODEX_TRANSIENT_WINDOW_RETENTION_MS) {
   const current = normalizeLimitsSummary(currentInput);
   if (!previousInput || !Number.isFinite(Number(retentionMs)) || Number(retentionMs) <= 0) return current;
   const previous = normalizeLimitsSummary(previousInput);
   const currentMs = Number.isFinite(Number(nowMs)) ? Number(nowMs) : Date.now();
   const previousByIdentity = new Map();
+  const eligiblePreviousCodexProviders = [];
 
   for (const provider of previous.providers) {
     if (provider.provider !== 'codex' || provider.status !== 'ok' || !hasProviderWindows(provider)) continue;
     const providerUpdatedAt = timestampMs(provider.updatedAt || previous.updatedAt);
     if (!providerUpdatedAt || currentMs - providerUpdatedAt < 0 || currentMs - providerUpdatedAt > Number(retentionMs)) continue;
+    eligiblePreviousCodexProviders.push(provider);
     for (const key of codexProviderIdentityKeys(provider)) {
       const existing = previousByIdentity.get(key);
       if (!existing || timestampMs(provider.updatedAt) >= timestampMs(existing.updatedAt)) previousByIdentity.set(key, provider);
     }
   }
 
+  const currentCodexProviders = current.providers.filter((provider) => provider.provider === 'codex');
+  const singletonFallback = currentCodexProviders.length === 1 && eligiblePreviousCodexProviders.length === 1
+    ? eligiblePreviousCodexProviders[0]
+    : null;
+
   return {
     ...current,
     providers: current.providers.map((provider) => {
-      if (provider.provider !== 'codex' || provider.status !== 'ok' || hasProviderWindows(provider)) return provider;
-      const previousProvider = codexProviderIdentityKeys(provider)
+      if (provider.provider !== 'codex') return provider;
+      const identityKeys = codexProviderIdentityKeys(provider);
+      const identityMatch = identityKeys
         .map((key) => previousByIdentity.get(key))
         .find(Boolean);
+      const previousProvider = identityMatch || (
+        CODEX_TRANSIENT_PROVIDER_STATUSES.has(provider.status) && identityKeys.length === 0
+          ? singletonFallback
+          : null
+      );
       if (!previousProvider) return provider;
-      return {
-        ...provider,
-        updatedAt: previousProvider.updatedAt || provider.updatedAt,
-        windows: previousProvider.windows.map((window) => ({ ...window }))
-      };
+      return mergeCodexProviderSnapshot(previousProvider, provider);
     })
   };
 }

--- a/worker/src/shared/limits.js
+++ b/worker/src/shared/limits.js
@@ -400,12 +400,14 @@ function mergeCodexTransientWindows(previousInput, currentInput, nowMs = Date.no
 
   for (const provider of previous.providers) {
     if (provider.provider !== 'codex' || provider.status !== 'ok' || !hasProviderWindows(provider)) continue;
-    const providerUpdatedAt = timestampMs(provider.updatedAt || previous.updatedAt);
+    const effectiveUpdatedAt = provider.updatedAt || previous.updatedAt;
+    const providerUpdatedAt = timestampMs(effectiveUpdatedAt);
     if (!providerUpdatedAt || currentMs - providerUpdatedAt < 0 || currentMs - providerUpdatedAt > Number(retentionMs)) continue;
-    eligiblePreviousCodexProviders.push(provider);
-    for (const key of codexProviderIdentityKeys(provider)) {
+    const eligibleProvider = provider.updatedAt ? provider : { ...provider, updatedAt: effectiveUpdatedAt };
+    eligiblePreviousCodexProviders.push(eligibleProvider);
+    for (const key of codexProviderIdentityKeys(eligibleProvider)) {
       const existing = previousByIdentity.get(key);
-      if (!existing || timestampMs(provider.updatedAt) >= timestampMs(existing.updatedAt)) previousByIdentity.set(key, provider);
+      if (!existing || providerUpdatedAt >= timestampMs(existing.updatedAt)) previousByIdentity.set(key, eligibleProvider);
     }
   }
 
@@ -419,9 +421,8 @@ function mergeCodexTransientWindows(previousInput, currentInput, nowMs = Date.no
     providers: current.providers.map((provider) => {
       if (provider.provider !== 'codex') return provider;
       const identityKeys = codexProviderIdentityKeys(provider);
-      const identityMatch = identityKeys
-        .map((key) => previousByIdentity.get(key))
-        .find(Boolean);
+      const identityMatches = new Set(identityKeys.map((key) => previousByIdentity.get(key)).filter(Boolean));
+      const identityMatch = identityMatches.size === 1 ? identityMatches.values().next().value : null;
       const previousProvider = identityMatch || (
         CODEX_TRANSIENT_PROVIDER_STATUSES.has(provider.status) && identityKeys.length === 0
           ? singletonFallback


### PR DESCRIPTION
## Summary

- prefer the canonical Codex quota snapshot and refuse to guess between conflicting alternate rate-limit buckets
- retain recent same-account quota windows only across empty or transient reads, including the identity-less single live-account failure path
- trust successful non-empty snapshots so upstream global resets, reset credits, and reset-time changes appear immediately
- keep account-scoped refreshes merged with the latest limits snapshot and sync the shared behavior to the Worker copy

## Testing

- `node --test tests/shared/limits.test.js tests/shared/limitCollector.codex.test.js`
- `npm run verify` (1069 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Codex quota refreshes by trusting canonical snapshots, validating fallback buckets, and retaining recent windows across transient reads. Prevents flicker and keeps managed-account refreshes consistent across the app and the Worker.

- **Bug Fixes**
  - Validate fallback snapshots: only use alternate limit IDs when their windows match; ignore ordering; keep `planType` and reset-credits only if every alternate agrees; never choose between conflicting alternates.
  - Retain recent Codex windows for up to 10 minutes when the current read is empty or transient (`unavailable`, `error`, `rateLimited`, `sourceRateLimited`), including the single live-account path with no identity; never guess identity when ambiguous.
  - Treat successful non-empty snapshots as authoritative so quota increases and reset-target changes take effect immediately; do not backfill older windows into them.
  - Apply `mergeCodexTransientWindows` in managed account refreshes and mirror the same logic in the Worker to keep behavior consistent (including stable timestamps during retention).

<sup>Written for commit bc62ae2479b35063acf608bae61e0defc4900c54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

