### PR TITLE
feat(dashboard): animate usage data visualizations

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -176,7 +176,6 @@ const TRAY_OPEN_VIEW_IDS = new Set(['home', 'project', 'session', 'limits', 'tre
 
 let mainWindow = null;
 let dashboardWindow = null;
-let dashboardShowFallback = null;
 let settingsPath = null;
 let settings = null;
 let sessionUsageArchive = null;
@@ -3333,18 +3332,10 @@ function replaceMainWindow(bounds, options = {}) {
   });
 }
 
-function clearDashboardShowFallback() {
-  if (dashboardShowFallback === null) return;
-  clearTimeout(dashboardShowFallback);
-  dashboardShowFallback = null;
-}
-
-function armDashboardShowFallback(win) {
-  clearDashboardShowFallback();
-  dashboardShowFallback = setTimeout(() => {
-    dashboardShowFallback = null;
-    if (!win.isDestroyed() && !win.isVisible()) win.show();
-  }, 2000);
+function discardFailedDashboardWindow(win, reason) {
+  if (!win || win !== dashboardWindow || win.isDestroyed()) return;
+  console.log(`[dashboard] ${reason}`);
+  win.destroy();
 }
 
 function createDashboardWindow() {
@@ -3352,7 +3343,6 @@ function createDashboardWindow() {
     // Reload so a reopened window always picks up the latest renderer + fresh history,
     // instead of showing whatever was loaded when it first opened.
     dashboardWindow.hide();
-    armDashboardShowFallback(dashboardWindow);
     dashboardWindow.webContents.reload();
     return dashboardWindow;
   }
@@ -3386,17 +3376,22 @@ function createDashboardWindow() {
     event.preventDefault();
     if (isAllowedExternalUrl(url)) shell.openExternal(url);
   });
-  // The renderer waits for history and installs the heatmap's hidden entry
-  // state before sending dashboard:ready. The fallback is armed immediately
-  // and re-armed on reload so a failed renderer cannot leave the window hidden.
-  win.on('show', clearDashboardShowFallback);
-  win.on('closed', () => {
-    clearDashboardShowFallback();
-    dashboardWindow = null;
+  // Only dashboard:ready may reveal a healthy window. Slow hub history must not
+  // race a wall-clock fallback and expose the unprepared heatmap. Actual load or
+  // renderer failures discard the hidden window so the next open starts cleanly.
+  win.webContents.on('did-fail-load', (_event, errorCode, errorDescription, _url, isMainFrame) => {
+    if (!isMainFrame || errorCode === -3) return; // ERR_ABORTED is expected during reloads.
+    discardFailedDashboardWindow(win, `load failed: ${errorDescription}`);
   });
-  armDashboardShowFallback(win);
+  win.webContents.on('render-process-gone', (_event, details) => {
+    discardFailedDashboardWindow(win, `renderer stopped: ${details.reason}`);
+  });
+  win.on('unresponsive', () => {
+    if (!win.isVisible()) discardFailedDashboardWindow(win, 'renderer became unresponsive while opening');
+  });
+  win.on('closed', () => { dashboardWindow = null; });
   win.loadFile(path.join(__dirname, 'renderer', 'dashboard.html'))
-    .catch((error) => console.log(`[dashboard] load failed: ${error.message}`));
+    .catch((error) => discardFailedDashboardWindow(win, `load failed: ${error.message}`));
   return win;
 }
 
@@ -3418,9 +3413,18 @@ async function getDashboardHistory() {
   const { url: hubUrl, secret } = effectiveHubConfig();
   if (!hubUrl) return aggregateHistory([]);
   const url = `${hubUrl.replace(/\/$/, '')}/api/history`;
-  const response = await fetch(url, { headers: secret ? { authorization: `Bearer ${secret}` } : {} });
-  if (!response.ok) throw new Error(`Hub ${response.status}: ${(await response.text()).slice(0, 200)}`);
-  return response.json();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15000);
+  try {
+    const response = await fetch(url, {
+      headers: secret ? { authorization: `Bearer ${secret}` } : {},
+      signal: controller.signal
+    });
+    if (!response.ok) throw new Error(`Hub ${response.status}: ${(await response.text()).slice(0, 200)}`);
+    return response.json();
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 let cursorStatusCache = { value: null, at: 0 };

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -176,6 +176,7 @@ const TRAY_OPEN_VIEW_IDS = new Set(['home', 'project', 'session', 'limits', 'tre
 
 let mainWindow = null;
 let dashboardWindow = null;
+let dashboardShowFallback = null;
 let settingsPath = null;
 let settings = null;
 let sessionUsageArchive = null;
@@ -3332,11 +3333,26 @@ function replaceMainWindow(bounds, options = {}) {
   });
 }
 
+function clearDashboardShowFallback() {
+  if (dashboardShowFallback === null) return;
+  clearTimeout(dashboardShowFallback);
+  dashboardShowFallback = null;
+}
+
+function armDashboardShowFallback(win) {
+  clearDashboardShowFallback();
+  dashboardShowFallback = setTimeout(() => {
+    dashboardShowFallback = null;
+    if (!win.isDestroyed() && !win.isVisible()) win.show();
+  }, 2000);
+}
+
 function createDashboardWindow() {
   if (dashboardWindow && !dashboardWindow.isDestroyed()) {
     // Reload so a reopened window always picks up the latest renderer + fresh history,
     // instead of showing whatever was loaded when it first opened.
     dashboardWindow.hide();
+    armDashboardShowFallback(dashboardWindow);
     dashboardWindow.webContents.reload();
     return dashboardWindow;
   }
@@ -3371,15 +3387,14 @@ function createDashboardWindow() {
     if (isAllowedExternalUrl(url)) shell.openExternal(url);
   });
   // The renderer waits for history and installs the heatmap's hidden entry
-  // state before sending dashboard:ready. ready-to-show alone is too early: on
-  // a cold transparent window it can expose an unprepared or retained surface.
-  win.once('ready-to-show', () => {
-    const fallback = setTimeout(() => {
-      if (!win.isDestroyed() && !win.isVisible()) win.show();
-    }, 2000);
-    win.once('show', () => clearTimeout(fallback));
+  // state before sending dashboard:ready. The fallback is armed immediately
+  // and re-armed on reload so a failed renderer cannot leave the window hidden.
+  win.on('show', clearDashboardShowFallback);
+  win.on('closed', () => {
+    clearDashboardShowFallback();
+    dashboardWindow = null;
   });
-  win.on('closed', () => { dashboardWindow = null; });
+  armDashboardShowFallback(win);
   win.loadFile(path.join(__dirname, 'renderer', 'dashboard.html'))
     .catch((error) => console.log(`[dashboard] load failed: ${error.message}`));
   return win;

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -3336,8 +3336,8 @@ function createDashboardWindow() {
   if (dashboardWindow && !dashboardWindow.isDestroyed()) {
     // Reload so a reopened window always picks up the latest renderer + fresh history,
     // instead of showing whatever was loaded when it first opened.
+    dashboardWindow.hide();
     dashboardWindow.webContents.reload();
-    dashboardWindow.focus();
     return dashboardWindow;
   }
   const glass = nativeBlurEnabled();
@@ -3370,7 +3370,15 @@ function createDashboardWindow() {
     event.preventDefault();
     if (isAllowedExternalUrl(url)) shell.openExternal(url);
   });
-  win.once('ready-to-show', () => win.show());
+  // The renderer waits for history and installs the heatmap's hidden entry
+  // state before sending dashboard:ready. ready-to-show alone is too early: on
+  // a cold transparent window it can expose an unprepared or retained surface.
+  win.once('ready-to-show', () => {
+    const fallback = setTimeout(() => {
+      if (!win.isDestroyed() && !win.isVisible()) win.show();
+    }, 2000);
+    win.once('show', () => clearTimeout(fallback));
+  });
   win.on('closed', () => { dashboardWindow = null; });
   win.loadFile(path.join(__dirname, 'renderer', 'dashboard.html'))
     .catch((error) => console.log(`[dashboard] load failed: ${error.message}`));
@@ -4216,6 +4224,13 @@ app.whenReady().then(() => {
   });
   ipcMain.handle('dashboard:open', () => { createDashboardWindow(); return true; });
   ipcMain.handle('dashboard:getHistory', () => getDashboardHistory());
+  ipcMain.on('dashboard:ready', (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win || win !== dashboardWindow || win.isDestroyed()) return;
+    if (win.isMinimized()) win.restore();
+    win.show();
+    win.focus();
+  });
   ipcMain.on('dashboard:minimize', (event) => { BrowserWindow.fromWebContents(event.sender)?.minimize(); });
   ipcMain.on('dashboard:close', (event) => { BrowserWindow.fromWebContents(event.sender)?.close(); });
   app.on('activate', () => { if (BrowserWindow.getAllWindows().length === 0) createWindow(); });

--- a/src/electron/preload.js
+++ b/src/electron/preload.js
@@ -20,6 +20,7 @@ contextBridge.exposeInMainWorld('tokenMonitor', {
     return () => ipcRenderer.removeListener('dashboard:historyChanged', listener);
   },
   dashboard: {
+    ready: () => ipcRenderer.send('dashboard:ready'),
     minimize: () => ipcRenderer.send('dashboard:minimize'),
     close: () => ipcRenderer.send('dashboard:close')
   },

--- a/src/electron/renderer/dashboard.css
+++ b/src/electron/renderer/dashboard.css
@@ -73,10 +73,11 @@ body.flat { background: rgb(var(--glass-rgb)); }
 .grid-line { stroke: rgba(var(--line-rgb), 0.07); stroke-width: 1; }
 .axis-label, .heat-month { fill: rgba(var(--line-rgb), 0.5); font-size: 10px; }
 .bar-seg { transition: opacity 0.1s ease; }
+.bar-stack { transform-box: fill-box; transform-origin: center bottom; }
 .bar-hover { fill: transparent; pointer-events: all; cursor: default; }
 .bar-hover:hover { fill: rgba(var(--overlay-rgb), 0.08); }
 .candle-wick { stroke-width: 1.5; }
-.candle-body { stroke: none; }
+.candle-body { stroke: none; transform-box: fill-box; transform-origin: center center; }
 .candle-up { stroke: #4ec77f; fill: #4ec77f; }
 .candle-down { stroke: #f06a7b; fill: #f06a7b; }
 
@@ -90,6 +91,7 @@ body.flat { background: rgb(var(--glass-rgb)); }
 .dash-legend-pct { font-variant-numeric: tabular-nums; opacity: 0.55; min-width: 50px; text-align: right; }
 
 .dash-heatmap-wrap { flex: none; overflow-x: auto; }
+.dash-heatmap-wrap.is-motion-pending .heat-base-layer .heat { opacity: 0; }
 .heat { stroke: none; stroke-width: 0; }
 .heat.lvl-0 { fill: rgba(var(--overlay-rgb), 0.03); }
 .heat.lvl-1 { fill: rgba(90, 170, 255, 0.18); }
@@ -109,7 +111,7 @@ body.flat { background: rgb(var(--glass-rgb)); }
 .dash-bd-row { display: flex; align-items: center; gap: 12px; font-size: 12px; padding: 2px 0; }
 .dash-bd-name { flex: none; width: 110px; display: flex; align-items: center; gap: 8px; opacity: 0.9; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .dash-bd-bar-bg { flex: 1; height: 4px; background: rgba(var(--overlay-rgb), 0.06); border-radius: 2px; overflow: hidden; }
-.dash-bd-bar-fill { height: 100%; border-radius: 2px; }
+.dash-bd-bar-fill { width: 100%; height: 100%; border-radius: 2px; transform: scaleX(var(--bar-scale, 0)); transform-origin: left center; }
 .dash-bd-val { flex: none; font-variant-numeric: tabular-nums; opacity: 0.8; text-align: right; }
 .dash-bd-pct { flex: none; width: 42px; font-variant-numeric: tabular-nums; opacity: 0.55; text-align: right; }
 
@@ -125,3 +127,7 @@ body.flat { background: rgb(var(--glass-rgb)); }
    still work when there's no history. */
 .dash-empty { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; opacity: 0.6; font-size: 13px; pointer-events: none; }
 .dash-empty.hidden { display: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .range-btn, .bar-seg { transition: none; }
+}

--- a/src/electron/renderer/dashboard.js
+++ b/src/electron/renderer/dashboard.js
@@ -30,7 +30,155 @@ const els = {
 };
 
 const RANGES = ['7', '30', '90', '365', 'all'];
-const state = { tab: 'activity', range: '30', stackBy: 'client', mode: 'bars', flat: false, locale: 'en', currency: 'USD', history: null, chartModel: null, chartKind: 'bars' };
+const state = {
+  tab: 'activity', range: '30', stackBy: 'client', mode: 'bars', flat: false,
+  locale: 'en', currency: 'USD', history: null, chartModel: null,
+  chartKind: 'bars', motion: 'none'
+};
+
+const DATA_MOTION_MS = 800;
+const KLINE_MOTION_MS = 560;
+const HEATMAP_MOTION_MS = 720;
+const HEAT_CELL_MOTION_MS = 280;
+let heatmapMotionGeneration = 0;
+
+function prefersReducedMotion() {
+  return Boolean(window.matchMedia?.('(prefers-reduced-motion: reduce)').matches);
+}
+
+function captureGeometry(root, selector = '[data-motion-key]') {
+  const geometry = new Map();
+  for (const el of root?.querySelectorAll(selector) || []) {
+    const rect = el.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) geometry.set(el.dataset.motionKey, rect);
+  }
+  return geometry;
+}
+
+function animateChartGeometry(previous, { fromZero = false } = {}) {
+  if (state.motion === 'none' || prefersReducedMotion()) return;
+  if (state.chartKind === 'candle') {
+    animateCandles();
+    return;
+  }
+  const shapes = Array.from(els.chart.querySelectorAll('.bar-stack[data-motion-key]'));
+  shapes.forEach((shape, index) => {
+    const target = shape.getBoundingClientRect();
+    const old = !fromZero && previous.get(shape.dataset.motionKey);
+    let first;
+    if (old && target.width > 0 && target.height > 0) {
+      const sx = old.width / target.width;
+      const sy = old.height / target.height;
+      const dx = old.left - target.left;
+      const dy = old.top - target.top;
+      if (Math.abs(dx) < 0.5 && Math.abs(dy) < 0.5 && Math.abs(sx - 1) < 0.01 && Math.abs(sy - 1) < 0.01) return;
+      first = { transformOrigin: '0 0', transform: `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})` };
+    } else {
+      first = { transformOrigin: 'center bottom', transform: 'scaleY(0)' };
+    }
+    shape.animate([first, { transformOrigin: first.transformOrigin, transform: 'none' }], {
+      duration: DATA_MOTION_MS,
+      delay: old ? 0 : Math.min(index, 18) * 12,
+      easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+      fill: 'backwards'
+    });
+  });
+}
+
+function animateCandles() {
+  const candles = Array.from(els.chart.querySelectorAll('.candle-stack'));
+  candles.forEach((candle, index) => {
+    const delay = Math.min(index, 18) * 10;
+    const body = candle.querySelector('.candle-body');
+    body?.animate([
+      { transform: 'scaleY(0)', transformOrigin: 'center center' },
+      { transform: 'scaleY(1)', transformOrigin: 'center center' }
+    ], {
+      duration: KLINE_MOTION_MS,
+      delay,
+      easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+      fill: 'backwards'
+    });
+    for (const wick of candle.querySelectorAll('.candle-wick')) {
+      const length = wick.getTotalLength?.() || 0;
+      if (length <= 0) continue;
+      wick.animate([
+        { strokeDasharray: `${length} ${length}`, strokeDashoffset: length },
+        { strokeDasharray: `${length} ${length}`, strokeDashoffset: 0 }
+      ], {
+        duration: KLINE_MOTION_MS,
+        delay,
+        easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+        fill: 'backwards'
+      });
+    }
+  });
+}
+
+function animateHeatmapEntry() {
+  if (prefersReducedMotion()) {
+    els.heatmap.classList.remove('is-motion-pending');
+    return;
+  }
+  // A focus event can trigger a second render while the cold entry animation
+  // is pending. Restart against that new SVG instead of exposing it or letting
+  // an obsolete schedule animate detached cells.
+  const continuingEntry = els.heatmap.classList.contains('is-motion-pending');
+  if (state.motion !== 'entry' && !continuingEntry) return;
+  els.heatmap.classList.add('is-motion-pending');
+  const generation = ++heatmapMotionGeneration;
+  const startWhenVisible = () => {
+    if (generation !== heatmapMotionGeneration) return;
+    if (state.tab !== 'activity') {
+      els.heatmap.classList.remove('is-motion-pending');
+      return;
+    }
+    if (!document.hasFocus()) {
+      window.addEventListener('focus', startWhenVisible, { once: true });
+      return;
+    }
+    if (refreshRunning) {
+      setTimeout(startWhenVisible, 16);
+      return;
+    }
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      if (generation !== heatmapMotionGeneration || state.tab !== 'activity') return;
+      const cells = Array.from(els.heatmap.querySelectorAll('.heat-base-layer .heat'));
+      if (!cells.length) {
+        els.heatmap.classList.remove('is-motion-pending');
+        return;
+      }
+      const columns = cells.map((cell) => Number(cell.getAttribute('x') || 0));
+      const first = Math.min(...columns);
+      const last = Math.max(...columns);
+      const delaySpan = HEATMAP_MOTION_MS - HEAT_CELL_MOTION_MS;
+      cells.forEach((cell, index) => {
+        const position = last > first ? (columns[index] - first) / (last - first) : 0;
+        const animation = cell.animate([{ opacity: 0 }, { opacity: 1 }], {
+          duration: HEAT_CELL_MOTION_MS,
+          delay: position * delaySpan,
+          easing: 'ease',
+          fill: 'both'
+        });
+        animation.finished.then(() => {
+          if (!cell.isConnected) return;
+          cell.removeAttribute('data-motion-hidden');
+          cell.removeAttribute('opacity');
+          animation.cancel();
+        }).catch(() => {});
+      });
+      // On a cold BrowserWindow the animation effect is not composited until
+      // the next paint. Keep the pre-paint guard for one more frame so there is
+      // never a gap where the fully-rendered heatmap can flash through.
+      requestAnimationFrame(() => {
+        if (generation === heatmapMotionGeneration && state.tab === 'activity') {
+          els.heatmap.classList.remove('is-motion-pending');
+        }
+      });
+    }));
+  };
+  startWhenVisible();
+}
 
 function t(key, params) { return i18n.translate(state.locale, key, params); }
 
@@ -111,7 +259,9 @@ function populateRangeSelect() {
   els.rangeSelect.innerHTML = RANGES.map((r) => `<button class="range-btn${r === state.range ? ' active' : ''}" data-val="${r}">${t(`dashboard.range.${r}`)}</button>`).join('');
   els.rangeSelect.querySelectorAll('.range-btn').forEach(btn => {
     btn.addEventListener('click', (e) => {
+      if (state.range === e.target.dataset.val) return;
       state.range = e.target.dataset.val;
+      state.motion = 'update';
       els.rangeSelect.querySelectorAll('.range-btn').forEach(b => b.classList.toggle('active', b === e.target));
       render();
     });
@@ -138,7 +288,7 @@ function colorFor(key) {
 // colors are carried in data-c and applied via the CSSOM (.style, which CSP allows).
 function applySwatchColors(root) {
   root.querySelectorAll('[data-c]').forEach((el) => { el.style.background = el.getAttribute('data-c'); });
-  root.querySelectorAll('[data-w]').forEach((el) => { el.style.width = el.getAttribute('data-w'); });
+  root.querySelectorAll('[data-w]').forEach((el) => { el.style.setProperty('--bar-scale', el.getAttribute('data-w')); });
 }
 
 function renderLegend(model) {
@@ -159,6 +309,8 @@ function renderLegend(model) {
 }
 
 function renderTrends() {
+  const previousKind = state.chartKind;
+  const previousGeometry = captureGeometry(els.chart, '.bar-stack[data-motion-key]');
   const daily = charts.clampDaily(state.history?.daily || [], state.range === 'all' ? 0 : Number(state.range));
   if (daily.length === 0) { els.chart.innerHTML = ''; els.legend.innerHTML = ''; state.chartModel = null; return; }
   const pad = { padTop: 10, padRight: 14, padBottom: 24, padLeft: 52 };
@@ -173,6 +325,7 @@ function renderTrends() {
     state.chartModel = model; state.chartKind = 'candle';
     const every = axisEvery(model.candles);
     els.chart.innerHTML = charts.candleChartSvg(model, { yTicks: 4, formatTick: formatCompact, axisLabel: (c, i) => (i % every === 0 ? shortDate(c.key) : '') });
+    animateChartGeometry(previousGeometry, { fromZero: state.motion === 'entry' || previousKind !== 'candle' });
     return;
   }
   
@@ -188,11 +341,13 @@ function renderTrends() {
   state.chartModel = model; state.chartKind = 'bars';
   const every = axisEvery(model.bars);
   els.chart.innerHTML = charts.barsChartSvg(model, { colorFor, yTicks: 4, formatTick: formatCompact, axisLabel: (bar, i) => (i % every === 0 ? shortDate(bar.label) : '') });
+  animateChartGeometry(previousGeometry, { fromZero: state.motion === 'entry' || state.motion === 'series' || previousKind !== 'bars' });
 }
 
 function renderBreakdown() {
   const elsBreakdown = document.getElementById('dashBreakdown');
   if (!elsBreakdown) return;
+  const previousBars = captureGeometry(elsBreakdown, '.dash-bd-bar-fill[data-motion-key]');
   const daily = state.history?.daily || [];
   if (daily.length === 0) { elsBreakdown.innerHTML = ''; return; }
   
@@ -214,9 +369,10 @@ function renderBreakdown() {
       const pctGrand = grandTotal > 0 ? (val / grandTotal * 100).toFixed(1) : '0.0';
       const pctMax = maxVal > 0 ? (val / maxVal * 100).toFixed(1) : '0.0';
       const color = displayColor(colorFn(key));
+      const motionKey = `${titleKey}:${encodeURIComponent(key)}`;
       return `<div class="dash-bd-row">
         <span class="dash-bd-name"><span class="dash-bd-swatch" data-c="${color}"></span>${String(key).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')}</span>
-        <div class="dash-bd-bar-bg"><div class="dash-bd-bar-fill" data-w="${pctMax}%" data-c="${color}"></div></div>
+        <div class="dash-bd-bar-bg"><div class="dash-bd-bar-fill" data-motion-key="${motionKey}" data-w="${Number(pctMax) / 100}" data-c="${color}"></div></div>
         <span class="dash-bd-val">${formatCompact(val)}</span>
         <span class="dash-bd-pct">${pctGrand}%</span>
       </div>`;
@@ -229,6 +385,18 @@ function renderBreakdown() {
   
   elsBreakdown.innerHTML = colModel + colClient;
   applySwatchColors(elsBreakdown);
+  if (state.motion !== 'none' && !prefersReducedMotion()) {
+    for (const fill of elsBreakdown.querySelectorAll('.dash-bd-bar-fill[data-motion-key]')) {
+      const trackWidth = fill.parentElement?.getBoundingClientRect().width || 0;
+      const old = state.motion === 'entry' ? null : previousBars.get(fill.dataset.motionKey);
+      const fromScale = old && trackWidth > 0 ? old.width / trackWidth : 0;
+      fill.animate([{ transform: `scaleX(${fromScale})` }, { transform: `scaleX(${fill.dataset.w})` }], {
+        duration: DATA_MOTION_MS,
+        easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+        fill: 'backwards'
+      });
+    }
+  }
 }
 
 let statCardMeasureCanvas = null;
@@ -287,9 +455,12 @@ function renderActivity() {
     const cell = Math.max(9, Math.min(22, (avail - heat.weeks * gap) / heat.weeks)); // fractional → fills exactly
     heat = charts.contribHeatmap(daily, { cell, gap, startDate: start, endDate: end });
   }
+  const hideHeatmapForEntry = !prefersReducedMotion()
+    && (state.motion === 'entry' || els.heatmap.classList.contains('is-motion-pending'));
   els.heatmap.innerHTML = heat.cells.length
-    ? charts.heatmapSvg(heat, { monthLabel: (m) => monthLabel(m.label) })
+    ? charts.heatmapSvg(heat, { monthLabel: (m) => monthLabel(m.label), initialHidden: hideHeatmapForEntry })
     : '';
+  animateHeatmapEntry();
   state.dayMap = new Map((state.history?.daily || []).map((d) => [String(d.date).slice(0, 10), { tokens: Number(d.tokens || 0), cost: Number(d.cost || 0) }]));
   const cards = charts.statsCards(state.history?.summary || {});
   const LABELS = {
@@ -317,7 +488,14 @@ function render() {
   els.modeBtns.forEach((b) => b.classList.toggle('active', b.dataset.mode === state.mode));
   els.stackBtns.forEach((b) => b.classList.toggle('active', b.dataset.stack === state.stackBy));
   document.querySelector('[data-control="stack"]').style.display = state.mode === 'kline' ? 'none' : '';
-  if (state.tab === 'trends') renderTrends(); else renderActivity();
+  if (state.tab === 'trends') {
+    heatmapMotionGeneration += 1;
+    els.heatmap.classList.remove('is-motion-pending');
+    renderTrends();
+  } else {
+    renderActivity();
+  }
+  state.motion = 'none';
 }
 
 function hideTooltip() { els.tooltip.classList.add('hidden'); }
@@ -375,9 +553,11 @@ async function refresh() {
   }
   refreshRunning = true;
   try {
+    state.motion = state.history ? 'update' : 'entry';
     state.history = await window.tokenMonitor.getDashboardHistory();
     render();
   } catch (error) {
+    state.motion = 'none';
     console.log(`[dashboard] history failed: ${error.message}`);
   } finally {
     refreshRunning = false;
@@ -402,6 +582,7 @@ async function boot() {
   populateRangeSelect();
   render();
   await refresh();
+  window.tokenMonitor.dashboard.ready();
 }
 
 // Effective rates can change after boot (auto refresh / manual override). The
@@ -425,9 +606,25 @@ window.tokenMonitor.onSettingsPush?.((next) => {
 
 window.tokenMonitor.onDashboardHistoryChanged?.(() => { void refresh(); });
 
-els.tabs.forEach((tab) => tab.addEventListener('click', () => { state.tab = tab.dataset.tab; els.tabs.forEach((x) => x.classList.toggle('active', x === tab)); render(); }));
-els.stackBtns.forEach((b) => b.addEventListener('click', () => { state.stackBy = b.dataset.stack; render(); }));
-els.modeBtns.forEach((b) => b.addEventListener('click', () => { state.mode = b.dataset.mode; render(); }));
+els.tabs.forEach((tab) => tab.addEventListener('click', () => {
+  if (state.tab === tab.dataset.tab) return;
+  state.tab = tab.dataset.tab;
+  state.motion = 'entry';
+  els.tabs.forEach((x) => x.classList.toggle('active', x === tab));
+  render();
+}));
+els.stackBtns.forEach((b) => b.addEventListener('click', () => {
+  if (state.stackBy === b.dataset.stack) return;
+  state.stackBy = b.dataset.stack;
+  state.motion = 'series';
+  render();
+}));
+els.modeBtns.forEach((b) => b.addEventListener('click', () => {
+  if (state.mode === b.dataset.mode) return;
+  state.mode = b.dataset.mode;
+  state.motion = 'update';
+  render();
+}));
 els.themeToggle.addEventListener('click', () => { state.flat = !state.flat; els.body.classList.toggle('flat', state.flat); window.tokenMonitor.updateSettings({ dashboardFlat: state.flat }); });
 els.refreshBtn.addEventListener('click', refresh);
 els.minBtn.addEventListener('click', () => window.tokenMonitor.dashboard.minimize());
@@ -458,7 +655,7 @@ els.heatmap.addEventListener('mouseleave', hideTooltip);
 let resizeTimer = null;
 window.addEventListener('resize', () => {
   clearTimeout(resizeTimer);
-  resizeTimer = setTimeout(render, 120); // both the chart and the heatmap are sized to the window
+  resizeTimer = setTimeout(() => { state.motion = 'none'; render(); }, 120); // both the chart and the heatmap are sized to the window
 });
 window.addEventListener('focus', refresh);
 

--- a/src/electron/renderer/usageCharts.js
+++ b/src/electron/renderer/usageCharts.js
@@ -426,7 +426,8 @@
       const title = tip ? `<title>${escapeXml(tip)}</title>` : '';
       const hover = `<rect data-i="${bar.index}" x="${svgRound(bar.x)}" y="${svgRound(p.y)}" width="${svgRound(bar.width)}" height="${svgRound(p.h)}" class="bar-hover">${title}</rect>`;
       const label = axisText(o.axisLabel(bar, bar.index, model.bars), bar.x + bar.width / 2, model.height - 4);
-      return drawn + hover + label;
+      const stack = `<g class="bar-stack" data-motion-key="${encodeURIComponent(String(bar.label))}">${drawn}</g>`;
+      return stack + hover + label;
     }).join('');
     const baseline = `<line class="axis-base" x1="${svgRound(p.x)}" y1="${svgRound(p.y + p.h)}" x2="${svgRound(p.x + p.w)}" y2="${svgRound(p.y + p.h)}"></line>`;
     return `<svg class="dash-chart" viewBox="0 0 ${model.width} ${model.height}" width="100%" height="100%">${grid}${baseline}${parts}</svg>`;
@@ -438,19 +439,23 @@
     const grid = yAxisSvg(p, model.maxVal, o.yTicks, o.formatTick);
     const parts = (model.candles || []).map((c, i) => {
       const cls = c.up ? 'candle-up' : 'candle-down';
-      const wick = `<line class="candle-wick ${cls}" x1="${svgRound(c.wickX)}" y1="${svgRound(c.yHigh)}" x2="${svgRound(c.wickX)}" y2="${svgRound(c.yLow)}"></line>`;
-      const body = `<rect class="candle-body ${cls}" x="${svgRound(c.x)}" y="${svgRound(c.bodyY)}" width="${svgRound(c.width)}" height="${svgRound(Math.max(1, c.bodyHeight))}" rx="1"></rect>`;
+      const bodyHeight = Math.max(1, c.bodyHeight);
+      const bodyMid = c.bodyY + bodyHeight / 2;
+      const wick = `<line class="candle-wick candle-wick-high ${cls}" x1="${svgRound(c.wickX)}" y1="${svgRound(bodyMid)}" x2="${svgRound(c.wickX)}" y2="${svgRound(c.yHigh)}"></line>`
+        + `<line class="candle-wick candle-wick-low ${cls}" x1="${svgRound(c.wickX)}" y1="${svgRound(bodyMid)}" x2="${svgRound(c.wickX)}" y2="${svgRound(c.yLow)}"></line>`;
+      const body = `<rect class="candle-body ${cls}" x="${svgRound(c.x)}" y="${svgRound(c.bodyY)}" width="${svgRound(c.width)}" height="${svgRound(bodyHeight)}" rx="1"></rect>`;
       const tip = o.titleOf(c);
       const title = tip ? `<title>${escapeXml(tip)}</title>` : '';
       const hover = `<rect data-i="${i}" x="${svgRound(c.x)}" y="${svgRound(p.y)}" width="${svgRound(c.width)}" height="${svgRound(p.h)}" class="bar-hover">${title}</rect>`;
       const label = axisText(o.axisLabel(c, i, model.candles), c.wickX, model.height - 4);
-      return wick + body + hover + label;
+      const candle = `<g class="candle-stack" data-motion-key="${encodeURIComponent(String(c.key))}">${wick}${body}</g>`;
+      return candle + hover + label;
     }).join('');
     return `<svg class="dash-chart" viewBox="0 0 ${model.width} ${model.height}" width="100%" height="100%">${grid}${parts}</svg>`;
   }
 
   function heatmapSvg(model, options) {
-    const o = Object.assign({ titleOf: () => '', monthLabel: (m) => m.label, radius: 3, glowFilterId: '', spotlightId: '', spotlightRadius: 86 }, options || {});
+    const o = Object.assign({ titleOf: () => '', monthLabel: (m) => m.label, radius: 3, glowFilterId: '', spotlightId: '', spotlightRadius: 86, initialHidden: false }, options || {});
     const botPad = 16;
     const pitch = (model.cell || 11) + (model.gap || 2);
     const glowFilterId = String(o.glowFilterId || '');
@@ -466,7 +471,8 @@
       defsParts.push(`<radialGradient id="${escapeXml(spotlightGradientId)}" gradientUnits="userSpaceOnUse" cx="-200" cy="-200" r="${radius}"><stop offset="0" stop-color="white" stop-opacity="1"></stop><stop offset="0.35" stop-color="white" stop-opacity="0.62"></stop><stop offset="0.75" stop-color="white" stop-opacity="0"></stop></radialGradient><mask id="${escapeXml(spotlightMaskId)}"><rect x="0" y="0" width="${svgRound(model.width)}" height="${svgRound(model.height)}" fill="url(#${escapeXml(spotlightGradientId)})"></rect></mask>`);
     }
     const defs = defsParts.length ? `<defs>${defsParts.join('')}</defs>` : '';
-    const cellAttrs = (c) => `class="heat lvl-${c.intensity}" data-d="${escapeXml(c.date)}" data-t="${svgRound(c.tokens || 0)}" data-cost="${svgRound(c.cost || 0)}" x="${svgRound(c.x)}" y="${svgRound(c.y)}" width="${svgRound(c.size)}" height="${svgRound(c.size)}" rx="${svgRound(Math.max(0, Number(o.radius) || 0))}"`;
+    const initialVisibility = o.initialHidden ? ' data-motion-hidden="true" opacity="0"' : '';
+    const cellAttrs = (c) => `class="heat lvl-${c.intensity}" data-d="${escapeXml(c.date)}" data-t="${svgRound(c.tokens || 0)}" data-cost="${svgRound(c.cost || 0)}" x="${svgRound(c.x)}" y="${svgRound(c.y)}" width="${svgRound(c.size)}" height="${svgRound(c.size)}" rx="${svgRound(Math.max(0, Number(o.radius) || 0))}"${initialVisibility}`;
     const cells = (model.cells || []).map((c) =>
       `<rect ${cellAttrs(c)}>${o.titleOf(c) ? `<title>${escapeXml(o.titleOf(c))}</title>` : ''}</rect>`
     ).join('');

--- a/tests/electron/dashboardCharts.test.js
+++ b/tests/electron/dashboardCharts.test.js
@@ -62,6 +62,7 @@ test('barsChartSvg renders one rect per segment with colorFor fill and a per-bar
   });
   assert.match(svg, /^<svg /);
   assert.equal((svg.match(/class="bar-seg"/g) || []).length, 2); // one shape per stacked segment
+  assert.match(svg, /class="bar-stack" data-motion-key="2026-06-01"/); // entry motion grows the whole stack from one baseline
   assert.match(svg, /<path d="M[\d.,\sLQZ-]+" fill="#49a3b0" class="bar-seg">/); // top segment gets a rounded-top cap
   assert.equal((svg.match(/class="bar-hover"/g) || []).length, 1); // plus a transparent hover overlay
   assert.match(svg, /fill="#cc7c5e"/);
@@ -85,14 +86,16 @@ test('barsChartSvg always emits a data-indexed hover target and draws y-axis tic
   assert.match(withAxis, /class="axis-label y-axis"/);
 });
 
-test('candleChartSvg marks up/down candles and renders a wick + body each', () => {
+test('candleChartSvg marks up/down candles and splits each wick from the body midpoint', () => {
   const model = candleChart(
     [{ date: '2026-06-01', tokens: 10 }, { date: '2026-06-07', tokens: 30 }],
     { width: 100, height: 100, padTop: 0, padRight: 0, padBottom: 0, padLeft: 0, gap: 0, metric: 'tokens' }
   );
   const svg = candleChartSvg(model, { titleOf: (c) => `o${c.open}c${c.close}`, axisLabel: () => '' });
   assert.match(svg, /candle-body candle-up/);
-  assert.match(svg, /<line /);            // wick
+  assert.match(svg, /class="candle-stack" data-motion-key="2026-06-01"/);
+  assert.match(svg, /candle-wick candle-wick-high candle-up/);
+  assert.match(svg, /candle-wick candle-wick-low candle-up/);
   assert.match(svg, /<title>o10c30<\/title>/);
 });
 
@@ -114,6 +117,12 @@ test('heatmapSvg colors cells by intensity level class', () => {
   assert.match(svg, /heat lvl-0/);
   assert.match(svg, /data-d="2026-06-01"/); // drives the custom hover tooltip
   assert.match(svg, /<title>2026-06-01<\/title>/);
+});
+
+test('heatmapSvg can hide entry cells in the initial SVG markup', () => {
+  const model = contribHeatmap([{ date: '2026-06-01', intensity: 2 }], { cell: 10, gap: 2 });
+  const svg = heatmapSvg(model, { initialHidden: true });
+  assert.match(svg, /data-motion-hidden="true" opacity="0"/);
 });
 
 test('statsCardsHtml renders a card per descriptor with label + formatted value', () => {

--- a/tests/electron/dashboardWindow.test.js
+++ b/tests/electron/dashboardWindow.test.js
@@ -30,6 +30,15 @@ test('main registers dashboard handlers and a sender-scoped close', () => {
   assert.match(main, /function getDashboardHistory/);
 });
 
+test('dashboard ready fallback is armed for initial load and every reload', () => {
+  const main = read('src', 'electron', 'main.js');
+  assert.match(main, /function armDashboardShowFallback\(win\)[\s\S]*?setTimeout\([\s\S]*?win\.show\(\)[\s\S]*?2000/);
+  assert.match(main, /dashboardWindow\.hide\(\);\s*armDashboardShowFallback\(dashboardWindow\);\s*dashboardWindow\.webContents\.reload\(\)/);
+  assert.match(main, /armDashboardShowFallback\(win\);\s*win\.loadFile/);
+  assert.match(main, /win\.on\('show', clearDashboardShowFallback\)/);
+  assert.match(main, /win\.on\('closed',[\s\S]*?clearDashboardShowFallback\(\)/);
+});
+
 test('getDashboardHistory mirrors the local/sync split of fetchStats', () => {
   const main = read('src', 'electron', 'main.js');
   assert.match(main, /aggregateHistory\(localDevice \? \[localDevice\] : \[\]\)/);

--- a/tests/electron/dashboardWindow.test.js
+++ b/tests/electron/dashboardWindow.test.js
@@ -14,6 +14,7 @@ test('preload exposes the dashboard IPC surface', () => {
   assert.match(preload, /getDashboardHistory: \(\) => ipcRenderer\.invoke\('dashboard:getHistory'\)/);
   assert.match(preload, /ipcRenderer\.on\('dashboard:historyChanged', listener\)/);
   assert.match(preload, /dashboard: \{/);
+  assert.match(preload, /ready: \(\) => ipcRenderer\.send\('dashboard:ready'\)/);
   assert.match(preload, /minimize: \(\) => ipcRenderer\.send\('dashboard:minimize'\)/);
   assert.match(preload, /close: \(\) => ipcRenderer\.send\('dashboard:close'\)/);
 });
@@ -23,6 +24,7 @@ test('main registers dashboard handlers and a sender-scoped close', () => {
   assert.match(main, /ipcMain\.handle\('dashboard:open'/);
   assert.match(main, /ipcMain\.handle\('dashboard:getHistory'/);
   assert.match(main, /ipcMain\.on\('dashboard:close'/);
+  assert.match(main, /ipcMain\.on\('dashboard:ready'/);
   assert.match(main, /BrowserWindow\.fromWebContents\(event\.sender\)/);
   assert.match(main, /function createDashboardWindow/);
   assert.match(main, /function getDashboardHistory/);
@@ -98,7 +100,26 @@ test('dashboard.js fetches history over IPC and renders both tabs', () => {
   assert.match(js, /charts\.heatmapSvg/);
   assert.match(js, /updateSettings\(\{ dashboardFlat: state\.flat \}\)/);
   assert.match(js, /dashboard\.minimize\(\)/);
+  assert.match(js, /dashboard\.ready\(\)/);
   assert.match(js, /onDashboardHistoryChanged\?\.\(\(\) => \{ void refresh\(\); \}\)/);
+});
+
+test('dashboard motion is data-scoped and respects reduced-motion preferences', () => {
+  const js = read('src', 'electron', 'renderer', 'dashboard.js');
+  const css = read('src', 'electron', 'renderer', 'dashboard.css');
+  assert.match(js, /prefers-reduced-motion: reduce/);
+  assert.match(js, /function animateChartGeometry/);
+  assert.match(js, /function animateCandles/);
+  assert.match(js, /function animateHeatmapEntry/);
+  assert.match(js, /document\.hasFocus\(\)/);
+  assert.match(js, /\.bar-stack\[data-motion-key\]/);
+  assert.match(js, /is-motion-pending/);
+  assert.doesNotMatch(js, /function animateValue/);
+  assert.match(js, /state\.motion = 'entry'/);
+  assert.match(css, /\.dash-bd-bar-fill[^}]*transform:\s*scaleX\(var\(--bar-scale/);
+  assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
+  assert.match(css, /\.dash-heatmap-wrap\.is-motion-pending[^}]*opacity:\s*0/);
+  assert.doesNotMatch(css, /\.dash-pane[^}]*transition/);
 });
 
 test('main invalidates an open dashboard only when stats history changes', () => {

--- a/tests/electron/dashboardWindow.test.js
+++ b/tests/electron/dashboardWindow.test.js
@@ -30,13 +30,15 @@ test('main registers dashboard handlers and a sender-scoped close', () => {
   assert.match(main, /function getDashboardHistory/);
 });
 
-test('dashboard ready fallback is armed for initial load and every reload', () => {
+test('dashboard readiness waits for data and recovers only from actual failures', () => {
   const main = read('src', 'electron', 'main.js');
-  assert.match(main, /function armDashboardShowFallback\(win\)[\s\S]*?setTimeout\([\s\S]*?win\.show\(\)[\s\S]*?2000/);
-  assert.match(main, /dashboardWindow\.hide\(\);\s*armDashboardShowFallback\(dashboardWindow\);\s*dashboardWindow\.webContents\.reload\(\)/);
-  assert.match(main, /armDashboardShowFallback\(win\);\s*win\.loadFile/);
-  assert.match(main, /win\.on\('show', clearDashboardShowFallback\)/);
-  assert.match(main, /win\.on\('closed',[\s\S]*?clearDashboardShowFallback\(\)/);
+  assert.doesNotMatch(main, /dashboardShowFallback|armDashboardShowFallback/);
+  assert.match(main, /webContents\.on\('did-fail-load'/);
+  assert.match(main, /errorCode === -3/);
+  assert.match(main, /webContents\.on\('render-process-gone'/);
+  assert.match(main, /win\.on\('unresponsive'/);
+  assert.match(main, /function discardFailedDashboardWindow\(win, reason\)[\s\S]*?win\.destroy\(\)/);
+  assert.match(main, /const controller = new AbortController\(\);[\s\S]*?signal: controller\.signal[\s\S]*?clearTimeout\(timeout\)/);
 });
 
 test('getDashboardHistory mirrors the local/sync split of fetchStats', () => {


### PR DESCRIPTION
## Summary

- animate Overview heatmap cells from left to right and grow breakdown bars from their current values
- animate Trends stacked bars as complete stacks across initial render and range changes
- give K-line charts candle-specific entry motion, with bodies and split wicks expanding from their own baselines
- keep Dashboard numbers static and avoid page-level fade transitions
- respect the system reduced-motion preference

## Implementation notes

- delay showing the Dashboard window until its initial renderer state is prepared, preventing the complete heatmap from flashing before the reveal animation
- scope motion to visualization updates and cancel superseded animations during rapid control changes
- keep stacked segments attached by animating the complete bar group rather than individual segments

## Validation

- `npm run verify` (1320 tests passed)
- manually checked Dashboard cold open, Overview/Trends switching, tool/model grouping, bar/K-line switching, and 7/30/90-day range changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Animate Dashboard usage charts to make changes easier to follow and prevent cold‑open flashes. Window reveal is now gated on renderer readiness; failed or stalled loads are discarded for a clean reopen.

- **New Features**
  - Heatmap reveals left‑to‑right on first load; entry waits until the window is visible and focused.
  - Trends bars animate as whole stacks on initial render and when range, mode, or series change; K‑line candles grow bodies and draw split wicks.
  - Breakdown bars grow from prior geometry via `--bar-scale`; legend/swatches update without layout shift and motion respects reduced‑motion.

- **Bug Fixes**
  - Show only on `dashboard:ready`; hide on reload, restore if minimized, and focus on reveal; removed wall‑clock fallbacks to avoid flashes.
  - Discard windows that fail to load, crash, or become unresponsive while hidden; log the reason for clean reopen.
  - Add a 15s timeout with abort for Hub history requests.

<sup>Written for commit 55bb3e7d3fdc30673c70d7060b11cb57b2cb9a3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

