### PR TITLE
fix(renderer): fit total tokens to width instead of clipping

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -451,22 +451,36 @@ function formatCompact(value) {
 }
 function updateTotalCompact(value) {
   if (!els.totalTokensCompact) return;
-  if (state.settings?.showCompactTotalTokens !== true) {
-    hideTotalCompact();
-    return;
-  }
   const num = Math.round(Number(value || 0));
-  if (Math.abs(num) < 1000) {
+  if (state.settings?.showCompactTotalTokens !== true || Math.abs(num) < 1000) {
     hideTotalCompact();
-    return;
+  } else {
+    els.totalTokensCompact.textContent = `≈ ${formatCompact(num)}`;
+    els.totalTokensCompact.classList.remove('hidden');
   }
-  els.totalTokensCompact.textContent = `≈ ${formatCompact(num)}`;
-  els.totalTokensCompact.classList.remove('hidden');
+  fitTotalNumber();
 }
 function hideTotalCompact() {
   if (!els.totalTokensCompact) return;
   els.totalTokensCompact.textContent = '';
   els.totalTokensCompact.classList.add('hidden');
+}
+// Scale the exact total to fit the width it is actually given instead of clipping
+// it to an ellipsis. The compact chip (when shown) is flex:0 0 auto and claims its
+// width first, so the number's clientWidth is its allotted box while scrollWidth is
+// its natural width; the ratio is how far the font must shrink to stay whole.
+function totalNumberFontScale(availableWidth, naturalWidth, minScale = 0.5) {
+  if (!(naturalWidth > 0) || !(availableWidth > 0)) return 1;
+  return Math.min(1, Math.max(minScale, availableWidth / naturalWidth));
+}
+function fitTotalNumber() {
+  const el = els.totalTokens;
+  if (!el) return;
+  el.style.fontSize = '';
+  const base = parseFloat(getComputedStyle(el).fontSize);
+  if (!(base > 0)) return;
+  const scale = totalNumberFontScale(el.clientWidth, el.scrollWidth);
+  if (scale < 1) el.style.fontSize = `${Math.floor(base * scale)}px`;
 }
 function trendShortLabel(label, labelKey) {
   const value = String(label || '');
@@ -3197,8 +3211,11 @@ function render() {
     updateTotalCompact(nextTotal);
     state.suppressInitialNumberAnimation = false;
   } else if (totalChanged) {
-    hideTotalCompact();
-    animateNumber(els.totalTokens, state.currentTotal, nextTotal, 2200, () => updateTotalCompact(nextTotal));
+    // Keep the compact chip visible through the count-up and lock the font to the
+    // settled width first, so the number neither vanishes nor resizes mid-roll.
+    els.totalTokens.textContent = formatNumber(nextTotal);
+    updateTotalCompact(nextTotal);
+    animateNumber(els.totalTokens, state.currentTotal, nextTotal, 2200);
     pulseLiveDot();
   } else {
     cancelNumberAnimation();
@@ -5661,6 +5678,7 @@ els.showCompactTotalTokensInput.addEventListener('change', async () => {
   await saveAppearanceFromControls();
   if (!numberAnimHandle) updateTotalCompact(state.currentTotal);
 });
+window.addEventListener('resize', () => { if (!numberAnimHandle) fitTotalNumber(); });
 els.settingsInTitlebarInput.addEventListener('change', saveAppearanceFromControls);
 els.discordRpcInput.addEventListener('change', saveAppearanceFromControls);
 els.windowBehaviorInput.addEventListener('change', () => saveSettings({ windowBehavior: els.windowBehaviorInput.value }));

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -3212,10 +3212,13 @@ function render() {
     state.suppressInitialNumberAnimation = false;
   } else if (totalChanged) {
     // Keep the compact chip visible through the count-up and lock the font to the
-    // settled width first, so the number neither vanishes nor resizes mid-roll.
-    els.totalTokens.textContent = formatNumber(nextTotal);
+    // widest endpoint first (a downward roll starts wider than it settles), so the
+    // number never vanishes, clips, or resizes mid-roll. Re-fit on completion so a
+    // window resize during the animation, or a downward settle, still ends correct.
+    const widest = formatNumber(nextTotal).length >= formatNumber(state.currentTotal).length ? nextTotal : state.currentTotal;
+    els.totalTokens.textContent = formatNumber(widest);
     updateTotalCompact(nextTotal);
-    animateNumber(els.totalTokens, state.currentTotal, nextTotal, 2200);
+    animateNumber(els.totalTokens, state.currentTotal, nextTotal, 2200, fitTotalNumber);
     pulseLiveDot();
   } else {
     cancelNumberAnimation();

--- a/src/electron/renderer/styles.css
+++ b/src/electron/renderer/styles.css
@@ -1606,6 +1606,9 @@ body.floating-bubble-collapsed-right .floating-bubble-tab {
   font-weight: 500;
   font-size: clamp(30px, 11vw, 46px);
   line-height: 1.05;
+  /* Equal-width digits so the counting animation does not wobble the number's
+     width (and shove the compact chip) frame to frame. */
+  font-variant-numeric: tabular-nums;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/tests/electron/totalTokenCompact.test.js
+++ b/tests/electron/totalTokenCompact.test.js
@@ -52,9 +52,10 @@ test('compact total is an opt-in appearance preference', () => {
 });
 
 test('compact total stays visible through the count-up, with the font pre-locked', () => {
-  // The final chip is shown and the font fitted before the roll starts, so the
-  // number does not vanish or resize mid-animation.
-  assert.match(app, /els\.totalTokens\.textContent = formatNumber\(nextTotal\);\s*updateTotalCompact\(nextTotal\);\s*animateNumber\(els\.totalTokens, state\.currentTotal, nextTotal, 2200\);/s);
+  // The font is fitted to the widest endpoint before the roll starts, so the number
+  // does not vanish, clip, or resize mid-animation in either direction.
+  assert.match(app, /const widest = formatNumber\(nextTotal\)\.length >= formatNumber\(state\.currentTotal\)\.length \? nextTotal : state\.currentTotal;/);
+  assert.match(app, /els\.totalTokens\.textContent = formatNumber\(widest\);\s*updateTotalCompact\(nextTotal\);\s*animateNumber\(els\.totalTokens, state\.currentTotal, nextTotal, 2200, fitTotalNumber\);/s);
   // animateNumber must not reset the font, or the pre-locked size would be lost.
   const animateBody = app.slice(app.indexOf('function animateNumber('), app.indexOf('function rowWidth('));
   assert.doesNotMatch(animateBody, /style\.fontSize/);

--- a/tests/electron/totalTokenCompact.test.js
+++ b/tests/electron/totalTokenCompact.test.js
@@ -51,6 +51,42 @@ test('compact total is an opt-in appearance preference', () => {
   assert.match(app, /state\.settings\?\.showCompactTotalTokens !== true[\s\S]*?hideTotalCompact\(\)/);
 });
 
-test('compact total appears after the exact total finishes animating', () => {
-  assert.match(app, /hideTotalCompact\(\);\s*animateNumber\([^;]+\(\) => updateTotalCompact\(nextTotal\)\)/s);
+test('compact total stays visible through the count-up, with the font pre-locked', () => {
+  // The final chip is shown and the font fitted before the roll starts, so the
+  // number does not vanish or resize mid-animation.
+  assert.match(app, /els\.totalTokens\.textContent = formatNumber\(nextTotal\);\s*updateTotalCompact\(nextTotal\);\s*animateNumber\(els\.totalTokens, state\.currentTotal, nextTotal, 2200\);/s);
+  // animateNumber must not reset the font, or the pre-locked size would be lost.
+  const animateBody = app.slice(app.indexOf('function animateNumber('), app.indexOf('function rowWidth('));
+  assert.doesNotMatch(animateBody, /style\.fontSize/);
+  // Tabular figures keep the number's width constant as it counts, so the chip
+  // beside it does not jitter.
+  assert.match(css, /\.total-number\s*\{[^}]*font-variant-numeric:\s*tabular-nums/s);
+});
+
+test('total number font scale shrinks to fit instead of clipping', () => {
+  const totalNumberFontScale = rendererFunction('totalNumberFontScale', 'fitTotalNumber');
+  // Fits: never scale up past the base font size.
+  assert.equal(totalNumberFontScale(200, 150), 1);
+  assert.equal(totalNumberFontScale(200, 200), 1);
+  // Overflows: shrink by the available/natural ratio.
+  assert.equal(totalNumberFontScale(150, 200), 0.75);
+  // Extreme overflow clamps at the minimum scale (ellipsis is the last resort).
+  assert.equal(totalNumberFontScale(50, 200), 0.5);
+  assert.equal(totalNumberFontScale(50, 200, 0.4), 0.4);
+  // Missing measurements are a no-op.
+  assert.equal(totalNumberFontScale(0, 200), 1);
+  assert.equal(totalNumberFontScale(200, 0), 1);
+});
+
+test('exact total is fitted to width, not left to clip', () => {
+  // updateTotalCompact always re-fits the number after toggling the chip.
+  assert.match(app, /els\.totalTokensCompact\.classList\.remove\('hidden'\);\s*\}\s*fitTotalNumber\(\);/s);
+  // fitTotalNumber measures the allotted vs natural width and scales the font.
+  assert.match(app, /function fitTotalNumber\(\)[\s\S]*?getComputedStyle\(el\)\.fontSize/);
+  assert.match(app, /totalNumberFontScale\(el\.clientWidth, el\.scrollWidth\)/);
+  assert.match(app, /el\.style\.fontSize = `\$\{Math\.floor\(base \* scale\)\}px`/);
+  // Resize re-fits the settled number.
+  assert.match(app, /window\.addEventListener\('resize',[\s\S]*?fitTotalNumber\(\)/);
+  // Ellipsis is kept only as the last-resort fallback.
+  assert.match(css, /\.total-number\s*\{[^}]*text-overflow:\s*ellipsis/s);
 });


### PR DESCRIPTION
## Summary

Make the hero total token number adapt its size to the width it is given instead of clipping to an ellipsis.

- Scale the font down to fit the number's allotted width (`fitTotalNumber` + a pure `totalNumberFontScale` helper), so the exact total is never cut to `5,088,652,0...`. Ellipsis is kept only as a last-resort fallback for extreme lengths.
- Keep the compact `≈ 5B` chip visible through the count-up and pre-lock the font to the settled width before animating, so the number no longer vanishes and then resizes when the animation finishes.
- Use tabular figures on the total so the counting animation does not wobble the number's width (and shove the chip) frame to frame.

## Why

This is a pre-existing rendering bug, not something the compact total introduced. `.total-number` has always used a fixed font size plus `overflow: hidden; text-overflow: ellipsis`, so a long enough total was clipped regardless. The compact approximation shares that row, so it just surfaced the clip sooner by claiming part of the width (see #114). The fix addresses the root cause and also cleans up the animation now that the number resizes.

## Verification

- `npm run verify` (lint + 1061 tests, including new coverage for the scale math and the render wiring).
- Checked in the widget on a 5B+ total: toggling the compact total and switching between DAY / MONTH / TOTAL, the exact number fits without an ellipsis, the chip stays put through the count-up, and neither the number nor the chip jitters.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The “Total tokens” number now scales to its available width instead of clipping. The compact “≈ 5B” chip stays visible during the count-up, with the font locked to the widest frame to avoid mid-animation clipping or jitter.

- **Bug Fixes**
  - Fit the exact total’s font to its allotted width; ellipsis only as a last resort.
  - Keep the compact chip visible during the roll; pre-lock to the wider of the two endpoints and re-fit on completion.
  - Use tabular figures to stop digit-width wobble and re-fit on window resize.

<sup>Written for commit 6a7e073c22230a1e0d6ed13b45166bddbf329113. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

