### PR TITLE
fix(limits): stabilize cross-device Codex quota

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -198,7 +198,7 @@ Response includes:
 - `devices`
 - stale status for devices that have not reported recently
 
-If multiple devices report the same provider account, the hub normally keeps the freshest valid limits status for that account. Codex is the exception: simultaneous app sessions can report different active quota buckets for the same account, so the hub keeps the tightest whole snapshot within a reset generation. When comparable reset anchors advance together, the newer generation wins immediately, including after an upstream reset or reset-credit action. Public Worker stats omit account identifiers.
+If multiple devices report the same provider account, the hub normally keeps the freshest valid limits status for that account. Codex is the exception: simultaneous app sessions can report different active quota buckets for the same account, so the hub keeps the tightest whole snapshot within a reset generation. When at least one comparable reset anchor advances and none regress, the newer generation wins immediately, including after an upstream reset or reset-credit action. Public Worker stats omit account identifiers.
 
 ## `GET /api/devices`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -198,7 +198,7 @@ Response includes:
 - `devices`
 - stale status for devices that have not reported recently
 
-If multiple devices report the same provider account, the hub keeps the freshest valid limits status for that account. Public Worker stats omit account identifiers.
+If multiple devices report the same provider account, the hub normally keeps the freshest valid limits status for that account. Codex is the exception: simultaneous app sessions can report different active quota buckets for the same account, so the hub keeps the tightest whole snapshot within a reset generation. When comparable reset anchors advance together, the newer generation wins immediately, including after an upstream reset or reset-credit action. Public Worker stats omit account identifiers.
 
 ## `GET /api/devices`
 

--- a/src/shared/limits.js
+++ b/src/shared/limits.js
@@ -345,11 +345,10 @@ function providerWindowRank(provider, nowMs) {
   return Array.isArray(provider.windows) && provider.windows.some((window) => activeLimitWindow(window, nowMs)) ? 1 : 0;
 }
 
