### PR TITLE
fix(updater): restore dismissed update actions

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -2877,6 +2877,7 @@ async function downloadTokscaleFromNpm() {
 }
 
 let appUpdateCheckInFlight = false;
+let appUpdateCheckPromise = null;
 let appUpdateLastError = null;
 let appUpdateBackgroundTimer = null;
 let appUpdateNativeBusy = false;
@@ -3004,7 +3005,14 @@ function sendAppUpdatePush() {
 }
 
 async function runAppUpdateCheck({ force = false } = {}) {
-  if (appUpdateCheckInFlight) return deriveAppUpdateState();
+  if (appUpdateCheckPromise) {
+    const activeResult = await appUpdateCheckPromise;
+    if (force && activeResult?.ok && activeResult.newer) {
+      restoreDismissedAppUpdate(activeResult.latest?.version);
+      sendAppUpdatePush();
+    }
+    return deriveAppUpdateState();
+  }
   const block = settings?.appUpdate || {};
   if (shouldSkipAppUpdateCheck({
     force,
@@ -3015,25 +3023,35 @@ async function runAppUpdateCheck({ force = false } = {}) {
   })) {
     return deriveAppUpdateState();
   }
-  appUpdateCheckInFlight = true;
-  appUpdateLastError = null;
-  if (force) sendAppUpdatePush();
-  try {
-    const result = await checkLatestRelease(app.getVersion());
-    if (result.ok) {
-      rememberLatestAppUpdate(result.latest, result.checkedAt);
-      if (force && result.newer) restoreDismissedAppUpdate(result.latest?.version);
-      appUpdateLastError = null;
-    } else {
-      appUpdateLastError = force ? (result.error || 'Update check failed') : null;
-      if (!force) console.warn('App update check failed:', result.error);
+  const checkTask = (async () => {
+    appUpdateCheckInFlight = true;
+    appUpdateLastError = null;
+    if (force) sendAppUpdatePush();
+    let result = null;
+    try {
+      result = await checkLatestRelease(app.getVersion());
+      if (result.ok) {
+        rememberLatestAppUpdate(result.latest, result.checkedAt);
+        if (force && result.newer) restoreDismissedAppUpdate(result.latest?.version);
+        appUpdateLastError = null;
+      } else {
+        appUpdateLastError = force ? (result.error || 'Update check failed') : null;
+        if (!force) console.warn('App update check failed:', result.error);
+      }
+    } catch (error) {
+      appUpdateLastError = force ? (error.message || String(error)) : null;
+      if (!force) console.warn('App update check threw:', error);
+    } finally {
+      appUpdateCheckInFlight = false;
+      sendAppUpdatePush();
     }
-  } catch (error) {
-    appUpdateLastError = force ? (error.message || String(error)) : null;
-    if (!force) console.warn('App update check threw:', error);
+    return result;
+  })();
+  appUpdateCheckPromise = checkTask;
+  try {
+    await checkTask;
   } finally {
-    appUpdateCheckInFlight = false;
-    sendAppUpdatePush();
+    if (appUpdateCheckPromise === checkTask) appUpdateCheckPromise = null;
   }
   return deriveAppUpdateState();
 }

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -3006,9 +3006,15 @@ function sendAppUpdatePush() {
 
 async function runAppUpdateCheck({ force = false } = {}) {
   if (appUpdateCheckPromise) {
+    if (force) sendAppUpdatePush();
     const activeResult = await appUpdateCheckPromise;
-    if (force && activeResult?.ok && activeResult.newer) {
-      restoreDismissedAppUpdate(activeResult.latest?.version);
+    if (force) {
+      if (activeResult?.ok) {
+        if (activeResult.newer) restoreDismissedAppUpdate(activeResult.latest?.version);
+        appUpdateLastError = null;
+      } else {
+        appUpdateLastError = activeResult?.error || 'Update check failed';
+      }
       sendAppUpdatePush();
     }
     return deriveAppUpdateState();
@@ -3027,7 +3033,7 @@ async function runAppUpdateCheck({ force = false } = {}) {
     appUpdateCheckInFlight = true;
     appUpdateLastError = null;
     if (force) sendAppUpdatePush();
-    let result = null;
+    let result;
     try {
       result = await checkLatestRelease(app.getVersion());
       if (result.ok) {
@@ -3039,8 +3045,10 @@ async function runAppUpdateCheck({ force = false } = {}) {
         if (!force) console.warn('App update check failed:', result.error);
       }
     } catch (error) {
-      appUpdateLastError = force ? (error.message || String(error)) : null;
+      const message = error.message || String(error);
+      appUpdateLastError = force ? message : null;
       if (!force) console.warn('App update check threw:', error);
+      return { ok: false, newer: false, latest: null, error: message };
     } finally {
       appUpdateCheckInFlight = false;
       sendAppUpdatePush();

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -58,6 +58,7 @@ const {
 const {
   appUpdateInstallSupport,
   checkLatestRelease,
+  deriveAppUpdateAvailability,
   downloadedAppUpdateMatchesLatest,
   GITHUB_REPO,
   mergeLatestReleaseMetadata,
@@ -2959,14 +2960,18 @@ function deriveAppUpdateState() {
   const latest = block.lastKnownLatest || null;
   const dismissedVersion = block.dismissedVersion || null;
   const installSupport = appUpdateInstallSupport({ isPackaged: app.isPackaged, platform: process.platform, env: process.env });
-  let hasUpdate = false;
-  if (latest && semver.valid(latest.version) && semver.valid(currentVersion)) {
-    hasUpdate = semver.gt(latest.version, currentVersion) && latest.version !== dismissedVersion;
-  }
+  const availability = deriveAppUpdateAvailability({
+    currentVersion,
+    latest,
+    dismissedVersion,
+    phase: appUpdateNativeState.phase,
+    downloadedVersion: appUpdateNativeState.version
+  });
   return {
     currentVersion,
     latest,
-    hasUpdate,
+    hasUpdate: availability.hasUpdate,
+    showUpdateNotice: availability.showUpdateNotice,
     dismissedVersion,
     lastCheckedAt: block.lastCheckedAt || null,
     checking: appUpdateCheckInFlight,
@@ -2977,13 +2982,20 @@ function deriveAppUpdateState() {
     installProgress: appUpdateNativeState.progress,
     installVersion: appUpdateNativeState.version,
     installError: appUpdateNativeState.error,
-    downloaded: downloadedAppUpdateMatchesLatest({
-      phase: appUpdateNativeState.phase,
-      downloadedVersion: appUpdateNativeState.version,
-      latest
-    }),
+    downloaded: availability.downloaded,
     installBusy: appUpdateNativeBusy || appUpdateNativeState.phase === 'checking' || appUpdateNativeState.phase === 'downloading'
   };
+}
+
+function restoreDismissedAppUpdate(version) {
+  const block = settings?.appUpdate || {};
+  if (!version || block.dismissedVersion !== version) return false;
+  settings.appUpdate = {
+    ...block,
+    dismissedVersion: null
+  };
+  saveSettings();
+  return true;
 }
 
 function sendAppUpdatePush() {
@@ -3010,6 +3022,7 @@ async function runAppUpdateCheck({ force = false } = {}) {
     const result = await checkLatestRelease(app.getVersion());
     if (result.ok) {
       rememberLatestAppUpdate(result.latest, result.checkedAt);
+      if (force && result.newer) restoreDismissedAppUpdate(result.latest?.version);
       appUpdateLastError = null;
     } else {
       appUpdateLastError = force ? (result.error || 'Update check failed') : null;
@@ -3059,6 +3072,7 @@ async function downloadAndPrepareAppUpdate() {
     downloadedVersion: appUpdateNativeState.version,
     latest
   })) return deriveAppUpdateState();
+  restoreDismissedAppUpdate(latest?.version);
   configureNativeAppUpdater();
   appUpdateNativeBusy = true;
   setNativeAppUpdateState({ phase: 'checking', progress: null, error: null });

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -661,21 +661,24 @@ function renderAppUpdatePill() {
   if (!pill) return;
   const mode = appUpdateActionMode(s);
   const version = s?.latest?.version || s?.installVersion || '';
-  if (!s || !mode || !version) {
+  if (!s || !mode || !version || !s.showUpdateNotice) {
     pill.classList.add('hidden');
     pill.setAttribute('title', '');
     els.appUpdatePillLabel.textContent = '';
     setAppUpdatePillDisclosure(false);
     return;
   }
-  const hasReleaseNotes = releaseNoteGroupsForCurrentLocale(s.latest).length > 0;
+  const hasReleaseNotes = mode !== 'install' && releaseNoteGroupsForCurrentLocale(s.latest).length > 0;
   setAppUpdatePillDisclosure(hasReleaseNotes);
   pill.classList.remove('hidden');
+  els.appUpdatePillDismiss.classList.toggle('hidden', mode === 'install' || s.installBusy);
   pill.setAttribute('title', mode === 'install' ? t('settings.appUpdate.ready') : (s.latest?.name || `v${version}`));
   if (s.installPhase === 'downloading' && Number.isFinite(s.installProgress)) {
     els.appUpdatePillLabel.textContent = `${Math.round(s.installProgress)}%`;
   } else {
-    els.appUpdatePillLabel.textContent = `${mode === 'install' ? '↻' : '↑'} v${version}`;
+    els.appUpdatePillLabel.textContent = mode === 'install'
+      ? `↻ ${t('settings.appUpdate.restart')}`
+      : `↑ v${version}`;
   }
 }
 function releaseNoteGroupsForCurrentLocale(latest) {
@@ -6392,6 +6395,10 @@ async function runAppUpdateAction() {
 }
 
 els.appUpdatePillAction.addEventListener('click', async () => {
+  if (appUpdateActionMode(state.appUpdate) === 'install') {
+    await runAppUpdateAction();
+    return;
+  }
   if (!renderAppUpdatePopover(state.appUpdate) || typeof els.appUpdatePopover.showPopover !== 'function') {
     await runAppUpdateAction();
     return;

--- a/src/electron/renderer/index.html
+++ b/src/electron/renderer/index.html
@@ -942,7 +942,7 @@
           <button id="appUpdatePillAction" type="button" class="update-pill-action">
             <span id="appUpdatePillLabel" class="update-pill-label"></span>
           </button>
-          <button id="appUpdatePillDismiss" type="button" class="update-pill-dismiss" title="Dismiss this version" aria-label="Dismiss this version">×</button>
+          <button id="appUpdatePillDismiss" type="button" class="update-pill-dismiss" data-i18n-title="settings.appUpdate.dismiss" data-i18n-aria-label="settings.appUpdate.dismiss" title="Dismiss this version" aria-label="Dismiss this version">×</button>
         </div>
         <span id="footerActionSlot"><button id="settingsButton" class="icon-button settings-icon-button" title="Settings" aria-label="Settings"></button></span>
       </footer>

--- a/src/electron/renderer/styles.css
+++ b/src/electron/renderer/styles.css
@@ -3254,6 +3254,7 @@ html.is-windows .limit-live-badge {
   cursor: pointer;
 }
 .update-pill-dismiss:hover { opacity: 1; }
+.update-pill-dismiss.hidden { display: none; }
 .app-update-popover {
   inset: auto;
   margin: 0;

--- a/src/shared/appUpdater.js
+++ b/src/shared/appUpdater.js
@@ -175,6 +175,26 @@ function downloadedAppUpdateMatchesLatest({
   return Boolean(version && latestVersion && version === latestVersion);
 }
 
+function deriveAppUpdateAvailability({
+  currentVersion,
+  latest,
+  dismissedVersion,
+  phase,
+  downloadedVersion
+} = {}) {
+  const current = semver.valid(currentVersion);
+  const latestVersion = semver.valid(latest?.version);
+  const hasUpdate = Boolean(current && latestVersion && semver.gt(latestVersion, current));
+  const dismissed = Boolean(hasUpdate && latestVersion === dismissedVersion);
+  const downloaded = downloadedAppUpdateMatchesLatest({ phase, downloadedVersion, latest });
+  return {
+    hasUpdate,
+    dismissed,
+    downloaded,
+    showUpdateNotice: downloaded || (hasUpdate && !dismissed)
+  };
+}
+
 async function withTimeout(ms, task) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), ms);
@@ -218,6 +238,7 @@ module.exports = {
   parseLatestReleasePayload,
   shouldSkipAppUpdateCheck,
   downloadedAppUpdateMatchesLatest,
+  deriveAppUpdateAvailability,
   extractReleaseNotes,
   mergeLatestReleaseMetadata,
   checkLatestRelease,

--- a/src/shared/appUpdater.js
+++ b/src/shared/appUpdater.js
@@ -154,12 +154,8 @@ function shouldSkipAppUpdateCheck({
   if (force || !lastCheckedAt) return false;
   const last = Date.parse(lastCheckedAt);
   if (!Number.isFinite(last)) return false;
-  const latestVersion = latest?.version;
-  const current = semver.valid(currentVersion);
-  const cachedUpdate = semver.valid(latestVersion)
-    && current
-    && semver.gt(latestVersion, current)
-    && latestVersion !== dismissedVersion;
+  const availability = deriveAppUpdateAvailability({ currentVersion, latest, dismissedVersion });
+  const cachedUpdate = availability.hasUpdate && !availability.dismissed;
   const cooldownMs = cachedUpdate ? APP_UPDATE_OUTDATED_COOLDOWN_MS : APP_UPDATE_BACKGROUND_COOLDOWN_MS;
   return nowMs - last < cooldownMs;
 }

--- a/tests/electron/appUpdateReleaseNotes.test.js
+++ b/tests/electron/appUpdateReleaseNotes.test.js
@@ -41,17 +41,30 @@ test('release notes render as text nodes and auto-open once for a new version', 
   assert.match(renderer, /s\.hasUpdate && state\.appUpdateNotesPresentedVersion !== version/);
 });
 
-test('footer pill progressively discloses notes before running the update action', () => {
+test('footer pill progressively discloses notes before download but installs directly once ready', () => {
   const app = read('app.js');
   const handler = app.slice(
     app.indexOf("els.appUpdatePillAction.addEventListener"),
     app.indexOf("els.appUpdatePillDismiss.addEventListener")
   );
+  assert.match(handler, /appUpdateActionMode\(state\.appUpdate\) === 'install'/);
+  assert.match(handler, /await runAppUpdateAction\(\);\s*return;/);
   assert.match(handler, /renderAppUpdatePopover\(state\.appUpdate\)/);
   assert.match(handler, /positionAppUpdatePopover\(\)/);
   assert.match(handler, /showPopover\(\)/);
   assert.match(handler, /appUpdatePopoverAction\.focus\(\)/);
   assert.match(handler, /await runAppUpdateAction\(\)/);
+});
+
+test('footer pill separates dismissed notices from available settings actions', () => {
+  const app = read('app.js');
+  const renderer = app.slice(
+    app.indexOf('function renderAppUpdatePill'),
+    app.indexOf('function releaseNoteGroupsForCurrentLocale')
+  );
+  assert.match(renderer, /!s\.showUpdateNotice/);
+  assert.match(renderer, /mode === 'install' \|\| s\.installBusy/);
+  assert.match(renderer, /t\('settings\.appUpdate\.restart'\)/);
 });
 
 test('footer pill only exposes dialog semantics when release notes are available', () => {

--- a/tests/electron/appUpdateState.test.js
+++ b/tests/electron/appUpdateState.test.js
@@ -20,11 +20,12 @@ test('manual update checks restore a matching dismissed version', () => {
   assert.match(check, /if \(force && result\.newer\) restoreDismissedAppUpdate\(result\.latest\?\.version\)/);
 });
 
-test('manual checks reuse an in-flight background check before restoring the notice', () => {
+test('manual checks preserve feedback when reusing an in-flight background check', () => {
   const check = sourceBetween('async function runAppUpdateCheck', 'function maybeRunBackgroundUpdateCheck');
-  assert.match(check, /const activeResult = await appUpdateCheckPromise/);
-  assert.match(check, /force && activeResult\?\.ok && activeResult\.newer/);
-  assert.match(check, /restoreDismissedAppUpdate\(activeResult\.latest\?\.version\)/);
+  assert.match(check, /if \(force\) sendAppUpdatePush\(\);\s*const activeResult = await appUpdateCheckPromise/);
+  assert.match(check, /if \(activeResult\.newer\) restoreDismissedAppUpdate\(activeResult\.latest\?\.version\)/);
+  assert.match(check, /appUpdateLastError = activeResult\?\.error \|\| 'Update check failed'/);
+  assert.match(check, /return \{ ok: false, newer: false, latest: null, error: message \}/);
 });
 
 test('starting a user-requested download restores its dismissed notification', () => {

--- a/tests/electron/appUpdateState.test.js
+++ b/tests/electron/appUpdateState.test.js
@@ -7,18 +7,27 @@ const test = require('node:test');
 
 const main = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'electron', 'main.js'), 'utf8');
 
+function sourceBetween(startMarker, endMarker) {
+  const start = main.indexOf(startMarker);
+  const end = main.indexOf(endMarker, start + startMarker.length);
+  assert.notEqual(start, -1, `${startMarker} should exist`);
+  assert.notEqual(end, -1, `${endMarker} should exist after ${startMarker}`);
+  return main.slice(start, end);
+}
+
 test('manual update checks restore a matching dismissed version', () => {
-  const check = main.slice(
-    main.indexOf('async function runAppUpdateCheck'),
-    main.indexOf('function maybeRunBackgroundUpdateCheck')
-  );
+  const check = sourceBetween('async function runAppUpdateCheck', 'function maybeRunBackgroundUpdateCheck');
   assert.match(check, /if \(force && result\.newer\) restoreDismissedAppUpdate\(result\.latest\?\.version\)/);
 });
 
+test('manual checks reuse an in-flight background check before restoring the notice', () => {
+  const check = sourceBetween('async function runAppUpdateCheck', 'function maybeRunBackgroundUpdateCheck');
+  assert.match(check, /const activeResult = await appUpdateCheckPromise/);
+  assert.match(check, /force && activeResult\?\.ok && activeResult\.newer/);
+  assert.match(check, /restoreDismissedAppUpdate\(activeResult\.latest\?\.version\)/);
+});
+
 test('starting a user-requested download restores its dismissed notification', () => {
-  const download = main.slice(
-    main.indexOf('async function downloadAndPrepareAppUpdate'),
-    main.indexOf('function installDownloadedAppUpdate')
-  );
+  const download = sourceBetween('async function downloadAndPrepareAppUpdate', 'function installDownloadedAppUpdate');
   assert.match(download, /restoreDismissedAppUpdate\(latest\?\.version\)/);
 });

--- a/tests/electron/appUpdateState.test.js
+++ b/tests/electron/appUpdateState.test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const main = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'electron', 'main.js'), 'utf8');
+
+test('manual update checks restore a matching dismissed version', () => {
+  const check = main.slice(
+    main.indexOf('async function runAppUpdateCheck'),
+    main.indexOf('function maybeRunBackgroundUpdateCheck')
+  );
+  assert.match(check, /if \(force && result\.newer\) restoreDismissedAppUpdate\(result\.latest\?\.version\)/);
+});
+
+test('starting a user-requested download restores its dismissed notification', () => {
+  const download = main.slice(
+    main.indexOf('async function downloadAndPrepareAppUpdate'),
+    main.indexOf('function installDownloadedAppUpdate')
+  );
+  assert.match(download, /restoreDismissedAppUpdate\(latest\?\.version\)/);
+});

--- a/tests/shared/appUpdater.test.js
+++ b/tests/shared/appUpdater.test.js
@@ -7,6 +7,7 @@ const test = require('node:test');
 
 const {
   appUpdateInstallSupport,
+  deriveAppUpdateAvailability,
   downloadedAppUpdateMatchesLatest,
   extractReleaseNotes,
   mergeLatestReleaseMetadata,
@@ -104,6 +105,35 @@ test('downloadedAppUpdateMatchesLatest only trusts the downloaded latest version
     downloadedVersion: '0.19.0',
     latest: null
   }), false);
+});
+
+test('deriveAppUpdateAvailability keeps availability separate from notification dismissal', () => {
+  assert.deepEqual(deriveAppUpdateAvailability({
+    currentVersion: '0.28.0',
+    latest: { version: '0.28.1' },
+    dismissedVersion: '0.28.1',
+    phase: 'idle'
+  }), {
+    hasUpdate: true,
+    dismissed: true,
+    downloaded: false,
+    showUpdateNotice: false
+  });
+});
+
+test('deriveAppUpdateAvailability always surfaces a downloaded matching update', () => {
+  assert.deepEqual(deriveAppUpdateAvailability({
+    currentVersion: '0.28.0',
+    latest: { version: '0.28.1' },
+    dismissedVersion: '0.28.1',
+    phase: 'downloaded',
+    downloadedVersion: '0.28.1'
+  }), {
+    hasUpdate: true,
+    dismissed: true,
+    downloaded: true,
+    showUpdateNotice: true
+  });
 });
 
 test('extractReleaseNotes reads marked bilingual summaries as plain text', () => {


### PR DESCRIPTION
## Summary

- keep update availability independent from whether the footer notification was dismissed
- restore the same-version notification after a manual update check or user-requested download
- keep the Settings download action available after dismissing the footer pill
- turn a downloaded update into a direct **Restart to update** action instead of reopening release notes
- hide the dismiss control while an update is downloading or ready to install, and localize its accessibility labels

## Behavior

| State | Footer pill | Settings action |
| --- | --- | --- |
| Update available | Shows release notes before download | Download update |
| Notification dismissed | Hidden until a manual check or newer release | Download update remains available |
| Downloading | Shows progress without a dismiss action | Disabled while busy |
| Downloaded | Direct Restart to update action | Restart to update |

The updater state is shared by macOS, Windows, and supported Linux AppImage builds, so the fix applies consistently across platforms.

## Testing

- `npm run verify` (1304 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the app update flow so dismissing the footer pill doesn’t block updates. Manual checks or starting a download restore access, and downloaded updates become a direct “Restart to update” action.

- **Bug Fixes**
  - Kept update availability separate from dismissal via `deriveAppUpdateAvailability` (adds `showUpdateNotice` and `downloaded`) and reused it for cooldown selection.
  - Manual checks await any in-flight background check, publish the checking state immediately, then restore a matching dismissed version and surface failures if the shared request fails.
  - Starting a user-requested download also restores a dismissed version.
  - Downloaded updates install directly (↻ Restart) without reopening release notes; the pill bypasses the popover in install mode and hides the dismiss control while downloading or ready.
  - Kept the Settings “Download update” action available even when the footer pill is dismissed; localized dismiss button labels.
  - Added tests for availability, dismissal restore, joined-check feedback, in-flight check reuse, and pill behavior; applies on macOS, Windows, and Linux AppImage.

<sup>Written for commit c8eee470febbd947bb20d9ba9165bf7b38274ba6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

