### PR TITLE
fix(mimo): avoid false Token Plan activation

### DIFF
--- a/src/electron/renderer/homeOverview.js
+++ b/src/electron/renderer/homeOverview.js
@@ -11,6 +11,13 @@
   ]);
 
   function finiteNumber(value) {
+    if (
+      value === null
+      || value === undefined
+      || (typeof value === 'string' && value.trim() === '')
+    ) {
+      return null;
+    }
     const number = Number(value);
     return Number.isFinite(number) ? number : null;
   }

--- a/src/shared/mimoLimits.js
+++ b/src/shared/mimoLimits.js
@@ -14,9 +14,22 @@ const MIMO_COOKIE_NAMES = new Set([
   'api-platform_slh'
 ]);
 const MIMO_REQUIRED_COOKIE_NAMES = new Set(['api-platform_serviceToken', 'userId']);
+const MIMO_NO_PLAN_CODES = new Set([
+  'default',
+  'none',
+  'no_plan',
+  'not_subscribed',
+  'unsubscribed'
+]);
+const MIMO_ACTIVE_STATUSES = new Set(['active', 'subscribed']);
+const MIMO_EXPIRED_STATUSES = new Set(['expired', 'ended']);
 
 function cleanText(value) {
   return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizePlanValue(value) {
+  return cleanText(value).toLowerCase().replace(/[\s-]+/g, '_');
 }
 
 function cookiePairs(value) {
@@ -93,12 +106,56 @@ function parseMimoProfile(body) {
 
 function parseMimoPlanDetail(body, now = Date.now()) {
   const data = unwrapApiBody(body);
+  const label = cleanText(
+    data.planCode
+    ?? data.plan_code
+    ?? data.planName
+    ?? data.plan_name
+  );
+  const normalizedLabel = normalizePlanValue(label);
+  const rawStatus = normalizePlanValue(
+    data.planStatus
+    ?? data.plan_status
+    ?? data.subscriptionStatus
+    ?? data.subscription_status
+    ?? data.status
+    ?? data.state
+  );
   const rawEnd = data.currentPeriodEnd ?? data.current_period_end;
-  const parsedEnd = rawEnd ? Date.parse(String(rawEnd).replace(' ', 'T') + (/Z$|[+-]\d\d:?\d\d$/.test(String(rawEnd)) ? '' : 'Z')) : NaN;
-  const expired = data.expired === true || (Number.isFinite(parsedEnd) && parsedEnd <= now);
+  const parsedEnd = rawEnd
+    ? Date.parse(
+      String(rawEnd).replace(' ', 'T')
+      + (/Z$|[+-]\d\d:?\d\d$/.test(String(rawEnd)) ? '' : 'Z')
+    )
+    : NaN;
+  const hasFuturePeriod = Number.isFinite(parsedEnd) && parsedEnd > now;
+  const hasExpiredPeriod = Number.isFinite(parsedEnd) && parsedEnd <= now;
+  const isKnownNoPlan = MIMO_NO_PLAN_CODES.has(normalizedLabel)
+    || MIMO_NO_PLAN_CODES.has(rawStatus);
+  const hasRealPlanIdentity = Boolean(normalizedLabel) && !MIMO_NO_PLAN_CODES.has(normalizedLabel);
+  const hasExplicitActiveFlag = typeof data.active === 'boolean'
+    || typeof data.isActive === 'boolean';
+  const explicitActive = MIMO_ACTIVE_STATUSES.has(rawStatus)
+    || data.active === true
+    || data.isActive === true;
+  const explicitExpired = MIMO_EXPIRED_STATUSES.has(rawStatus)
+    || data.expired === true
+    || String(data.expired).toLowerCase() === 'true';
+  const hasExplicitStatus = Boolean(rawStatus) || hasExplicitActiveFlag;
+  const expired = !isKnownNoPlan && (
+    explicitExpired
+    || (hasRealPlanIdentity && hasExpiredPeriod)
+  );
+  const active = !isKnownNoPlan
+    && !expired
+    && (
+      explicitActive
+      || (!hasExplicitStatus && hasRealPlanIdentity && hasFuturePeriod)
+    );
   return {
-    label: cleanText(data.planCode ?? data.plan_code ?? data.planName ?? data.plan_name),
+    label,
     resetsAt: Number.isFinite(parsedEnd) ? new Date(parsedEnd).toISOString() : null,
+    active,
     expired
   };
 }
@@ -107,10 +164,16 @@ function parseMimoPlanUsage(body) {
   const data = unwrapApiBody(body);
   const month = data.monthUsage ?? data.month_usage ?? {};
   const items = Array.isArray(month.items) ? month.items : [];
-  const item = items.find((entry) => cleanText(entry?.name) === 'month_total_token') || items[0] || month;
+  const totalItem = items.find(
+    (entry) => cleanText(entry?.name).toLowerCase() === 'month_total_token'
+  );
+  if (items.length > 0 && !totalItem) {
+    return { used: null, limit: null, usedPercent: null };
+  }
+  const item = totalItem || month;
   const used = numberFrom(item.used);
   const limit = numberFrom(item.limit);
-  const usedPercent = normalizePercent(item.percent ?? month.percent, used, limit);
+  const usedPercent = normalizePercent(item.percent, used, limit);
   return { used, limit, usedPercent };
 }
 
@@ -188,7 +251,7 @@ async function fetchMimoAccount(account, deps = {}) {
     const detail = parseMimoPlanDetail(detailBody, (deps.now || Date.now)());
     const usage = parseMimoPlanUsage(usageBody);
     const windows = [];
-    const hasTokenPlan = !detail.expired && usage.limit !== null && usage.limit > 0;
+    const hasTokenPlan = detail.active && usage.limit !== null && usage.limit > 0;
     const hasExpiredTokenPlan = detail.expired && Boolean(detail.label || (usage.limit !== null && usage.limit > 0));
     if (hasTokenPlan) {
       windows.push({
@@ -210,7 +273,9 @@ async function fetchMimoAccount(account, deps = {}) {
       accountKey: cleanText(account.accountKey) || mimoAccountKey(cookieHeader),
       accountName: '',
       accountEmail,
-      accountLabel: detail.label || (windows.length ? 'Token Plan' : ''),
+      accountLabel: hasTokenPlan || hasExpiredTokenPlan
+        ? (detail.label || 'Token Plan')
+        : '',
       windows,
       balance: {
         ...balance,

--- a/tests/electron/homeOverview.test.js
+++ b/tests/electron/homeOverview.test.js
@@ -220,6 +220,90 @@ test('homeLimitAccountsForProviders includes MiMo Token Plan status and balance'
   ]);
 });
 
+test('MiMo balance without plan data does not synthesize a Token Plan meter', () => {
+  const rows = homeLimitAccountsForProviders({
+    providers: [{
+      provider: 'mimo',
+      accountKey: 'mimo-no-plan',
+      status: 'ok',
+      windows: [],
+      balance: {
+        amount: 9.61,
+        currency: 'CNY',
+        planStatus: null,
+        planUsed: null,
+        planLimit: null,
+        planPercent: null
+      }
+    }],
+    providerOptions: [{ id: 'mimo', label: 'MiMo' }],
+    enabledProviderIds: ['mimo'],
+    colors: { mimo: '#5daeea' },
+    limit: 5
+  });
+
+  assert.equal(rows.length, 1);
+  assert.deepEqual(rows[0].windows.map((window) => window.kind), ['balance']);
+  assert.equal(rows[0].windows.some((window) => window.kind === 'billing'), false);
+  assert.equal(rows[0].windows[0].amount, 9.61);
+});
+
+test('MiMo empty plan values do not synthesize a Token Plan meter', () => {
+  const rows = homeLimitAccounts([
+    {
+      key: 'mimo-empty-plan',
+      providerId: 'mimo',
+      name: 'MiMo',
+      windows: [],
+      balance: {
+        amount: 4.83,
+        currency: 'CNY',
+        planUsed: '',
+        planLimit: '',
+        planPercent: ''
+      }
+    }
+  ]);
+
+  assert.equal(rows.length, 1);
+  assert.deepEqual(rows[0].windows.map((window) => window.kind), ['balance']);
+});
+
+test('MiMo active unused plan keeps a real 100 percent remaining meter', () => {
+  const rows = homeLimitAccounts([
+    {
+      key: 'mimo-active-plan',
+      providerId: 'mimo',
+      name: 'MiMo',
+      windows: [],
+      balance: {
+        amount: 9.61,
+        currency: 'CNY',
+        planUsed: 0,
+        planLimit: 1000,
+        planPercent: 0
+      }
+    }
+  ]);
+
+  assert.equal(rows.length, 1);
+  const billing = rows[0].windows.find((window) => window.kind === 'billing');
+  assert.ok(billing);
+  assert.equal(billing.remainingPercent, 100);
+});
+
+test('home limit windows ignore missing percentage values', () => {
+  const rows = homeLimitAccounts([
+    {
+      key: 'missing-meter',
+      providerId: 'mimo',
+      windows: [{ kind: 'billing', usedPercent: null, remainingPercent: null }]
+    }
+  ]);
+
+  assert.deepEqual(rows, []);
+});
+
 test('homeModelRows returns one-line token shares without cost fields', () => {
   const rows = homeModelRows([
     { name: 'claude-opus-4-8', value: 34_000_000, cost: 21.96, color: '#cc7c5e' },

--- a/tests/shared/mimoLimits.test.js
+++ b/tests/shared/mimoLimits.test.js
@@ -79,10 +79,58 @@ test('MiMo parsers match the official balance and Token Plan shapes', () => {
   } }, 0);
   assert.equal(detail.label, 'standard');
   assert.equal(detail.expired, false);
+  assert.equal(detail.active, true);
   assert.match(detail.resetsAt, /^2099-01-01T00:00:00/);
   assert.deepEqual(parseMimoProfile({ data: { email: 'user@example.com' } }), {
     email: 'user@example.com'
   });
+});
+
+test('MiMo usage parser selects only the exact month_total_token item', () => {
+  assert.deepEqual(parseMimoPlanUsage({ data: { monthUsage: { items: [
+    { name: 'model_a', used: 10, limit: 100 },
+    { name: 'MONTH_TOTAL_TOKEN', used: 30, limit: 1000 },
+    { name: 'model_b', used: 20, limit: 200 }
+  ] } } }), { used: 30, limit: 1000, usedPercent: 3 });
+});
+
+test('MiMo plan detail requires explicit activation evidence', () => {
+  const now = Date.parse('2026-07-12T00:00:00Z');
+  const defaultPlan = parseMimoPlanDetail({ data: {
+    planCode: 'default', currentPeriodEnd: '2099-01-01 00:00:00'
+  } }, now);
+  assert.equal(defaultPlan.active, false);
+  assert.equal(defaultPlan.expired, false);
+
+  const labelOnly = parseMimoPlanDetail({ data: { planCode: 'standard' } }, now);
+  assert.equal(labelOnly.active, false);
+
+  assert.equal(parseMimoPlanDetail({ data: { status: 'active', planCode: 'standard' } }, now).active, true);
+  assert.equal(parseMimoPlanDetail({ data: {
+    planCode: 'standard', currentPeriodEnd: '2099-01-01 00:00:00'
+  } }, now).active, true);
+});
+
+test('MiMo negative statuses never become active', () => {
+  for (const status of ['not_active', 'not_available', 'not_valid', 'unknown']) {
+    const detail = parseMimoPlanDetail({ data: {
+      status,
+      planCode: 'standard',
+      currentPeriodEnd: '2099-01-01 00:00:00'
+    } });
+    assert.equal(detail.active, false);
+    assert.equal(detail.expired, false);
+  }
+});
+
+test('MiMo boolean inactive flag blocks future-period activation', () => {
+  const detail = parseMimoPlanDetail({ data: {
+    planCode: 'standard',
+    active: false,
+    currentPeriodEnd: '2099-01-01 00:00:00'
+  } });
+  assert.equal(detail.active, false);
+  assert.equal(detail.expired, false);
 });
 
 test('fetchMimoLimits requests fixed official endpoints concurrently with minimized cookies', async () => {
@@ -94,8 +142,8 @@ test('fetchMimoLimits requests fixed official endpoints concurrently with minimi
       assert.equal(init.redirect, 'manual');
       if (url.endsWith('/balance')) return response({ code: 0, data: { balance: '25.51', currency: 'USD' } });
       if (url.endsWith('/userProfile')) return response({ code: 0, data: { email: 'user@example.com' } });
-      if (url.endsWith('/tokenPlan/detail')) return response({ code: 0, data: { planCode: 'standard', expired: false } });
-      return response({ code: 0, data: { monthUsage: { items: [{ used: 10, limit: 100, percent: 0.1 }] } } });
+      if (url.endsWith('/tokenPlan/detail')) return response({ code: 0, data: { planCode: 'standard', currentPeriodEnd: '2099-01-01 00:00:00', expired: false } });
+      return response({ code: 0, data: { monthUsage: { items: [{ name: 'month_total_token', used: 10, limit: 100, percent: 0.1 }] } } });
     }
   });
   assert.equal(result.length, 1);
@@ -137,6 +185,145 @@ test('fetchMimoLimits does not synthesize a Token Plan from zero-valued no-plan 
   assert.equal(provider.balance.planLimit, null);
   assert.equal(provider.balance.planPercent, null);
   assert.equal(provider.balance.planStatus, null);
+});
+
+test('fetchMimoLimits does not activate a default plan with positive quota', async () => {
+  const [provider] = await fetchMimoLimits({ mimoManagedAccounts: [managed()] }, {
+    fetch: async (url) => {
+      if (url.endsWith('/balance')) return response({ code: 0, data: { balance: '9.73', currency: 'CNY' } });
+      if (url.endsWith('/tokenPlan/detail')) return response({ code: 0, data: {
+        planCode: 'default', status: 'active', currentPeriodEnd: '2099-01-01 00:00:00'
+      } });
+      if (url.endsWith('/tokenPlan/usage')) return response({ code: 0, data: {
+        monthUsage: { items: [{ name: 'month_total_token', used: 1000, limit: 1000, percent: 1 }] }
+      } });
+      return response({ code: 0, data: {} });
+    }
+  });
+  assert.equal(provider.windows.length, 0);
+  assert.equal(provider.balance.planUsed, null);
+  assert.equal(provider.balance.planLimit, null);
+  assert.equal(provider.balance.planPercent, null);
+  assert.equal(provider.balance.planStatus, null);
+  assert.equal(provider.accountLabel, '');
+});
+
+test('MiMo no-plan code takes priority over active status', () => {
+  const detail = parseMimoPlanDetail({ data: {
+    planCode: 'default',
+    status: 'active',
+    currentPeriodEnd: '2099-01-01 00:00:00'
+  } });
+  assert.equal(detail.active, false);
+  assert.equal(detail.expired, false);
+});
+
+test('fetchMimoLimits does not infer a Token Plan from quota without detail evidence', async () => {
+  const [provider] = await fetchMimoLimits({ mimoManagedAccounts: [managed()] }, {
+    fetch: async (url) => {
+      if (url.endsWith('/balance')) return response({ code: 0, data: { balance: '9.73', currency: 'CNY' } });
+      if (url.endsWith('/tokenPlan/detail')) return response({ code: 0, data: {} });
+      if (url.endsWith('/tokenPlan/usage')) return response({ code: 0, data: {
+        monthUsage: { items: [{ name: 'month_total_token', used: 0, limit: 1000, percent: 0 }] }
+      } });
+      return response({ code: 0, data: {} });
+    }
+  });
+  assert.equal(provider.windows.length, 0);
+});
+
+test('fetchMimoLimits activates an explicitly active Token Plan', async () => {
+  const [provider] = await fetchMimoLimits({ mimoManagedAccounts: [managed()] }, {
+    fetch: async (url) => {
+      if (url.endsWith('/balance')) return response({ code: 0, data: { balance: '9.73', currency: 'CNY' } });
+      if (url.endsWith('/tokenPlan/detail')) return response({ code: 0, data: {
+        status: 'active', planCode: 'standard'
+      } });
+      if (url.endsWith('/tokenPlan/usage')) return response({ code: 0, data: {
+        monthUsage: { items: [{ name: 'month_total_token', used: 100, limit: 1000, percent: 0.1 }] }
+      } });
+      return response({ code: 0, data: {} });
+    }
+  });
+  assert.equal(provider.windows.length, 1);
+  assert.equal(provider.windows[0].remainingPercent, 90);
+  assert.equal(provider.balance.planUsed, 100);
+  assert.equal(provider.balance.planLimit, 1000);
+});
+
+test('fetchMimoLimits keeps an explicitly active exhausted plan at zero remaining', async () => {
+  const [provider] = await fetchMimoLimits({ mimoManagedAccounts: [managed()] }, {
+    fetch: async (url) => {
+      if (url.endsWith('/balance')) return response({ code: 0, data: { balance: '9.73', currency: 'CNY' } });
+      if (url.endsWith('/tokenPlan/detail')) return response({ code: 0, data: {
+        status: 'subscribed', planCode: 'standard'
+      } });
+      if (url.endsWith('/tokenPlan/usage')) return response({ code: 0, data: {
+        monthUsage: { items: [{ name: 'month_total_token', used: 1000, limit: 1000, percent: 1 }] }
+      } });
+      return response({ code: 0, data: {} });
+    }
+  });
+  assert.equal(provider.windows[0].remaining, 0);
+  assert.equal(provider.windows[0].remainingPercent, 0);
+});
+
+test('fetchMimoLimits keeps expired Token Plan behavior', async () => {
+  const [provider] = await fetchMimoLimits({ mimoManagedAccounts: [managed()] }, {
+    fetch: async (url) => {
+      if (url.endsWith('/balance')) return response({ code: 0, data: { balance: '9.73', currency: 'CNY' } });
+      if (url.endsWith('/tokenPlan/detail')) return response({ code: 0, data: {
+        planCode: 'standard', currentPeriodEnd: '2020-01-01 00:00:00'
+      } });
+      if (url.endsWith('/tokenPlan/usage')) return response({ code: 0, data: {
+        monthUsage: { items: [{ name: 'month_total_token', used: 1000, limit: 1000, percent: 1 }] }
+      } });
+      return response({ code: 0, data: {} });
+    }
+  });
+  assert.equal(provider.windows.length, 0);
+  assert.equal(provider.balance.planStatus, 'expired');
+});
+
+test('MiMo no-plan code never becomes expired', () => {
+  const detail = parseMimoPlanDetail({ data: {
+    planCode: 'default',
+    status: 'expired',
+    currentPeriodEnd: '2020-01-01 00:00:00'
+  } });
+  assert.equal(detail.active, false);
+  assert.equal(detail.expired, false);
+});
+
+test('MiMo no-plan status fields override a historical plan label', () => {
+  for (const field of ['status', 'state', 'subscriptionStatus']) {
+    const detail = parseMimoPlanDetail({ data: {
+      planCode: 'standard',
+      [field]: 'default',
+      currentPeriodEnd: '2020-01-01 00:00:00'
+    } });
+    assert.equal(detail.active, false);
+    assert.equal(detail.expired, false);
+  }
+});
+
+test('MiMo usage parser returns empty quota when total item is absent', () => {
+  assert.deepEqual(parseMimoPlanUsage({ data: { monthUsage: {
+    percent: 0.5,
+    items: [
+      { name: 'model_a', used: 10, limit: 100 },
+      { name: 'model_b', used: 20, limit: 200 }
+    ]
+  } } }), { used: null, limit: null, usedPercent: null });
+});
+
+test('MiMo usage parser preserves direct month quota compatibility', () => {
+  assert.deepEqual(parseMimoPlanUsage({ data: { monthUsage: {
+    used: 20,
+    limit: 200,
+    percent: 0.1,
+    items: []
+  } } }), { used: 20, limit: 200, usedPercent: 10 });
 });
 
 test('fetchMimoLimits rejects a successful-looking response without a balance', async () => {


### PR DESCRIPTION
## Problem

MiMo accounts without an active Token Plan could still show a
`Token Plan 100% left` meter.

This happened for two reasons:

- positive or model-level quota data could be treated as proof of an active plan;
- the Home renderer converted missing plan values such as `null` into numeric zero.

As a result, an account that had never subscribed could appear to have an unused Token Plan.

## Changes

- Require explicit active-plan evidence before displaying Token Plan quota.
- Treat known no-plan codes as authoritative.
- Prevent negative or unknown statuses from falling back to a future billing period.
- Select only the exact `month_total_token` aggregate item.
- Stop falling back to the first model-level usage item.
- Preserve missing renderer values as `null` instead of converting them to zero.
- Keep expired plans visible as `Expired`.
- Hide Token Plan entirely for accounts that have never subscribed.

## Behavior

- Active plan: shows the remaining Token Plan percentage.
- Exhausted active plan: shows `0% left`.
- Expired plan: shows `Expired`.
- No plan: shows only Balance.
- Optional Token Plan endpoint failure: preserves Balance without synthesizing a plan meter.

## Testing

- `node --test tests/shared/mimoLimits.test.js`
- `node --test tests/electron/homeOverview.test.js`
- `npm run verify`
- `git diff --check upstream/main...HEAD`

Manually verified with:

- one MiMo account whose Token Plan had expired;
- one MiMo account that had never subscribed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false Token Plan activation in MiMo by only showing the meter when an active plan is explicitly confirmed. Never‑subscribed or inactive accounts no longer display “100% left”.

- **Bug Fixes**
  - Require explicit activation via status `active/subscribed` or boolean `active/isActive`; only fall back to a future period if there’s a real plan and no explicit status.
  - Treat no‑plan codes (`default`, `none`, `no_plan`, `not_subscribed`, `unsubscribed`) as authoritative, even if status says active or quotas are positive.
  - Keep expired plans labeled `Expired`; never auto‑activate from usage limits.
  - Use only the exact `month_total_token` item; return empty quota if it’s missing and ignore `month.percent` fallbacks.
  - Preserve `null` and ignore empty strings in the renderer; don’t create meters without a valid percent.
  - Hide the Token Plan for accounts that never subscribed; keep Balance visible even if the Token Plan endpoint fails.
  - Only set `accountLabel` when an active or expired Token Plan is present.

<sup>Written for commit fa37ad303eba7866d6c8ab2616d0e678c63663cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

