### PR TITLE
fix(trends): retain offline history and refresh dashboard

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -1828,9 +1828,11 @@ function sendPush(payload) {
   if (mainWindow && !mainWindow.isDestroyed()) {
     try { mainWindow.webContents.send('stats:push', payload); } catch (_) {}
   }
-  const nextHistoryRevision = statsHistoryRevision(payload?.data?.stats);
-  if (nextHistoryRevision !== previousHistoryRevision && dashboardWindow && !dashboardWindow.isDestroyed()) {
-    try { dashboardWindow.webContents.send('dashboard:historyChanged'); } catch (_) {}
+  if (payload?.data?.stats) {
+    const nextHistoryRevision = statsHistoryRevision(payload.data.stats);
+    if (nextHistoryRevision !== previousHistoryRevision && dashboardWindow && !dashboardWindow.isDestroyed()) {
+      try { dashboardWindow.webContents.send('dashboard:historyChanged'); } catch (_) {}
+    }
   }
 }
 

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -1493,7 +1493,7 @@ function applyNativeMaterial(source = settings) {
 }
 
 function withHistoryPreview(stats, devices) {
-  const history = settings?.historyEnabled === false ? aggregateHistory([], 0) : aggregateHistory(devices, 0);
+  const history = settings?.historyEnabled === false ? aggregateHistory([]) : aggregateHistory(devices);
   stats.historyPreview = historyPreview(history);
   return stats;
 }
@@ -1825,6 +1825,9 @@ function sendPush(payload) {
   }
   if (mainWindow && !mainWindow.isDestroyed()) {
     try { mainWindow.webContents.send('stats:push', payload); } catch (_) {}
+  }
+  if (payload?.data?.stats && dashboardWindow && !dashboardWindow.isDestroyed()) {
+    try { dashboardWindow.webContents.send('dashboard:historyChanged'); } catch (_) {}
   }
 }
 