-function codexResetGeneration(provider, nowMs) {
+function codexResetGeneration(provider) {
   if (provider?.provider !== 'codex' || !Array.isArray(provider.windows)) return null;
   const generation = new Map();
   for (const window of provider.windows) {
-    if (!activeLimitWindow(window, nowMs)) continue;
     const resetMs = timestampMs(window.resetsAt);
     if (!resetMs) continue;
     const key = `${window.kind}:${window.label || ''}`;
@@ -358,19 +357,21 @@ function codexResetGeneration(provider, nowMs) {
   return generation.size > 0 ? generation : null;
 }
 
-function compareCodexResetGeneration(first, second, nowMs) {
-  const firstGeneration = codexResetGeneration(first, nowMs);
-  const secondGeneration = codexResetGeneration(second, nowMs);
-  if (!firstGeneration || !secondGeneration || firstGeneration.size !== secondGeneration.size) return 0;
+function compareCodexResetGeneration(first, second) {
+  const firstGeneration = codexResetGeneration(first);
+  const secondGeneration = codexResetGeneration(second);
+  if (!firstGeneration || !secondGeneration) return 0;
   let direction = 0;
+  let comparable = 0;
   for (const [key, firstReset] of firstGeneration) {
     const secondReset = secondGeneration.get(key);
-    if (!secondReset) return 0;
+    if (!secondReset) continue;
+    comparable += 1;
     const nextDirection = firstReset > secondReset ? 1 : (firstReset < secondReset ? -1 : 0);
     if (nextDirection && direction && nextDirection !== direction) return 0;
     if (nextDirection) direction = nextDirection;
   }
-  return direction;
+  return comparable > 0 ? direction : 0;
 }
 
 function codexQuotaPressure(provider, nowMs) {
@@ -403,6 +404,14 @@ function compareQuotaPressure(first, second) {
     if (firstValue > secondValue) return 1;
   }
   return 0;
+}
+
+function stableProviderTieBreak(current, candidate) {
+  const timestampDiff = timestampMs(candidate.updatedAt) - timestampMs(current.updatedAt);
+  if (timestampDiff !== 0) return timestampDiff > 0 ? candidate : current;
+  const deviceDiff = String(candidate.sourceDeviceId || '').localeCompare(String(current.sourceDeviceId || ''));
+  if (deviceDiff !== 0) return deviceDiff < 0 ? candidate : current;
+  return JSON.stringify(candidate).localeCompare(JSON.stringify(current)) < 0 ? candidate : current;
 }
 
 function codexProviderIdentityKeys(provider) {
@@ -507,16 +516,6 @@ function pickBetterProvider(current, candidate, nowMs = Date.now()) {
     && candidate.provider === 'codex'
     && current.accountKey
     && current.accountKey === candidate.accountKey) {
-    // A complete move of comparable reset anchors is a new quota generation,
-    // including an upstream reset or reset-credit action observed on one device
-    // first. It outranks an older, tighter snapshot before that snapshot expires.
-    // Reset-credit counts are deliberately not evidence: unused credits expire.
-    const generationDiff = compareCodexResetGeneration(candidate, current, nowMs);
-    if (generationDiff !== 0) return generationDiff > 0 ? candidate : current;
-
-    // Concurrent devices can otherwise expose different successful buckets for
-    // the same generation. Keep the tightest whole snapshot deterministically
-    // instead of oscillating with whichever device reported most recently.
     const currentPressure = codexQuotaPressure(current, nowMs);
     const candidatePressure = codexQuotaPressure(candidate, nowMs);
     if (currentPressure !== null && candidatePressure !== null) {
@@ -524,7 +523,34 @@ function pickBetterProvider(current, candidate, nowMs = Date.now()) {
       if (pressureDiff !== 0) return pressureDiff < 0 ? candidate : current;
     }
   }
-  return timestampMs(candidate.updatedAt) >= timestampMs(current.updatedAt) ? candidate : current;
+  return stableProviderTieBreak(current, candidate);
+}
+
+function filterMaxRank(candidates, rank) {
+  const maximum = Math.max(...candidates.map(rank));
+  return candidates.filter((candidate) => rank(candidate) === maximum);
+}
+
+function pickBestProvider(candidates, nowMs) {
+  if (candidates.length === 1) return candidates[0];
+  let eligible = filterMaxRank(candidates, (candidate) => candidate.stale ? 0 : 1);
+  eligible = filterMaxRank(eligible, (candidate) => statusRank(candidate.status));
+  eligible = filterMaxRank(eligible, (candidate) => providerWindowRank(candidate, nowMs));
+
+  const first = eligible[0];
+  if (first?.provider === 'codex' && first.accountKey
+    && eligible.every((candidate) => candidate.accountKey === first.accountKey)) {
+    // Generation precedence is a group decision, not a pairwise reduce: mixed
+    // reset anchors can make pairwise generation/pressure comparisons
+    // non-transitive. Remove every snapshot dominated by any newer comparable
+    // generation, then apply quota pressure only to the remaining frontier.
+    const generationFrontier = eligible.filter((candidate) => !eligible.some((other) => (
+      other !== candidate && compareCodexResetGeneration(other, candidate) > 0
+    )));
+    if (generationFrontier.length > 0) eligible = generationFrontier;
+  }
+
+  return eligible.reduce((best, candidate) => pickBetterProvider(best, candidate, nowMs), null);
 }
 
 function aggregateLimits(devices, staleAfterMs = 0, nowMs = Date.now()) {
@@ -548,16 +574,20 @@ function aggregateLimits(devices, staleAfterMs = 0, nowMs = Date.now()) {
         if (isConfiguredProvider(provider)) providersWithFreshConfiguredAccounts.add(provider.provider);
       }
       const key = providerAggregateKey(provider);
-      byKey.set(key, pickBetterProvider(byKey.get(key), candidate, nowMs));
+      const candidates = byKey.get(key) || [];
+      candidates.push(candidate);
+      byKey.set(key, candidates);
     }
   }
+
+  const selectedByKey = Array.from(byKey.values(), (candidates) => pickBestProvider(candidates, nowMs));
 
   // Second pass: collapse by provider name. Same OAuth account on Mac vs Windows
   // hashes to different accountKeys (keychain identity vs file path), so byKey
   // keeps them as separate entries; without this pass the renderer's per-provider
   // Map.set() would arbitrarily overwrite the fresh one with the stale one.
   const byProvider = new Map();
-  for (const candidate of byKey.values()) {
+  for (const candidate of selectedByKey) {
     const hasFreshObservation = providersWithFreshObservations.has(candidate.provider);
     if (candidate.stale && hasFreshObservation) continue;
     const configuredProviders = hasFreshObservation

--- a/src/shared/limits.js
+++ b/src/shared/limits.js
@@ -357,7 +357,7 @@ function codexResetGeneration(provider) {
   return generation.size > 0 ? generation : null;
 }
 
-function compareCodexResetGeneration(first, second) {
+function compareCodexResetGeneration(first, second, nowMs) {
   const firstGeneration = codexResetGeneration(first);
   const secondGeneration = codexResetGeneration(second);
   if (!firstGeneration || !secondGeneration) return 0;
@@ -366,6 +366,7 @@ function compareCodexResetGeneration(first, second) {
   for (const [key, firstReset] of firstGeneration) {
     const secondReset = secondGeneration.get(key);
     if (!secondReset) continue;
+    if (firstReset <= nowMs && secondReset <= nowMs) continue;
     comparable += 1;
     const nextDirection = firstReset > secondReset ? 1 : (firstReset < secondReset ? -1 : 0);
     if (nextDirection && direction && nextDirection !== direction) return 0;
@@ -553,7 +554,7 @@ function pickBestProvider(candidates, nowMs) {
     // non-transitive. Remove every snapshot dominated by any newer comparable
     // generation, then apply quota pressure only to the remaining frontier.
     const generationFrontier = eligible.filter((candidate) => !eligible.some((other) => (
-      other !== candidate && compareCodexResetGeneration(other, candidate) > 0
+      other !== candidate && compareCodexResetGeneration(other, candidate, nowMs) > 0
     )));
     if (generationFrontier.length > 0) eligible = generationFrontier;
   }

--- a/src/shared/limits.js
+++ b/src/shared/limits.js
@@ -335,9 +335,74 @@ function providerCollapseKey(provider) {
   return provider.provider;
 }
 
-function providerWindowRank(provider) {
+function activeLimitWindow(window, nowMs) {
+  const resetMs = timestampMs(window?.resetsAt);
+  return !resetMs || resetMs > nowMs;
+}
+
+function providerWindowRank(provider, nowMs) {
   if (provider?.provider !== 'codex') return 0;
-  return Array.isArray(provider.windows) && provider.windows.length > 0 ? 1 : 0;
+  return Array.isArray(provider.windows) && provider.windows.some((window) => activeLimitWindow(window, nowMs)) ? 1 : 0;
+}
+
+function codexResetGeneration(provider, nowMs) {
+  if (provider?.provider !== 'codex' || !Array.isArray(provider.windows)) return null;
+  const generation = new Map();
+  for (const window of provider.windows) {
+    if (!activeLimitWindow(window, nowMs)) continue;
+    const resetMs = timestampMs(window.resetsAt);
+    if (!resetMs) continue;
+    const key = `${window.kind}:${window.label || ''}`;
+    generation.set(key, Math.max(generation.get(key) || 0, resetMs));
+  }
+  return generation.size > 0 ? generation : null;
+}
+
+function compareCodexResetGeneration(first, second, nowMs) {
+  const firstGeneration = codexResetGeneration(first, nowMs);
+  const secondGeneration = codexResetGeneration(second, nowMs);
+  if (!firstGeneration || !secondGeneration || firstGeneration.size !== secondGeneration.size) return 0;
+  let direction = 0;
+  for (const [key, firstReset] of firstGeneration) {
+    const secondReset = secondGeneration.get(key);
+    if (!secondReset) return 0;
+    const nextDirection = firstReset > secondReset ? 1 : (firstReset < secondReset ? -1 : 0);
+    if (nextDirection && direction && nextDirection !== direction) return 0;
+    if (nextDirection) direction = nextDirection;
+  }
+  return direction;
+}
+
+function codexQuotaPressure(provider, nowMs) {
+  if (provider?.provider !== 'codex' || !Array.isArray(provider.windows)) return null;
+  const activeWindows = provider.windows
+    .filter((window) => activeLimitWindow(window, nowMs))
+    .map((window) => ({
+      kind: window.kind,
+      remaining: numberOrNull(window.remainingPercent),
+      resetMs: timestampMs(window.resetsAt) || Number.POSITIVE_INFINITY
+    }))
+    .filter((window) => window.remaining !== null);
+  if (activeWindows.length === 0) return null;
+  const remainingForKind = (kind) => {
+    const values = activeWindows.filter((window) => window.kind === kind).map((window) => window.remaining);
+    return values.length > 0 ? Math.min(...values) : 101;
+  };
+  return [
+    Math.min(...activeWindows.map((window) => window.remaining)),
+    ...WINDOW_ORDER.map(remainingForKind),
+    Math.min(...activeWindows.map((window) => window.resetMs))
+  ];
+}
+
+function compareQuotaPressure(first, second) {
+  for (let index = 0; index < Math.max(first.length, second.length); index += 1) {
+    const firstValue = first[index] ?? Number.POSITIVE_INFINITY;
+    const secondValue = second[index] ?? Number.POSITIVE_INFINITY;
+    if (firstValue < secondValue) return -1;
+    if (firstValue > secondValue) return 1;
+  }
+  return 0;
 }
 
 function codexProviderIdentityKeys(provider) {
@@ -431,13 +496,34 @@ function mergeCodexTransientWindows(previousInput, currentInput, nowMs = Date.no
   };
 }
 
-function pickBetterProvider(current, candidate) {
+function pickBetterProvider(current, candidate, nowMs = Date.now()) {
   if (!current) return candidate;
   if (current.stale !== candidate.stale) return current.stale ? candidate : current;
   const rankDiff = statusRank(candidate.status) - statusRank(current.status);
   if (rankDiff !== 0) return rankDiff > 0 ? candidate : current;
-  const windowRankDiff = providerWindowRank(candidate) - providerWindowRank(current);
+  const windowRankDiff = providerWindowRank(candidate, nowMs) - providerWindowRank(current, nowMs);
   if (windowRankDiff !== 0) return windowRankDiff > 0 ? candidate : current;
+  if (current.provider === 'codex'
+    && candidate.provider === 'codex'
+    && current.accountKey
+    && current.accountKey === candidate.accountKey) {
+    // A complete move of comparable reset anchors is a new quota generation,
+    // including an upstream reset or reset-credit action observed on one device
+    // first. It outranks an older, tighter snapshot before that snapshot expires.
+    // Reset-credit counts are deliberately not evidence: unused credits expire.
+    const generationDiff = compareCodexResetGeneration(candidate, current, nowMs);
+    if (generationDiff !== 0) return generationDiff > 0 ? candidate : current;
+
+    // Concurrent devices can otherwise expose different successful buckets for
+    // the same generation. Keep the tightest whole snapshot deterministically
+    // instead of oscillating with whichever device reported most recently.
+    const currentPressure = codexQuotaPressure(current, nowMs);
+    const candidatePressure = codexQuotaPressure(candidate, nowMs);
+    if (currentPressure !== null && candidatePressure !== null) {
+      const pressureDiff = compareQuotaPressure(candidatePressure, currentPressure);
+      if (pressureDiff !== 0) return pressureDiff < 0 ? candidate : current;
+    }
+  }
   return timestampMs(candidate.updatedAt) >= timestampMs(current.updatedAt) ? candidate : current;
 }
 
@@ -462,7 +548,7 @@ function aggregateLimits(devices, staleAfterMs = 0, nowMs = Date.now()) {
         if (isConfiguredProvider(provider)) providersWithFreshConfiguredAccounts.add(provider.provider);
       }
       const key = providerAggregateKey(provider);
-      byKey.set(key, pickBetterProvider(byKey.get(key), candidate));
+      byKey.set(key, pickBetterProvider(byKey.get(key), candidate, nowMs));
     }
   }
 
@@ -479,7 +565,7 @@ function aggregateLimits(devices, staleAfterMs = 0, nowMs = Date.now()) {
       : providersWithConfiguredAccounts;
     if (!isConfiguredProvider(candidate) && configuredProviders.has(candidate.provider)) continue;
     const collapseKey = providerCollapseKey(candidate);
-    byProvider.set(collapseKey, pickBetterProvider(byProvider.get(collapseKey), candidate));
+    byProvider.set(collapseKey, pickBetterProvider(byProvider.get(collapseKey), candidate, nowMs));
   }
   aggregate.providers = Array.from(byProvider.values())
     .sort((a, b) => {

--- a/src/shared/limits.js
+++ b/src/shared/limits.js
@@ -407,6 +407,14 @@ function compareQuotaPressure(first, second) {
 }
 
 function stableProviderTieBreak(current, candidate) {
+  const sameCodexAccount = current.provider === 'codex'
+    && candidate.provider === 'codex'
+    && current.accountKey
+    && current.accountKey === candidate.accountKey;
+  if (sameCodexAccount) {
+    const deviceDiff = String(candidate.sourceDeviceId || '').localeCompare(String(current.sourceDeviceId || ''));
+    if (deviceDiff !== 0) return deviceDiff < 0 ? candidate : current;
+  }
   const timestampDiff = timestampMs(candidate.updatedAt) - timestampMs(current.updatedAt);
   if (timestampDiff !== 0) return timestampDiff > 0 ? candidate : current;
   const deviceDiff = String(candidate.sourceDeviceId || '').localeCompare(String(current.sourceDeviceId || ''));

--- a/tests/shared/limits.test.js
+++ b/tests/shared/limits.test.js
@@ -311,6 +311,38 @@ test('aggregateLimits advances an expired Codex session cycle while the weekly w
   assert.equal(aggregate.providers[0].windows[0].resetsAt, '2026-07-11T17:00:00.000Z');
 });
 
+test('aggregateLimits ignores conflicting Codex anchors that expired in both snapshots', () => {
+  const oldTight = codexProvider('sha256:codex-a', 'a@example.com', 10, '2026-07-11T12:20:00.000Z');
+  oldTight.windows[0].resetsAt = '2026-07-11T12:00:00.000Z';
+  oldTight.windows.push({
+    kind: 'weekly',
+    usedPercent: 90,
+    remainingPercent: 10,
+    resetsAt: '2026-07-18T20:00:00.000Z',
+    windowMinutes: 10_080
+  });
+  const newGeneration = codexProvider('sha256:codex-a', 'a@example.com', 90, '2026-07-11T12:22:00.000Z');
+  newGeneration.windows[0].resetsAt = '2026-07-11T11:00:00.000Z';
+  newGeneration.windows.push({
+    kind: 'weekly',
+    usedPercent: 10,
+    remainingPercent: 90,
+    resetsAt: '2026-07-19T20:00:00.000Z',
+    windowMinutes: 10_080
+  });
+  const devices = [
+    { deviceId: 'old', limits: { providers: [oldTight] } },
+    { deviceId: 'new', limits: { providers: [newGeneration] } }
+  ];
+
+  const forward = aggregateLimits(devices, 0, Date.parse('2026-07-11T13:00:00.000Z'));
+  const reversed = aggregateLimits([...devices].reverse(), 0, Date.parse('2026-07-11T13:00:00.000Z'));
+
+  assert.equal(forward.providers[0].sourceDeviceId, 'new');
+  assert.equal(forward.providers[0].windows[1].resetsAt, '2026-07-19T20:00:00.000Z');
+  assert.deepEqual(reversed.providers, forward.providers);
+});
+
 test('aggregateLimits breaks equal Codex snapshot ties by source device id', () => {
   const first = codexProvider('sha256:codex-a', 'a@example.com', 50, '2026-07-11T12:20:00.000Z');
   const second = codexProvider('sha256:codex-a', 'a@example.com', 50, '2026-07-11T12:20:00.000Z');

--- a/tests/shared/limits.test.js
+++ b/tests/shared/limits.test.js
@@ -111,7 +111,7 @@ test('publicLimits preserves MiMo plan status while removing account identity', 
   assert.equal(Object.hasOwn(payload.providers[0], 'accountName'), false);
 });
 
-test('aggregateLimits merges the same Codex account across devices and keeps distinct ones', () => {
+test('aggregateLimits keeps the tightest same-generation Codex snapshot across devices', () => {
   const aggregate = aggregateLimits([
     {
       deviceId: 'macbook',
@@ -140,10 +140,98 @@ test('aggregateLimits merges the same Codex account across devices and keeps dis
     new Set(codexProviders.map((provider) => provider.accountKey)),
     new Set(['sha256:codex-a', 'sha256:codex-b', 'sha256:codex-c'])
   );
-  // The account both devices report merges into one, keeping the freshest snapshot.
+  // The account both devices report merges into one without oscillating to the
+  // freshest-but-looser snapshot.
   const accountA = codexProviders.find((provider) => provider.accountKey === 'sha256:codex-a');
-  assert.equal(accountA.windows[0].remainingPercent, 50);
-  assert.equal(accountA.sourceDeviceId, 'desktop');
+  assert.equal(accountA.windows[0].remainingPercent, 18);
+  assert.equal(accountA.sourceDeviceId, 'macbook');
+});
+
+test('aggregateLimits Codex selection is stable when device report order changes', () => {
+  const tighter = codexProvider('sha256:codex-a', 'a@example.com', 12, '2026-07-11T12:20:17.101Z');
+  const looser = codexProvider('sha256:codex-a', 'a@example.com', 96, '2026-07-11T12:22:53.166Z');
+  tighter.windows[0].resetsAt = '2026-07-11T15:00:00.000Z';
+  looser.windows[0].resetsAt = '2026-07-11T15:00:00.000Z';
+  const devices = [
+    { deviceId: 'windows', limits: { providers: [looser] } },
+    { deviceId: 'macbook', limits: { providers: [tighter] } }
+  ];
+
+  const forward = aggregateLimits(devices, 0, Date.parse('2026-07-11T13:00:00.000Z'));
+  const reversed = aggregateLimits([...devices].reverse(), 0, Date.parse('2026-07-11T13:00:00.000Z'));
+
+  assert.equal(forward.providers[0].windows[0].remainingPercent, 12);
+  assert.equal(forward.providers[0].sourceDeviceId, 'macbook');
+  assert.deepEqual(reversed.providers, forward.providers);
+});
+
+test('aggregateLimits accepts a newer Codex quota generation before the tighter snapshot expires', () => {
+  const oldTight = codexProvider('sha256:codex-a', 'a@example.com', 12, '2026-07-11T12:20:00.000Z');
+  oldTight.windows[0].resetsAt = '2026-07-11T15:00:00.000Z';
+  const newLoose = codexProvider('sha256:codex-a', 'a@example.com', 96, '2026-07-11T12:22:00.000Z');
+  newLoose.windows[0].resetsAt = '2026-07-11T17:00:00.000Z';
+  const devices = [
+    { deviceId: 'old', limits: { providers: [oldTight] } },
+    { deviceId: 'new', limits: { providers: [newLoose] } }
+  ];
+
+  const forward = aggregateLimits(devices, 0, Date.parse('2026-07-11T13:00:00.000Z'));
+  const reversed = aggregateLimits([...devices].reverse(), 0, Date.parse('2026-07-11T13:00:00.000Z'));
+
+  assert.equal(forward.providers[0].windows[0].remainingPercent, 96);
+  assert.equal(forward.providers[0].windows[0].resetsAt, '2026-07-11T17:00:00.000Z');
+  assert.equal(forward.providers[0].sourceDeviceId, 'new');
+  assert.deepEqual(reversed.providers, forward.providers);
+});
+
+test('aggregateLimits requires a reset-cycle move before a reset-credit decrease can replace tighter quota', () => {
+  const oldTight = codexProvider('sha256:codex-a', 'a@example.com', 12, '2026-07-11T12:20:00.000Z');
+  oldTight.windows[0].resetsAt = '2026-07-11T15:00:00.000Z';
+  oldTight.resetCredits = { availableCount: 2 };
+  const creditExpired = codexProvider('sha256:codex-a', 'a@example.com', 96, '2026-07-11T12:22:00.000Z');
+  creditExpired.windows[0].resetsAt = '2026-07-11T15:00:00.000Z';
+  creditExpired.resetCredits = { availableCount: 1 };
+
+  const aggregate = aggregateLimits([
+    { deviceId: 'old', limits: { providers: [oldTight] } },
+    { deviceId: 'expired-credit', limits: { providers: [creditExpired] } }
+  ], 0, Date.parse('2026-07-11T13:00:00.000Z'));
+
+  assert.equal(aggregate.providers[0].windows[0].remainingPercent, 12);
+  assert.equal(aggregate.providers[0].sourceDeviceId, 'old');
+});
+
+test('aggregateLimits accepts a reset-credit action when the quota cycle also advances', () => {
+  const oldTight = codexProvider('sha256:codex-a', 'a@example.com', 12, '2026-07-11T12:20:00.000Z');
+  oldTight.windows[0].resetsAt = '2026-07-11T15:00:00.000Z';
+  oldTight.resetCredits = { availableCount: 2 };
+  const afterReset = codexProvider('sha256:codex-a', 'a@example.com', 100, '2026-07-11T12:22:00.000Z');
+  afterReset.windows[0].resetsAt = '2026-07-11T17:00:00.000Z';
+  afterReset.resetCredits = { availableCount: 1 };
+
+  const aggregate = aggregateLimits([
+    { deviceId: 'old', limits: { providers: [oldTight] } },
+    { deviceId: 'after-reset', limits: { providers: [afterReset] } }
+  ], 0, Date.parse('2026-07-11T13:00:00.000Z'));
+
+  assert.equal(aggregate.providers[0].windows[0].remainingPercent, 100);
+  assert.equal(aggregate.providers[0].resetCredits.availableCount, 1);
+  assert.equal(aggregate.providers[0].sourceDeviceId, 'after-reset');
+});
+
+test('aggregateLimits accepts a new Codex cycle after the tighter window expires', () => {
+  const expiredTight = codexProvider('sha256:codex-a', 'a@example.com', 12, '2026-07-11T15:20:00.000Z');
+  expiredTight.windows[0].resetsAt = '2026-07-11T14:01:11.000Z';
+  const newCycle = codexProvider('sha256:codex-a', 'a@example.com', 96, '2026-07-11T15:20:17.101Z');
+  newCycle.windows[0].resetsAt = '2026-07-11T20:17:51.000Z';
+
+  const aggregate = aggregateLimits([
+    { deviceId: 'macbook', limits: { providers: [expiredTight] } },
+    { deviceId: 'windows', limits: { providers: [newCycle] } }
+  ], 0, Date.parse('2026-07-11T15:30:00.000Z'));
+
+  assert.equal(aggregate.providers[0].windows[0].remainingPercent, 96);
+  assert.equal(aggregate.providers[0].sourceDeviceId, 'windows');
 });
 
 test('aggregateLimits keeps Codex quota windows over a newer empty transient snapshot', () => {

--- a/tests/shared/limits.test.js
+++ b/tests/shared/limits.test.js
@@ -219,6 +219,95 @@ test('aggregateLimits accepts a reset-credit action when the quota cycle also ad
   assert.equal(aggregate.providers[0].sourceDeviceId, 'after-reset');
 });
 
+test('aggregateLimits selects a stable generation frontier across three mixed Codex snapshots', () => {
+  const sessionOnly = codexProvider('sha256:codex-a', 'a@example.com', 80, '2026-07-11T12:20:00.000Z');
+  sessionOnly.windows[0].resetsAt = '2026-07-11T17:00:00.000Z';
+
+  const bridge = codexProvider('sha256:codex-a', 'a@example.com', 70, '2026-07-11T12:20:00.000Z');
+  bridge.windows[0].resetsAt = '2026-07-11T16:00:00.000Z';
+  bridge.windows.push({
+    kind: 'weekly',
+    usedPercent: 30,
+    remainingPercent: 70,
+    resetsAt: '2026-07-18T22:00:00.000Z',
+    windowMinutes: 10_080
+  });
+
+  const weeklyOnly = codexProvider('sha256:codex-a', 'a@example.com', 10, '2026-07-11T12:20:00.000Z');
+  weeklyOnly.windows = [{
+    kind: 'weekly',
+    usedPercent: 90,
+    remainingPercent: 10,
+    resetsAt: '2026-07-18T21:00:00.000Z',
+    windowMinutes: 10_080
+  }];
+
+  const devices = [
+    { deviceId: 'session-new', limits: { providers: [sessionOnly] } },
+    { deviceId: 'bridge', limits: { providers: [bridge] } },
+    { deviceId: 'weekly-old', limits: { providers: [weeklyOnly] } }
+  ];
+  const permutations = [
+    devices,
+    [devices[0], devices[2], devices[1]],
+    [devices[1], devices[0], devices[2]],
+    [devices[1], devices[2], devices[0]],
+    [devices[2], devices[0], devices[1]],
+    [devices[2], devices[1], devices[0]]
+  ];
+
+  for (const ordered of permutations) {
+    const aggregate = aggregateLimits(ordered, 0, Date.parse('2026-07-11T13:00:00.000Z'));
+    assert.equal(aggregate.providers[0].sourceDeviceId, 'session-new');
+  }
+});
+
+test('aggregateLimits advances an expired Codex session cycle while the weekly window remains active', () => {
+  const oldTight = codexProvider('sha256:codex-a', 'a@example.com', 10, '2026-07-11T12:20:00.000Z');
+  oldTight.windows[0].resetsAt = '2026-07-11T12:00:00.000Z';
+  oldTight.windows.push({
+    kind: 'weekly',
+    usedPercent: 90,
+    remainingPercent: 10,
+    resetsAt: '2026-07-18T20:00:00.000Z',
+    windowMinutes: 10_080
+  });
+  const newCycle = codexProvider('sha256:codex-a', 'a@example.com', 90, '2026-07-11T12:22:00.000Z');
+  newCycle.windows[0].resetsAt = '2026-07-11T17:00:00.000Z';
+  newCycle.windows.push({
+    kind: 'weekly',
+    usedPercent: 10,
+    remainingPercent: 90,
+    resetsAt: '2026-07-18T20:00:00.000Z',
+    windowMinutes: 10_080
+  });
+
+  const aggregate = aggregateLimits([
+    { deviceId: 'old', limits: { providers: [oldTight] } },
+    { deviceId: 'new', limits: { providers: [newCycle] } }
+  ], 0, Date.parse('2026-07-11T13:00:00.000Z'));
+
+  assert.equal(aggregate.providers[0].sourceDeviceId, 'new');
+  assert.equal(aggregate.providers[0].windows[0].resetsAt, '2026-07-11T17:00:00.000Z');
+});
+
+test('aggregateLimits breaks equal Codex snapshot ties by source device id', () => {
+  const first = codexProvider('sha256:codex-a', 'a@example.com', 50, '2026-07-11T12:20:00.000Z');
+  const second = codexProvider('sha256:codex-a', 'a@example.com', 50, '2026-07-11T12:20:00.000Z');
+  first.windows[0].resetsAt = '2026-07-11T15:00:00.000Z';
+  second.windows[0].resetsAt = '2026-07-11T15:00:00.000Z';
+  const devices = [
+    { deviceId: 'device-b', limits: { providers: [first] } },
+    { deviceId: 'device-a', limits: { providers: [second] } }
+  ];
+
+  const forward = aggregateLimits(devices, 0, Date.parse('2026-07-11T13:00:00.000Z'));
+  const reversed = aggregateLimits([...devices].reverse(), 0, Date.parse('2026-07-11T13:00:00.000Z'));
+
+  assert.equal(forward.providers[0].sourceDeviceId, 'device-a');
+  assert.deepEqual(reversed.providers, forward.providers);
+});
+
 test('aggregateLimits accepts a new Codex cycle after the tighter window expires', () => {
   const expiredTight = codexProvider('sha256:codex-a', 'a@example.com', 12, '2026-07-11T15:20:00.000Z');
   expiredTight.windows[0].resetsAt = '2026-07-11T14:01:11.000Z';

--- a/tests/shared/limits.test.js
+++ b/tests/shared/limits.test.js
@@ -165,6 +165,26 @@ test('aggregateLimits Codex selection is stable when device report order changes
   assert.deepEqual(reversed.providers, forward.providers);
 });
 
+test('aggregateLimits keeps equal-pressure Codex fields stable as devices refresh', () => {
+  const desktop = codexProvider('sha256:codex-a', 'a@example.com', 50, '2026-07-11T12:20:00.000Z');
+  const windows = codexProvider('sha256:codex-a', 'a@example.com', 50, '2026-07-11T12:25:00.000Z');
+  desktop.windows[0].resetsAt = '2026-07-11T15:00:00.000Z';
+  windows.windows[0].resetsAt = '2026-07-11T15:00:00.000Z';
+  desktop.resetCredits = { availableCount: 2 };
+  windows.resetCredits = { availableCount: 1 };
+  const devices = [
+    { deviceId: 'windows', limits: { providers: [windows] } },
+    { deviceId: 'desktop', limits: { providers: [desktop] } }
+  ];
+
+  const forward = aggregateLimits(devices, 0, Date.parse('2026-07-11T13:00:00.000Z'));
+  const reversed = aggregateLimits([...devices].reverse(), 0, Date.parse('2026-07-11T13:00:00.000Z'));
+
+  assert.equal(forward.providers[0].sourceDeviceId, 'desktop');
+  assert.equal(forward.providers[0].resetCredits.availableCount, 2);
+  assert.deepEqual(reversed.providers, forward.providers);
+});
+
 test('aggregateLimits accepts a newer Codex quota generation before the tighter snapshot expires', () => {
   const oldTight = codexProvider('sha256:codex-a', 'a@example.com', 12, '2026-07-11T12:20:00.000Z');
   oldTight.windows[0].resetsAt = '2026-07-11T15:00:00.000Z';

--- a/worker/src/shared/limits.js
+++ b/worker/src/shared/limits.js
@@ -338,9 +338,74 @@ function providerCollapseKey(provider) {
   return provider.provider;
 }
 
-function providerWindowRank(provider) {
+function activeLimitWindow(window, nowMs) {
+  const resetMs = timestampMs(window?.resetsAt);
+  return !resetMs || resetMs > nowMs;
+}
+
+function providerWindowRank(provider, nowMs) {
   if (provider?.provider !== 'codex') return 0;
-  return Array.isArray(provider.windows) && provider.windows.length > 0 ? 1 : 0;
+  return Array.isArray(provider.windows) && provider.windows.some((window) => activeLimitWindow(window, nowMs)) ? 1 : 0;
+}
+
+function codexResetGeneration(provider, nowMs) {
+  if (provider?.provider !== 'codex' || !Array.isArray(provider.windows)) return null;
+  const generation = new Map();
+  for (const window of provider.windows) {
+    if (!activeLimitWindow(window, nowMs)) continue;
+    const resetMs = timestampMs(window.resetsAt);
+    if (!resetMs) continue;
+    const key = `${window.kind}:${window.label || ''}`;
+    generation.set(key, Math.max(generation.get(key) || 0, resetMs));
+  }
+  return generation.size > 0 ? generation : null;
+}
+
+function compareCodexResetGeneration(first, second, nowMs) {
+  const firstGeneration = codexResetGeneration(first, nowMs);
+  const secondGeneration = codexResetGeneration(second, nowMs);
+  if (!firstGeneration || !secondGeneration || firstGeneration.size !== secondGeneration.size) return 0;
+  let direction = 0;
+  for (const [key, firstReset] of firstGeneration) {
+    const secondReset = secondGeneration.get(key);
+    if (!secondReset) return 0;
+    const nextDirection = firstReset > secondReset ? 1 : (firstReset < secondReset ? -1 : 0);
+    if (nextDirection && direction && nextDirection !== direction) return 0;
+    if (nextDirection) direction = nextDirection;
+  }
+  return direction;
+}
+
+function codexQuotaPressure(provider, nowMs) {
+  if (provider?.provider !== 'codex' || !Array.isArray(provider.windows)) return null;
+  const activeWindows = provider.windows
+    .filter((window) => activeLimitWindow(window, nowMs))
+    .map((window) => ({
+      kind: window.kind,
+      remaining: numberOrNull(window.remainingPercent),
+      resetMs: timestampMs(window.resetsAt) || Number.POSITIVE_INFINITY
+    }))
+    .filter((window) => window.remaining !== null);
+  if (activeWindows.length === 0) return null;
+  const remainingForKind = (kind) => {
+    const values = activeWindows.filter((window) => window.kind === kind).map((window) => window.remaining);
+    return values.length > 0 ? Math.min(...values) : 101;
+  };
+  return [
+    Math.min(...activeWindows.map((window) => window.remaining)),
+    ...WINDOW_ORDER.map(remainingForKind),
+    Math.min(...activeWindows.map((window) => window.resetMs))
+  ];
+}
+
+function compareQuotaPressure(first, second) {
+  for (let index = 0; index < Math.max(first.length, second.length); index += 1) {
+    const firstValue = first[index] ?? Number.POSITIVE_INFINITY;
+    const secondValue = second[index] ?? Number.POSITIVE_INFINITY;
+    if (firstValue < secondValue) return -1;
+    if (firstValue > secondValue) return 1;
+  }
+  return 0;
 }
 
 function codexProviderIdentityKeys(provider) {
@@ -434,13 +499,34 @@ function mergeCodexTransientWindows(previousInput, currentInput, nowMs = Date.no
   };
 }
 
-function pickBetterProvider(current, candidate) {
+function pickBetterProvider(current, candidate, nowMs = Date.now()) {
   if (!current) return candidate;
   if (current.stale !== candidate.stale) return current.stale ? candidate : current;
   const rankDiff = statusRank(candidate.status) - statusRank(current.status);
   if (rankDiff !== 0) return rankDiff > 0 ? candidate : current;
-  const windowRankDiff = providerWindowRank(candidate) - providerWindowRank(current);
+  const windowRankDiff = providerWindowRank(candidate, nowMs) - providerWindowRank(current, nowMs);
   if (windowRankDiff !== 0) return windowRankDiff > 0 ? candidate : current;
+  if (current.provider === 'codex'
+    && candidate.provider === 'codex'
+    && current.accountKey
+    && current.accountKey === candidate.accountKey) {
+    // A complete move of comparable reset anchors is a new quota generation,
+    // including an upstream reset or reset-credit action observed on one device
+    // first. It outranks an older, tighter snapshot before that snapshot expires.
+    // Reset-credit counts are deliberately not evidence: unused credits expire.
+    const generationDiff = compareCodexResetGeneration(candidate, current, nowMs);
+    if (generationDiff !== 0) return generationDiff > 0 ? candidate : current;
+
+    // Concurrent devices can otherwise expose different successful buckets for
+    // the same generation. Keep the tightest whole snapshot deterministically
+    // instead of oscillating with whichever device reported most recently.
+    const currentPressure = codexQuotaPressure(current, nowMs);
+    const candidatePressure = codexQuotaPressure(candidate, nowMs);
+    if (currentPressure !== null && candidatePressure !== null) {
+      const pressureDiff = compareQuotaPressure(candidatePressure, currentPressure);
+      if (pressureDiff !== 0) return pressureDiff < 0 ? candidate : current;
+    }
+  }
   return timestampMs(candidate.updatedAt) >= timestampMs(current.updatedAt) ? candidate : current;
 }
 
@@ -465,7 +551,7 @@ function aggregateLimits(devices, staleAfterMs = 0, nowMs = Date.now()) {
         if (isConfiguredProvider(provider)) providersWithFreshConfiguredAccounts.add(provider.provider);
       }
       const key = providerAggregateKey(provider);
-      byKey.set(key, pickBetterProvider(byKey.get(key), candidate));
+      byKey.set(key, pickBetterProvider(byKey.get(key), candidate, nowMs));
     }
   }
 
@@ -482,7 +568,7 @@ function aggregateLimits(devices, staleAfterMs = 0, nowMs = Date.now()) {
       : providersWithConfiguredAccounts;
     if (!isConfiguredProvider(candidate) && configuredProviders.has(candidate.provider)) continue;
     const collapseKey = providerCollapseKey(candidate);
-    byProvider.set(collapseKey, pickBetterProvider(byProvider.get(collapseKey), candidate));
+    byProvider.set(collapseKey, pickBetterProvider(byProvider.get(collapseKey), candidate, nowMs));
   }
   aggregate.providers = Array.from(byProvider.values())
     .sort((a, b) => {

--- a/worker/src/shared/limits.js
+++ b/worker/src/shared/limits.js
@@ -348,11 +348,10 @@ function providerWindowRank(provider, nowMs) {
   return Array.isArray(provider.windows) && provider.windows.some((window) => activeLimitWindow(window, nowMs)) ? 1 : 0;
 }
 
-function codexResetGeneration(provider, nowMs) {
+function codexResetGeneration(provider) {
   if (provider?.provider !== 'codex' || !Array.isArray(provider.windows)) return null;
   const generation = new Map();
   for (const window of provider.windows) {
-    if (!activeLimitWindow(window, nowMs)) continue;
     const resetMs = timestampMs(window.resetsAt);
     if (!resetMs) continue;
     const key = `${window.kind}:${window.label || ''}`;
@@ -361,19 +360,21 @@ function codexResetGeneration(provider, nowMs) {
   return generation.size > 0 ? generation : null;
 }
 
-function compareCodexResetGeneration(first, second, nowMs) {
-  const firstGeneration = codexResetGeneration(first, nowMs);
-  const secondGeneration = codexResetGeneration(second, nowMs);
-  if (!firstGeneration || !secondGeneration || firstGeneration.size !== secondGeneration.size) return 0;
+function compareCodexResetGeneration(first, second) {
+  const firstGeneration = codexResetGeneration(first);
+  const secondGeneration = codexResetGeneration(second);
+  if (!firstGeneration || !secondGeneration) return 0;
   let direction = 0;
+  let comparable = 0;
   for (const [key, firstReset] of firstGeneration) {
     const secondReset = secondGeneration.get(key);
-    if (!secondReset) return 0;
+    if (!secondReset) continue;
+    comparable += 1;
     const nextDirection = firstReset > secondReset ? 1 : (firstReset < secondReset ? -1 : 0);
     if (nextDirection && direction && nextDirection !== direction) return 0;
     if (nextDirection) direction = nextDirection;
   }
-  return direction;
+  return comparable > 0 ? direction : 0;
 }
 
 function codexQuotaPressure(provider, nowMs) {
@@ -406,6 +407,14 @@ function compareQuotaPressure(first, second) {
     if (firstValue > secondValue) return 1;
   }
   return 0;
+}
+
+function stableProviderTieBreak(current, candidate) {
+  const timestampDiff = timestampMs(candidate.updatedAt) - timestampMs(current.updatedAt);
+  if (timestampDiff !== 0) return timestampDiff > 0 ? candidate : current;
+  const deviceDiff = String(candidate.sourceDeviceId || '').localeCompare(String(current.sourceDeviceId || ''));
+  if (deviceDiff !== 0) return deviceDiff < 0 ? candidate : current;
+  return JSON.stringify(candidate).localeCompare(JSON.stringify(current)) < 0 ? candidate : current;
 }
 
 function codexProviderIdentityKeys(provider) {
@@ -510,16 +519,6 @@ function pickBetterProvider(current, candidate, nowMs = Date.now()) {
     && candidate.provider === 'codex'
     && current.accountKey
     && current.accountKey === candidate.accountKey) {
-    // A complete move of comparable reset anchors is a new quota generation,
-    // including an upstream reset or reset-credit action observed on one device
-    // first. It outranks an older, tighter snapshot before that snapshot expires.
-    // Reset-credit counts are deliberately not evidence: unused credits expire.
-    const generationDiff = compareCodexResetGeneration(candidate, current, nowMs);
-    if (generationDiff !== 0) return generationDiff > 0 ? candidate : current;
-
-    // Concurrent devices can otherwise expose different successful buckets for
-    // the same generation. Keep the tightest whole snapshot deterministically
-    // instead of oscillating with whichever device reported most recently.
     const currentPressure = codexQuotaPressure(current, nowMs);
     const candidatePressure = codexQuotaPressure(candidate, nowMs);
     if (currentPressure !== null && candidatePressure !== null) {
@@ -527,7 +526,34 @@ function pickBetterProvider(current, candidate, nowMs = Date.now()) {
       if (pressureDiff !== 0) return pressureDiff < 0 ? candidate : current;
     }
   }
-  return timestampMs(candidate.updatedAt) >= timestampMs(current.updatedAt) ? candidate : current;
+  return stableProviderTieBreak(current, candidate);
+}
+
+function filterMaxRank(candidates, rank) {
+  const maximum = Math.max(...candidates.map(rank));
+  return candidates.filter((candidate) => rank(candidate) === maximum);
+}
+
+function pickBestProvider(candidates, nowMs) {
+  if (candidates.length === 1) return candidates[0];
+  let eligible = filterMaxRank(candidates, (candidate) => candidate.stale ? 0 : 1);
+  eligible = filterMaxRank(eligible, (candidate) => statusRank(candidate.status));
+  eligible = filterMaxRank(eligible, (candidate) => providerWindowRank(candidate, nowMs));
+
+  const first = eligible[0];
+  if (first?.provider === 'codex' && first.accountKey
+    && eligible.every((candidate) => candidate.accountKey === first.accountKey)) {
+    // Generation precedence is a group decision, not a pairwise reduce: mixed
+    // reset anchors can make pairwise generation/pressure comparisons
+    // non-transitive. Remove every snapshot dominated by any newer comparable
+    // generation, then apply quota pressure only to the remaining frontier.
+    const generationFrontier = eligible.filter((candidate) => !eligible.some((other) => (
+      other !== candidate && compareCodexResetGeneration(other, candidate) > 0
+    )));
+    if (generationFrontier.length > 0) eligible = generationFrontier;
+  }
+
+  return eligible.reduce((best, candidate) => pickBetterProvider(best, candidate, nowMs), null);
 }
 
 function aggregateLimits(devices, staleAfterMs = 0, nowMs = Date.now()) {
@@ -551,16 +577,20 @@ function aggregateLimits(devices, staleAfterMs = 0, nowMs = Date.now()) {
         if (isConfiguredProvider(provider)) providersWithFreshConfiguredAccounts.add(provider.provider);
       }
       const key = providerAggregateKey(provider);
-      byKey.set(key, pickBetterProvider(byKey.get(key), candidate, nowMs));
+      const candidates = byKey.get(key) || [];
+      candidates.push(candidate);
+      byKey.set(key, candidates);
     }
   }
+
+  const selectedByKey = Array.from(byKey.values(), (candidates) => pickBestProvider(candidates, nowMs));
 
   // Second pass: collapse by provider name. Same OAuth account on Mac vs Windows
   // hashes to different accountKeys (keychain identity vs file path), so byKey
   // keeps them as separate entries; without this pass the renderer's per-provider
   // Map.set() would arbitrarily overwrite the fresh one with the stale one.
   const byProvider = new Map();
-  for (const candidate of byKey.values()) {
+  for (const candidate of selectedByKey) {
     const hasFreshObservation = providersWithFreshObservations.has(candidate.provider);
     if (candidate.stale && hasFreshObservation) continue;
     const configuredProviders = hasFreshObservation

--- a/worker/src/shared/limits.js
+++ b/worker/src/shared/limits.js
@@ -360,7 +360,7 @@ function codexResetGeneration(provider) {
   return generation.size > 0 ? generation : null;
 }
 
-function compareCodexResetGeneration(first, second) {
+function compareCodexResetGeneration(first, second, nowMs) {
   const firstGeneration = codexResetGeneration(first);
   const secondGeneration = codexResetGeneration(second);
   if (!firstGeneration || !secondGeneration) return 0;
@@ -369,6 +369,7 @@ function compareCodexResetGeneration(first, second) {
   for (const [key, firstReset] of firstGeneration) {
     const secondReset = secondGeneration.get(key);
     if (!secondReset) continue;
+    if (firstReset <= nowMs && secondReset <= nowMs) continue;
     comparable += 1;
     const nextDirection = firstReset > secondReset ? 1 : (firstReset < secondReset ? -1 : 0);
     if (nextDirection && direction && nextDirection !== direction) return 0;
@@ -556,7 +557,7 @@ function pickBestProvider(candidates, nowMs) {
     // non-transitive. Remove every snapshot dominated by any newer comparable
     // generation, then apply quota pressure only to the remaining frontier.
     const generationFrontier = eligible.filter((candidate) => !eligible.some((other) => (
-      other !== candidate && compareCodexResetGeneration(other, candidate) > 0
+      other !== candidate && compareCodexResetGeneration(other, candidate, nowMs) > 0
     )));
     if (generationFrontier.length > 0) eligible = generationFrontier;
   }

--- a/worker/src/shared/limits.js
+++ b/worker/src/shared/limits.js
@@ -410,6 +410,14 @@ function compareQuotaPressure(first, second) {
 }
 
 function stableProviderTieBreak(current, candidate) {
+  const sameCodexAccount = current.provider === 'codex'
+    && candidate.provider === 'codex'
+    && current.accountKey
+    && current.accountKey === candidate.accountKey;
+  if (sameCodexAccount) {
+    const deviceDiff = String(candidate.sourceDeviceId || '').localeCompare(String(current.sourceDeviceId || ''));
+    if (deviceDiff !== 0) return deviceDiff < 0 ? candidate : current;
+  }
   const timestampDiff = timestampMs(candidate.updatedAt) - timestampMs(current.updatedAt);
   if (timestampDiff !== 0) return timestampDiff > 0 ? candidate : current;
   const deviceDiff = String(candidate.sourceDeviceId || '').localeCompare(String(current.sourceDeviceId || ''));


### PR DESCRIPTION
## Summary

- stabilize same-account Codex limits when multiple devices report different successful quota snapshots
- prefer the tightest whole snapshot within one reset generation instead of whichever device reported last
- accept a newer quota generation immediately when comparable reset anchors advance, including upstream resets and reset-credit actions
- keep reset-credit counts out of generation detection so an expiring unused credit cannot mimic a manual reset

## Why

Two fresh devices can report the same Codex `accountKey` while returning different active quota buckets. The hub currently collapses those rows by account and selects the newest `updatedAt`, so alternating device reports can make the UI jump between substantially different session and weekly percentages.

This is separate from the transient or empty-read handling in #116: both cross-device snapshots are successful and non-empty. The aggregation rule now remains deterministic without retaining historical state or synthesizing windows from different devices, so `sourceDeviceId` continues to identify the selected whole snapshot.

## Reset handling

Comparable active reset anchors define the quota generation. A generation wins only when its anchors move in one direction with at least one advancing and none moving backward. This lets a new upstream/global reset or a reset-credit action replace an older tighter snapshot before its previous reset time.

`resetCredits.availableCount` is not used as reset evidence. The count may decrease when an unused credit expires, so a quota-cycle movement is still required.

## Verification

- `npm run verify` (1119 tests passed)
- `node --test tests/shared/limits.test.js tests/shared/usage.test.js` (65 tests passed)
- `git diff --check`

The regression coverage includes reversed device order, same-generation conflicts, an upstream reset before expiry, reset-credit expiry without a cycle change, a reset-credit action with a cycle change, and normal transition after expiry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes cross‑device Codex quota aggregation and makes it order‑independent. We keep the tightest active snapshot per account and switch only when a newer reset generation is detected; equal‑pressure snapshots now resolve consistently.

- **Bug Fixes**
  - Deterministic same‑`accountKey` selection: build a generation frontier across device snapshots, then pick the tightest active whole snapshot; device report order no longer changes the result.
  - Generation changes: when comparable reset anchors advance, accept the newer generation immediately (upstream resets or reset‑credit actions); ignore `resetCredits.availableCount` alone and skip jointly expired anchors.
  - Active windows only: rank and compare using only active limit windows.
  - Stable ties: for equal‑pressure same‑account Codex snapshots, break by `sourceDeviceId`, then `updatedAt`, then a final structural tiebreaker; updated `docs/API.md` and added tests for order permutations, equal‑pressure refreshes, mixed‑window frontier, expired session with active weekly, jointly expired anchors, credit expiry without a cycle move, and normal cycle transitions.

<sup>Written for commit adf0087ccf271c4e949b9119f6bd16e5a5d1ca0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

