### PR TITLE
fix(settings): anchor clicked section header during accordion collapse

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -416,27 +416,53 @@ function setSettingsSectionExpanded(section, expanded) {
 // header to its on-screen position for the duration of the 250ms accordion
 // transition (rAF-corrected each frame; a single pass when motion is off).
 const SETTINGS_SCROLL_ANCHOR_MS = 360;
+let settingsScrollAnchorFrame = null;
+
+function cancelSettingsScrollAnchor() {
+  if (settingsScrollAnchorFrame === null) return;
+  cancelAnimationFrame(settingsScrollAnchorFrame);
+  settingsScrollAnchorFrame = null;
+}
+
+function shouldAnchorSettingsScroll(section, expanding) {
+  if (!expanding) return false;
+  const sectionIndex = SETTINGS_SECTION_IDS.indexOf(section);
+  return SETTINGS_SECTION_IDS.slice(0, sectionIndex).some(id => state.settingsSections[id]);
+}
+
 function anchorSettingsScroll(anchorEl, mutate) {
+  cancelSettingsScrollAnchor();
   const panel = els.settingsPanel;
   if (!panel || !anchorEl) { mutate(); return; }
   const offset = anchorEl.getBoundingClientRect().top - panel.getBoundingClientRect().top;
   mutate();
+  const reducedMotion = prefersReducedMotion();
   const deadline = performance.now() + SETTINGS_SCROLL_ANCHOR_MS;
   const pin = () => {
+    settingsScrollAnchorFrame = null;
+    if (!anchorEl.isConnected || panel.classList.contains('hidden')) return;
     const drift = anchorEl.getBoundingClientRect().top - panel.getBoundingClientRect().top - offset;
-    if (drift) panel.scrollTop += drift;
-    if (performance.now() < deadline) requestAnimationFrame(pin);
+    if (Math.abs(drift) > 0.5) panel.scrollTop += drift;
+    if (!reducedMotion && performance.now() < deadline) {
+      settingsScrollAnchorFrame = requestAnimationFrame(pin);
+    }
   };
-  requestAnimationFrame(pin);
+  settingsScrollAnchorFrame = requestAnimationFrame(pin);
 }
 
 function setupSettingsSections() {
   for (const toggle of document.querySelectorAll('[data-settings-section]')) {
     const section = toggle.dataset.settingsSection;
-    toggle.addEventListener('click', () =>
-      anchorSettingsScroll(toggle, () => setSettingsSectionExpanded(section, !state.settingsSections[section])));
+    toggle.addEventListener('click', () => {
+      const expanding = !state.settingsSections[section];
+      const mutate = () => setSettingsSectionExpanded(section, expanding);
+      if (shouldAnchorSettingsScroll(section, expanding)) anchorSettingsScroll(toggle, mutate);
+      else { cancelSettingsScrollAnchor(); mutate(); }
+    });
     setSettingsSectionExpanded(section, state.settingsSections[section]);
   }
+  els.settingsPanel?.addEventListener('pointerdown', cancelSettingsScrollAnchor, { passive: true });
+  els.settingsPanel?.addEventListener('wheel', cancelSettingsScrollAnchor, { passive: true });
 }
 
 function refreshIntervalLabel(value) {

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -410,10 +410,31 @@ function setSettingsSectionExpanded(section, expanded) {
   applySettingsSectionDom(id, next);
 }
 
+// Expanding a section auto-collapses the previously open one. When that one
+// sits ABOVE the clicked header, the content above shrinks while scrollTop
+// stays put, so the clicked card visually flies upward. Pin the clicked
+// header to its on-screen position for the duration of the 250ms accordion
+// transition (rAF-corrected each frame; a single pass when motion is off).
+const SETTINGS_SCROLL_ANCHOR_MS = 360;
+function anchorSettingsScroll(anchorEl, mutate) {
+  const panel = els.settingsPanel;
+  if (!panel || !anchorEl) { mutate(); return; }
+  const offset = anchorEl.getBoundingClientRect().top - panel.getBoundingClientRect().top;
+  mutate();
+  const deadline = performance.now() + SETTINGS_SCROLL_ANCHOR_MS;
+  const pin = () => {
+    const drift = anchorEl.getBoundingClientRect().top - panel.getBoundingClientRect().top - offset;
+    if (drift) panel.scrollTop += drift;
+    if (performance.now() < deadline) requestAnimationFrame(pin);
+  };
+  requestAnimationFrame(pin);
+}
+
 function setupSettingsSections() {
   for (const toggle of document.querySelectorAll('[data-settings-section]')) {
     const section = toggle.dataset.settingsSection;
-    toggle.addEventListener('click', () => setSettingsSectionExpanded(section, !state.settingsSections[section]));
+    toggle.addEventListener('click', () =>
+      anchorSettingsScroll(toggle, () => setSettingsSectionExpanded(section, !state.settingsSections[section])));
     setSettingsSectionExpanded(section, state.settingsSections[section]);
   }
 }

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -416,12 +416,17 @@ function setSettingsSectionExpanded(section, expanded) {
 // header to its on-screen position for the duration of the 250ms accordion
 // transition (rAF-corrected each frame; a single pass when motion is off).
 const SETTINGS_SCROLL_ANCHOR_MS = 360;
+const SETTINGS_SCROLL_KEYS = new Set(['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' ', 'Tab']);
 let settingsScrollAnchorFrame = null;
 
 function cancelSettingsScrollAnchor() {
   if (settingsScrollAnchorFrame === null) return;
   cancelAnimationFrame(settingsScrollAnchorFrame);
   settingsScrollAnchorFrame = null;
+}
+
+function cancelSettingsScrollAnchorOnKeydown(event) {
+  if (SETTINGS_SCROLL_KEYS.has(event.key)) cancelSettingsScrollAnchor();
 }
 
 function shouldAnchorSettingsScroll(section, expanding) {
@@ -463,6 +468,7 @@ function setupSettingsSections() {
   }
   els.settingsPanel?.addEventListener('pointerdown', cancelSettingsScrollAnchor, { passive: true });
   els.settingsPanel?.addEventListener('wheel', cancelSettingsScrollAnchor, { passive: true });
+  els.settingsPanel?.addEventListener('keydown', cancelSettingsScrollAnchorOnKeydown);
 }
 
 function refreshIntervalLabel(value) {

--- a/tests/electron/settingsScrollAnchor.test.js
+++ b/tests/electron/settingsScrollAnchor.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const app = fs.readFileSync(path.join(__dirname, '../../src/electron/renderer/app.js'), 'utf8');
+
+function scrollAnchorHarness({ reducedMotion = false, settingsSections = {} } = {}) {
+  const start = app.indexOf('const SETTINGS_SCROLL_ANCHOR_MS');
+  const end = app.indexOf('\nfunction setupSettingsSections', start);
+  assert.ok(start >= 0 && end > start, 'settings scroll anchor helpers should be present');
+
+  let nextFrame = 1;
+  const frames = new Map();
+  const cancelled = [];
+  const panel = {
+    scrollTop: 0,
+    classList: { contains: () => false },
+    getBoundingClientRect: () => ({ top: 20 })
+  };
+  const context = {
+    SETTINGS_SECTION_IDS: ['general', 'main', 'window', 'appearance'],
+    state: { settingsSections },
+    els: { settingsPanel: panel },
+    prefersReducedMotion: () => reducedMotion,
+    performance: { now: () => 0 },
+    requestAnimationFrame(callback) {
+      const id = nextFrame++;
+      frames.set(id, callback);
+      return id;
+    },
+    cancelAnimationFrame(id) {
+      cancelled.push(id);
+      frames.delete(id);
+    }
+  };
+  vm.runInNewContext(
+    `${app.slice(start, end)}\nglobalThis.scrollAnchorApi = { anchorSettingsScroll, cancelSettingsScrollAnchor, shouldAnchorSettingsScroll };`,
+    context
+  );
+  return { api: context.scrollAnchorApi, cancelled, frames, panel };
+}
+
+function anchor(top = 100) {
+  return { isConnected: true, getBoundingClientRect: () => ({ top }) };
+}
+
+test('settings scroll anchoring only runs when an expanded section above will collapse', () => {
+  const { api } = scrollAnchorHarness({
+    settingsSections: { general: true, main: false, window: false, appearance: false }
+  });
+  assert.equal(api.shouldAnchorSettingsScroll('window', true), true);
+  assert.equal(api.shouldAnchorSettingsScroll('general', true), false);
+  assert.equal(api.shouldAnchorSettingsScroll('window', false), false);
+});
+
+test('a new settings scroll anchor cancels the previous animation frame', () => {
+  const { api, cancelled, frames } = scrollAnchorHarness();
+  api.anchorSettingsScroll(anchor(), () => {});
+  assert.deepEqual([...frames.keys()], [1]);
+
+  api.anchorSettingsScroll(anchor(120), () => {});
+  assert.deepEqual(cancelled, [1]);
+  assert.deepEqual([...frames.keys()], [2]);
+});
+
+test('reduced motion performs one scroll correction without scheduling a loop', () => {
+  const { api, frames, panel } = scrollAnchorHarness({ reducedMotion: true });
+  let top = 100;
+  const anchorEl = { isConnected: true, getBoundingClientRect: () => ({ top }) };
+  api.anchorSettingsScroll(anchorEl, () => { top = 70; });
+
+  const frame = frames.get(1);
+  frames.delete(1);
+  frame();
+
+  assert.equal(panel.scrollTop, -30);
+  assert.equal(frames.size, 0);
+});
+
+test('manual interaction can cancel an active settings scroll anchor', () => {
+  const { api, cancelled, frames } = scrollAnchorHarness();
+  api.anchorSettingsScroll(anchor(), () => {});
+  api.cancelSettingsScrollAnchor();
+
+  assert.deepEqual(cancelled, [1]);
+  assert.equal(frames.size, 0);
+});

--- a/tests/electron/settingsScrollAnchor.test.js
+++ b/tests/electron/settingsScrollAnchor.test.js
@@ -38,7 +38,7 @@ function scrollAnchorHarness({ reducedMotion = false, settingsSections = {} } = 
     }
   };
   vm.runInNewContext(
-    `${app.slice(start, end)}\nglobalThis.scrollAnchorApi = { anchorSettingsScroll, cancelSettingsScrollAnchor, shouldAnchorSettingsScroll };`,
+    `${app.slice(start, end)}\nglobalThis.scrollAnchorApi = { anchorSettingsScroll, cancelSettingsScrollAnchor, cancelSettingsScrollAnchorOnKeydown, shouldAnchorSettingsScroll };`,
     context
   );
   return { api: context.scrollAnchorApi, cancelled, frames, panel };
@@ -88,4 +88,21 @@ test('manual interaction can cancel an active settings scroll anchor', () => {
 
   assert.deepEqual(cancelled, [1]);
   assert.equal(frames.size, 0);
+});
+
+test('keyboard scroll and focus-navigation keys cancel an active settings scroll anchor', () => {
+  for (const key of ['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' ', 'Tab']) {
+    const { api, cancelled, frames } = scrollAnchorHarness();
+    api.anchorSettingsScroll(anchor(), () => {});
+    api.cancelSettingsScrollAnchorOnKeydown({ key });
+    assert.deepEqual(cancelled, [1], `${key} should cancel the active frame`);
+    assert.equal(frames.size, 0);
+  }
+
+  const { api, cancelled, frames } = scrollAnchorHarness();
+  api.anchorSettingsScroll(anchor(), () => {});
+  api.cancelSettingsScrollAnchorOnKeydown({ key: 'a' });
+  assert.deepEqual(cancelled, []);
+  assert.deepEqual([...frames.keys()], [1]);
+  assert.match(app, /settingsPanel\?\.addEventListener\('keydown', cancelSettingsScrollAnchorOnKeydown\)/);
 });


### PR DESCRIPTION
## Summary

Expanding a settings section auto-collapses the previously open one. When the collapsing section sits **above** the clicked header, the content above shrinks while `scrollTop` stays put, so the clicked card visually flies upward — sometimes out of view. Expanding sections bottom-to-top never showed the bug (the collapse happens below the click point), which is why it felt intermittent.

This adds scroll anchoring to the section toggles: the clicked header is pinned to its on-screen position with a per-frame rAF correction for the duration of the 250ms accordion transition. When the anchor position is geometrically unreachable (the remaining content above is shorter than the previous offset), the scroll clamps and the header settles fully visible near the top of the panel — the same behaviour as native collapsing lists.

No visual or markup changes; independent of the settings redesign work.

## Verification

- `npm run verify` (lint + 1352 tests) green
- Driven via CDP against the running widget: reproduced the top-to-bottom expansion sequence (General → Main → Window) and measured the clicked header's viewport drift per step — `0 / -58 / -6` px, where the `-58` case is the geometric clamp (header lands fully visible at the panel top; previously it drifted hundreds of px with the content)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the settings accordion scroll jump by anchoring the clicked section header during collapse so it stays in place instead of jumping out of view.

- **Bug Fixes**
  - Added `anchorSettingsScroll` to pin the clicked header (~360ms via rAF) with a geometric clamp; honors reduced motion with a single correction.
  - Hardened behavior: only anchors when expanding with a section above; cancels on pointer/wheel, keyboard navigation (Arrow/Page/Home/End/Space/Tab), and on new clicks. Tests cover conditions, cancellation (including keyboard and reduced-motion), and clamp handling.

<sup>Written for commit 6ab062e34d6150e018ba1d9c195939af0ef21651. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

