### PR TITLE
fix(updater): make release notes popover readable

### DIFF
--- a/src/electron/renderer/styles.css
+++ b/src/electron/renderer/styles.css
@@ -3261,10 +3261,14 @@ html.is-windows .limit-live-badge {
   max-height: min(360px, calc(100vh - 64px));
   padding: 12px;
   overflow: auto;
-  border: 1px solid rgba(var(--line-rgb), 0.14);
+  border: 1px solid rgba(var(--line-rgb), 0.22);
   border-radius: 10px;
-  background: color-mix(in srgb, var(--bg) 96%, transparent);
-  box-shadow: 0 14px 38px rgba(0, 0, 0, 0.28);
+  background:
+    linear-gradient(180deg, rgba(var(--overlay-rgb), 0.075), rgba(var(--overlay-rgb), 0.025)),
+    rgba(var(--glass-rgb), 0.76);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(var(--overlay-rgb), 0.1);
+  -webkit-backdrop-filter: blur(28px) saturate(115%);
+  backdrop-filter: blur(28px) saturate(115%);
   color: var(--muted);
   font-size: 10px;
   opacity: 0;

--- a/tests/electron/appUpdateReleaseNotes.test.js
+++ b/tests/electron/appUpdateReleaseNotes.test.js
@@ -89,6 +89,18 @@ test('release-note disclosure has keyboard focus and compact reading styles', ()
   assert.match(css, /@media \(prefers-reduced-motion: reduce\)[\s\S]*\.app-update-popover/);
 });
 
+test('release-note popover uses the view switcher glass surface', () => {
+  const css = read('styles.css');
+  const start = css.indexOf('.app-update-popover {');
+  const end = css.indexOf('}', start);
+  assert.notEqual(start, -1);
+  assert.notEqual(end, -1);
+  const popover = css.slice(start, end);
+  assert.match(popover, /rgba\(var\(--glass-rgb\), 0\.76\)/);
+  assert.match(popover, /backdrop-filter: blur\(28px\) saturate\(115%\)/);
+  assert.doesNotMatch(popover, /var\(--bg\)/);
+});
+
 test('Japanese release-note heading describes updates rather than only new features', () => {
   const i18n = read('i18n.js');
   assert.match(i18n, /'settings\.appUpdate\.whatsNew': 'v\{version\} の更新内容'/);


### PR DESCRIPTION
## Summary

- replace the undefined `--bg` release-note background that caused the popover to render almost transparent
- reuse the footer view switcher's glass surface, border, blur, highlight, and shadow so the two floating surfaces stay visually consistent
- add a regression test that guards the theme-aware glass material and prevents the undefined background variable from returning

## Visual verification

- verified in an isolated macOS Electron instance with a seeded update
- confirmed the release-note popover now matches the footer view switcher while keeping the underlying dashboard subdued and readable

## Testing

- `npm run verify` (1307 tests)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unreadable release notes popover by replacing the undefined background with the shared glass surface and improving contrast. The popover now matches the footer view switcher and stays readable over the dashboard.

- **Bug Fixes**
  - Replace `var(--bg)` with layered glass background (`rgba(var(--glass-rgb), 0.76)` + overlay), add `backdrop-filter` blur, increase border contrast, and adjust shadow.
  - Add a regression test to assert glass styles and ensure `--bg` isn’t reintroduced.

<sup>Written for commit 7ae57603903ccde98834511e1aee1ba52c0de3af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

