### PR TITLE
test(sync): anchor composeLocalSyncStats clock so today totals don't expire

### DIFF
--- a/tests/electron/syncDisplayStats.test.js
+++ b/tests/electron/syncDisplayStats.test.js
@@ -51,7 +51,7 @@ test('composeLocalSyncStats replaces the hub copy of the local device without do
   const result = composeLocalSyncStats(hubStats, device('local', 120, {
     updatedAt: '2026-07-16T00:02:00.000Z',
     receivedAt: '2026-07-16T00:02:00.000Z'
-  }));
+  }), { nowMs: Date.parse('2026-07-16T00:02:00.000Z') });
 
   assert.equal(result.periods.today.totalTokens, 170);
   assert.equal(result.devices.length, 2);
@@ -66,7 +66,7 @@ test('composeLocalSyncStats replaces the hub copy of the local device without do
 });
 
 test('composeLocalSyncStats can render a local device before the first hub snapshot', () => {
-  const result = composeLocalSyncStats(null, device('local', 25));
+  const result = composeLocalSyncStats(null, device('local', 25), { nowMs: Date.parse('2026-07-16T00:00:00.000Z') });
 
   assert.equal(result.periods.today.totalTokens, 25);
   assert.equal(result.devices.length, 1);


### PR DESCRIPTION
## Summary

`tests/electron/syncDisplayStats.test.js` hardcodes `2026-07-16` usage data but two `composeLocalSyncStats` calls omit `nowMs`, so it falls back to the real clock. `aggregateDevices` then runs `isPeriodExpired` against the current date, decides the fixtures belong to a past UTC day, and drops the `today` bucket to 0 — so `today.totalTokens` asserted 170 but got 0 the moment the wall clock rolled past 2026-07-16. The suite passed on the day it merged (#148) and started failing on every runner at the next UTC midnight.

The fix passes an explicit `nowMs` anchored to the fixture date to both calls, matching the `aggregateDevices(..., Date.parse('2026-07-16T00:01:00.000Z'))` call the same test already pins. The assertions are now wall-clock independent.

## Verification

- `npm test` → 1357 pass, 0 fail (previously 2 failing on any run after 2026-07-16).
- Diff is 2 lines, test-only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchors the test clock in `tests/electron/syncDisplayStats.test.js` by passing `nowMs` to `composeLocalSyncStats` so “today” totals don’t expire when the real date moves past 2026-07-16. This makes the “today” and “before-first-hub” cases deterministic by aligning the clock with the fixture date.

<sup>Written for commit cb0ae0a5c173802d065b38c124073db7e309bde4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