@@ -3029,14 +3032,14 @@ function createDashboardWindow() {
 }
 
 async function getDashboardHistory() {
-  if (settings?.historyEnabled === false) return aggregateHistory([], 0);
+  if (settings?.historyEnabled === false) return aggregateHistory([]);
   if (mode === 'local') {
     // The local collector keeps localDevice.history current (watch + interval
     // ticks, with carry-forward), so read it directly — exactly as the hub
     // branch reads /api/history. Forcing a full collection tick here made the
     // fetch take seconds; on a quick close/reopen the response outlived the
     // renderer and was dropped, stranding the dashboard on its empty state.
-    return aggregateHistory(localDevice ? [localDevice] : [], 0);
+    return aggregateHistory(localDevice ? [localDevice] : []);
   }
   if (settings.hubMode === 'host' && embeddedHub) {
     // Host mode reads its own hub store in-process, so the dashboard history
@@ -3044,7 +3047,7 @@ async function getDashboardHistory() {
     return embeddedHub.hub.getHistory();
   }
   const { url: hubUrl, secret } = effectiveHubConfig();
-  if (!hubUrl) return aggregateHistory([], 0);
+  if (!hubUrl) return aggregateHistory([]);
   const url = `${hubUrl.replace(/\/$/, '')}/api/history`;
   const response = await fetch(url, { headers: secret ? { authorization: `Bearer ${secret}` } : {} });
   if (!response.ok) throw new Error(`Hub ${response.status}: ${(await response.text()).slice(0, 200)}`);

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -81,7 +81,7 @@ const {
   fetchMimoLimits,
   normalizeMimoCookieHeader
 } = require('../shared/mimoLimits');
-const { historyPreview } = require('../shared/history');
+const { historyPreview, historyRevision } = require('../shared/history');
 const { readSessionDetail } = require('../shared/sessionDetail');
 const { startDiscordRpc, stopDiscordRpc, updateDiscordRpc } = require('./discordRpc');
 const linuxAutostart = require('./linuxAutostart');
@@ -1495,6 +1495,7 @@ function applyNativeMaterial(source = settings) {
 function withHistoryPreview(stats, devices) {
   const history = settings?.historyEnabled === false ? aggregateHistory([]) : aggregateHistory(devices);
   stats.historyPreview = historyPreview(history);
+  stats.historyRevision = historyRevision(history);
   return stats;
 }
 
@@ -1813,6 +1814,7 @@ function injectLocalDeviceStatus(stats) {
 }
 
 function sendPush(payload) {
+  const previousHistoryRevision = statsHistoryRevision(latestStats);
   if (payload?.data?.stats) {
     injectLocalDeviceStatus(payload.data.stats);
     latestStats = payload.data.stats;
@@ -1826,9 +1828,17 @@ function sendPush(payload) {
   if (mainWindow && !mainWindow.isDestroyed()) {
     try { mainWindow.webContents.send('stats:push', payload); } catch (_) {}
   }
-  if (payload?.data?.stats && dashboardWindow && !dashboardWindow.isDestroyed()) {
+  const nextHistoryRevision = statsHistoryRevision(payload?.data?.stats);
+  if (nextHistoryRevision !== previousHistoryRevision && dashboardWindow && !dashboardWindow.isDestroyed()) {
     try { dashboardWindow.webContents.send('dashboard:historyChanged'); } catch (_) {}
   }
+}
+
+function statsHistoryRevision(stats) {
+  const revision = String(stats?.historyRevision || '').trim();
+  if (revision) return revision;
+  // Compatibility with an older remote hub that has not shipped revisions yet.
+  return JSON.stringify(stats?.historyPreview || null);
 }
 
 let rateCache = null;            // { rates, date, source, fetchedAt }

--- a/src/electron/preload.js
+++ b/src/electron/preload.js
@@ -13,6 +13,11 @@ contextBridge.exposeInMainWorld('tokenMonitor', {
   getServiceStatus: (options) => ipcRenderer.invoke('serviceStatus:get', options),
   openDashboard: () => ipcRenderer.invoke('dashboard:open'),
   getDashboardHistory: () => ipcRenderer.invoke('dashboard:getHistory'),
+  onDashboardHistoryChanged: (callback) => {
+    const listener = () => { try { callback(); } catch (_) {} };
+    ipcRenderer.on('dashboard:historyChanged', listener);
+    return () => ipcRenderer.removeListener('dashboard:historyChanged', listener);
+  },
   dashboard: {
     minimize: () => ipcRenderer.send('dashboard:minimize'),
     close: () => ipcRenderer.send('dashboard:close')

--- a/src/electron/renderer/dashboard.js
+++ b/src/electron/renderer/dashboard.js
@@ -365,10 +365,27 @@ function showHeatTooltip(date, day, ev) {
   positionTooltip(ev);
 }
 
+let refreshRunning = false;
+let refreshQueued = false;
+
 async function refresh() {
-  try { state.history = await window.tokenMonitor.getDashboardHistory(); }
-  catch (error) { console.log(`[dashboard] history failed: ${error.message}`); state.history = { daily: [], monthly: [], summary: {} }; }
-  render();
+  if (refreshRunning) {
+    refreshQueued = true;
+    return;
+  }
+  refreshRunning = true;
+  try {
+    state.history = await window.tokenMonitor.getDashboardHistory();
+    render();
+  } catch (error) {
+    console.log(`[dashboard] history failed: ${error.message}`);
+  } finally {
+    refreshRunning = false;
+    if (refreshQueued) {
+      refreshQueued = false;
+      void refresh();
+    }
+  }
 }
 
 async function boot() {
@@ -405,6 +422,8 @@ window.tokenMonitor.onSettingsPush?.((next) => {
   }
   if (needsRender) render();
 });
+
+window.tokenMonitor.onDashboardHistoryChanged?.(() => { void refresh(); });
 
 els.tabs.forEach((tab) => tab.addEventListener('click', () => { state.tab = tab.dataset.tab; els.tabs.forEach((x) => x.classList.toggle('active', x === tab)); render(); }));
 els.stackBtns.forEach((b) => b.addEventListener('click', () => { state.stackBy = b.dataset.stack; render(); }));

--- a/src/hub/server.js
+++ b/src/hub/server.js
@@ -40,12 +40,12 @@ function createHub({
 
   function getStats() {
     const stats = aggregateDevices(Object.values(store.devices), staleAfterMs);
-    stats.historyPreview = historyPreview(aggregateHistory(Object.values(store.devices), staleAfterMs));
+    stats.historyPreview = historyPreview(aggregateHistory(Object.values(store.devices)));
     return stats;
   }
 
   function getHistory() {
-    return aggregateHistory(Object.values(store.devices), staleAfterMs);
+    return aggregateHistory(Object.values(store.devices));
   }
 
   const sseClients = new Set();

--- a/src/hub/server.js
+++ b/src/hub/server.js
@@ -4,7 +4,7 @@ const http = require('node:http');
 const path = require('node:path');
 const { URL } = require('node:url');
 const { aggregateDevices, mergeDeviceRecord, aggregateHistory } = require('../shared/usage');
-const { historyPreview } = require('../shared/history');
+const { historyPreview, historyRevision } = require('../shared/history');
 const { isAuthorized, readJsonBody, sendJson, sendText } = require('../shared/http');
 const { loadDotEnv, parseArgs, projectRoot, readJson, writeJsonAtomic } = require('../shared/config');
 
@@ -40,7 +40,9 @@ function createHub({
 
   function getStats() {
     const stats = aggregateDevices(Object.values(store.devices), staleAfterMs);
-    stats.historyPreview = historyPreview(aggregateHistory(Object.values(store.devices)));
+    const history = aggregateHistory(Object.values(store.devices));
+    stats.historyPreview = historyPreview(history);
+    stats.historyRevision = historyRevision(history);
     return stats;
   }
 

--- a/src/shared/history.js
+++ b/src/shared/history.js
@@ -154,6 +154,16 @@ function monthlyRollup(days) {
 
 const DEFAULT_CAP_DAYS = 370;
 
+function rollingDailyWindow(days, todayKey, capDays = DEFAULT_CAP_DAYS) {
+  const count = Math.max(0, Math.floor(num(capDays)));
+  if (count === 0) return [];
+  const startKey = dayKeyAddDays(todayKey, -(count - 1));
+  return (Array.isArray(days) ? days : []).filter((d) => {
+    const key = String(d?.date || '').slice(0, 10);
+    return key >= startKey && key <= todayKey;
+  });
+}
+
 function favoriteModelOf(contributions) {
   const totals = {};
   for (const d of contributions) {
@@ -179,10 +189,7 @@ function normalizeHistory(graphData, options = {}) {
     .slice()
     .sort((a, b) => a.date.localeCompare(b.date));
 
-  const cutoffMs = Date.parse(`${todayKey}T00:00:00Z`) - capDays * 86400000;
-  const daily = full
-    .filter((d) => Date.parse(`${d.date}T00:00:00Z`) >= cutoffMs)
-    .map((d) => ({ ...d }));
+  const daily = rollingDailyWindow(full, todayKey, capDays).map((d) => ({ ...d }));
   computeIntensities(daily);
 
   const monthly = monthlyRollup(full);
@@ -242,8 +249,12 @@ function mergeMonthlyMaps(histories) {
 function mergeHistories(histories, options = {}) {
   const list = Array.isArray(histories) ? histories : [];
   const todayKey = String(options.todayKey || new Date().toISOString().slice(0, 10)).slice(0, 10);
+  const capDays = Number.isFinite(options.capDays) ? options.capDays : DEFAULT_CAP_DAYS;
 
-  const daily = mergeDailyMaps(list);
+  // Re-cap after merging: an offline device's persisted daily tier no longer
+  // advances at collection time, but the aggregate must keep a rolling window.
+  // Monthly/lifetime data remains durable and uncapped.
+  const daily = rollingDailyWindow(mergeDailyMaps(list), todayKey, capDays);
   computeIntensities(daily);
   const monthly = mergeMonthlyMaps(list);
 
@@ -289,8 +300,33 @@ function historyPreview(history, options = {}) {
   return { daily, monthly, summary: h.summary };
 }
 
+function stableJson(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null';
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  const entries = Object.keys(value)
+    .filter((key) => value[key] !== undefined)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`);
+  return `{${entries.join(',')}}`;
+}
+
+// Compact, deterministic invalidation token for the full history payload. This
+// includes daily/monthly breakdowns (not just headline totals), stays portable
+// to the Worker runtime, and keeps /api/stats small.
+function historyRevision(history) {
+  const source = stableJson(coerceHistory(history));
+  let first = 0x811c9dc5;
+  let second = 0x9e3779b9;
+  for (let i = 0; i < source.length; i += 1) {
+    const code = source.charCodeAt(i);
+    first = Math.imul(first ^ code, 0x01000193);
+    second = Math.imul(second ^ code, 0x85ebca6b);
+  }
+  return `${(first >>> 0).toString(16).padStart(8, '0')}${(second >>> 0).toString(16).padStart(8, '0')}`;
+}
+
 module.exports = {
   num, sumTokens, parseGraphResult, computeIntensities,
   computeStreaks, monthlyRollup, normalizeHistory, mergeHistories,
-  coerceHistory, historyPreview
+  coerceHistory, historyPreview, historyRevision
 };

--- a/src/shared/usage.js
+++ b/src/shared/usage.js
@@ -668,14 +668,15 @@ function carryDeviceHistory(previous, incoming) {
   return incoming;
 }
 
-function aggregateHistory(devices, staleAfterMs, nowMs = Date.now()) {
+// History is durable device data, not live presence. Keep a stored device's
+// contributions in the aggregate while it is offline; explicit device deletion
+// is the boundary that removes them. Staleness still applies independently to
+// live limits and expired today/month period snapshots.
+function aggregateHistory(devices) {
   const histories = [];
   for (const record of devices) {
     const normalized = normalizeDeviceRecord(record);
     if (!hasOwn(normalized, 'history')) continue;
-    const ageMs = nowMs - Date.parse(normalized.receivedAt || normalized.updatedAt || 0);
-    const stale = Number.isFinite(ageMs) && staleAfterMs > 0 ? ageMs > staleAfterMs : false;
-    if (stale) continue;
     histories.push(normalized.history);
   }
   return mergeHistories(histories);

--- a/tests/electron/dashboardWindow.test.js
+++ b/tests/electron/dashboardWindow.test.js
@@ -103,6 +103,7 @@ test('dashboard.js fetches history over IPC and renders both tabs', () => {
 
 test('main invalidates an open dashboard when a stats update arrives', () => {
   const main = read('src', 'electron', 'main.js');
+  assert.match(main, /nextHistoryRevision !== previousHistoryRevision/);
   assert.match(main, /dashboardWindow\.webContents\.send\('dashboard:historyChanged'\)/);
 });
 

--- a/tests/electron/dashboardWindow.test.js
+++ b/tests/electron/dashboardWindow.test.js
@@ -12,6 +12,7 @@ test('preload exposes the dashboard IPC surface', () => {
   const preload = read('src', 'electron', 'preload.js');
   assert.match(preload, /openDashboard: \(\) => ipcRenderer\.invoke\('dashboard:open'\)/);
   assert.match(preload, /getDashboardHistory: \(\) => ipcRenderer\.invoke\('dashboard:getHistory'\)/);
+  assert.match(preload, /ipcRenderer\.on\('dashboard:historyChanged', listener\)/);
   assert.match(preload, /dashboard: \{/);
   assert.match(preload, /minimize: \(\) => ipcRenderer\.send\('dashboard:minimize'\)/);
   assert.match(preload, /close: \(\) => ipcRenderer\.send\('dashboard:close'\)/);
@@ -29,7 +30,7 @@ test('main registers dashboard handlers and a sender-scoped close', () => {
 
 test('getDashboardHistory mirrors the local/sync split of fetchStats', () => {
   const main = read('src', 'electron', 'main.js');
-  assert.match(main, /aggregateHistory\(localDevice \? \[localDevice\] : \[\], 0\)/);
+  assert.match(main, /aggregateHistory\(localDevice \? \[localDevice\] : \[\]\)/);
   assert.match(main, /\/api\/history/);
 });
 
@@ -47,7 +48,7 @@ test('dashboard history is gated by the historyEnabled setting', () => {
   const main = read('src', 'electron', 'main.js');
   assert.match(main, /historyEnabled:\s*true/);
   assert.match(main, /historyEnabled:\s*parseBoolean\(patch\.historyEnabled[\s\S]*?,\s*false\)/);
-  assert.match(main, /if \(settings\?\.historyEnabled === false\) return aggregateHistory\(\[\], 0\)/);
+  assert.match(main, /if \(settings\?\.historyEnabled === false\) return aggregateHistory\(\[\]\)/);
   assert.match(main, /historyEnabled:\s*settings\.historyEnabled !== false/);
 });
 
@@ -97,6 +98,12 @@ test('dashboard.js fetches history over IPC and renders both tabs', () => {
   assert.match(js, /charts\.heatmapSvg/);
   assert.match(js, /updateSettings\(\{ dashboardFlat: state\.flat \}\)/);
   assert.match(js, /dashboard\.minimize\(\)/);
+  assert.match(js, /onDashboardHistoryChanged\?\.\(\(\) => \{ void refresh\(\); \}\)/);
+});
+
+test('main invalidates an open dashboard when a stats update arrives', () => {
+  const main = read('src', 'electron', 'main.js');
+  assert.match(main, /dashboardWindow\.webContents\.send\('dashboard:historyChanged'\)/);
 });
 
 test('dashboard repains on a rate-only settings push, not just a currency-code change', () => {

--- a/tests/electron/dashboardWindow.test.js
+++ b/tests/electron/dashboardWindow.test.js
@@ -101,10 +101,11 @@ test('dashboard.js fetches history over IPC and renders both tabs', () => {
   assert.match(js, /onDashboardHistoryChanged\?\.\(\(\) => \{ void refresh\(\); \}\)/);
 });
 
-test('main invalidates an open dashboard when a stats update arrives', () => {
+test('main invalidates an open dashboard only when stats history changes', () => {
   const main = read('src', 'electron', 'main.js');
-  assert.match(main, /nextHistoryRevision !== previousHistoryRevision/);
-  assert.match(main, /dashboardWindow\.webContents\.send\('dashboard:historyChanged'\)/);
+  const sendPush = /function sendPush\(payload\)\s*\{([\s\S]*?)\n\}\n\nfunction statsHistoryRevision/.exec(main);
+  assert.ok(sendPush, 'sendPush should be defined before statsHistoryRevision');
+  assert.match(sendPush[1], /if \(payload\?\.data\?\.stats\) \{[\s\S]*?nextHistoryRevision !== previousHistoryRevision[\s\S]*?dashboardWindow\.webContents\.send\('dashboard:historyChanged'\)/);
 });
 
 test('dashboard repains on a rate-only settings push, not just a currency-code change', () => {

--- a/tests/shared/history.test.js
+++ b/tests/shared/history.test.js
@@ -221,7 +221,34 @@ test('mergeHistories handles empty list', () => {
   assert.equal(m.summary.totalTokens, 0);
 });
 
-const { coerceHistory, historyPreview } = require('../../src/shared/history');
+const { coerceHistory, historyPreview, historyRevision } = require('../../src/shared/history');
+
+test('mergeHistories re-caps stale device daily rows without losing lifetime totals', () => {
+  const history = {
+    daily: [
+      { date: '2025-05-01', tokens: 100, cost: 5, perClient: {}, perModel: {} },
+      { date: '2026-06-07', tokens: 10, cost: 1, perClient: {}, perModel: {} }
+    ],
+    monthly: [
+      { month: '2025-05', tokens: 100, cost: 5, perClient: {}, perModel: {} },
+      { month: '2026-06', tokens: 10, cost: 1, perClient: {}, perModel: {} }
+    ],
+    summary: {}
+  };
+  const merged = mergeHistories([history], { todayKey: '2026-06-07', capDays: 370 });
+  assert.deepEqual(merged.daily.map((day) => day.date), ['2026-06-07']);
+  assert.equal(merged.summary.activeDays, 1);
+  assert.equal(merged.summary.peakDayTokens, 10);
+  assert.equal(merged.summary.totalTokens, 110);
+});
+
+test('historyRevision is key-order stable and tracks breakdown changes', () => {
+  const first = { daily: [{ date: '2026-06-07', tokens: 10, perClient: { codex: { tokens: 10 } } }], monthly: [], summary: { totalTokens: 10 } };
+  const reordered = { summary: { totalTokens: 10 }, monthly: [], daily: [{ perClient: { codex: { tokens: 10 } }, tokens: 10, date: '2026-06-07' }] };
+  const changed = { ...first, daily: [{ date: '2026-06-07', tokens: 10, perClient: { claude: { tokens: 10 } } }] };
+  assert.equal(historyRevision(first), historyRevision(reordered));
+  assert.notEqual(historyRevision(first), historyRevision(changed));
+});
 
 test('coerceHistory normalizes shape and drops garbage', () => {
   assert.deepEqual(coerceHistory(null), { daily: [], monthly: [], summary: {} });

--- a/tests/shared/usage.test.js
+++ b/tests/shared/usage.test.js
@@ -675,8 +675,7 @@ test('mergeDeviceRecord clears prior history when incoming history is explicitly
   assert.deepEqual(merged.history, { daily: [], monthly: [], summary: {} });
 });
 
-test('aggregateHistory merges non-stale devices and skips stale ones', () => {
-  const now = Date.parse('2026-06-07T12:00:00.000Z');
+test('aggregateHistory retains stored history from stale devices', () => {
   const fresh = {
     deviceId: 'm1', receivedAt: '2026-06-07T11:59:00.000Z',
     history: { daily: [{ date: '2026-06-07', tokens: 10, cost: 1, perClient: { claude: { tokens: 10, cost: 1, messages: 1 } }, perModel: {} }],
@@ -687,14 +686,14 @@ test('aggregateHistory merges non-stale devices and skips stale ones', () => {
     history: { daily: [{ date: '2026-06-07', tokens: 999, cost: 99, perClient: {}, perModel: {} }],
       monthly: [{ month: '2026-06', tokens: 999, cost: 99, perClient: {}, perModel: {} }], summary: {} }
   };
-  const merged = aggregateHistory([fresh, stale], 10 * 60 * 1000, now);
+  const merged = aggregateHistory([fresh, stale]);
   assert.equal(merged.daily.length, 1);
-  assert.equal(merged.daily[0].tokens, 10);     // stale m2 excluded
-  assert.equal(merged.summary.totalTokens, 10);
+  assert.equal(merged.daily[0].tokens, 1009);
+  assert.equal(merged.summary.totalTokens, 1009);
 });
 
 test('aggregateHistory tolerates devices without history', () => {
-  const merged = aggregateHistory([{ deviceId: 'm1', receivedAt: new Date().toISOString() }], 10 * 60 * 1000);
+  const merged = aggregateHistory([{ deviceId: 'm1', receivedAt: new Date().toISOString() }]);
   assert.deepEqual(merged.daily, []);
 });
 
@@ -736,7 +735,7 @@ test('a history-less local tick keeps the trends dashboard populated', () => {
       monthly: [{ month: '2026-06', tokens: 5, cost: 1, perClient: {}, perModel: {} }], summary: {} }
   };
   const second = carryDeviceHistory(first, { deviceId: 'm1', receivedAt: '2026-06-08T00:05:00.000Z' });
-  const agg = aggregateHistory([second], 0);
+  const agg = aggregateHistory([second]);
   assert.equal(agg.daily.length, 1);
   assert.equal(agg.daily[0].tokens, 5);
 });

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -77,7 +77,7 @@ export class HubDO {
   async getStats() {
     const devices = await this.listDevices();
     const stats = aggregateDevices(devices, this.staleAfterMs);
-    stats.historyPreview = historyPreview(aggregateHistory(devices, this.staleAfterMs));
+    stats.historyPreview = historyPreview(aggregateHistory(devices));
     return stats;
   }
 
@@ -163,7 +163,7 @@ export class HubDO {
 
     if ((request.method === 'GET' || request.method === 'HEAD') && url.pathname === '/api/history') {
       const devices = await this.listDevices();
-      return jsonResponse(200, aggregateHistory(devices, this.staleAfterMs));
+      return jsonResponse(200, aggregateHistory(devices));
     }
 
     if (request.method === 'GET' && url.pathname === '/api/stats/stream') {

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,6 +1,6 @@
 import { publicLimits } from './shared/limits.js';
 import { aggregateDevices, mergeDeviceRecord, aggregateHistory } from './shared/usage.js';
-import { historyPreview } from './shared/history.js';
+import { historyPreview, historyRevision } from './shared/history.js';
 
 const CORS_HEADERS = {
   'access-control-allow-origin': '*',
@@ -77,7 +77,9 @@ export class HubDO {
   async getStats() {
     const devices = await this.listDevices();
     const stats = aggregateDevices(devices, this.staleAfterMs);
-    stats.historyPreview = historyPreview(aggregateHistory(devices));
+    const history = aggregateHistory(devices);
+    stats.historyPreview = historyPreview(history);
+    stats.historyRevision = historyRevision(history);
     return stats;
   }
 

--- a/worker/src/shared/history.js
+++ b/worker/src/shared/history.js
@@ -157,6 +157,16 @@ function monthlyRollup(days) {
 
 const DEFAULT_CAP_DAYS = 370;
 
+function rollingDailyWindow(days, todayKey, capDays = DEFAULT_CAP_DAYS) {
+  const count = Math.max(0, Math.floor(num(capDays)));
+  if (count === 0) return [];
+  const startKey = dayKeyAddDays(todayKey, -(count - 1));
+  return (Array.isArray(days) ? days : []).filter((d) => {
+    const key = String(d?.date || '').slice(0, 10);
+    return key >= startKey && key <= todayKey;
+  });
+}
+
 function favoriteModelOf(contributions) {
   const totals = {};
   for (const d of contributions) {
@@ -182,10 +192,7 @@ function normalizeHistory(graphData, options = {}) {
     .slice()
     .sort((a, b) => a.date.localeCompare(b.date));
 
-  const cutoffMs = Date.parse(`${todayKey}T00:00:00Z`) - capDays * 86400000;
-  const daily = full
-    .filter((d) => Date.parse(`${d.date}T00:00:00Z`) >= cutoffMs)
-    .map((d) => ({ ...d }));
+  const daily = rollingDailyWindow(full, todayKey, capDays).map((d) => ({ ...d }));
   computeIntensities(daily);
 
   const monthly = monthlyRollup(full);
@@ -245,8 +252,12 @@ function mergeMonthlyMaps(histories) {
 function mergeHistories(histories, options = {}) {
   const list = Array.isArray(histories) ? histories : [];
   const todayKey = String(options.todayKey || new Date().toISOString().slice(0, 10)).slice(0, 10);
+  const capDays = Number.isFinite(options.capDays) ? options.capDays : DEFAULT_CAP_DAYS;
 
-  const daily = mergeDailyMaps(list);
+  // Re-cap after merging: an offline device's persisted daily tier no longer
+  // advances at collection time, but the aggregate must keep a rolling window.
+  // Monthly/lifetime data remains durable and uncapped.
+  const daily = rollingDailyWindow(mergeDailyMaps(list), todayKey, capDays);
   computeIntensities(daily);
   const monthly = mergeMonthlyMaps(list);
 
@@ -292,8 +303,33 @@ function historyPreview(history, options = {}) {
   return { daily, monthly, summary: h.summary };
 }
 
+function stableJson(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null';
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  const entries = Object.keys(value)
+    .filter((key) => value[key] !== undefined)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`);
+  return `{${entries.join(',')}}`;
+}
+
+// Compact, deterministic invalidation token for the full history payload. This
+// includes daily/monthly breakdowns (not just headline totals), stays portable
+// to the Worker runtime, and keeps /api/stats small.
+function historyRevision(history) {
+  const source = stableJson(coerceHistory(history));
+  let first = 0x811c9dc5;
+  let second = 0x9e3779b9;
+  for (let i = 0; i < source.length; i += 1) {
+    const code = source.charCodeAt(i);
+    first = Math.imul(first ^ code, 0x01000193);
+    second = Math.imul(second ^ code, 0x85ebca6b);
+  }
+  return `${(first >>> 0).toString(16).padStart(8, '0')}${(second >>> 0).toString(16).padStart(8, '0')}`;
+}
+
 module.exports = {
   num, sumTokens, parseGraphResult, computeIntensities,
   computeStreaks, monthlyRollup, normalizeHistory, mergeHistories,
-  coerceHistory, historyPreview
+  coerceHistory, historyPreview, historyRevision
 };

--- a/worker/src/shared/usage.js
+++ b/worker/src/shared/usage.js
@@ -671,14 +671,15 @@ function carryDeviceHistory(previous, incoming) {
   return incoming;
 }
 
-function aggregateHistory(devices, staleAfterMs, nowMs = Date.now()) {
+// History is durable device data, not live presence. Keep a stored device's
+// contributions in the aggregate while it is offline; explicit device deletion
+// is the boundary that removes them. Staleness still applies independently to
+// live limits and expired today/month period snapshots.
+function aggregateHistory(devices) {
   const histories = [];
   for (const record of devices) {
     const normalized = normalizeDeviceRecord(record);
     if (!hasOwn(normalized, 'history')) continue;
-    const ageMs = nowMs - Date.parse(normalized.receivedAt || normalized.updatedAt || 0);
-    const stale = Number.isFinite(ageMs) && staleAfterMs > 0 ? ageMs > staleAfterMs : false;
-    if (stale) continue;
     histories.push(normalized.history);
   }
   return mergeHistories(histories);


### PR DESCRIPTION
## Summary

- retain persisted device history when a device becomes stale, while keeping stale handling for live limits and expired today/month snapshots
- refresh an already-open Usage Dashboard when the hub publishes updated stats
- coalesce overlapping dashboard history refreshes so a slower request cannot overwrite newer data
- re-cap merged daily history to the rolling retention window while keeping monthly/lifetime totals durable
- publish a compact full-history revision so limit-only and unchanged stats pushes do not rerender the dashboard
- keep the Cloudflare Worker shared history behavior aligned with the Node hub

## Why

History is durable usage data. Previously, `aggregateHistory()` excluded stale devices even though their history remained persisted in the hub store. That made offline devices disappear from `/api/history` and `historyPreview`, and could make Home disagree with an already-open Usage Dashboard because the two surfaces refreshed on different schedules.

## Verification

- `npm run sync:worker`
- `npm run verify` (1122 tests passed)
- `node --test tests/shared/history.test.js tests/shared/usage.test.js tests/electron/dashboardWindow.test.js tests/hub/server.test.js` (77 tests passed)
