### PR TITLE
fix(limits): mark the local Codex login, not a synced account

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -1485,20 +1485,30 @@ function codexAccountsShareIdentity(left, right) {
   return Boolean(leftEmail && rightEmail && leftEmail === rightEmail);
 }
 
+// The account THIS device's Codex app/CLI is signed into is a purely local fact:
+// the local device's own record for it carries a live (non-managed) sourceDetail.
+// Read it from the local device's RAW limits, not the cross-device aggregate:
+// aggregateLimits() keeps one record per account by freshness, so after sync the
+// selected codex row can belong to a remote device signed into a *different*
+// account. Reading the aggregate would move the active marker onto that remote
+// login, or drop it entirely when every selected row is 'managed'. Legacy stats
+// without per-device rows fall back to the aggregate (localDeviceLimitsProviders
+// returns null there), mirroring localProviderStatus().
+function localLiveCodexProvider() {
+  const localProviders = localDeviceLimitsProviders();
+  const providers = localProviders !== null ? localProviders : (state.stats?.limits?.providers || []);
+  return providers.find((provider) => limitProviderPresentationApi.isCodexLiveAccount(provider)) || null;
+}
+
 function codexActiveAccountFromStats() {
-  const providers = state.stats?.limits?.providers || [];
-  for (const provider of providers) {
-    if (provider?.provider !== 'codex') continue;
-    const provenance = limitProviderProvenance(provider);
-    if (!limitProviderPresentationApi.isCodexLiveAccount(provider, provenance)) continue;
-    return {
-      id: codexSwitchAccountForProvider(provider)?.id || '',
-      email: provider.accountEmail || '',
-      accountKey: provider.accountKey || '',
-      accountLabel: provider.accountLabel || ''
-    };
-  }
-  return null;
+  const provider = localLiveCodexProvider();
+  if (!provider) return null;
+  return {
+    id: codexSwitchAccountForProvider(provider)?.id || '',
+    email: provider.accountEmail || '',
+    accountKey: provider.accountKey || '',
+    accountLabel: provider.accountLabel || ''
+  };
 }
 
 function clearCodexPendingActiveAccount() {
@@ -1591,14 +1601,13 @@ function renderLimitProviderHead(id, label, provider, color, options = {}) {
   title.className = 'limit-name-title';
   title.textContent = options.title || label;
   const provenance = limitProviderProvenance(provider);
-  const liveCodexAccount = options.accountTitle && limitProviderPresentationApi.isCodexLiveAccount(provider, provenance);
-  // The local marker only disambiguates rows when the Codex provider is
-  // rendered as a multi-account group. A single visible account is necessarily
-  // the only choice, so a checkmark there adds noise and can look selected.
-  const activeCodexAccount = options.showActiveBadge && (
-    codexActiveAccountMatchesProvider(provider) ||
-    (!state.codexActiveAccount && liveCodexAccount)
-  );
+  // The ✓ marks the account THIS device's Codex is signed into
+  // (state.codexActiveAccount, derived locally by codexActiveAccountFromStats).
+  // It only disambiguates rows in the multi-account group, so it's gated on
+  // showActiveBadge. Never re-derive "live" from the row being rendered — in
+  // sync mode that row can be a remote device's record for a different account,
+  // which would move the ✓ onto the wrong one.
+  const activeCodexAccount = options.showActiveBadge && codexActiveAccountMatchesProvider(provider);
   const switchAccount = options.allowSystemSwitch && !activeCodexAccount ? codexSwitchAccountForProvider(provider) : null;
   if (switchAccount && window.tokenMonitor?.codex?.switchSystemAccount) {
     const switchZone = document.createElement('span');

--- a/tests/electron/cursorSettingsLayout.test.js
+++ b/tests/electron/cursorSettingsLayout.test.js
@@ -298,7 +298,12 @@ test('Codex system account switching is exposed from limits account rows', () =>
   assert.match(renderHead, /activeZone\.append\(title, badge, activePopover\)/);
   assert.match(renderHead, /badge\.textContent = '\\u2713';/);
   assert.doesNotMatch(renderHead, /badge\.textContent = 'Active'/);
-  assert.match(renderHead, /options\.showActiveBadge && \(/);
+  // The ✓ tracks state.codexActiveAccount only (the account THIS device's Codex
+  // is signed into). It must NOT re-derive "live" from the row being rendered:
+  // in sync mode that row can be a remote device's record for a different account.
+  assert.match(renderHead, /options\.showActiveBadge && codexActiveAccountMatchesProvider\(provider\)/);
+  assert.doesNotMatch(renderHead, /!state\.codexActiveAccount && liveCodexAccount/);
+  assert.doesNotMatch(renderHead, /const liveCodexAccount =/);
   assert.match(renderHead, /codexSwitchAccountForProvider\(provider\)/);
   assert.match(renderHead, /switchZone\.className = 'limit-account-switch-zone'/);
   assert.match(renderHead, /switchPopover\.className = 'limit-account-switch-popover'/);

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -71,6 +71,15 @@ function runLocalProviderStatus(source, state, providerName) {
   );
 }
 
+function runLocalLiveCodexProvider(source, state) {
+  const localDeviceHelper = functionBody(source, 'localDeviceLimitsProviders', 'localProviderStatus');
+  const liveHelper = functionBody(source, 'localLiveCodexProvider', 'codexActiveAccountFromStats');
+  return vm.runInNewContext(
+    `${localDeviceHelper}\n${liveHelper}\nlocalLiveCodexProvider();`,
+    { state, limitProviderPresentationApi: { isCodexLiveAccount } }
+  );
+}
+
 test('capability tags explain how each provider is collected in settings', () => {
   assert.deepEqual(limitProviderCapabilityTags('claude'), ['Auto', 'OAuth/CLI']);
   assert.deepEqual(limitProviderCapabilityTags('codex'), ['Auto', 'App/CLI RPC']);
@@ -756,6 +765,61 @@ test('account validation does not use a remote aggregate when the local device l
   }, 'minimax');
 
   assert.equal(provider, null);
+});
+
+test('active Codex account follows the local login, not a remote device signed into a different account', () => {
+  // Local machine is signed into `quality` (App) and only manages the other two.
+  // A synced device (9950x3d) is signed into `javis`, so aggregateLimits() picks
+  // its live App record for the `javis` row — which sorts first. Reading the
+  // aggregate would move the ✓ onto `javis`; the marker must instead track this
+  // device's own live login (`quality`).
+  const app = readRendererFile('app.js');
+  const localProviders = [
+    { provider: 'codex', status: 'ok', sourceDetail: 'managed', accountKey: 'sha256:javis', accountEmail: 'javis603@gmail.com' },
+    { provider: 'codex', status: 'ok', sourceDetail: 'managed', accountKey: 'sha256:linus', accountEmail: 'linus@gmail.com' },
+    { provider: 'codex', status: 'ok', sourceDetail: 'app', accountKey: 'sha256:quality', accountEmail: 'quality@icloud.com' }
+  ];
+  const remoteJavisLive = { provider: 'codex', status: 'ok', sourceDetail: 'app', accountKey: 'sha256:javis', accountEmail: 'javis603@gmail.com', sourceDeviceId: '9950x3d' };
+  const provider = runLocalLiveCodexProvider(app, {
+    settings: { deviceId: 'this-mac' },
+    stats: {
+      devices: [
+        { deviceId: 'this-mac', limits: { providers: localProviders } },
+        { deviceId: '9950x3d', limits: { providers: [remoteJavisLive] } }
+      ],
+      limits: { providers: [remoteJavisLive, localProviders[1], localProviders[2]] }
+    }
+  });
+
+  assert.equal(provider.accountKey, 'sha256:quality');
+});
+
+test('no active Codex account when this device is signed out, even if a synced device is live', () => {
+  const app = readRendererFile('app.js');
+  const remoteLive = { provider: 'codex', status: 'ok', sourceDetail: 'app', accountKey: 'sha256:javis', sourceDeviceId: '9950x3d' };
+  const provider = runLocalLiveCodexProvider(app, {
+    settings: { deviceId: 'this-mac' },
+    stats: {
+      devices: [
+        { deviceId: 'this-mac', limits: { providers: [{ provider: 'codex', status: 'ok', sourceDetail: 'managed', accountKey: 'sha256:javis' }] } },
+        { deviceId: '9950x3d', limits: { providers: [remoteLive] } }
+      ],
+      limits: { providers: [remoteLive] }
+    }
+  });
+
+  assert.equal(provider, null);
+});
+
+test('active Codex account falls back to the aggregate for legacy stats without device rows', () => {
+  const app = readRendererFile('app.js');
+  const live = { provider: 'codex', status: 'ok', sourceDetail: 'app', accountKey: 'sha256:solo' };
+  const provider = runLocalLiveCodexProvider(app, {
+    settings: { deviceId: 'this-mac' },
+    stats: { limits: { providers: [live] } }
+  });
+
+  assert.equal(provider.accountKey, 'sha256:solo');
 });
 
 test('account validation keeps aggregate fallback for legacy stats without device rows', () => {


### PR DESCRIPTION
## Problem

With multiple Codex accounts synced across devices, the local active-account checkmark (✓) behaved wrong:

- **✓ jumped to the wrong account** — this machine is signed into account C, but after another device (signed into account A) synced a fresher record, the ✓ moved onto account A.
- **✓ disappeared entirely** — when every account's selected record ended up as `managed`, no row was marked at all.

## Root cause

`codexActiveAccountFromStats()` derived the active account from the **cross-device aggregate** (`state.stats.limits.providers`). `aggregateLimits()` keeps one record per account chosen by freshness (`pickBetterProvider`), so after sync the selected Codex row for an account can belong to a **remote** device that is signed into a *different* account. Reading the aggregate therefore attributed "live" to whichever non-`managed` row won the merge (a remote device's login), or found none when every winning row was `managed`.

The render-time fallback `(!state.codexActiveAccount && liveCodexAccount)` in `renderLimitProviderHead` re-derived liveness from the row being rendered, which is the same aggregate-based mistake via a second path.

This is the same class of bug already fixed for the DeepSeek/Minimax account status, where a remote `ok` row masked the local truth.

## Fix

- Derive the active account from the **local device's own raw limits** (`localDeviceLimitsProviders()` → the `state.stats.devices` entry whose `deviceId` matches this device), picking its live (non-`managed`, `status:ok`) Codex login. Legacy stats without per-device rows fall back to the aggregate, mirroring `localProviderStatus()`.
- Drop the render-time fallback so the ✓ tracks `state.codexActiveAccount` alone — a single, local source of truth. The account key is stable across devices, so the badge still lands on the right row even when a remote `managed` record won the merge for that account's display.

Which account this device is signed into is a purely local fact; it should never be inferred from another device's synced record.

## Verification

- `npm run verify` (lint + full suite): **1119 tests pass**, lint clean.
- Added three behaviour tests reproducing the reported scenarios (remote device live on a different account; local signed-out with a remote live device; legacy-stats aggregate fallback). They fail on the old aggregate-based logic and pass on the fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Codex active-account checkmark so it always reflects this device’s login. Prevents the ✓ from jumping to a remote account or disappearing after sync.

- **Bug Fixes**
  - Updated `codexActiveAccountFromStats()` to read the active account from the local device’s raw limits via `localLiveCodexProvider()` and `localDeviceLimitsProviders()`.
  - Kept a fallback to the aggregate for legacy stats without per-device rows.
  - Removed the render-time fallback in `renderLimitProviderHead`; the ✓ now relies only on `state.codexActiveAccount`.
  - Added tests for remote-live/different-account, local-signed-out with remote live, and legacy fallback; adjusted UI test to assert the new single-source-of-truth behavior.

<sup>Written for commit 023018a763a7fd1f7e1c655c3899d2667540d061. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

