### PR TITLE
feat(renderer): animate usage data transitions

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -972,6 +972,11 @@ function cancelNumberAnimation() {
 
 function animateNumber(el, from, to, duration = 1000, onDone = null) {
   cancelNumberAnimation();
+  if (prefersReducedMotion()) {
+    el.textContent = formatNumber(to);
+    if (typeof onDone === 'function') onDone();
+    return;
+  }
   const start = performance.now();
   const delta = to - from;
   function frame(now) {
@@ -1167,6 +1172,7 @@ function applyBarScale(fill, scale) {
   const safeScale = Math.max(0, Math.min(1, Number(scale) || 0));
   fill.style.setProperty('--bar-scale', String(safeScale));
   if (!state.animateBarsFromZero || prefersReducedMotion() || !fill.animate) return;
+  for (const animation of fill.getAnimations()) animation.cancel();
   fill.animate([
     { transform: 'scaleX(0)' },
     { transform: `scaleX(${safeScale})` }
@@ -4106,10 +4112,15 @@ function renderBreakdownChange(breakdown, options = {}) {
   if (!setBreakdown(breakdown, options)) return false;
   state.animateBarsFromZero = true;
   state.animateChartsOnRender = true;
+  let renderSucceeded = false;
   try {
     render();
+    renderSucceeded = true;
   } finally {
     state.animateBarsFromZero = false;
+    // Home consumes this flag asynchronously after ResizeObserver confirms layout.
+    // Clear it only after a failed render so that deferred entry motion still runs.
+    if (!renderSucceeded) state.animateChartsOnRender = false;
   }
   return true;
 }

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -201,6 +201,9 @@ function normalizeInitialViewValue(value, allowed, fallback) {
 
 const state = { period: normalizeInitialViewValue(initialViewState.period, viewPeriodValues, 'today'), appUpdate: null, breakdown: normalizeInitialViewValue(initialViewState.breakdown, viewBreakdownValues, 'home'), viewSwitcherOpen: false, viewSwitcherHasOpened: false, resetCreditsTooltipHasOpened: false, resetCreditsTooltipActive: false, resetCreditsTooltipRenderPending: false, settings: null, stats: null, homeHistory: null, homeHistoryBusy: false, homeHistoryRequested: false, homeHistoryPreviewKey: '', homeActivityScrollLeft: null, homeActivityFollowEnd: true, homeActivityResizeObserver: null, serviceStatus: null, serviceStatusBusy: false, serviceProvidersExpanded: false, trendSettingsExpanded: false, trendsActivating: false, homeSettingsExpanded: false, homeLimitSettingsExpanded: false, serviceStatusTicker: null, refreshTimer: null, refreshBusy: false, refreshFeedbackTimer: null, currentTotal: 0, rowSignature: '', streamConnected: false, streamFailure: null, mode: 'idle', appInfo: null, tokscaleStatus: null, tokscaleCheck: null, tokscaleBusy: false, hubInfo: null, cursorAccount: { status: null, error: '' }, cursorAccountExpanded: false, codexAccountExpanded: false, codexAccountError: '', codexSignInBusy: false, codexSignInFlowId: '', codexLoginUrl: '', codexLoginStatus: '', codexLoginOutput: '', codexActiveAccount: null, codexPendingActiveAccount: null, codexPendingActiveAccountUntil: 0, codexPendingActiveAccountTimer: null, codexSystemSwitchingAccountId: '', codexSystemSwitchErrorAccountId: '', codexSystemSwitchError: '', codexSwitchPopoverHasOpened: false, codexSwitchPopoverActive: false, codexSwitchPopoverRenderPending: false, customPricingExpanded: false, opencodeProfileCount: 0, opencodeCookieExpanded: false, deepseekAccountExpanded: false, deepseekPendingCheckSince: 0, minimaxAccountExpanded: false, minimaxPendingCheckSince: 0, zaiAccountExpanded: false, zaiPendingCheckSince: 0, zaiteamAccountExpanded: false, zaiteamPendingCheckSince: 0, volcengineAccountExpanded: false, volcenginePendingCheckSince: 0, qoderAccountExpanded: false, qoderPendingCheckSince: 0, kimiAccountExpanded: false, kimiPendingCheckSince: 0, ollamaAccountExpanded: false, ollamaPendingCheckSince: 0, mimoAccountExpanded: false, mimoAccountError: '', copilotAccountExpanded: false, copilotManualExpanded: false, copilotPendingCheckSince: 0, copilotSignInBusy: false, copilotSignInCancelable: false, copilotSignInFlowId: '', copilotAuthorizeMessage: '', copilotLoginStatus: '', copilotErrorMessage: '', floatingBubble: initialFloatingBubble, suppressInitialNumberAnimation: window.__TOKEN_MONITOR_SUPPRESS_INITIAL_NUMBER_ANIMATION__ === true, openSession: null, detailSort: 'time', recordingWindowShortcut: false, windowShortcutInvalid: false };
 state.appUpdateNotesPresentedVersion = '';
+state.periodMotionActive = false;
+state.animateBarsFromZero = false;
+state.animateChartsOnRender = true;
 let directBreakdownOverride = null;
 state.projectSettingsExpanded = false;
 state.settingsSections = Object.fromEntries(SETTINGS_SECTION_IDS.map((id) => [id, false]));
@@ -967,7 +970,7 @@ function cancelNumberAnimation() {
   if (numberAnimHandle) { cancelAnimationFrame(numberAnimHandle); numberAnimHandle = 0; }
 }
 
-function animateNumber(el, from, to, duration = 2200, onDone = null) {
+function animateNumber(el, from, to, duration = 1000, onDone = null) {
   cancelNumberAnimation();
   const start = performance.now();
   const delta = to - from;
@@ -982,6 +985,192 @@ function animateNumber(el, from, to, duration = 2200, onDone = null) {
     }
   }
   numberAnimHandle = requestAnimationFrame(frame);
+}
+
+const rowNumberAnimationHandles = new WeakMap();
+
+function prefersReducedMotion() {
+  return Boolean(window.matchMedia?.('(prefers-reduced-motion: reduce)').matches);
+}
+
+function captureBreakdownMotion() {
+  const snapshot = new Map();
+  for (const row of els.breakdown?.querySelectorAll('.row[data-key]') || []) {
+    const rect = row.getBoundingClientRect();
+    const fill = row.querySelector('.bar-fill');
+    const trackWidth = fill?.parentElement?.getBoundingClientRect().width || 0;
+    const fillWidth = fill?.getBoundingClientRect().width || 0;
+    snapshot.set(row.dataset.key, {
+      top: rect.top,
+      value: Number(row.querySelector('.row-value')?.dataset.motionValue || row.dataset.motionValue || 0),
+      barScale: trackWidth > 0 ? Math.max(0, Math.min(1, fillWidth / trackWidth)) : 0
+    });
+  }
+  return snapshot;
+}
+
+function animateRowNumber(el, from, to, duration = 420) {
+  const previousHandle = rowNumberAnimationHandles.get(el);
+  if (previousHandle) cancelAnimationFrame(previousHandle);
+  if (!Number.isFinite(from) || !Number.isFinite(to) || from === to || prefersReducedMotion()) {
+    el.textContent = formatNumber(to);
+    el.dataset.motionValue = String(Number(to) || 0);
+    rowNumberAnimationHandles.delete(el);
+    return;
+  }
+  const startedAt = performance.now();
+  const delta = to - from;
+  el.textContent = formatNumber(from);
+  el.dataset.motionValue = String(from);
+  function frame(now) {
+    const progress = Math.min(1, (now - startedAt) / duration);
+    const current = from + delta * easeOutQuart(progress);
+    el.textContent = formatNumber(current);
+    el.dataset.motionValue = String(current);
+    if (progress < 1) {
+      rowNumberAnimationHandles.set(el, requestAnimationFrame(frame));
+    } else {
+      rowNumberAnimationHandles.delete(el);
+    }
+  }
+  rowNumberAnimationHandles.set(el, requestAnimationFrame(frame));
+}
+
+function animateBreakdownFrom(snapshot, { duration = 420 } = {}) {
+  if (prefersReducedMotion()) return;
+  let enteringIndex = 0;
+  for (const row of els.breakdown?.querySelectorAll('.row[data-key]') || []) {
+    const previous = snapshot.get(row.dataset.key);
+    const value = Number(row.dataset.motionValue || 0);
+    const fill = row.querySelector('.bar-fill');
+    const targetScale = Math.max(0, Math.min(1, Number(fill?.style.getPropertyValue('--bar-scale')) || 0));
+    if (previous) {
+      const deltaY = previous.top - row.getBoundingClientRect().top;
+      if (Math.abs(deltaY) > 0.5) {
+        row.animate([
+          { transform: `translate3d(0, ${deltaY}px, 0)` },
+          { transform: 'translate3d(0, 0, 0)' }
+        ], { duration: 280, easing: 'cubic-bezier(0.22, 1, 0.36, 1)' });
+      }
+      animateBarBetween(fill, previous.barScale, targetScale, 0, duration);
+      animateRowNumber(row.querySelector('.row-value'), previous.value, value, duration);
+      continue;
+    }
+    row.animate([
+      { opacity: 0, transform: 'translate3d(0, 7px, 0)' },
+      { opacity: 1, transform: 'translate3d(0, 0, 0)' }
+    ], {
+      duration: 240,
+      delay: Math.min(enteringIndex, 6) * 18,
+      easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+      fill: 'backwards'
+    });
+    const delay = Math.min(enteringIndex, 6) * 18;
+    animateBarBetween(fill, 0, targetScale, delay, Math.max(1, duration - delay));
+    animateRowNumber(row.querySelector('.row-value'), 0, value, duration);
+    enteringIndex += 1;
+  }
+}
+
+function animateBarBetween(fill, fromScale, toScale, delay = 0, duration = 420) {
+  if (!fill?.animate || Math.abs(toScale - fromScale) < 0.001) return;
+  for (const animation of fill.getAnimations()) animation.cancel();
+  fill.animate([
+    { transform: `scaleX(${fromScale})` },
+    { transform: `scaleX(${toScale})` }
+  ], {
+    duration,
+    delay,
+    easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+    fill: 'backwards'
+  });
+}
+
+function captureTrendBarMotion() {
+  const snapshot = new Map();
+  for (const bar of els.trendsPanel?.querySelectorAll('.spark-bar[data-motion-key]') || []) {
+    snapshot.set(bar.dataset.motionKey, { height: bar.getBoundingClientRect().height });
+  }
+  return snapshot;
+}
+
+function animateTrendBarsFrom(snapshot, { fromZero = false } = {}) {
+  if (prefersReducedMotion()) return;
+  const bars = Array.from(els.trendsPanel?.querySelectorAll('.spark-bar[data-motion-key]') || []);
+  bars.forEach((bar, index) => {
+    const previous = snapshot.get(bar.dataset.motionKey);
+    const targetHeight = bar.getBoundingClientRect().height;
+    const fromScale = fromZero || !previous
+      ? 0
+      : targetHeight > 0 ? previous.height / targetHeight : 1;
+    if (Math.abs(fromScale - 1) < 0.001) return;
+    bar.animate([
+      { transform: `scaleY(${fromScale})` },
+      { transform: 'scaleY(1)' }
+    ], {
+      duration: 420,
+      delay: previous && !fromZero ? 0 : Math.min(index, 14) * 14,
+      easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+      fill: 'backwards'
+    });
+  });
+}
+
+const HOME_HISTORY_MOTION_MS = 920;
+const HOME_HEAT_CELL_MOTION_MS = 360;
+
+function animateHomeHistoryVisuals(activityScroll, activityCanvas, trendChart) {
+  if (!state.animateChartsOnRender) return;
+  state.animateChartsOnRender = false;
+  if (prefersReducedMotion()) return;
+
+  const heatCells = Array.from(activityCanvas?.querySelectorAll('.heat-base-layer .heat') || []);
+  const viewport = activityScroll?.getBoundingClientRect();
+  const visibleCells = heatCells.map((cell, index) => ({ cell, column: Math.floor(index / 7), rect: cell.getBoundingClientRect() }))
+    .filter(({ rect }) => viewport && rect.right > viewport.left && rect.left < viewport.right);
+  const firstVisibleColumn = visibleCells.length ? visibleCells[0].column : 0;
+  const lastVisibleColumn = visibleCells.length ? visibleCells[visibleCells.length - 1].column : firstVisibleColumn;
+  const heatColumnDelay = (HOME_HISTORY_MOTION_MS - HOME_HEAT_CELL_MOTION_MS) / Math.max(1, lastVisibleColumn - firstVisibleColumn);
+  visibleCells.forEach(({ cell, column }) => {
+    cell.animate([{ opacity: 0 }, { opacity: 1 }], {
+      duration: HOME_HEAT_CELL_MOTION_MS,
+      delay: (column - firstVisibleColumn) * heatColumnDelay,
+      easing: 'ease',
+      fill: 'backwards'
+    });
+  });
+
+  const line = trendChart?.querySelector('.area-line-stroke');
+  const fill = trendChart?.querySelector('.area-line-fill');
+  const length = line?.getTotalLength?.() || 0;
+  if (length > 0) {
+    line.animate([
+      { strokeDasharray: `${length} ${length}`, strokeDashoffset: length },
+      { strokeDasharray: `${length} ${length}`, strokeDashoffset: 0 }
+    ], {
+      duration: HOME_HISTORY_MOTION_MS,
+      easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+      fill: 'backwards'
+    });
+  }
+  fill?.animate([
+    { clipPath: 'inset(0 100% 0 0)' },
+    { clipPath: 'inset(0 0 0 0)' }
+  ], {
+    duration: HOME_HISTORY_MOTION_MS,
+    easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+    fill: 'backwards'
+  });
+}
+
+function applyBarScale(fill, scale) {
+  const safeScale = Math.max(0, Math.min(1, Number(scale) || 0));
+  fill.style.setProperty('--bar-scale', String(safeScale));
+  if (!state.animateBarsFromZero || prefersReducedMotion() || !fill.animate) return;
+  fill.animate([
+    { transform: 'scaleX(0)' },
+    { transform: `scaleX(${safeScale})` }
+  ], { duration: 420, easing: 'cubic-bezier(0.22, 1, 0.36, 1)' });
 }
 
 function rowWidth(value, max) {
@@ -1033,11 +1222,14 @@ function updateRow(row, { name, subtitle, detail, value, cost, max, color, barBa
   const detailEl = row.querySelector('.row-detail');
   detailEl.textContent = detail || '';
   detailEl.classList.toggle('hidden', !detail);
-  row.querySelector('.row-value').textContent = formatNumber(value);
+  const valueEl = row.querySelector('.row-value');
+  valueEl.textContent = formatNumber(value);
+  valueEl.dataset.motionValue = String(Number(value) || 0);
+  row.dataset.motionValue = String(Number(value) || 0);
   row.querySelector('.row-cost').textContent = formatCost(cost || 0);
   const fill = row.querySelector('.bar-fill');
   fill.style.background = barBackground || color;
-  fill.style.width = `${width}%`;
+  applyBarScale(fill, width / 100);
 
   const accordionInner = row.querySelector('.row-accordion-inner');
   if (Array.isArray(accordionRows) && accordionRows.length > 0) {
@@ -1134,6 +1326,9 @@ function renderRows(rows, { showProjectIncompleteHint = false } = {}) {
     return;
   }
   const max = Math.max(1, ...rows.map((row) => row.value));
+  const liveMotionSnapshot = !state.periodMotionActive && !state.animateBarsFromZero
+    ? captureBreakdownMotion()
+    : null;
   const hintText = showProjectIncompleteHint ? t('projects.incomplete') : '';
   const signature = JSON.stringify([state.breakdown, hintText, rows.map((row) => row.key)]);
   const children = Array.from(els.breakdown.children);
@@ -1158,6 +1353,7 @@ function renderRows(rows, { showProjectIncompleteHint = false } = {}) {
     const row = current.get(rowData.key);
     if (row) updateRow(row, { ...rowData, max });
   }
+  if (liveMotionSnapshot) animateBreakdownFrom(liveMotionSnapshot, { duration: 600 });
 }
 
 function deviceLabel(device) {
@@ -1624,7 +1820,7 @@ function limitMeterNode(color, percent, tone = 1) {
   meter.style.background = colorWithAlpha(color, 0.16);
   const fill = document.createElement('div');
   fill.className = 'limit-meter-fill';
-  fill.style.width = `${safePercent}%`;
+  applyBarScale(fill, safePercent / 100);
   fill.style.background = color;
   fill.style.opacity = tone;
   meter.append(fill);
@@ -2658,7 +2854,7 @@ function exchangeNode(row, max) {
   wrap.querySelector('.detail-ex-sub').textContent = row.subtitle;
   wrap.querySelector('.detail-ex-value').textContent = formatNumber(row.value);
   wrap.querySelector('.detail-ex-cost').textContent = formatCost(row.cost);
-  wrap.querySelector('.bar-fill').style.width = `${rowWidth(row.value, max)}%`;
+  applyBarScale(wrap.querySelector('.bar-fill'), rowWidth(row.value, max) / 100);
 
   const turnsEl = wrap.querySelector('.detail-turns');
   for (const turn of row.turns) turnsEl.append(turnNode(turn));
@@ -2694,6 +2890,7 @@ let contentReadySignaled = false;
 
 function renderTrends() {
   const charts = window.TokenMonitorUsageCharts;
+  const previousBars = captureTrendBarMotion();
   const preview = state.stats?.historyPreview || { daily: [], monthly: [], summary: {} };
   const todayTotal = Number(state.stats?.periods?.today?.totalTokens || 0);
   const { points, metric, labelKey } = charts.selectPreviewSeries(preview, state.period);
@@ -2728,6 +2925,13 @@ function renderTrends() {
     + `<div class="trends-spark" role="button" tabindex="0" title="${t('trends.open')}">${svg}</div>`
     + `<div class="trends-axis"><span>${first}</span><span>${last}</span></div>`
     + `<div class="trends-stats">${statsHtml}</div>`;
+  const bars = Array.from(els.trendsPanel.querySelectorAll('.spark-bar'));
+  bars.forEach((bar, index) => {
+    bar.dataset.motionKey = String(finalPoints[index]?.[labelKey] || index);
+  });
+  const fromZero = state.animateChartsOnRender;
+  animateTrendBarsFrom(previousBars, { fromZero });
+  if (fromZero) state.animateChartsOnRender = false;
 }
 
 function viewLabelById(id) {
@@ -2777,8 +2981,7 @@ function openViewFromTray(viewId) {
   els.settingsPanel?.classList.add('hidden');
   els.shell.classList.remove('settings-open');
   state.openSession = null;
-  setBreakdown(viewId, { allowHidden: true });
-  render();
+  renderBreakdownChange(viewId, { allowHidden: true });
 }
 
 async function loadHomeHistory() {
@@ -2894,7 +3097,8 @@ function renderViewSwitcher({ focusMenu = false, focusDisclosure = false } = {})
       return;
     }
     state.viewSwitcherOpen = false;
-    if (setBreakdown(nextBreakdown(state.breakdown))) render();
+    updateViewSwitcherOpenState();
+    renderBreakdownChange(nextBreakdown(state.breakdown));
   });
   current.addEventListener('pointerdown', (event) => {
     if (event.button !== 0) return;
@@ -2955,8 +3159,9 @@ function renderViewSwitcher({ focusMenu = false, focusDisclosure = false } = {})
     item.append(itemLabel);
     item.addEventListener('click', () => {
       state.viewSwitcherOpen = false;
-      if (setBreakdown(id)) render();
-      else renderViewSwitcher({ focusDisclosure: true });
+      updateViewSwitcherOpenState();
+      if (id === state.breakdown) renderViewSwitcher({ focusDisclosure: true });
+      else renderBreakdownChange(id);
     });
     menu.append(item);
   }
@@ -2994,13 +3199,13 @@ function homeModuleShell(kind, title, viewId, meta = '') {
   module.setAttribute('aria-label', title);
   module.addEventListener('click', (event) => {
     if (event.target.closest('.home-activity-scroll')) return;
-    if (setBreakdown(viewId)) render();
+    renderBreakdownChange(viewId);
   });
   module.addEventListener('keydown', (event) => {
     if (event.target !== module) return;
     if (event.key !== 'Enter' && event.key !== ' ') return;
     event.preventDefault();
-    if (setBreakdown(viewId)) render();
+    renderBreakdownChange(viewId);
   });
   const head = document.createElement('div');
   head.className = 'home-module-head';
@@ -3263,8 +3468,17 @@ function applyHomeActivityScroll(scroller) {
   scroller.classList.toggle('is-scrolled', target > 2);
 }
 
-function setupHomeActivityScroller(scroller) {
+function setupHomeActivityScroller(scroller, onReady = null) {
   let drag = null;
+  let readySignaled = false;
+  const applySettledLayout = () => {
+    applyHomeActivityScroll(scroller);
+    if (readySignaled || typeof onReady !== 'function') return;
+    const svg = scroller.querySelector('.dash-heatmap');
+    if (scroller.clientWidth <= 0 || !svg || svg.getBoundingClientRect().width <= 0) return;
+    readySignaled = true;
+    onReady();
+  };
   scroller.addEventListener('scroll', () => {
     scroller.classList.toggle('is-scrolled', scroller.scrollLeft > 2);
     const record = homeOverviewApi.homeActivityScrollRecord({
@@ -3305,8 +3519,10 @@ function setupHomeActivityScroller(scroller) {
   // the panel becomes visible / the window resizes, so the measurement is always real.
   state.homeActivityResizeObserver?.disconnect();
   if (typeof ResizeObserver === 'function') {
-    state.homeActivityResizeObserver = new ResizeObserver(() => applyHomeActivityScroll(scroller));
+    state.homeActivityResizeObserver = new ResizeObserver(applySettledLayout);
     state.homeActivityResizeObserver.observe(scroller);
+  } else if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(() => requestAnimationFrame(applySettledLayout));
   }
   applyHomeActivityScroll(scroller);
 }
@@ -3518,8 +3734,6 @@ function renderHomeTrendsModule() {
     spotlightRadius: 82
   });
   activityScroll.append(activityCanvas);
-  setupHomeActivityScroller(activityScroll);
-  setupHomeActivityHover(activityScroll);
   const linePoints = charts.clampDaily(points, 45);
   const summary = homeOverviewApi.homeTrendSummary(linePoints);
   const trendHead = document.createElement('div');
@@ -3546,6 +3760,8 @@ function renderHomeTrendsModule() {
     dates.append(label);
   }
   body.append(activityScroll, trendHead, plot, dates);
+  setupHomeActivityScroller(activityScroll, () => animateHomeHistoryVisuals(activityScroll, activityCanvas, chart));
+  setupHomeActivityHover(activityScroll);
   return module;
 }
 
@@ -3613,7 +3829,7 @@ function render() {
     const widest = formatNumber(nextTotal).length >= formatNumber(state.currentTotal).length ? nextTotal : state.currentTotal;
     els.totalTokens.textContent = formatNumber(widest);
     updateTotalCompact(nextTotal);
-    animateNumber(els.totalTokens, state.currentTotal, nextTotal, 2200, fitTotalNumber);
+    animateNumber(els.totalTokens, state.currentTotal, nextTotal, state.periodMotionActive ? 800 : 1000, fitTotalNumber);
     pulseLiveDot();
   } else {
     cancelNumberAnimation();
@@ -3883,6 +4099,18 @@ function setBreakdown(breakdown, options = {}) {
   state.breakdown = next;
   state.rowSignature = '';
   publishViewState();
+  return true;
+}
+
+function renderBreakdownChange(breakdown, options = {}) {
+  if (!setBreakdown(breakdown, options)) return false;
+  state.animateBarsFromZero = true;
+  state.animateChartsOnRender = true;
+  try {
+    render();
+  } finally {
+    state.animateBarsFromZero = false;
+  }
   return true;
 }
 
@@ -4662,8 +4890,13 @@ async function refreshHubInfo() {
 }
 
 function syncPeriodTabs() {
-  for (const tab of document.querySelectorAll('.tab')) {
-    tab.classList.toggle('active', tab.dataset.period === state.period);
+  const tabs = Array.from(document.querySelectorAll('.tab'));
+  const activeIndex = Math.max(0, tabs.findIndex((tab) => tab.dataset.period === state.period));
+  document.querySelector('.tabs')?.style.setProperty('--period-index', String(activeIndex));
+  for (const tab of tabs) {
+    const active = tab.dataset.period === state.period;
+    tab.classList.toggle('active', active);
+    tab.setAttribute('aria-pressed', String(active));
   }
 }
 
@@ -6091,12 +6324,15 @@ async function init() {
 
 for (const tab of document.querySelectorAll('.tab')) {
   tab.addEventListener('click', () => {
-    setPeriod(tab.dataset.period);
+    const snapshot = captureBreakdownMotion();
+    if (!setPeriod(tab.dataset.period)) return;
     syncPeriodTabs();
     if (state.openSession) openSessionDetail(state.openSession);
-    state.currentTotal = 0;
     state.rowSignature = '';
+    state.periodMotionActive = true;
     render();
+    state.periodMotionActive = false;
+    animateBreakdownFrom(snapshot, { duration: 800 });
   });
 }
 

--- a/src/electron/renderer/index.html
+++ b/src/electron/renderer/index.html
@@ -16,6 +16,7 @@
         </div>
         <div class="title-controls">
           <nav class="tabs" aria-label="Period tabs">
+            <span class="tab-indicator" aria-hidden="true"></span>
             <button class="tab active" data-period="today">DAY</button>
             <button class="tab" data-period="month">MONTH</button>
             <button class="tab" data-period="allTime">TOTAL</button>

--- a/src/electron/renderer/styles.css
+++ b/src/electron/renderer/styles.css
@@ -1644,6 +1644,7 @@ body.floating-bubble-collapsed-right .floating-bubble-tab {
   }
 }
 .tabs {
+  --period-index: 0;
   position: relative;
   z-index: 1;
   display: grid;
@@ -1658,7 +1659,24 @@ body.floating-bubble-collapsed-right .floating-bubble-tab {
   -webkit-backdrop-filter: blur(18px);
   backdrop-filter: blur(18px);
 }
+.tab-indicator {
+  position: absolute;
+  z-index: 0;
+  top: 3px;
+  bottom: 3px;
+  left: 3px;
+  width: calc((100% - 10px) / 3);
+  border: 1px solid rgba(var(--line-rgb), 0.13);
+  border-radius: 6px;
+  background: rgba(var(--overlay-rgb), 0.06);
+  box-shadow: inset 0 1px 0 rgba(var(--overlay-rgb), 0.075);
+  pointer-events: none;
+  transform: translate3d(calc(var(--period-index) * (100% + 2px)), 0, 0);
+  transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
 .tab {
+  position: relative;
+  z-index: 1;
   height: 22px;
   border-color: transparent;
   border-radius: 6px;
@@ -1669,10 +1687,10 @@ body.floating-bubble-collapsed-right .floating-bubble-tab {
 }
 .tab:hover { color: var(--text); }
 .tab.active {
-  border-color: rgba(var(--line-rgb), 0.13);
+  border-color: transparent;
   color: var(--green);
-  background: rgba(var(--overlay-rgb), 0.06);
-  box-shadow: inset 0 1px 0 rgba(var(--overlay-rgb), 0.075);
+  background: transparent;
+  box-shadow: none;
 }
 .total-panel {
   position: relative;
@@ -2434,7 +2452,15 @@ body.floating-bubble-collapsed-right .floating-bubble-tab {
 .row-value { color: var(--text); white-space: nowrap; }
 .row-cost { color: var(--muted); font-size: 10px; white-space: nowrap; }
 .bar { width: 100%; height: 6px; overflow: hidden; border-radius: 3px; background: rgba(var(--sunken-rgb), 0.46); box-shadow: inset 0 1px 0 rgba(var(--overlay-rgb), 0.04); }
-.bar-fill { height: 100%; width: 0; border-radius: 3px; background: var(--blue); transition: width 450ms ease; }
+.bar-fill {
+  width: 100%;
+  height: 100%;
+  border-radius: 3px;
+  background: var(--blue);
+  transform: scaleX(var(--bar-scale, 0));
+  transform-origin: left center;
+  transition: transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
+}
 .row.stale .row-name, .row.stale .row-value, .row.stale .row-cost { color: var(--muted); }
 .home-device-badge,
 .row.local .row-name::after {
@@ -2857,16 +2883,21 @@ html.is-windows .limit-live-badge {
   background: rgba(var(--sunken-rgb), 0.44);
 }
 .limit-meter-fill {
-  width: 0;
+  width: 100%;
   height: 100%;
   border-radius: 3px;
-  transition: width 420ms ease;
+  transform: scaleX(var(--bar-scale, 0));
+  transform-origin: left center;
+  transition: transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 @media (prefers-reduced-motion: reduce) {
-  .limit-meter-fill {
+  .bar-fill,
+  .limit-meter-fill,
+  .tab-indicator {
     transition: none;
   }
 }
+
 .limit-reset {
   min-height: 11px;
   overflow: hidden;
@@ -3628,7 +3659,12 @@ html.is-windows .limit-live-badge {
 .trends-spark { flex: 1 1 auto; min-height: 0; display: flex; cursor: pointer; border-radius: 8px; padding: 6px 4px; transition: background 0.12s ease; }
 .trends-spark:hover { background: rgba(var(--overlay-rgb), 0.05); }
 .trends-spark .sparkline { width: 100%; height: 100%; display: block; }
-.trends-spark .spark-bar { fill: #6ab4f0; opacity: 0.5; }
+.trends-spark .spark-bar {
+  fill: #6ab4f0;
+  opacity: 0.5;
+  transform-box: fill-box;
+  transform-origin: bottom center;
+}
 .trends-spark .spark-bar--last { opacity: 1; }
 .trends-axis { flex: none; display: flex; justify-content: space-between; padding: 0 4px; font-size: 10px; opacity: 0.45; font-variant-numeric: tabular-nums; }
 .trends-stats { flex: none; display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }

--- a/tests/electron/homeLimitBars.test.js
+++ b/tests/electron/homeLimitBars.test.js
@@ -37,7 +37,7 @@ test('Home highlights only low and critical remaining limits', () => {
   assert.match(css, /\.home-limit-value-critical\s*\{[^}]*color:\s*var\(--red\)/s);
   assert.doesNotMatch(css, /\.home-limit-value-critical\s*\{[^}]*display:\s*inline-flex/s);
   assert.match(css, /\.home-limit-value-critical::before\s*\{[^}]*width:\s*4px;[^}]*height:\s*4px;/s);
-  assert.match(css, /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.limit-meter-fill\s*\{[^}]*transition:\s*none;/);
+  assert.match(css, /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.limit-meter-fill,[\s\S]*?\.tab-indicator\s*\{[^}]*transition:\s*none;/);
 });
 
 test('Home low-limit indicator setting is translated in every locale', () => {

--- a/tests/electron/rendererMotion.test.js
+++ b/tests/electron/rendererMotion.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const rendererDir = path.join(__dirname, '..', '..', 'src', 'electron', 'renderer');
+
+function read(name) {
+  return fs.readFileSync(path.join(rendererDir, name), 'utf8');
+}
+
+test('period tabs use one sliding selection indicator', () => {
+  const html = read('index.html');
+  const css = read('styles.css');
+  const app = read('app.js');
+
+  assert.match(html, /<nav class="tabs"[\s\S]*?<span class="tab-indicator" aria-hidden="true"><\/span>[\s\S]*?data-period="today"[\s\S]*?data-period="month"[\s\S]*?data-period="allTime"/);
+  assert.match(css, /\.tab-indicator\s*\{[^}]*transform:\s*translate3d\(calc\(var\(--period-index\)/s);
+  assert.match(css, /\.tab-indicator\s*\{[^}]*transition:\s*transform 220ms cubic-bezier\(0\.22, 1, 0\.36, 1\)/s);
+  assert.match(app, /style\.setProperty\('--period-index', String\(activeIndex\)\)/);
+  assert.match(app, /tab\.setAttribute\('aria-pressed', String\(active\)\)/);
+});
+
+test('data bars animate on the compositor instead of changing layout width', () => {
+  const css = read('styles.css');
+  const app = read('app.js');
+
+  assert.match(css, /\.bar-fill\s*\{[^}]*transform:\s*scaleX\(var\(--bar-scale, 0\)\)/s);
+  assert.match(css, /\.limit-meter-fill\s*\{[^}]*transform:\s*scaleX\(var\(--bar-scale, 0\)\)/s);
+  assert.doesNotMatch(css, /(?:\.bar-fill|\.limit-meter-fill)\s*\{[^}]*transition:\s*width/s);
+  assert.match(app, /applyBarScale\(fill, width \/ 100\)/);
+  assert.match(app, /applyBarScale\(fill, safePercent \/ 100\)/);
+  assert.match(app, /state\.animateBarsFromZero[\s\S]*?transform: 'scaleX\(0\)'[\s\S]*?duration: 420/s);
+  assert.match(app, /for \(const animation of fill\.getAnimations\(\)\) animation\.cancel\(\)/);
+});
+
+test('period changes preserve row identity, animate rank changes, and count from the previous total', () => {
+  const app = read('app.js');
+  const handler = app.slice(
+    app.indexOf("for (const tab of document.querySelectorAll('.tab'))"),
+    app.indexOf("els.breakdown.addEventListener('click'", app.indexOf("for (const tab of document.querySelectorAll('.tab'))"))
+  );
+
+  assert.match(handler, /const snapshot = captureBreakdownMotion\(\)/);
+  assert.match(handler, /animateBreakdownFrom\(snapshot, \{ duration: 800 \}\)/);
+  assert.doesNotMatch(handler, /state\.currentTotal = 0/);
+  assert.match(app, /barScale: trackWidth > 0 \? Math\.max\(0, Math\.min\(1, fillWidth \/ trackWidth\)\) : 0/);
+  assert.match(app, /previous\.top - row\.getBoundingClientRect\(\)\.top/);
+  assert.match(app, /animateBarBetween\(fill, previous\.barScale, targetScale, 0, duration\)/);
+  assert.match(app, /animateBarBetween\(fill, 0, targetScale, delay, Math\.max\(1, duration - delay\)\)/);
+  assert.match(app, /function animateRowNumber\(el, from, to, duration = 420\)/);
+  assert.match(app, /animateRowNumber\(row\.querySelector\('\.row-value'\), previous\.value, value, duration\)/);
+  assert.match(app, /value: Number\(row\.querySelector\('\.row-value'\)\?\.dataset\.motionValue/);
+});
+
+test('live row updates count and resize bars together without slowing the headline', () => {
+  const app = read('app.js');
+
+  assert.match(app, /const liveMotionSnapshot = !state\.periodMotionActive && !state\.animateBarsFromZero[\s\S]*?captureBreakdownMotion\(\)/);
+  assert.match(app, /if \(liveMotionSnapshot\) animateBreakdownFrom\(liveMotionSnapshot, \{ duration: 600 \}\)/);
+  assert.match(app, /animateNumber\(els\.totalTokens, state\.currentTotal, nextTotal, state\.periodMotionActive \? 800 : 1000, fitTotalNumber\)/);
+  assert.match(app, /animateRowNumber\(row\.querySelector\('\.row-value'\), 0, value, duration\)/);
+});
+
+test('view changes render immediately without a page crossfade', () => {
+  const css = read('styles.css');
+  const app = read('app.js');
+
+  assert.doesNotMatch(app, /startViewTransition|renderViewChange|animateFallbackViewPanel/);
+  assert.doesNotMatch(css, /view-transition-name|::view-transition|motion-view-(?:in|out)/);
+  assert.match(app, /function renderBreakdownChange\(breakdown, options = \{\}\)/);
+  assert.match(app, /state\.animateBarsFromZero = true;[\s\S]*?render\(\);[\s\S]*?state\.animateBarsFromZero = false;/);
+  assert.match(app, /else renderBreakdownChange\(id\)/);
+  assert.match(app, /renderBreakdownChange\(viewId\)/);
+  assert.match(css, /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.bar-fill,[\s\S]*?\.tab-indicator[\s\S]*?transition:\s*none/s);
+});
+
+test('Trends bars grow from the baseline and preserve matching period heights', () => {
+  const app = read('app.js');
+  const css = read('styles.css');
+
+  assert.match(app, /function captureTrendBarMotion\(\)[\s\S]*?\.spark-bar\[data-motion-key\][\s\S]*?getBoundingClientRect\(\)\.height/);
+  assert.match(app, /bar\.dataset\.motionKey = String\(finalPoints\[index\]\?\.\[labelKey\] \|\| index\)/);
+  assert.match(app, /const fromScale = fromZero \|\| !previous[\s\S]*?previous\.height \/ targetHeight/);
+  assert.match(app, /transform: `scaleY\(\$\{fromScale\}\)`[\s\S]*?transform: 'scaleY\(1\)'[\s\S]*?duration: 420/);
+  assert.match(css, /\.trends-spark \.spark-bar\s*\{[^}]*transform-box:\s*fill-box;[^}]*transform-origin:\s*bottom center;/s);
+});
+
+test('Home history visuals reveal left to right only when entering the view', () => {
+  const app = read('app.js');
+
+  assert.match(app, /state\.animateChartsOnRender = true/);
+  assert.match(app, /\.heat-base-layer \.heat/);
+  assert.match(app, /const HOME_HISTORY_MOTION_MS = 920/);
+  assert.match(app, /const HOME_HEAT_CELL_MOTION_MS = 360/);
+  assert.match(app, /const viewport = activityScroll\?\.getBoundingClientRect\(\)/);
+  assert.match(app, /rect\.right > viewport\.left && rect\.left < viewport\.right/);
+  assert.match(app, /const firstVisibleColumn = visibleCells\.length \? visibleCells\[0\]\.column : 0/);
+  assert.match(app, /const heatColumnDelay = \(HOME_HISTORY_MOTION_MS - HOME_HEAT_CELL_MOTION_MS\) \/ Math\.max\(1, lastVisibleColumn - firstVisibleColumn\)/);
+  assert.match(app, /delay: \(column - firstVisibleColumn\) \* heatColumnDelay/);
+  assert.match(app, /duration: HOME_HEAT_CELL_MOTION_MS/);
+  assert.match(app, /strokeDasharray: `\$\{length\} \$\{length\}`[\s\S]*?strokeDashoffset: length[\s\S]*?strokeDashoffset: 0/);
+  assert.equal((app.match(/duration: HOME_HISTORY_MOTION_MS/g) || []).length, 2);
+  assert.match(app, /clipPath: 'inset\(0 100% 0 0\)'[\s\S]*?clipPath: 'inset\(0 0 0 0\)'/);
+  assert.match(app, /if \(prefersReducedMotion\(\)\) return/);
+  assert.match(app, /new ResizeObserver\(applySettledLayout\)/);
+  assert.match(app, /setupHomeActivityScroller\(activityScroll, \(\) => animateHomeHistoryVisuals\(activityScroll, activityCanvas, chart\)\)/);
+});

--- a/tests/electron/rendererMotion.test.js
+++ b/tests/electron/rendererMotion.test.js
@@ -26,6 +26,10 @@ test('period tabs use one sliding selection indicator', () => {
 test('data bars animate on the compositor instead of changing layout width', () => {
   const css = read('styles.css');
   const app = read('app.js');
+  const applyBarScale = app.slice(
+    app.indexOf('function applyBarScale('),
+    app.indexOf('function rowWidth(', app.indexOf('function applyBarScale('))
+  );
 
   assert.match(css, /\.bar-fill\s*\{[^}]*transform:\s*scaleX\(var\(--bar-scale, 0\)\)/s);
   assert.match(css, /\.limit-meter-fill\s*\{[^}]*transform:\s*scaleX\(var\(--bar-scale, 0\)\)/s);
@@ -33,7 +37,7 @@ test('data bars animate on the compositor instead of changing layout width', () 
   assert.match(app, /applyBarScale\(fill, width \/ 100\)/);
   assert.match(app, /applyBarScale\(fill, safePercent \/ 100\)/);
   assert.match(app, /state\.animateBarsFromZero[\s\S]*?transform: 'scaleX\(0\)'[\s\S]*?duration: 420/s);
-  assert.match(app, /for \(const animation of fill\.getAnimations\(\)\) animation\.cancel\(\)/);
+  assert.match(applyBarScale, /for \(const animation of fill\.getAnimations\(\)\) animation\.cancel\(\)/);
 });
 
 test('period changes preserve row identity, animate rank changes, and count from the previous total', () => {
@@ -71,10 +75,20 @@ test('view changes render immediately without a page crossfade', () => {
   assert.doesNotMatch(app, /startViewTransition|renderViewChange|animateFallbackViewPanel/);
   assert.doesNotMatch(css, /view-transition-name|::view-transition|motion-view-(?:in|out)/);
   assert.match(app, /function renderBreakdownChange\(breakdown, options = \{\}\)/);
-  assert.match(app, /state\.animateBarsFromZero = true;[\s\S]*?render\(\);[\s\S]*?state\.animateBarsFromZero = false;/);
+  assert.match(app, /state\.animateBarsFromZero = true;[\s\S]*?let renderSucceeded = false;[\s\S]*?render\(\);[\s\S]*?renderSucceeded = true;[\s\S]*?state\.animateBarsFromZero = false;[\s\S]*?if \(!renderSucceeded\) state\.animateChartsOnRender = false;/);
   assert.match(app, /else renderBreakdownChange\(id\)/);
   assert.match(app, /renderBreakdownChange\(viewId\)/);
   assert.match(css, /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.bar-fill,[\s\S]*?\.tab-indicator[\s\S]*?transition:\s*none/s);
+});
+
+test('headline counting respects reduced-motion preferences', () => {
+  const app = read('app.js');
+  const animateNumber = app.slice(
+    app.indexOf('function animateNumber('),
+    app.indexOf('const rowNumberAnimationHandles', app.indexOf('function animateNumber('))
+  );
+
+  assert.match(animateNumber, /if \(prefersReducedMotion\(\)\) \{[\s\S]*?el\.textContent = formatNumber\(to\);[\s\S]*?onDone\(\);[\s\S]*?return;/);
 });
 
 test('Trends bars grow from the baseline and preserve matching period heights', () => {

--- a/tests/electron/totalTokenCompact.test.js
+++ b/tests/electron/totalTokenCompact.test.js
@@ -55,7 +55,7 @@ test('compact total stays visible through the count-up, with the font pre-locked
   // The font is fitted to the widest endpoint before the roll starts, so the number
   // does not vanish, clip, or resize mid-animation in either direction.
   assert.match(app, /const widest = formatNumber\(nextTotal\)\.length >= formatNumber\(state\.currentTotal\)\.length \? nextTotal : state\.currentTotal;/);
-  assert.match(app, /els\.totalTokens\.textContent = formatNumber\(widest\);\s*updateTotalCompact\(nextTotal\);\s*animateNumber\(els\.totalTokens, state\.currentTotal, nextTotal, 2200, fitTotalNumber\);/s);
+  assert.match(app, /els\.totalTokens\.textContent = formatNumber\(widest\);\s*updateTotalCompact\(nextTotal\);\s*animateNumber\(els\.totalTokens, state\.currentTotal, nextTotal, state\.periodMotionActive \? 800 : 1000, fitTotalNumber\);/s);
   // animateNumber must not reset the font, or the pre-locked size would be lost.
   const animateBody = app.slice(app.indexOf('function animateNumber('), app.indexOf('function rowWidth('));
   assert.doesNotMatch(animateBody, /style\.fontSize/);


### PR DESCRIPTION
## Summary

- add coordinated token-number and bar transitions for Day, Month, and Total changes
- keep view navigation immediate while growing newly entered bars from zero
- animate live row updates, rank reordering, Trends bars, and the Home heatmap/line reveal
- add a sliding period indicator and respect reduced-motion preferences
- keep the headline and breakdown timing aligned by interaction type

## Behavior

View changes do not use page-level fades or crossfades. Motion is limited to data visualization and direct control feedback: token counts, proportional bars, row reordering, the period selector, Trends bars, and Home history visuals.

## Validation

- `npm run verify`
- 1,317 tests passed
- ESLint passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds clear, lightweight motion to usage views so data changes are easier to follow without slowing navigation. Numbers, bars, and charts animate together and respect reduced-motion.

- **New Features**
  - Numbers and bars animate on Day/Month/Total changes and live updates, including rank reordering.
  - Period tabs now use a sliding selection indicator and set `aria-pressed`.
  - Bars and limit meters use transform-based `scaleX(--bar-scale)` instead of width for smoother, GPU-friendly motion.
  - Charts: Trends bars grow from the baseline and keep relative heights; Home heatmap and line reveal left-to-right on first render only.
  - View switches are instant; new bars grow from zero, with no page crossfades.
  - Honors `prefers-reduced-motion` across bars, tabs, and charts.

- **Bug Fixes**
  - Hardened motion lifecycle: snapshot rows before period changes, animate after render, and cancel stale animations to prevent jitter.
  - Home history animations wait for layout readiness and only animate visible columns to avoid mis-timed reveals.

<sup>Written for commit f289f93af424c58eb4173002e1636288caba890a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

