### PR TITLE
fix(sync): restore the TOTAL session view in sync/host mode

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -1875,13 +1875,15 @@ function injectLocalDeviceStatus(stats) {
     }
   }
   // syncPayload drops the unbounded allTime.sessions from uploads (#118), so the hub's
-  // aggregate carries no all-time session detail and the TOTAL session view would fall back to
-  // a model list. Rebuild it: the hub's cross-device month sessions are the immediate
-  // baseline (available on the first frame — before this restart's first local scan), then
-  // this machine's own full all-time sessions merge in once collected (free, in-process).
-  // Totals/breakdowns are untouched, so this only restores the session list.
+  // aggregate carries no all-time session detail and the TOTAL session view would fall back
+  // to a model list. Rebuild the list — the hub's cross-device month sessions as the
+  // immediate baseline (present on the first frame, before this restart's first local scan),
+  // then this machine's own full all-time sessions once collected (free, in-process). Carry
+  // it as a display-only sibling instead of mutating periods.allTime.sessions: the exporter
+  // writes periods verbatim under a lossless contract, so the export must keep the true
+  // aggregate. The renderer overlays this onto periods.allTime for the session view.
   if (stats.periods?.allTime) {
-    stats.periods.allTime.sessions = mergedLocalAllTimeSessions(stats.periods, lastCollectedDevice);
+    stats.allTimeSessionsView = mergedLocalAllTimeSessions(stats.periods, lastCollectedDevice);
   }
   return stats;
 }

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -1874,7 +1874,7 @@ function injectLocalDeviceStatus(stats) {
       if (lastCollectedDevice.wslStatus) device.wslStatus = lastCollectedDevice.wslStatus;
     }
   }
-  // syncPayload drops the unbounded allTime.sessions from uploads (#118), so the hub's
+  // syncPayload drops the unbounded allTime.sessions from uploads (#118), so a hub
   // aggregate carries no all-time session detail and the TOTAL session view would fall back
   // to a model list. Rebuild the list — the hub's cross-device month sessions as the
   // immediate baseline (present on the first frame, before this restart's first local scan),
