### PR TITLE
perf(archive): restore session usage in linear time

### DIFF
--- a/src/shared/sessionUsageArchive.js
+++ b/src/shared/sessionUsageArchive.js
@@ -255,12 +255,17 @@ function applySessionUsageArchive(summary, archive, options = {}) {
   const normalizedArchive = normalizeSessionUsageArchive(archive);
   const now = toDate(options.now);
   const next = clone(summary);
+  const targetPeriods = new Map();
+  const targetFor = (periodName) => {
+    if (!targetPeriods.has(periodName)) targetPeriods.set(periodName, targetPeriod(next, periodName));
+    return targetPeriods.get(periodName);
+  };
 
   for (const entry of Object.values(normalizedArchive.sessions)) {
     for (const periodName of PERIODS) {
       const session = entry.periods?.[periodName];
       if (!session || !hasSessionUsage(session) || !shouldApplyPeriod(periodName, entry, now)) continue;
-      addArchivedSession(targetPeriod(next, periodName), session);
+      addArchivedSession(targetFor(periodName), session);
     }
   }
 

--- a/tests/shared/sessionUsageArchive.test.js
+++ b/tests/shared/sessionUsageArchive.test.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert/strict');
 const path = require('node:path');
+const { performance } = require('node:perf_hooks');
 const test = require('node:test');
 
 let archiveApi = {};
@@ -392,4 +393,35 @@ test('allocates tied model remainders independently of map property order', () =
   assert.deepEqual(forward.modelCacheReads, reverse.modelCacheReads);
   assert.deepEqual(forward.modelCacheWrites, reverse.modelCacheWrites);
   assert.deepEqual(forward.modelOutputs, reverse.modelOutputs);
+});
+
+test('reapplies a large session archive without repeatedly normalizing growing periods', () => {
+  const archive = { version: 1, sessions: {} };
+  for (let index = 0; index < 2000; index += 1) {
+    const sessionId = `session-${index}`;
+    archive.sessions[`codex:${sessionId}`] = {
+      client: 'codex',
+      sessionId,
+      capturedAt: '2026-07-15T00:00:00.000Z',
+      periods: {
+        allTime: {
+          client: 'codex',
+          sessionId,
+          totalTokens: index + 1,
+          cacheReadTokens: index,
+          outputTokens: 2,
+          models: { 'gpt-5': index + 1 }
+        }
+      }
+    };
+  }
+
+  const startedAt = performance.now();
+  const visible = applySessionUsageArchive({ allTime: { sessions: {} } }, archive, {
+    now: new Date('2026-07-15T00:00:00.000Z')
+  });
+  const elapsedMs = performance.now() - startedAt;
+
+  assert.equal(Object.keys(visible.allTime.sessions).length, 2000);
+  assert.ok(elapsedMs < 250, `large archive apply took ${elapsedMs.toFixed(1)}ms`);
 });


### PR DESCRIPTION
## Summary

- Cache each normalized target period while replaying the session usage archive.
- Reduce archive restoration from quadratic to linear time without changing period totals, session deduplication, or archive window semantics.
- Add a 2,000-session performance regression test so repeated normalization cannot silently return.

## Performance

- A real 568-session archive improved from about 1,109 ms to 13 ms.
- A synthetic 2,000-session archive improved from about 1,565 ms to 24 ms in the focused benchmark.
- Electron smoke testing no longer showed the repeating approximately one-second main-process event-loop stalls, and the widget remained responsive while usage values updated.

This also removes substantial transient allocation and GC pressure, but it does not claim to have independently resolved every resident-memory concern reported in #155.

## Verification

- `npm run verify` (1,299 tests passed; lint clean)
- Manual Electron smoke test during live AI-tool usage

Fixes #143
Addresses #155


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore session usage archive replay to linear time and eliminate main-process stalls while usage updates. Period totals, session dedup, and archive window semantics are unchanged. Fixes #143; addresses #155.

- **Refactors**
  - Cache a `targetPeriods` map and reuse each `targetPeriod(...)` during archive apply to avoid repeated normalization.
  - Add a 2,000-session performance regression test; ~1109ms → 13ms on a 568-session archive, ~1565ms → 24ms on 2,000 sessions; Electron remains responsive.

<sup>Written for commit 507872b526b98fdbea0c885b7d90f5ac86ee9b95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

