### PR TITLE
fix(collector): stop project decoration from stalling watch ticks

### DIFF
--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -340,14 +340,28 @@ function projectIdentity(value) {
   return { projectId: hashKey('project', normalized), projectLabel: label };
 }
 
+// Keyed by path -> { key: `size:mtimeMs`, value }, mirroring projectPathCache.
+// The tail timestamp only moves when the transcript grows, so a mtime match lets
+// a full-tick decoration skip re-reading every idle session (issue: periodic UI
+// stutter once project tracking made this run on every session each tick).
+const jsonlTimestampCache = new Map();
+
 function lastJsonlTimestamp(filePath) {
+  let stat;
+  try { stat = fs.statSync(filePath); } catch (_) { return ''; }
+  const cacheKey = `${stat.size}:${stat.mtimeMs}`;
+  const cached = jsonlTimestampCache.get(filePath);
+  if (cached?.key === cacheKey) return cached.value;
   const tail = readFileTail(filePath);
   const lines = tail.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  let value = '';
   for (let index = lines.length - 1; index >= 0; index -= 1) {
     const timestamp = timestampFromJsonLine(lines[index]);
-    if (timestamp) return timestamp;
+    if (timestamp) { value = timestamp; break; }
   }
-  try { return fs.statSync(filePath).mtime.toISOString(); } catch (_) { return ''; }
+  if (!value) value = stat.mtime.toISOString();
+  jsonlTimestampCache.set(filePath, { key: cacheKey, value });
+  return value;
 }
 
 function sessionRefsForPeriods(periods) {
@@ -424,6 +438,30 @@ function sessionTimestampMap(periods, home = os.homedir(), deps = {}) {
   for (const ref of refs.values()) attemptedSessionKeys.add(`${ref.client}:${ref.sessionId}`);
 
   return metadata;
+}
+
+// Copy freshly decorated identities/timestamps from `today` onto the same session
+// in the delta-derived periods. Used on watch ticks, where month/allTime are not
+// re-decorated: a session that started today is absent from the anchor, so its
+// project label would otherwise be missing from the broader-period breakdown.
+function propagateTodayProjects(today, periods) {
+  for (const [key, session] of Object.entries(today?.sessions || {})) {
+    if (!session) continue;
+    for (const period of periods) {
+      const target = period?.sessions?.[key];
+      if (!target) continue;
+      if (session.projectId && !target.projectId) {
+        target.projectId = session.projectId;
+        target.projectLabel = session.projectLabel;
+      }
+      if (session.startedAt && (!target.startedAt || Date.parse(session.startedAt) < Date.parse(target.startedAt))) {
+        target.startedAt = session.startedAt;
+      }
+      if (session.lastUsedAt && (!target.lastUsedAt || Date.parse(session.lastUsedAt) > Date.parse(target.lastUsedAt))) {
+        target.lastUsedAt = session.lastUsedAt;
+      }
+    }
+  }
 }
 
 function applySessionTimestamps(periods, home, deps = {}) {
@@ -618,7 +656,20 @@ async function collectUsageOnce(options) {
       const allTimeJson = await runTokscaleFn({ clients: tokscaleClients, flags: ['--since', allTimeSince], commandTimeoutMs });
       allTime = extractUsageFromTokscale(allTimeJson);
     }
-    if (projectsEnabled) decorateLocalPeriods({ today, month, allTime }, { retryMisses: true });
+    if (projectsEnabled) {
+      if (anchorUsed) {
+        // Watch tick: `today` is a fresh scan and must be decorated, but month/
+        // allTime are derived from the last full-scan anchor and already carry each
+        // session's project label + timestamps through applyPeriodDelta. Decorating
+        // them again would re-stat every historical session file every few seconds
+        // (the perceived UI stutter). Decorate only today, then propagate its freshly
+        // resolved identities onto sessions that started today (absent from the anchor).
+        decorateLocalPeriods({ today }, { retryMisses: true });
+        propagateTodayProjects(today, [month, allTime]);
+      } else {
+        decorateLocalPeriods({ today, month, allTime }, { retryMisses: true });
+      }
+    }
     if (promaPeriods && !anchorUsed) {
       today = mergePeriods(today, promaPeriods.today);
       month = mergePeriods(month, promaPeriods.month);

--- a/tests/shared/collectorSessionTimestamps.test.js
+++ b/tests/shared/collectorSessionTimestamps.test.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const test = require('node:test');
 
 const { applySessionTimestamps } = require('../../src/shared/collector');
@@ -67,6 +70,48 @@ test('applySessionTimestamps reuses resolved metadata across progressive periods
   assert.deepEqual(calls, [['s1'], ['s2']]);
   assert.equal(month.sessions['opencode:s1'].projectLabel, 's1');
   assert.equal(month.sessions['opencode:s2'].projectLabel, 's2');
+});
+
+test('applySessionTimestamps does not re-read an unchanged session file on the next tick', () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-tick-'));
+  const realOpen = fs.openSync;
+  try {
+    const dir = path.join(home, '.claude', 'projects', '-work-app');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'sess-1.jsonl');
+    fs.writeFileSync(file, `${JSON.stringify({ cwd: '/work/app', timestamp: '2026-07-13T10:00:00.000Z' })}\n`);
+
+    let opens = 0;
+    fs.openSync = (target, ...rest) => { if (target === file) opens += 1; return realOpen(target, ...rest); };
+
+    // Each collector tick rebuilds the per-tick dedup caches, so persistence
+    // must survive a fresh deps object — that is what a real interval tick sees.
+    // applySessionTimestamps mutates the periods object in place.
+    const tick = () => {
+      const periods = { today: { sessions: { 'claude:sess-1': { client: 'claude', sessionId: 'sess-1' } } } };
+      applySessionTimestamps(periods, home, {
+        metadataCache: new Map(), resolvedSessionKeys: new Set(), attemptedSessionKeys: new Set()
+      });
+      return periods.today.sessions['claude:sess-1'];
+    };
+
+    tick(); // first tick warms the caches
+    opens = 0;
+    const unchanged = tick(); // second tick, file untouched
+    assert.equal(opens, 0, 'an unchanged session file must not be re-read on the next tick');
+    assert.equal(unchanged.projectLabel, 'app');
+    assert.equal(unchanged.lastUsedAt, '2026-07-13T10:00:00.000Z');
+
+    // A grown session (new size/mtime) must invalidate the cache and refresh lastUsedAt.
+    fs.appendFileSync(file, `${JSON.stringify({ cwd: '/work/app', timestamp: '2026-07-13T11:30:00.000Z' })}\n`);
+    opens = 0;
+    const grown = tick();
+    assert.ok(opens > 0, 'a changed session file must be re-read');
+    assert.equal(grown.lastUsedAt, '2026-07-13T11:30:00.000Z');
+  } finally {
+    fs.openSync = realOpen;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
 });
 
 test('applySessionTimestamps retries a progressive miss in the final pass', () => {

--- a/tests/shared/collectorTodayDelta.test.js
+++ b/tests/shared/collectorTodayDelta.test.js
@@ -85,6 +85,59 @@ test('collectUsageOnce with a valid anchor runs a single --today scan and derive
   }
 });
 
+test('an anchored watch tick does not re-read session files that only appear in the derived periods', async () => {
+  const childProcess = require('node:child_process');
+  const originalSpawn = childProcess.spawn;
+  const calls = [];
+  childProcess.spawn = recordingSpawn(calls, 50);
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-home-'));
+  const realOpen = fs.openSync;
+  try {
+    const dir = path.join(home, '.claude', 'projects', '-p');
+    fs.mkdirSync(dir, { recursive: true });
+    const s1File = path.join(dir, 's1.jsonl');
+    const s2File = path.join(dir, 's2.jsonl');
+    const line = (cwd, ts) => `${JSON.stringify({ cwd, timestamp: ts })}\n`;
+    fs.writeFileSync(s1File, line('/work/one', '2026-07-13T10:00:00.000Z'));
+    fs.writeFileSync(s2File, line('/work/two', '2026-07-13T09:00:00.000Z'));
+
+    const { collectUsageOnce, localTodayKey } = freshCollector();
+    const { emptyPeriod } = require('../../src/shared/usage');
+    // s2 is only in the broader windows, already resolved at the last full scan.
+    const withS2 = (totalTokens) => ({
+      ...emptyPeriod(),
+      totalTokens,
+      clients: { claude: totalTokens },
+      sessions: { 'claude:s2': { client: 'claude', sessionId: 's2', totalTokens, projectId: 'pid2', projectLabel: 'two' } }
+    });
+    const anchor = {
+      dateKey: localTodayKey(),
+      today: { ...emptyPeriod(), totalTokens: 30, clients: { claude: 30 } },
+      month: withS2(100),
+      allTime: withS2(1000)
+    };
+
+    let s1Opens = 0;
+    let s2Opens = 0;
+    fs.openSync = (target, ...rest) => {
+      if (target === s1File) s1Opens += 1;
+      if (target === s2File) s2Opens += 1;
+      return realOpen(target, ...rest);
+    };
+
+    const summary = await collectUsageOnce({ ...baseOptions, homeDir: home, todayOnlyAnchor: anchor });
+
+    assert.ok(s1Opens > 0, "today's own session must still be decorated on a watch tick");
+    assert.equal(s2Opens, 0, 'a session only in the derived periods must not be re-read on a watch tick');
+    assert.equal(summary.month.sessions['claude:s2'].projectLabel, 'two');
+  } finally {
+    fs.openSync = realOpen;
+    childProcess.spawn = originalSpawn;
+    fs.rmSync(home, { recursive: true, force: true });
+    delete require.cache[collectorPath];
+  }
+});
+
 test('collectUsageOnce ignores a stale anchor from a previous day and runs the full scan', async () => {
   const childProcess = require('node:child_process');
   const originalSpawn = childProcess.spawn;

--- a/tests/shared/collectorTodayDelta.test.js
+++ b/tests/shared/collectorTodayDelta.test.js
@@ -18,7 +18,7 @@ function freshCollector() {
   return require(collectorPath);
 }
 
-function recordingSpawn(calls, tokens = 50) {
+function recordingSpawn(calls, tokens = 50, sessionMeta = {}) {
   return (_bin, args) => {
     calls.push(args);
     const child = new EventEmitter();
@@ -28,7 +28,15 @@ function recordingSpawn(calls, tokens = 50) {
     child.kill = () => {};
     setImmediate(() => {
       child.stdout.emit('data', Buffer.from(JSON.stringify({
-        entries: [{ client: 'claude', sessionId: 's1', model: 'claude-opus-4-8', input: tokens, output: 0, cost: tokens / 100 }]
+        entries: [{
+          client: 'claude',
+          sessionId: 's1',
+          model: 'claude-opus-4-8',
+          input: tokens,
+          output: 0,
+          cost: tokens / 100,
+          ...sessionMeta
+        }]
       })));
       child.emit('close', 0);
     });
@@ -89,7 +97,10 @@ test('an anchored watch tick does not re-read session files that only appear in 
   const childProcess = require('node:child_process');
   const originalSpawn = childProcess.spawn;
   const calls = [];
-  childProcess.spawn = recordingSpawn(calls, 50);
+  childProcess.spawn = recordingSpawn(calls, 50, {
+    startedAt: '2026-07-13T08:00:00.000Z',
+    lastUsedAt: '2026-07-13T08:30:00.000Z'
+  });
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-home-'));
   const realOpen = fs.openSync;
   try {
@@ -130,6 +141,18 @@ test('an anchored watch tick does not re-read session files that only appear in 
     assert.ok(s1Opens > 0, "today's own session must still be decorated on a watch tick");
     assert.equal(s2Opens, 0, 'a session only in the derived periods must not be re-read on a watch tick');
     assert.equal(summary.month.sessions['claude:s2'].projectLabel, 'two');
+    const todayS1 = summary.today.sessions['claude:s1'];
+    assert.ok(todayS1.projectId, "today's new session must be decorated");
+    assert.equal(todayS1.projectLabel, 'one');
+    assert.equal(todayS1.startedAt, '2026-07-13T08:00:00.000Z');
+    assert.equal(todayS1.lastUsedAt, '2026-07-13T10:00:00.000Z');
+    for (const period of [summary.month, summary.allTime]) {
+      const derivedS1 = period.sessions['claude:s1'];
+      assert.equal(derivedS1.projectId, todayS1.projectId);
+      assert.equal(derivedS1.projectLabel, todayS1.projectLabel);
+      assert.equal(derivedS1.startedAt, todayS1.startedAt);
+      assert.equal(derivedS1.lastUsedAt, todayS1.lastUsedAt);
+    }
   } finally {
     fs.openSync = realOpen;
     childProcess.spawn = originalSpawn;


### PR DESCRIPTION
## What

Project tracking made the widget hitch every few seconds while open. Each collector tick re-read **every** session transcript to resolve its project label + timestamps, so with a large history the main process stalled long enough to drop frames on every update.

## Root cause

Two costs, both gated behind project tracking, ran on the Electron main process on every tick:

1. `lastJsonlTimestamp()` re-read each transcript's tail on every full tick — the one decoration read not covered by the existing `projectPathCache` mtime cache.
2. On **watch** ticks (which fire every few seconds while a tool is in use), the decoration re-resolved `today` + `month` + `allTime` — re-statting every historical session file — even though `month`/`allTime` already carry each session's label through the `applyPeriodDelta` anchor.

## Fix

- Cache each transcript's tail timestamp by `size:mtime` (mirroring `projectPathCache`), so an idle session is never re-read; a grown transcript still invalidates and refreshes `lastUsedAt`.
- On watch ticks, decorate only `today`. `month`/`allTime` keep their labels via the anchor delta, and sessions that started today get their freshly resolved identity propagated onto the derived periods (no attribution loss).

Full-tick / cold-start behaviour is unchanged (all three periods still decorated).

## Measured impact

Main-process event-loop stall per watch tick, driven against a real ~500-session history:

| | stall per watch tick |
|---|---|
| before | 25–48 ms (every few seconds) |
| after | 11–22 ms = the project-tracking-**off** baseline |

## Testing

- TDD: two failing tests first — an unchanged session file is not re-read on the next tick, and an anchored watch tick does not re-read session files that only appear in the derived periods.
- `npm run verify` (lint + full suite) green.

## Notes

Partially addresses #143 (removes the project-tracking watch-tick stall). The broader "keep the whole app fluid" work — coalescing the renderer's per-push re-render and moving the collector off the main process — is tracked separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes periodic UI stutter by stopping main-process stalls during project decoration on watch ticks. Caches transcript tail timestamps and decorates only `today` during watch ticks; full scans are unchanged.

- Bug Fixes
  - Cache each transcript’s tail timestamp by `size:mtime` so unchanged sessions aren’t re-read; growing files still refresh `lastUsedAt`.
  - On watch ticks, decorate only `today` and propagate its project labels/timestamps to `month`/`allTime` via the anchor delta; avoids re-statting historical sessions.
  - Add tests covering watch-tick propagation and ensuring sessions only in derived periods aren’t re-read; verify cache invalidates when a file grows.
  - Impact: main-process stall per watch tick drops from 25–48 ms to 11–22 ms.

<sup>Written for commit 75d18a58cdc4d4f705d2180a01d098408629f131. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