@@ -1882,7 +1882,9 @@ function injectLocalDeviceStatus(stats) {
   // it as a display-only sibling instead of mutating periods.allTime.sessions: the exporter
   // writes periods verbatim under a lossless contract, so the export must keep the true
   // aggregate. The renderer overlays this onto periods.allTime for the session view.
-  if (stats.periods?.allTime) {
+  // Only sync/host mode needs this: in local mode periods.allTime.sessions already holds the
+  // full native list, so building the sibling there would just ship the unbounded map twice.
+  if (mode !== 'local' && stats.periods?.allTime) {
     stats.allTimeSessionsView = mergedLocalAllTimeSessions(stats.periods, lastCollectedDevice);
   }
   return stats;

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -85,6 +85,7 @@ const {
 } = require('../shared/sessionUsageArchive');
 const { aggregateDevices, aggregateHistory, carryDeviceHistory } = require('../shared/usage');
 const { syncPayload } = require('../shared/syncPayload');
+const { mergedLocalAllTimeSessions } = require('../shared/localSessions');
 const {
   MIMO_PLATFORM_CONSOLE_URL,
   createMimoManagedAccount,
@@ -1865,11 +1866,23 @@ function startHostStats() {
 // sync/host mode without depending on the hub (or a remote Worker) being
 // redeployed to preserve these fields.
 function injectLocalDeviceStatus(stats) {
-  if (!stats || !lastCollectedDevice || !Array.isArray(stats.devices)) return stats;
-  const device = stats.devices.find((entry) => entry.deviceId === lastCollectedDevice.deviceId);
-  if (!device) return stats;
-  if (lastCollectedDevice.clientStatus) device.clientStatus = lastCollectedDevice.clientStatus;
-  if (lastCollectedDevice.wslStatus) device.wslStatus = lastCollectedDevice.wslStatus;
+  if (!stats || !Array.isArray(stats.devices)) return stats;
+  if (lastCollectedDevice) {
+    const device = stats.devices.find((entry) => entry.deviceId === lastCollectedDevice.deviceId);
+    if (device) {
+      if (lastCollectedDevice.clientStatus) device.clientStatus = lastCollectedDevice.clientStatus;
+      if (lastCollectedDevice.wslStatus) device.wslStatus = lastCollectedDevice.wslStatus;
+    }
+  }
+  // syncPayload drops the unbounded allTime.sessions from uploads (#118), so the hub's
+  // aggregate carries no all-time session detail and the TOTAL session view would fall back to
+  // a model list. Rebuild it: the hub's cross-device month sessions are the immediate
+  // baseline (available on the first frame — before this restart's first local scan), then
+  // this machine's own full all-time sessions merge in once collected (free, in-process).
+  // Totals/breakdowns are untouched, so this only restores the session list.
+  if (stats.periods?.allTime) {
+    stats.periods.allTime.sessions = mergedLocalAllTimeSessions(stats.periods, lastCollectedDevice);
+  }
   return stats;
 }
 

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -3532,6 +3532,18 @@ function settleRefreshButtonState(status) {
   }, REFRESH_BUTTON_FEEDBACK_MS);
 }
 
+// The main process rebuilds the TOTAL session list for display but ships it as a
+// display-only sibling (`allTimeSessionsView`) so it never pollutes the lossless
+// period export. Overlay it onto periods.allTime here, on the renderer's own copy, so
+// every session-view reader (list, archived count, detail lookup) sees it. See
+// injectLocalDeviceStatus in main.js.
+function overlayAllTimeSessions(stats) {
+  if (stats && stats.allTimeSessionsView && stats.periods?.allTime) {
+    stats.periods.allTime.sessions = stats.allTimeSessionsView;
+  }
+  return stats;
+}
+
 async function refreshStats(options = {}) {
   const feedback = options.feedback === true;
   if (feedback) {
@@ -3541,7 +3553,7 @@ async function refreshStats(options = {}) {
     setRefreshButtonState('refreshing');
   }
   try {
-    state.stats = await window.tokenMonitor.getStats(options);
+    state.stats = overlayAllTimeSessions(await window.tokenMonitor.getStats(options));
     applyCodexActiveAccountFromStats();
     setStatus(statusTextFor(state.mode, state.streamConnected));
     render();
@@ -6021,7 +6033,7 @@ window.tokenMonitor.onStatsPush?.((payload) => {
     state.streamConnected = true;
     state.streamFailure = null;
     if (payload.data?.mode) state.mode = payload.data.mode;
-    state.stats = payload.data.stats;
+    state.stats = overlayAllTimeSessions(payload.data.stats);
     applyCodexActiveAccountFromStats();
     // Progressive mid-tick pushes never carry a fresh history scan (see
     // AGENTS.md collector notes), so only the final push can retire the

--- a/src/shared/localSessions.js
+++ b/src/shared/localSessions.js
@@ -1,0 +1,29 @@
+'use strict';
+
+// `allTime.sessions` is an unbounded, ever-growing collection, so syncPayload drops it
+// from uploads to keep them under the hub's ingest limit (#118). That leaves the hub's
+// aggregate with no all-time session detail, which would blank the TOTAL session view (it
+// falls back to a model list). Rebuild the view-layer all-time session map from what is
+// actually available:
+//   - the hub's cross-device month sessions as the immediate, always-synced baseline
+//     (today ⊆ month, so month already covers today) — this is what shows on the first
+//     frame after launch, before this machine's own scan has run;
+//   - the local device's authoritative all-time sessions, merged last (free — already
+//     collected in-process) so its full history replaces the month-scoped value for the
+//     same session once the scan lands (~seconds after launch).
+// Passing a null/absent localDevice yields just the month baseline, which is exactly the
+// desired startup placeholder.
+
+function asSessions(value) {
+  return value && typeof value === 'object' ? value : null;
+}
+
+function mergedLocalAllTimeSessions(periods, localDevice) {
+  return {
+    ...asSessions(periods?.month?.sessions),
+    ...asSessions(periods?.allTime?.sessions),
+    ...asSessions(localDevice?.allTime?.sessions)
+  };
+}
+
+module.exports = { mergedLocalAllTimeSessions };

--- a/tests/shared/localSessions.test.js
+++ b/tests/shared/localSessions.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { mergedLocalAllTimeSessions } = require('../../src/shared/localSessions');
+
+test('rebuilds all-time sessions from the local device when the hub dropped them', () => {
+  const periods = {
+    month: { sessions: {} },
+    allTime: { sessions: {} } // stripped on the wire by syncPayload (#118)
+  };
+  const localDevice = {
+    allTime: { sessions: { 'claude:s1': { totalTokens: 100, client: 'claude', sessionId: 's1' } } }
+  };
+
+  assert.deepEqual(mergedLocalAllTimeSessions(periods, localDevice), {
+    'claude:s1': { totalTokens: 100, client: 'claude', sessionId: 's1' }
+  });
+});
+
+test('unions cross-device month sessions the local device does not have', () => {
+  const periods = {
+    month: { sessions: { 'codex:remote': { totalTokens: 20, client: 'codex', sessionId: 'remote' } } },
+    allTime: { sessions: {} }
+  };
+  const localDevice = {
+    allTime: { sessions: { 'claude:local': { totalTokens: 100, client: 'claude', sessionId: 'local' } } }
+  };
+
+  assert.deepEqual(
+    Object.keys(mergedLocalAllTimeSessions(periods, localDevice)).sort(),
+    ['claude:local', 'codex:remote']
+  );
+});
+
+test('local all-time value wins over the month-scoped value for the same session', () => {
+  const periods = {
+    month: { sessions: { 'claude:s1': { totalTokens: 30, client: 'claude', sessionId: 's1' } } },
+    allTime: { sessions: {} }
+  };
+  const localDevice = {
+    allTime: { sessions: { 'claude:s1': { totalTokens: 100, client: 'claude', sessionId: 's1' } } }
+  };
+
+  assert.equal(mergedLocalAllTimeSessions(periods, localDevice)['claude:s1'].totalTokens, 100);
+});
+
+test('falls back to the hub month sessions as the startup placeholder before local data lands', () => {
+  const periods = {
+    month: { sessions: {
+      'codex:recent': { totalTokens: 20, client: 'codex', sessionId: 'recent', lastUsedAt: '2026-07-12T09:00:00Z' }
+    } },
+    allTime: { sessions: {} } // stripped on the wire
+  };
+
+  // No local device yet (first frame after launch) -> the TOTAL view shows the hub's
+  // cross-device month sessions instead of blanking / falling back to a model list.
+  assert.deepEqual(mergedLocalAllTimeSessions(periods, null), {
+    'codex:recent': { totalTokens: 20, client: 'codex', sessionId: 'recent', lastUsedAt: '2026-07-12T09:00:00Z' }
+  });
+  assert.deepEqual(mergedLocalAllTimeSessions(periods, undefined), periods.month.sessions);
+});
+
+test('tolerates missing periods and device without throwing', () => {
+  assert.deepEqual(mergedLocalAllTimeSessions(undefined, undefined), {});
+  assert.deepEqual(mergedLocalAllTimeSessions({}, {}), {});
+  assert.deepEqual(mergedLocalAllTimeSessions({ allTime: {} }, { allTime: {} }), {});
+});


### PR DESCRIPTION
## Summary

Follow-up to #121. Bounding sync payloads (#118) works by stripping the unbounded `allTime.sessions` from uploads, so a hub's aggregate carries no all-time session detail. In sync/host mode that blanked the **TOTAL → Sessions** view: `sessionRowsForPeriod` found no session rows but a non-zero `totalTokens`, so it silently fell back to the **model** list — a "Sessions" view rendering models. DAY/MONTH were unaffected (their sessions are still synced).

This rebuilds the all-time session list for display in `injectLocalDeviceStatus`, without putting `allTime.sessions` back on the wire:

- **Immediate baseline** — the hub's cross-device `month.sessions` (always synced, `today ⊆ month`) is shown on the first frame after launch, so the view is populated right away instead of falling back to models.
- **Full local history merges in** — once this machine's first scan lands (~seconds), its own complete `allTime.sessions` (already collected in-process, so free) merges over the baseline, its authoritative values winning per session.

`allTime` stays out of the upload payload, so #118's bound is untouched; totals and breakdowns are untouched, so there's no double-counting.

## Behavior

- Sync/host mode, TOTAL → Sessions: shows recent cross-device sessions immediately, then this machine's full history a few seconds after launch.
- Local mode: unchanged (it already carries full `allTime.sessions` natively).
- Known residual (tracked separately, not addressed here): a device with all-time tokens but no activity **this month** briefly shows the model fallback until its first scan; and tools that never expose sessions still fall back to models. The silent model fallback itself is a latent UX wart worth converting to an explicit empty state later.

## Verification

- `npm run verify` — lint clean, 1180 tests pass (new `tests/shared/localSessions.test.js`, incl. the null-local → month-placeholder case).
- End-to-end through the real renderer `sessionRows` module: first frame with no local data yet renders the hub's month session (kind=session, not a model row); after the local merge it renders the full history.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the TOTAL → Sessions view in sync/host mode by rebuilding the all‑time session list locally, without uploading `allTime.sessions`. The rebuilt list is display-only (`allTimeSessionsView`) to keep exports lossless; users see recent cross‑device sessions immediately, then full local history after the first scan.

- **Bug Fixes**
  - Rebuild for display in `injectLocalDeviceStatus` via `mergedLocalAllTimeSessions`: hub `month.sessions` as the startup baseline, merged with local `allTime.sessions` (local wins per session).
  - Do not mutate `periods.allTime.sessions`; carry the list as `allTimeSessionsView` and overlay it in the renderer only; apply this only in sync/host mode (skip in local) to avoid duplicating the unbounded list over IPC.
  - Preserve `syncPayload` limits (no `allTime.sessions` on the wire); totals and breakdowns unchanged.

<sup>Written for commit 7c9a9d8f722f787065be8f9fe9b8956928ec63c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

