### PR TITLE
fix(tray): keep popover on fullscreen Space

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -108,6 +108,7 @@ const {
   sortCodexAccountsForDisplay
 } = require('./tray');
 const {
+  macTrayPopoverWorkspaceOptions,
   macActivationPolicyMode,
   mainWindowCloseAction,
   normalizeTrayModeSettings,
@@ -2210,6 +2211,7 @@ function showPopover() {
   if (!mainWindow || mainWindow.isDestroyed() || !tray) return;
   applyMacActivationPolicy();
   applyWindowSettings();
+  applyTrayPopoverWorkspaceVisibility();
   const current = mainWindow.getBounds();
   const target = popoverBounds(tray, current.width, current.height);
   mainWindow.setBounds(target);
@@ -2626,6 +2628,15 @@ function destroyTray() {
   tray = null;
 }
 
+function applyTrayPopoverWorkspaceVisibility() {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  const options = macTrayPopoverWorkspaceOptions(settings);
+  if (!options || typeof mainWindow.setVisibleOnAllWorkspaces !== 'function') return;
+  // Reapply before every show: macOS can occasionally lose the native Space
+  // collection behavior while the long-lived popover window is hidden.
+  mainWindow.setVisibleOnAllWorkspaces(true, options);
+}
+
 function enterTrayMode() {
   applyMacActivationPolicy();
   ensureTray();
@@ -2634,11 +2645,7 @@ function enterTrayMode() {
   applyMacActivationPolicy();
   if (mainWindow && !mainWindow.isDestroyed()) {
     if (typeof mainWindow.setSkipTaskbar === 'function') mainWindow.setSkipTaskbar(true);
-    // Without this, .show() yanks the user back to the Space the window was last
-    // shown on instead of popping over the current Space / fullscreen app.
-    if (typeof mainWindow.setVisibleOnAllWorkspaces === 'function') {
-      mainWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
-    }
+    applyTrayPopoverWorkspaceVisibility();
     mainWindow.hide();
   }
 }

--- a/src/electron/trayModeSettings.js
+++ b/src/electron/trayModeSettings.js
@@ -27,6 +27,17 @@ function trayToggleAction(settings = {}) {
   return normalized.trayMode ? 'togglePopover' : 'focusWindow';
 }
 
+function macTrayPopoverWorkspaceOptions(settings = {}, platform = process.platform) {
+  const normalized = normalizeTrayModeSettings(settings);
+  if (platform !== 'darwin' || !normalized.trayMode) return null;
+  return {
+    visibleOnFullScreen: true,
+    // Tray mode already uses the accessory activation policy (UIElement on
+    // macOS), so Electron does not need to briefly transform the process type.
+    skipTransformProcessType: true
+  };
+}
+
 function macActivationPolicyMode(settings = {}, state = {}) {
   const normalized = normalizeTrayModeSettings(settings);
   if (normalized.trayMode) return 'accessory';
@@ -42,6 +53,7 @@ function mainWindowCloseAction(settings = {}, _state = {}) {
 }
 
 module.exports = {
+  macTrayPopoverWorkspaceOptions,
   macActivationPolicyMode,
   mainWindowCloseAction,
   normalizeTrayModeSettings,

--- a/tests/electron/tray.test.js
+++ b/tests/electron/tray.test.js
@@ -268,6 +268,12 @@ test('tray main-process actions surface refresh errors and expand a collapsed bu
   assert.match(source, /if \(value === 'tray'\)[\s\S]*?saveSettings\(\);\s*syncFloatingBubbleAvailability\(\);\s*enterTrayMode\(\);/);
 });
 
+test('tray popover reapplies macOS workspace visibility before every show', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../../src/electron/main.js'), 'utf8');
+  assert.match(source, /function showPopover\(\)[\s\S]*?applyMacActivationPolicy\(\);\s*applyWindowSettings\(\);\s*applyTrayPopoverWorkspaceVisibility\(\);[\s\S]*?mainWindow\.show\(\);/);
+  assert.match(source, /function applyTrayPopoverWorkspaceVisibility\(\)[\s\S]*?mainWindow\.setVisibleOnAllWorkspaces\(true, options\);/);
+});
+
 test('usage tray icon picks the top token client for day and total token modes', () => {
   assert.equal(pickUsageTrayIconId(stats, 'tokens', ['claude', 'codex']), 'codex');
   assert.equal(pickUsageTrayIconId(stats, 'both', ['claude', 'codex']), 'codex');

--- a/tests/electron/trayModeSettings.test.js
+++ b/tests/electron/trayModeSettings.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 
 const {
+  macTrayPopoverWorkspaceOptions,
   macActivationPolicyMode,
   mainWindowCloseAction,
   normalizeTrayModeSettings,
@@ -52,6 +53,15 @@ test('uses accessory activation when macOS is running from the menu bar only', (
   assert.equal(macActivationPolicyMode({ showTrayIcon: true, trayMode: false }, { mainWindowVisible: false }), 'accessory');
   assert.equal(macActivationPolicyMode({ showTrayIcon: true, trayMode: false }, { mainWindowVisible: true }), 'regular');
   assert.equal(macActivationPolicyMode({ showTrayIcon: false, trayMode: false }, { mainWindowVisible: false }), 'regular');
+});
+
+test('keeps the macOS tray popover visible across Spaces and fullscreen apps', () => {
+  assert.deepEqual(macTrayPopoverWorkspaceOptions({ showTrayIcon: true, trayMode: true }, 'darwin'), {
+    visibleOnFullScreen: true,
+    skipTransformProcessType: true
+  });
+  assert.equal(macTrayPopoverWorkspaceOptions({ showTrayIcon: true, trayMode: false }, 'darwin'), null);
+  assert.equal(macTrayPopoverWorkspaceOptions({ showTrayIcon: true, trayMode: true }, 'win32'), null);
 });
 
 test('maps main-window close to the platform-appropriate background behavior', () => {


### PR DESCRIPTION
## Summary

- reapply the macOS all-Spaces/fullscreen workspace behavior immediately before showing the tray-only popover
- keep the app in its existing accessory process type while refreshing the native window behavior to avoid Dock or window flicker
- add regression coverage for macOS tray workspace options and the main-process show path

## Verification

- `npm run verify` (1300 tests passed)

Closes #140


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS tray mode so the popover stays on the current Space and remains visible over fullscreen apps. Prevents Space jumps and Dock/window flicker when opening the tray. Closes #140.

- **Bug Fixes**
  - Reapply workspace visibility on every show by calling `setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true, skipTransformProcessType: true })`.
  - Keep the process in accessory mode while refreshing the popover to avoid Dock/taskbar flicker.
  - Added tests for macOS tray workspace options and the main-process show path.

<sup>Written for commit b951db479ec9bf18d08ea6ee3da5d959cb993748. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

