### PR TITLE
fix(limits): fall back to Claude CLI without OAuth credentials

### DIFF
--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -110,7 +110,7 @@ function errorWithStatus(status, message) {
 }
 
 function shouldTryClaudeCliFallback(error) {
-  return ['sourceRateLimited', 'unavailable', 'error'].includes(error?.status);
+  return ['notConfigured', 'sourceRateLimited', 'unavailable', 'error'].includes(error?.status);
 }
 
 async function readJsonFile(filePath, deps) {

--- a/tests/shared/limitCollector.claude.test.js
+++ b/tests/shared/limitCollector.claude.test.js
@@ -59,6 +59,39 @@ test('Claude limits fall back to direct CLI usage on Windows when OAuth usage is
   assert.equal(provider.windows[1].usedPercent, 20);
 });
 
+test('Claude limits fall back to CLI usage when OAuth credentials are not discoverable', async () => {
+  let cliCalls = 0;
+  const provider = await fetchClaudeLimits({}, {
+    platform: 'darwin',
+    now: () => Date.parse('2026-07-15T00:00:00Z'),
+    claudeCredentialPath: '/tmp/missing-claude-credentials.json',
+    stat: async () => {
+      const error = new Error('missing');
+      error.code = 'ENOENT';
+      throw error;
+    },
+    readMacKeychain: false,
+    runClaudeUsageCli: async () => {
+      cliCalls += 1;
+      return [
+        'Current session',
+        '95% left',
+        'Resets 6pm',
+        'Current week',
+        '80% left',
+        'Resets Jul 22'
+      ].join('\n');
+    }
+  });
+
+  assert.equal(cliCalls, 1);
+  assert.equal(provider.provider, 'claude');
+  assert.equal(provider.status, 'ok');
+  assert.equal(provider.source, 'cli');
+  assert.equal(provider.windows[0].usedPercent, 5);
+  assert.equal(provider.windows[1].usedPercent, 20);
+});
+
 test('Claude limits read Windows Credential Manager credentials when credential files are absent', async () => {
   const provider = await fetchClaudeLimits({}, {
     platform: 'win32',


### PR DESCRIPTION
## Summary

- fall back to Claude CLI usage when OAuth credentials cannot be discovered
- preserve the original `notConfigured` status when the CLI fallback is unavailable

Fixes #154

## Verification

- `node --test tests/shared/limitCollector.claude.test.js tests/shared/limitPlanLabels.test.js`
- `npm run verify`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Falls back to Claude CLI when OAuth credentials can’t be found, and preserves the original notConfigured status if the CLI isn’t available. Improves reliability when collecting usage limits. Fixes #154.

- **Bug Fixes**
  - Try CLI fallback when status is 'notConfigured'.
  - Add test for missing OAuth credentials on macOS to verify CLI fallback and parsed percentages.

<sup>Written for commit b4c6147ad904878c3d0b6f2a0ede2038c91e69ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

