### PR TITLE
fix(sync): bound usage payloads and return 413

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -192,7 +192,7 @@ Response includes:
 - `periods.month`
 - `periods.allTime`
 - `periods.*.clientModels` and `periods.*.clientModelCosts` for preserving model breakdowns when a tracked tool is disabled
-- `periods.*.sessions` keyed by `client:sessionId` for session-level usage when tokscale exposes session groups; widgets may use `lastUsedAt` for recent-first sorting when present
+- `periods.today.sessions` / `periods.month.sessions` keyed by `client:sessionId` for session-level usage when tokscale exposes session groups; synchronized clients omit the unbounded `allTime.sessions` collection while preserving all aggregate totals and breakdowns
 - `historyPreview.daily[].activeTimeMs`, `historyPreview.monthly[].activeTimeMs`, and `historyPreview.summary.activeTimeMs` when tokscale graph exposes session active-time metrics
 - `limits.providers` aggregated by provider account
 - `devices`

--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -7,7 +7,7 @@ const { appVersion } = require('../shared/appVersion');
 const { clientsCsvForSetting } = require('../shared/clientTracking');
 const { collectUsageOnce, normalizeHistoryIntervalMs, startCollector } = require('../shared/collector');
 const { normalizeLimitsRefreshMs, parseBoolean, parseLimitProviders } = require('../shared/limitCollector');
-const { syncLimits } = require('../shared/limits');
+const { syncPayload } = require('../shared/syncPayload');
 
 loadDotEnv();
 const args = parseArgs(process.argv.slice(2));
