### PR TITLE
fix(macos): follow Liquid Glass transparency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
           - os: windows-latest
             node-version: '24'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
               dist/*.blockmap
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: npm
@@ -95,7 +95,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/download-artifact@v4
         with:
           path: artifacts

--- a/src/electron/macVibrancy.js
+++ b/src/electron/macVibrancy.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const os = require('node:os');
+
+const LIQUID_GLASS_DARWIN_MAJOR = 25;
+
+function macVibrancyMaterial(platform = process.platform, osRelease = os.release()) {
+  if (platform !== 'darwin') return null;
+  const darwinMajor = Number.parseInt(String(osRelease).split('.')[0], 10);
+  return Number.isFinite(darwinMajor) && darwinMajor >= LIQUID_GLASS_DARWIN_MAJOR
+    ? 'under-window'
+    : 'hud';
+}
+
+module.exports = { LIQUID_GLASS_DARWIN_MAJOR, macVibrancyMaterial };

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -141,6 +141,7 @@ const {
   moveFloatingBubbleBounds
 } = require('./floatingBubble');
 const { applyWindowsChrome } = require('./windowsChrome');
+const { macVibrancyMaterial } = require('./macVibrancy');
 
 if (!app.isPackaged) loadDotEnv();
 
@@ -1562,7 +1563,7 @@ function applyNativeMaterial(source = settings) {
   if (!mainWindow) return;
   const enabled = nativeBlurEnabled(source);
   if (process.platform === 'darwin' && typeof mainWindow.setVibrancy === 'function') {
-    mainWindow.setVibrancy(enabled ? 'hud' : null);
+    mainWindow.setVibrancy(enabled ? macVibrancyMaterial() : null);
     if (typeof mainWindow.setVisualEffectState === 'function') {
       mainWindow.setVisualEffectState(enabled ? 'active' : 'inactive');
     }
@@ -3218,6 +3219,7 @@ function createWindow(boundsOverride, options = {}) {
   ensureSettingsLoaded();
   const collapsedFloatingBubble = options.collapsedFloatingBubble === true;
   const glass = nativeBlurEnabled();
+  const macMaterial = macVibrancyMaterial();
   const bounds = boundsOverride || restoredBounds() || DEFAULT_WINDOW;
   const collapsedSizeLimits = {
     minWidth: bounds.width,
@@ -3239,7 +3241,7 @@ function createWindow(boundsOverride, options = {}) {
     skipTaskbar: collapsedFloatingBubble || Boolean(settings?.trayMode),
     ...(collapsedFloatingBubble ? { fullscreenable: false, maximizable: false, minimizable: false } : {}),
     ...floatingBubbleWindowChrome(process.platform, collapsedFloatingBubble),
-    ...(process.platform === 'darwin' && glass ? { vibrancy: 'hud', visualEffectState: 'active' } : {}),
+    ...(macMaterial && glass ? { vibrancy: macMaterial, visualEffectState: 'active' } : {}),
     ...(process.platform === 'win32' && glass ? { backgroundMaterial: 'acrylic' } : {}),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
@@ -3341,6 +3343,7 @@ function createDashboardWindow() {
     return dashboardWindow;
   }
   const glass = nativeBlurEnabled();
+  const macMaterial = macVibrancyMaterial();
   const win = new BrowserWindow({
     width: 920,
     height: 620,
@@ -3352,7 +3355,7 @@ function createDashboardWindow() {
     backgroundColor: '#00000000',
     icon: APP_ICON_PATH,
     skipTaskbar: false,
-    ...(process.platform === 'darwin' && glass ? { vibrancy: 'hud', visualEffectState: 'active' } : {}),
+    ...(macMaterial && glass ? { vibrancy: macMaterial, visualEffectState: 'active' } : {}),
     ...(process.platform === 'win32' && glass ? { backgroundMaterial: 'acrylic' } : {}),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),

--- a/tests/electron/macVibrancy.test.js
+++ b/tests/electron/macVibrancy.test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { macVibrancyMaterial } = require('../../src/electron/macVibrancy');
+
+test('uses system-managed vibrancy on Liquid Glass macOS releases', () => {
+  assert.equal(macVibrancyMaterial('darwin', '25.0.0'), 'under-window');
+  assert.equal(macVibrancyMaterial('darwin', '26.0.0'), 'under-window');
+});
+
+test('keeps the legacy HUD material on older macOS releases', () => {
+  assert.equal(macVibrancyMaterial('darwin', '24.6.0'), 'hud');
+  assert.equal(macVibrancyMaterial('darwin', 'unknown'), 'hud');
+});
+
+test('does not select a macOS material on other platforms', () => {
+  assert.equal(macVibrancyMaterial('win32', '10.0.0'), null);
+  assert.equal(macVibrancyMaterial('linux', '6.8.0'), null);
+});


### PR DESCRIPTION
## Summary

- use the system-managed `under-window` vibrancy material on macOS 26 and newer
- preserve the existing `hud` material on older macOS releases
- apply the adaptive material consistently at window creation and during live settings changes
- add unit coverage for Liquid Glass, legacy macOS, and non-macOS platforms

## Root cause

The widget always requested Electron's `hud` vibrancy material. On macOS releases with Liquid Glass, that legacy HUD material keeps its own dark tint instead of following the system Liquid Glass transparency preference.

## User impact

When System Glass is enabled, the widget and dashboard now use the native system-managed material on macOS 26/27, so their transparency follows the system Appearance setting. Older macOS versions retain the previous appearance.

Closes #153

## Validation

- `npm run lint` — passed as part of `npm run verify`
- `node --test tests/electron/macVibrancy.test.js` — passed (3 tests)
- `npm run verify` — 1319/1321 tests passed; the two failures reproduce independently in unchanged Windows collector path-guard tests: `clientDataDirPresence requires an actual VS Code Copilot chat source` and `watchIgnoreMatcher prunes the Hermes runtime but keeps the state.db family and the watch root`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Follow macOS Liquid Glass transparency by using the system `under-window` vibrancy on supported releases, while keeping `hud` on older macOS. Also upgrades CI workflows to `actions/checkout@v6` and `actions/setup-node@v6`.

- **Bug Fixes**
  - Added `macVibrancyMaterial()` to select `under-window` on Darwin >= 25, else `hud` (null on non-macOS), and applied it to the main window and dashboard when native blur is enabled.
  - Added unit tests covering Liquid Glass, legacy macOS, and non-macOS platforms.

<sup>Written for commit d6716bb2f67cae5c65d726cce568423d96271cb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

