### PR TITLE
fix(limits): expand lone Codex quota window

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -1768,8 +1768,16 @@ function renderProviderWindows(provider, color) {
   if (provider.provider === 'codex') {
     const session = windowForKind(provider, 'session');
     const weekly = windowForKind(provider, 'weekly');
-    if (session) windows.append(limitWindowNode(session.label || 'Session', session, color, 0.95));
-    if (weekly) windows.append(limitWindowNode(weekly.label || 'Weekly', weekly, color, 0.68));
+    if (session) {
+      const sessionNode = limitWindowNode(session.label || 'Session', session, color, 0.95);
+      if (!weekly) sessionNode.classList.add('limit-window-wide');
+      windows.append(sessionNode);
+    }
+    if (weekly) {
+      const weeklyNode = limitWindowNode(weekly.label || 'Weekly', weekly, color, 0.68);
+      if (!session) weeklyNode.classList.add('limit-window-wide');
+      windows.append(weeklyNode);
+    }
     const resetNode = codexResetCreditsNode(provider.resetCredits);
     if (resetNode) windows.append(resetNode);
   } else if (provider.provider === 'cursor') {

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -459,6 +459,8 @@ test('Codex renders manual reset credits below session and weekly windows', () =
   assert.match(app, /resetCreditsTooltipActive: false/);
   assert.match(app, /resetCreditsTooltipRenderPending: false/);
   assert.match(renderProviderWindows, /provider\.provider === 'codex'/);
+  assert.match(renderProviderWindows, /if \(!weekly\) sessionNode\.classList\.add\('limit-window-wide'\);/);
+  assert.match(renderProviderWindows, /if \(!session\) weeklyNode\.classList\.add\('limit-window-wide'\);/);
   assert.match(renderProviderWindows, /const resetNode = codexResetCreditsNode\(provider\.resetCredits\);/);
   assert.doesNotMatch(renderProviderWindows, /limitWindowNode\('Reset credits'/);
   assert.match(resetCreditsValue, /if \(count <= 0\) return '';/);


### PR DESCRIPTION
## Summary

- make a lone Codex Session or Weekly quota window span the full row
- keep Session and Weekly at half width when both windows are available
- keep reset credits as a separate full-width informational row
- add renderer regression coverage for both single-window cases

## Verification

- `npm run verify`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Codex quota layout: a lone Session or Weekly window now spans the full row; when both are present, each stays half width. Reset credits remains a separate full-width row, and renderer tests cover the single-window cases.

<sup>Written for commit 34b3d352de604a5aa207b20f649beac747ffc8b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