@@ -32,11 +32,10 @@ const dryRun = Boolean(args['dry-run'] || args.dryRun);
 const collectorOptions = { clients, allTimeSince, commandTimeoutMs, deviceId, agentVersion: appVersion(), agentRuntime: 'headless-agent', historyEnabled, historyIntervalMs: normalizeHistoryIntervalMs(process.env.TOKEN_MONITOR_HISTORY_INTERVAL_MS), limitsEnabled, limitProviders, limitsRefreshMs, wslScanEnabled, opencodeCookie };
 
 async function postUsage(summary) {
-  const payload = { ...summary, limits: syncLimits(summary.limits) };
   const response = await fetch(`${hubUrl}/api/ingest`, {
     method: 'POST',
     headers: { 'content-type': 'application/json', ...(secret ? { authorization: `Bearer ${secret}` } : {}) },
-    body: JSON.stringify(payload)
+    body: JSON.stringify(syncPayload(summary))
   });
   if (!response.ok) throw new Error(`Hub responded ${response.status}: ${(await response.text()).slice(0, 300)}`);
   return response.json();

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -73,7 +73,7 @@ const {
   pruneArchivedClientUsage
 } = require('../shared/clientUsageArchive');
 const { aggregateDevices, aggregateHistory, carryDeviceHistory } = require('../shared/usage');
-const { syncLimits } = require('../shared/limits');
+const { syncPayload } = require('../shared/syncPayload');
 const { historyPreview } = require('../shared/history');
 const { readSessionDetail } = require('../shared/sessionDetail');
 const { startDiscordRpc, stopDiscordRpc, updateDiscordRpc } = require('./discordRpc');
@@ -1499,7 +1499,7 @@ async function postToHub(summary) {
   const response = await fetch(url, {
     method: 'POST',
     headers: { 'content-type': 'application/json', ...(secret ? { authorization: `Bearer ${secret}` } : {}) },
-    body: JSON.stringify({ ...summary, limits: syncLimits(summary.limits) })
+    body: JSON.stringify(syncPayload(summary))
   });
   if (!response.ok) throw new Error(`Hub ${response.status}: ${(await response.text()).slice(0, 200)}`);
   if (settings.lastPostedDeviceId !== summary.deviceId) {
@@ -1615,7 +1615,7 @@ function startHostCollector() {
         if (stale && stale !== visibleSummary.deviceId) {
           embeddedHub.hub.deleteDevice(stale);
         }
-        embeddedHub.hub.ingest({ ...visibleSummary, limits: syncLimits(visibleSummary.limits) });
+        embeddedHub.hub.ingest(syncPayload(visibleSummary));
         if (settings.lastPostedDeviceId !== visibleSummary.deviceId) {
           settings.lastPostedDeviceId = visibleSummary.deviceId;
           saveSettings();

--- a/src/hub/server.js
+++ b/src/hub/server.js
@@ -138,6 +138,7 @@ function createHub({
         return sendJson(res, 200, { ok: true, deviceId: record.deviceId, stats: getStats() });
       } catch (error) {
         if (error.message === 'deviceId_required') return sendJson(res, 400, { error: 'deviceId_required' });
+        if (error.code === 'payload_too_large') return sendJson(res, 413, { error: 'payload_too_large', message: error.message });
         return sendJson(res, 400, { error: 'bad_request', message: error.message });
       }
     }

--- a/src/shared/http.js
+++ b/src/shared/http.js
@@ -30,15 +30,24 @@ function sendText(res, statusCode, body, contentType = 'text/plain; charset=utf-
 function readJsonBody(req, maxBytes = 1024 * 256) {
   return new Promise((resolve, reject) => {
     let body = '';
+    let bytes = 0;
+    let tooLarge = false;
     req.setEncoding('utf8');
     req.on('data', (chunk) => {
-      body += chunk;
-      if (body.length > maxBytes) {
-        reject(new Error('Request body too large'));
-        req.destroy();
+      if (tooLarge) return;
+      bytes += Buffer.byteLength(chunk, 'utf8');
+      if (bytes > maxBytes) {
+        tooLarge = true;
+        body = '';
+        const error = new Error('Request body too large');
+        error.code = 'payload_too_large';
+        reject(error);
+        return;
       }
+      body += chunk;
     });
     req.on('end', () => {
+      if (tooLarge) return;
       if (!body.trim()) return resolve({});
       try { resolve(JSON.parse(body)); }
       catch (error) { reject(new Error(`Invalid JSON body: ${error.message}`)); }

--- a/src/shared/syncPayload.js
+++ b/src/shared/syncPayload.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const { syncLimits } = require('./limits');
+
+function syncPayload(summary) {
+  if (!summary || typeof summary !== 'object') return summary;
+  const payload = { ...summary, limits: syncLimits(summary.limits) };
+  if (summary.allTime && typeof summary.allTime === 'object') {
+    payload.allTime = { ...summary.allTime };
+    delete payload.allTime.sessions;
+  }
+  return payload;
+}
+
+module.exports = { syncPayload };

--- a/tests/hub/server.test.js
+++ b/tests/hub/server.test.js
@@ -84,3 +84,27 @@ test('onStats fires on ingest and on deleteDevice, and unsubscribe stops it', ()
     fs.rmSync(dataFile, { force: true });
   }
 });
+
+test('oversized ingest returns 413 without storing the device', async () => {
+  const dataFile = tempDataFile();
+  const hub = createHub({ port: 0, host: '127.0.0.1', secret: '', dataFile, logger: { error() {} } });
+  await hub.start();
+  try {
+    const { port } = hub.server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/ingest`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ deviceId: 'oversized', padding: '🚀'.repeat(70_000) })
+    });
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(await response.json(), {
+      error: 'payload_too_large',
+      message: 'Request body too large'
+    });
+    assert.equal(hub.getStats().devices.length, 0);
+  } finally {
+    await hub.stop();
+    fs.rmSync(dataFile, { force: true });
+  }
+});

--- a/tests/shared/syncPayload.test.js
+++ b/tests/shared/syncPayload.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { syncPayload } = require('../../src/shared/syncPayload');
+
+test('syncPayload bounds uploads by omitting all-time sessions', () => {
+  const summary = {
+    deviceId: 'dev-a',
+    today: { totalTokens: 10, sessions: { today: { totalTokens: 10 } } },
+    month: { totalTokens: 20, sessions: { month: { totalTokens: 20 } } },
+    allTime: {
+      totalTokens: 30,
+      clients: { claude: 30 },
+      models: { opus: 30 },
+      sessions: { old: { totalTokens: 30 } }
+    },
+    history: { daily: [{ date: '2026-07-11', totalTokens: 10 }] },
+    limits: { providers: [] }
+  };
+
+  const payload = syncPayload(summary);
+
+  assert.equal(Object.hasOwn(payload.allTime, 'sessions'), false);
+  assert.deepEqual(payload.today, summary.today);
+  assert.deepEqual(payload.month, summary.month);
+  assert.deepEqual(payload.allTime.clients, summary.allTime.clients);
+  assert.deepEqual(payload.allTime.models, summary.allTime.models);
+  assert.deepEqual(payload.history, summary.history);
+  assert.equal(summary.allTime.sessions.old.totalTokens, 30);
+});


### PR DESCRIPTION
## Summary

- keep synchronized usage payloads bounded by omitting the continuously growing `allTime.sessions` collection while preserving DAY, MONTH, and TOTAL aggregates and today/month session summaries
- share the same payload shaping between the widget, embedded host, and headless agent
- return a structured HTTP 413 response for oversized embedded-hub requests instead of destroying the connection
- count request limits in UTF-8 bytes and cover the payload boundary with regression tests

Closes #118

## Verification

- `npm run verify` (1077 tests passed)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound usage sync payloads by omitting unbounded all-time session lists while keeping daily/month aggregates intact and unifying payload shaping across the widget, embedded host, and headless agent. The hub now returns a structured 413 JSON error for oversized requests using UTF-8 byte counting, avoiding connection drops.

- **Bug Fixes**
  - Omit `allTime.sessions` from synchronized payloads; keep aggregates and today/month session summaries.
  - Use a shared `syncPayload` across widget, embedded host, and headless agent.
  - Return 413 with `{ error: 'payload_too_large', message: 'Request body too large' }` instead of destroying the connection.
  - Enforce request size in UTF-8 bytes; added regression tests and updated API docs.

<sup>Written for commit 4a07a2ef60232bdaa98f5a52ac0b4d5083a484f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

