### PR TITLE
feat(minimax): track MiniMax Code usage from local SQLite stores

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,8 +23,8 @@ TOKEN_MONITOR_SYNC_UPLOAD_INTERVAL_MS=0
 
 # Comma-separated client list. Optional — leave unset to track all supported tools.
 # Set to empty to disable tracking.
-# Example: claude,codex,hermes,opencode,openclaw,cursor,antigravity,cline,kimi,qwen,grok,copilot,pi,zed,kilocode,micode,zcode,kiro,codebuddy,workbuddy,proma
-TOKEN_MONITOR_CLIENTS=claude,codex,hermes,opencode,openclaw,cursor,antigravity,cline,kimi,qwen,grok,copilot,pi,zed,kilocode,micode,zcode,kiro,codebuddy,workbuddy,proma
+# Example: claude,codex,hermes,opencode,openclaw,cursor,antigravity,cline,kimi,qwen,grok,copilot,pi,zed,kilocode,micode,zcode,kiro,codebuddy,workbuddy,proma,minimax
+TOKEN_MONITOR_CLIENTS=claude,codex,hermes,opencode,openclaw,cursor,antigravity,cline,kimi,qwen,grok,copilot,pi,zed,kilocode,micode,zcode,kiro,codebuddy,workbuddy,proma,minimax
 
 # Projects — collect local workspace metadata for the Projects view.
 # Optional — defaults to disabled. Set to 1 to enable.

--- a/README.ja.md
+++ b/README.ja.md
@@ -56,7 +56,7 @@ Token Monitor は **トークン使用量**、**アカウント制限**、**セ�
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`, `~/.workbuddy/workbuddy.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/proma.png" width="28" alt="Proma" /> | Proma | `~/.proma/agent-sessions/*.jsonl` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/deepseek.png" width="28" alt="DeepSeek" /> | DeepSeek | DeepSeek API キー（DeepSeek API で残高取得） | — | ✅ | — |
-| <img src=".github/assets/tools-icon/minimax.png" width="28" alt="Minimax" /> | Minimax | Minimax API キー（Minimax API で Token Plan クォータ取得） | — | ✅ | — |
+| <img src=".github/assets/tools-icon/minimax.png" width="28" alt="Minimax" /> | MiniMax Code | `~/.minimax` SQLite（`token_usage` + runtime）; API key for Token Plan quota | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/volcengine.png" width="28" alt="Volcengine" /> | Volcengine | Ark API key または Volcengine AK/SK（Volcengine API で Ark Coding Plan クォータ取得） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/qoder.png" width="28" alt="Qoder" /> | Qoder | Qoder dashboard cookie（Qoder usage API で big-model credits 取得） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie（ollama.com/settings で session/weekly 使用量を取得） | — | ✅ | — |

--- a/README.ko.md
+++ b/README.ko.md
@@ -56,7 +56,7 @@ Token Monitor는 **토큰 사용량**, **계정 한도**, **세션 상세**를 �
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`, `~/.workbuddy/workbuddy.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/proma.png" width="28" alt="Proma" /> | Proma | `~/.proma/agent-sessions/*.jsonl` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/deepseek.png" width="28" alt="DeepSeek" /> | DeepSeek | DeepSeek API 키 (DeepSeek API로 잔액 조회) | — | ✅ | — |
-| <img src=".github/assets/tools-icon/minimax.png" width="28" alt="Minimax" /> | Minimax | Minimax API 키 (Minimax API로 Token Plan 할당량 조회) | — | ✅ | — |
+| <img src=".github/assets/tools-icon/minimax.png" width="28" alt="Minimax" /> | MiniMax Code | `~/.minimax` SQLite (`token_usage` + runtime); API key for Token Plan quota | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/volcengine.png" width="28" alt="Volcengine" /> | Volcengine | Ark API key 또는 Volcengine AK/SK (Volcengine API로 Ark Coding Plan 할당량 조회) | — | ✅ | — |
 | <img src=".github/assets/tools-icon/qoder.png" width="28" alt="Qoder" /> | Qoder | Qoder dashboard cookie (Qoder usage API로 big-model credits 조회) | — | ✅ | — |
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie (ollama.com/settings에서 session/weekly 사용량 조회) | — | ✅ | — |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Token Monitor supports token usage, account-limit checks, and session details se
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`, `~/.workbuddy/workbuddy.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/proma.png" width="28" alt="Proma" /> | Proma | `~/.proma/agent-sessions/*.jsonl` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/deepseek.png" width="28" alt="DeepSeek" /> | DeepSeek | DeepSeek API key (balance via DeepSeek API) | — | ✅ | — |
-| <img src=".github/assets/tools-icon/minimax.png" width="28" alt="Minimax" /> | Minimax | Minimax API key (Token Plan quota via Minimax API) | — | ✅ | — |
+| <img src=".github/assets/tools-icon/minimax.png" width="28" alt="Minimax" /> | MiniMax Code | `~/.minimax` SQLite (`token_usage` + runtime); API key for Token Plan quota | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/volcengine.png" width="28" alt="Volcengine" /> | Volcengine | Ark API key or Volcengine AK/SK (Ark Coding Plan quota via Volcengine API) | — | ✅ | — |
 | <img src=".github/assets/tools-icon/qoder.png" width="28" alt="Qoder" /> | Qoder | Qoder dashboard cookie (big-model credits via Qoder usage API) | — | ✅ | — |
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie (session/weekly usage via ollama.com/settings) | — | ✅ | — |
@@ -67,7 +67,7 @@ Most usage monitors are useful on the machine they run on. Token Monitor is buil
 
 ## Features
 
-- **Live token tracking** for Claude Code, Codex, Hermes Agent, OpenCode, OpenClaw, Cursor, Antigravity, Cline, Kimi, Qwen, Grok Build, GitHub Copilot, Pi, Zed, Kilo Code, MiMo Code, ZCode, Kiro, CodeBuddy, WorkBuddy, and Proma (UI updates within seconds of each turn)
+- **Live token tracking** for Claude Code, Codex, Hermes Agent, OpenCode, OpenClaw, Cursor, Antigravity, Cline, Kimi, Qwen, Grok Build, GitHub Copilot, Pi, Zed, Kilo Code, MiMo Code, ZCode, Kiro, CodeBuddy, WorkBuddy, Proma, and MiniMax Code (UI updates within seconds of each turn)
 - **WSL usage (Windows)** — usage from AI tools running inside a running WSL distro is detected automatically and merged into your totals (refreshed on the periodic scan, about every 5 minutes)
 - **Real-time multi-device sync** over Server-Sent Events
 - **Breakdown views** grouped by tool, device, model, session, or account limits

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -56,7 +56,7 @@ Token Monitor 对「Token 用量」「账户额度」和「session 明细」分�
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`、`~/.workbuddy/workbuddy.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/proma.png" width="28" alt="Proma" /> | Proma | `~/.proma/agent-sessions/*.jsonl` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/deepseek.png" width="28" alt="DeepSeek" /> | DeepSeek | DeepSeek API 密钥（通过 DeepSeek API 查询余额） | — | ✅ | — |
-| <img src=".github/assets/tools-icon/minimax.png" width="28" alt="Minimax" /> | Minimax | Minimax API 密钥（通过 Minimax API 查询 Token Plan 额度） | — | ✅ | — |
+| <img src=".github/assets/tools-icon/minimax.png" width="28" alt="Minimax" /> | MiniMax Code | `~/.minimax` SQLite（`token_usage` + runtime）；API 密钥查询 Token Plan 额度 | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/volcengine.png" width="28" alt="Volcengine" /> | Volcengine | Ark API key 或火山引擎 AK/SK（通过火山引擎 API 查询火山方舟 Coding Plan 额度） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/qoder.png" width="28" alt="Qoder" /> | Qoder | Qoder dashboard cookie（通过 Qoder usage API 查询 big-model credits） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie（通过 ollama.com/settings 查询 session／每周用量） | — | ✅ | — |
@@ -67,7 +67,7 @@ Token Monitor 对「Token 用量」「账户额度」和「session 明细」分�
 
 ## 功能特性
 
-- **实时 Token 追踪**：覆盖 Claude Code、Codex、Hermes Agent、OpenCode、OpenClaw、Cursor、Antigravity、Cline、Kimi、Qwen、Grok Build、GitHub Copilot、Pi、Zed、Kilo Code、MiMo Code、ZCode、Kiro、CodeBuddy、WorkBuddy、Proma（每轮对话后 UI 在数秒内刷新）
+- **实时 Token 追踪**：覆盖 Claude Code、Codex、Hermes Agent、OpenCode、OpenClaw、Cursor、Antigravity、Cline、Kimi、Qwen、Grok Build、GitHub Copilot、Pi、Zed、Kilo Code、MiMo Code、ZCode、Kiro、CodeBuddy、WorkBuddy、Proma、MiniMax Code（每轮对话后 UI 在数秒内刷新）
 - **WSL 用量（Windows）**：在运行中的 WSL 发行版里使用的 AI 工具用量会自动识别并并入总量（随定期扫描刷新，约每 5 分钟一次）
 - **多设备实时同步**：通过 Server-Sent Events 推送
 - **分组统计视图**：可按工具、设备、模型、session 或账户额度分组

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -56,7 +56,7 @@ Token Monitor 對「Token 用量」「帳戶額度」與「session 明細」分�
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`、`~/.workbuddy/workbuddy.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/proma.png" width="28" alt="Proma" /> | Proma | `~/.proma/agent-sessions/*.jsonl` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/deepseek.png" width="28" alt="DeepSeek" /> | DeepSeek | DeepSeek API 金鑰（透過 DeepSeek API 查詢餘額） | — | ✅ | — |
-| <img src=".github/assets/tools-icon/minimax.png" width="28" alt="Minimax" /> | Minimax | Minimax API 金鑰（透過 Minimax API 查詢 Token Plan 額度） | — | ✅ | — |
+| <img src=".github/assets/tools-icon/minimax.png" width="28" alt="Minimax" /> | MiniMax Code | `~/.minimax` SQLite（`token_usage` + runtime）；API 金鑰查詢 Token Plan 額度 | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/volcengine.png" width="28" alt="Volcengine" /> | Volcengine | Ark API key 或火山引擎 AK/SK（透過火山引擎 API 查詢火山方舟 Coding Plan 額度） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/qoder.png" width="28" alt="Qoder" /> | Qoder | Qoder dashboard cookie（透過 Qoder usage API 查詢 big-model credits） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie（透過 ollama.com/settings 查詢 session／每週用量） | — | ✅ | — |

--- a/src/electron/discordRpc.js
+++ b/src/electron/discordRpc.js
@@ -7,14 +7,14 @@ const CLIENT_ID = '1507034330436862062';
 const GITHUB_URL = 'https://github.com/Javis603/token-monitor';
 const KNOWN_CLIENT_ASSETS = new Set([
   'claude', 'codex', 'hermes', 'gemini', 'cursor', 'opencode', 'openclaw', 'antigravity', 'cline',
-  'kimi', 'qwen', 'grok', 'copilot', 'pi', 'zed', 'kilocode', 'micode', 'zcode', 'kiro', 'codebuddy', 'workbuddy', 'proma'
+  'kimi', 'qwen', 'grok', 'copilot', 'pi', 'zed', 'kilocode', 'micode', 'zcode', 'kiro', 'codebuddy', 'workbuddy', 'proma', 'minimax'
 ]);
 const CLIENT_LABELS = {
   claude: 'Claude', codex: 'Codex', hermes: 'Hermes',
   gemini: 'Gemini', cursor: 'Cursor', opencode: 'OpenCode', openclaw: 'OpenClaw',
   antigravity: 'Antigravity', cline: 'Cline',
   kimi: 'Kimi', qwen: 'Qwen', grok: 'Grok Build', copilot: 'GitHub Copilot',
-  pi: 'Pi', zed: 'Zed', kilocode: 'Kilo Code', micode: 'MiMo Code', zcode: 'ZCode', kiro: 'Kiro', codebuddy: 'CodeBuddy', workbuddy: 'WorkBuddy', proma: 'Proma'
+  pi: 'Pi', zed: 'Zed', kilocode: 'Kilo Code', micode: 'MiMo Code', zcode: 'ZCode', kiro: 'Kiro', codebuddy: 'CodeBuddy', workbuddy: 'WorkBuddy', proma: 'Proma', minimax: 'MiniMax Code'
 };
 const UPDATE_MIN_INTERVAL_MS = 15000;
 const RECONNECT_DELAY_MS = 30000;

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const clientLabels = { claude: 'Claude Code', codex: 'Codex', hermes: 'Hermes', gemini: 'Gemini', cursor: 'Cursor', opencode: 'OpenCode', openclaw: 'OpenClaw', antigravity: 'Antigravity', cline: 'Cline', kimi: 'Kimi', qwen: 'Qwen', grok: 'Grok Build', copilot: 'GitHub Copilot', pi: 'Pi', zed: 'Zed', kilocode: 'Kilo Code', micode: 'MiMo Code', zcode: 'ZCode', kiro: 'Kiro', codebuddy: 'CodeBuddy', workbuddy: 'WorkBuddy', proma: 'Proma' };
+const clientLabels = { claude: 'Claude Code', codex: 'Codex', hermes: 'Hermes', gemini: 'Gemini', cursor: 'Cursor', opencode: 'OpenCode', openclaw: 'OpenClaw', antigravity: 'Antigravity', cline: 'Cline', kimi: 'Kimi', qwen: 'Qwen', grok: 'Grok Build', copilot: 'GitHub Copilot', pi: 'Pi', zed: 'Zed', kilocode: 'Kilo Code', micode: 'MiMo Code', zcode: 'ZCode', kiro: 'Kiro', codebuddy: 'CodeBuddy', workbuddy: 'WorkBuddy', proma: 'Proma', minimax: 'MiniMax Code' };
 const { clientColors, fallbackModelColors, modelVendorFor, modelColor } = window.TokenMonitorUsageCharts;
 const motionPreferenceApi = window.TokenMonitorMotionPreference;
 const reducedMotionMedia = window.matchMedia?.('(prefers-reduced-motion: reduce)');
@@ -61,7 +61,8 @@ const KNOWN_CLIENTS = [
   { id: 'kiro', label: 'Kiro' },
   { id: 'codebuddy', label: 'CodeBuddy' },
   { id: 'workbuddy', label: 'WorkBuddy' },
-  { id: 'proma', label: 'Proma' }
+  { id: 'proma', label: 'Proma' },
+  { id: 'minimax', label: 'MiniMax Code' }
 ];
 const LIMIT_PROVIDERS = [
   { id: 'claude', label: 'Claude', settingsLabel: 'Claude Code' },

--- a/src/shared/clientTracking.js
+++ b/src/shared/clientTracking.js
@@ -5,7 +5,8 @@
 // `claude` client. tokscale 4.0.5 fixed the scan path but does not dedup imports, and
 // the imported rows aren't cleanly separable (MiMo is multi-model). It stays a known
 // client — one click to enable in Settings → tools — until tokscale dedups upstream.
-const DEFAULT_CLIENTS = 'claude,codex,hermes,opencode,openclaw,cursor,antigravity,cline,kimi,qwen,grok,copilot,pi,zed,kilocode,zcode,kiro,codebuddy,workbuddy,proma';
+// minimax = MiniMax Code local usage (parse-local from ~/.minimax; not a tokscale client).
+const DEFAULT_CLIENTS = 'claude,codex,hermes,opencode,openclaw,cursor,antigravity,cline,kimi,qwen,grok,copilot,pi,zed,kilocode,zcode,kiro,codebuddy,workbuddy,proma,minimax';
 
 // Every wired client id, including opt-in ones kept out of DEFAULT_CLIENTS (micode).
 // Display-preference normalization (hide/pin/reorder) keys off this list, so an opt-in

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -20,7 +20,11 @@ const cursorAuth = require('./cursorAuth');
 const { findSessionFiles, codexSessionFile } = require('./sessionFiles');
 const opencodeSession = require('./opencodeSession');
 const { buildPromaHistoryGraph, buildPromaPeriods, collectPromaRows } = require('./promaUsage');
+const { buildMinimaxHistoryGraph, buildMinimaxPeriods, collectMinimaxRows } = require('./minimaxUsage');
 const { hashKey } = require('./hashKey');
+
+// Clients parsed from local stores (not accepted by tokscale --client).
+const LOCALLY_PARSED_CLIENTS = new Set(['proma', 'minimax']);
 
 function toUnpackedPath(p) {
   // electron-builder asarUnpack stores real files at .../app.asar.unpacked/...
@@ -557,6 +561,7 @@ async function collectHistoryOnce(options) {
     }
   }
   if (options.promaGraph) histories.push(normalizeHistory(parseGraphResult(options.promaGraph), { capDays, todayKey }));
+  if (options.minimaxGraph) histories.push(normalizeHistory(parseGraphResult(options.minimaxGraph), { capDays, todayKey }));
   if (histories.length === 0) return null;
   const history = histories.length === 1 ? histories[0] : mergeHistories(histories, { todayKey });
   return history.daily.length || history.monthly.length ? history : null;
@@ -594,11 +599,14 @@ async function collectUsageOnce(options) {
     options.homeDir || os.homedir(),
     { ...localSessionMetadataDeps, retryMisses }
   );
-  // tokscale doesn't know about Proma yet — filter it out of the subprocess
-  // calls so --client doesn't reject an unknown value. Proma is parsed
-  // separately below and merged back in.
-  const tokscaleClients = normalizedClients ? normalizedClients.split(',').filter((c) => c !== 'proma').join(',') : normalizedClients;
+  // tokscale doesn't know about parse-local clients (Proma, MiniMax Code) —
+  // filter them out of the subprocess so --client doesn't reject unknown values.
+  // They are parsed separately below and merged back in.
+  const tokscaleClients = normalizedClients
+    ? normalizedClients.split(',').filter((c) => !LOCALLY_PARSED_CLIENTS.has(c)).join(',')
+    : normalizedClients;
   const includesProma = normalizedClients.split(',').includes('proma');
+  const includesMinimax = normalizedClients.split(',').includes('minimax');
   let today = emptyPeriod();
   let month = emptyPeriod();
   let allTime = emptyPeriod();
@@ -607,6 +615,8 @@ async function collectUsageOnce(options) {
   let promaPeriods = null;
   let promaRows = null;
   let promaPricing = null;
+  let minimaxPeriods = null;
+  let minimaxRows = null;
   if (normalizedClients) {
     await maybeSyncCursor(tokscaleClients, options.logger);
     await maybeSyncAntigravity(tokscaleClients, options.logger, options.homeDir || os.homedir());
@@ -628,6 +638,28 @@ async function collectUsageOnce(options) {
         if (typeof options.logger === 'function') options.logger(`proma parse failed: ${err.message}`);
       }
     }
+    if (includesMinimax) {
+      try {
+        minimaxRows = collectMinimaxRows({
+          homeDir: options.minimaxHomeDir,
+          env: options.env,
+          rows: options.minimaxRows,
+          sqlite: options.minimaxSqlite
+        });
+        const minimaxJson = buildMinimaxPeriods({
+          now: collectedAt,
+          allTimeSince,
+          rows: minimaxRows
+        });
+        minimaxPeriods = {
+          today: extractUsageFromTokscale(minimaxJson.today),
+          month: extractUsageFromTokscale(minimaxJson.month),
+          allTime: extractUsageFromTokscale(minimaxJson.allTime)
+        };
+      } catch (err) {
+        if (typeof options.logger === 'function') options.logger(`minimax parse failed: ${err.message}`);
+      }
+    }
     if (anchorUsed) {
       // Anchored tick (watch-triggered): every tokscale period scan costs the
       // same full load + filter, so scan only --today and update the broader
@@ -637,9 +669,10 @@ async function collectUsageOnce(options) {
         today = extractUsageFromTokscale(todayJson);
       }
       // The persisted anchor contains every Windows-side client, including
-      // locally parsed Proma. Include its fresh today usage before deriving
+      // locally parsed clients. Include their fresh today usage before deriving
       // broader windows so base + (fresh today - anchor today) stays exact.
       if (promaPeriods) today = mergePeriods(today, promaPeriods.today);
+      if (minimaxPeriods) today = mergePeriods(today, minimaxPeriods.today);
       month = applyPeriodDelta(anchor.month, today, anchor.today);
       allTime = applyPeriodDelta(anchor.allTime, today, anchor.today);
     } else if (tokscaleClients) {
@@ -674,6 +707,11 @@ async function collectUsageOnce(options) {
       today = mergePeriods(today, promaPeriods.today);
       month = mergePeriods(month, promaPeriods.month);
       allTime = mergePeriods(allTime, promaPeriods.allTime);
+    }
+    if (minimaxPeriods && !anchorUsed) {
+      today = mergePeriods(today, minimaxPeriods.today);
+      month = mergePeriods(month, minimaxPeriods.month);
+      allTime = mergePeriods(allTime, minimaxPeriods.allTime);
     }
   }
 
@@ -789,6 +827,16 @@ async function collectUsageOnce(options) {
     const history = await collectHistoryOnce({
       clients: tokscaleClients,
       promaGraph: includesProma ? buildPromaHistoryGraph({ rows: promaRows || collectPromaRows(), pricingByModel: promaPricing || {} }) : null,
+      minimaxGraph: includesMinimax
+        ? buildMinimaxHistoryGraph({
+          rows: minimaxRows || collectMinimaxRows({
+            homeDir: options.minimaxHomeDir,
+            env: options.env,
+            rows: options.minimaxRows,
+            sqlite: options.minimaxSqlite
+          })
+        })
+        : null,
       historyEnabled: options.historyEnabled,
       commandTimeoutMs: options.historyTimeoutMs,
       capDays: options.historyCapDays,
@@ -894,6 +942,15 @@ function clientWatchCandidates(clientsCsv) {
   add('workbuddy', path.join(home, '.workbuddy', 'projects'));
   // Proma — session transcripts at ~/.proma/agent-sessions/*.jsonl
   add('proma', path.join(home, '.proma', 'agent-sessions'));
+  // MiniMax Code — usage DBs under ~/.minimax (or MINIMAX_HOME / MAVIS_HOME).
+  // Watch the home + v2/sqlite so sqlite.db and runtime-state.sqlite refresh in
+  // seconds; watchIgnoreMatcher prunes sessions/agents/logs so we never poll
+  // conversation trees (privacy + CPU).
+  {
+    const minimaxHome = String(process.env.MINIMAX_HOME || process.env.MAVIS_HOME || '').trim()
+      || path.join(home, '.minimax');
+    add('minimax', minimaxHome, path.join(minimaxHome, 'v2', 'sqlite'));
+  }
   // Kiro (AWS): tokscale reads home-relative roots — the sessions tree used by
   // both CLI and IDE, the Kiro IDE globalStorage root (native macOS / Linux /
   // Windows), and the kiro-cli sqlite dir. None falls back to a host-absolute
@@ -974,15 +1031,36 @@ function watchPathsForClients(clientsCsv) {
 // never recurses into an ignored dir (so the runaway poll is gone), yet a
 // newly created state.db-wal is still seen on the next top-level readdir.
 const HERMES_DB_FILES = new Set(['state.db', 'state.db-wal', 'state.db-shm']);
+// MiniMax Code only needs the usage SQLite files (+ WAL/SHM). Everything else
+// under ~/.minimax (sessions, agents, scratchpads, logs) is ignored.
+const MINIMAX_DB_FILES = new Set([
+  'sqlite.db',
+  'sqlite.db-wal',
+  'sqlite.db-shm',
+  'runtime-state.sqlite',
+  'runtime-state.sqlite-wal',
+  'runtime-state.sqlite-shm'
+]);
+
+function minimaxPathAllowed(resolved, root) {
+  if (resolved === root) return true;
+  if (!resolved.startsWith(root + path.sep)) return false;
+  if (MINIMAX_DB_FILES.has(path.basename(resolved))) return true;
+  // Keep the short intermediate dirs so chokidar can readdir into the db folder.
+  const rel = path.relative(root, resolved);
+  return rel === 'v2' || rel === path.join('v2', 'sqlite');
+}
 
 function watchIgnoreMatcher(clientsCsv) {
   const candidates = clientWatchCandidates(clientsCsv);
   const hermesRoots = (candidates.hermes || []).map((dir) => path.resolve(dir));
   const hermesRootSet = new Set(hermesRoots);
+  const minimaxRoots = (candidates.minimax || []).map((dir) => path.resolve(dir));
+  const minimaxRootSet = new Set(minimaxRoots);
   const copilotRoots = (candidates.copilot || [])
     .filter((dir) => path.basename(dir) === 'workspaceStorage')
     .map((dir) => path.resolve(dir));
-  if (hermesRoots.length === 0 && copilotRoots.length === 0) return undefined;
+  if (hermesRoots.length === 0 && copilotRoots.length === 0 && minimaxRoots.length === 0) return undefined;
   return (target) => {
     const resolved = path.resolve(target);
     // Every explicit watch root stays watched — the home dir AND each profile
@@ -993,6 +1071,12 @@ function watchIgnoreMatcher(clientsCsv) {
     for (const root of hermesRoots) {
       if (resolved.startsWith(root + path.sep)) return !HERMES_DB_FILES.has(path.basename(resolved));
     }
+    if (minimaxRootSet.has(resolved)) return false;
+    for (const root of minimaxRoots) {
+      if (resolved === root || resolved.startsWith(root + path.sep)) {
+        return !minimaxPathAllowed(resolved, root);
+      }
+    }
     for (const root of copilotRoots) {
       if (resolved === root) return false;
       if (!resolved.startsWith(root + path.sep)) continue;
@@ -1002,7 +1086,7 @@ function watchIgnoreMatcher(clientsCsv) {
       if (parts.length === 2 && parts[1] === 'workspace.json') return false;
       return true;
     }
-    return false; // paths outside the bounded Hermes/Copilot roots are never ignored
+    return false; // paths outside the bounded Hermes/MiniMax/Copilot roots are never ignored
   };
 }
 
@@ -1338,6 +1422,7 @@ module.exports = {
   projectPathFromJsonl,
   collectHistoryOnce,
   collectUsageOnce,
+  LOCALLY_PARSED_CLIENTS,
   clientDataDirPresence,
   computePeriodWindows,
   configFingerprint,

--- a/src/shared/localUsageHelpers.js
+++ b/src/shared/localUsageHelpers.js
@@ -1,0 +1,64 @@
+'use strict';
+
+/**
+ * Shared pure helpers for parse-local usage adapters (Proma, MiniMax Code, …).
+ * Keep numeric/timestamp/window semantics in one place so period shaping stays
+ * aligned across clients that do not go through tokscale.
+ */
+
+function numberValue(value) {
+  const n = Number(value || 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function timestampMs(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value > 0 && value < 1e12 ? value * 1000 : value;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return numeric > 0 && numeric < 1e12 ? numeric * 1000 : numeric;
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+  return 0;
+}
+
+function normalizedModelId(value) {
+  const raw = String(value || '').trim().toLowerCase();
+  return raw || 'unknown';
+}
+
+function localDateKey(timestamp) {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '';
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function windowStartMs(windows = {}) {
+  return Math.max(
+    0,
+    timestampMs(windows.todayStart),
+    timestampMs(windows.monthStart),
+    timestampMs(windows.allTimeSince)
+  );
+}
+
+function localPeriodBounds(nowInput) {
+  const now = nowInput ? new Date(nowInput) : new Date();
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0).getTime();
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1, 0, 0, 0, 0).getTime();
+  return { now, todayStart, monthStart };
+}
+
+module.exports = {
+  numberValue,
+  timestampMs,
+  normalizedModelId,
+  localDateKey,
+  windowStartMs,
+  localPeriodBounds
+};

--- a/src/shared/minimaxUsage.js
+++ b/src/shared/minimaxUsage.js
@@ -14,33 +14,19 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const {
+  numberValue,
+  timestampMs,
+  normalizedModelId,
+  localDateKey,
+  windowStartMs,
+  localPeriodBounds
+} = require('./localUsageHelpers');
 
 let sqlite = null;
 try { sqlite = require('node:sqlite'); } catch (_) { sqlite = null; }
 
 const CLIENT_ID = 'minimax';
-
-function numberValue(value) {
-  const n = Number(value || 0);
-  return Number.isFinite(n) ? n : 0;
-}
-
-function timestampMs(value) {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return value > 0 && value < 1e12 ? value * 1000 : value;
-  }
-  if (typeof value === 'string' && value.trim()) {
-    const numeric = Number(value);
-    if (Number.isFinite(numeric)) return numeric > 0 && numeric < 1e12 ? numeric * 1000 : numeric;
-    const parsed = Date.parse(value);
-    return Number.isNaN(parsed) ? 0 : parsed;
-  }
-  return 0;
-}
-
-function normalizedModelId(value) {
-  return String(value || '').trim() || 'unknown';
-}
 
 function resolveMinimaxHome(options = {}) {
   const env = options.env || process.env;
@@ -136,9 +122,11 @@ function normalizeUsageRow(raw = {}) {
  * 3. Exact rowKey duplicates (true clones) are kept once.
  */
 function dedupeUsageRows(rows) {
+  // Always re-run normalizeUsageRow so injected/pre-built rows get canonical
+  // source + lowercased model ids (legacy-wins and aggregation stay correct).
   const normalized = [];
   for (const row of rows || []) {
-    const n = row && row.rowKey ? row : normalizeUsageRow(row);
+    const n = normalizeUsageRow(row);
     if (n) normalized.push(n);
   }
 
@@ -206,7 +194,7 @@ function readRowsFromDbPath(dbPath, tableName, sourceTag, sqliteMod) {
  */
 function collectMinimaxRows(options = {}) {
   if (Array.isArray(options.rows)) {
-    return dedupeUsageRows(options.rows.map((row) => (row && row.dedupeKey ? row : normalizeUsageRow(row))));
+    return dedupeUsageRows(options.rows);
   }
   const sqliteMod = options.sqlite !== undefined ? options.sqlite : sqlite;
   if (!sqliteMod) return [];
@@ -215,19 +203,6 @@ function collectMinimaxRows(options = {}) {
   const runtimeRows = readRowsFromDbPath(runtimeDbPath(homeDir), 'local_runtime_token_usage', 'runtime', sqliteMod);
   // Within each store keep multi-step rows; cross-store legacy wins by turn_id.
   return dedupeUsageRows([...legacyRows, ...runtimeRows]);
-}
-
-function windowStartMs(windows) {
-  return Math.max(0, timestampMs(windows.todayStart), timestampMs(windows.monthStart), timestampMs(windows.allTimeSince));
-}
-
-function localDateKey(timestamp) {
-  const date = new Date(timestamp);
-  if (Number.isNaN(date.getTime())) return '';
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
 }
 
 /**
@@ -329,7 +304,7 @@ function buildMinimaxHistoryGraph(options = {}) {
       day = { date, clients: [] };
       byDate.set(date, day);
     }
-    const modelId = String(row.model || 'unknown').toLowerCase();
+    const modelId = normalizedModelId(row.model);
     let client = day.clients.find((entry) => entry.modelId === modelId);
     if (!client) {
       client = {
@@ -353,11 +328,9 @@ function buildMinimaxHistoryGraph(options = {}) {
 }
 
 function buildMinimaxPeriods(options = {}) {
-  const now = options.now ? new Date(options.now) : new Date();
+  const { todayStart, monthStart } = localPeriodBounds(options.now);
   const rows = Array.isArray(options.rows) ? dedupeUsageRows(options.rows) : collectMinimaxRows(options);
   const buildOptions = { rows, sqlite: options.sqlite, homeDir: options.homeDir, env: options.env };
-  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0).getTime();
-  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1, 0, 0, 0, 0).getTime();
   return {
     today: buildTokscaleJson({ todayStart }, buildOptions),
     month: buildTokscaleJson({ monthStart }, buildOptions),

--- a/src/shared/minimaxUsage.js
+++ b/src/shared/minimaxUsage.js
@@ -1,0 +1,379 @@
+'use strict';
+
+/**
+ * MiniMax Code (Mavis) local usage parser.
+ *
+ * Reads token usage from the MiniMax data root (default ~/.minimax):
+ *   - sqlite.db → token_usage
+ *   - v2/sqlite/runtime-state.sqlite → local_runtime_token_usage
+ *
+ * Returns tokscale-shaped JSON so collector can extractUsageFromTokscale /
+ * mergePeriods the same way Proma is handled. Client id is always `minimax`.
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+let sqlite = null;
+try { sqlite = require('node:sqlite'); } catch (_) { sqlite = null; }
+
+const CLIENT_ID = 'minimax';
+
+function numberValue(value) {
+  const n = Number(value || 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function timestampMs(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value > 0 && value < 1e12 ? value * 1000 : value;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return numeric > 0 && numeric < 1e12 ? numeric * 1000 : numeric;
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+  return 0;
+}
+
+function normalizedModelId(value) {
+  return String(value || '').trim() || 'unknown';
+}
+
+function resolveMinimaxHome(options = {}) {
+  const env = options.env || process.env;
+  const explicit = String(options.homeDir || env.MINIMAX_HOME || env.MAVIS_HOME || '').trim();
+  if (explicit) return path.resolve(explicit);
+  const home = env.HOME || env.USERPROFILE || os.homedir();
+  return path.join(home, '.minimax');
+}
+
+function legacyDbPath(homeDir) {
+  return path.join(homeDir, 'sqlite.db');
+}
+
+function runtimeDbPath(homeDir) {
+  return path.join(homeDir, 'v2', 'sqlite', 'runtime-state.sqlite');
+}
+
+function openReadOnlyDb(dbPath, sqliteMod) {
+  const db = new sqliteMod.DatabaseSync(dbPath, { readOnly: true });
+  try { db.exec('PRAGMA busy_timeout = 250'); } catch (_) { /* ignore */ }
+  return db;
+}
+
+function tableExists(db, name) {
+  try {
+    const row = db.prepare("SELECT 1 AS ok FROM sqlite_master WHERE type='table' AND name=? LIMIT 1").get(name);
+    return Boolean(row && row.ok);
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
+ * Map a raw DB row (either store) into a normalized usage record.
+ * Pure — no I/O. Accepts either snake_case column names or already-normalized keys.
+ *
+ * Important: a single turn_id can own many rows (multi-step model calls inside
+ * one agent turn). Those must SUM — never collapse to one row per turn_id.
+ * Cross-store overlap is handled separately in mergeUsageStores / dedupeUsageRows.
+ */
+function normalizeUsageRow(raw = {}) {
+  if (!raw || typeof raw !== 'object') return null;
+  const sessionId = String(raw.session_id || raw.sessionId || '').trim() || 'unknown';
+  const turnId = String(raw.turn_id || raw.turnId || '').trim();
+  const model = normalizedModelId(raw.model);
+  const createdAt = timestampMs(raw.ts ?? raw.createdAt ?? raw.created_at);
+  const input = numberValue(raw.input_tokens ?? raw.input);
+  const output = numberValue(raw.output_tokens ?? raw.output);
+  const reasoning = numberValue(raw.reasoning_tokens ?? raw.reasoning);
+  const cacheRead = numberValue(raw.cache_read_tokens ?? raw.cacheRead);
+  const cacheWrite = numberValue(raw.cache_write_tokens ?? raw.cacheWrite);
+  const cost = numberValue(raw.cost_usd ?? raw.cost);
+  // Prefer explicit total from raw JSON when present; otherwise sum additive components.
+  // reasoning is informational (often subset of output) — do not add into total.
+  let total = numberValue(raw.total_tokens ?? raw.totalTokens);
+  if (!total) total = input + output + cacheRead + cacheWrite;
+  const source = String(raw._source || raw.source || '');
+  const rowId = raw.id != null && raw.id !== '' ? String(raw.id) : '';
+  // Per-step identity (never turn_id alone — multi-step turns must all survive).
+  const rowKey = rowId
+    ? `${source || 'row'}:id:${rowId}`
+    : `${source || 'row'}|${sessionId}|${createdAt}|${model}|${input}|${output}|${cacheRead}|${cacheWrite}|${reasoning}|${turnId}|${cost}`;
+  // Least privilege: do not carry agent_name / framework_type / raw. They are
+  // unused on the wire and not needed for token aggregation.
+  return {
+    sessionId,
+    turnId,
+    model,
+    createdAt,
+    input,
+    output,
+    reasoning,
+    cacheRead,
+    cacheWrite,
+    total,
+    cost,
+    messages: 1,
+    rowKey,
+    // Back-compat alias used by older tests / call sites.
+    dedupeKey: rowKey,
+    source
+  };
+}
+
+/**
+ * Merge usage rows from one or both MiniMax stores.
+ *
+ * Rules:
+ * 1. Within a store, keep every distinct step (same turn_id, different tokens/ts/id → SUM).
+ * 2. Cross-store: if a non-empty turn_id appears in any legacy row, drop ALL runtime
+ *    rows with that turn_id (legacy wins after migration). Do not collapse multi-step
+ *    legacy rows for that turn.
+ * 3. Exact rowKey duplicates (true clones) are kept once.
+ */
+function dedupeUsageRows(rows) {
+  const normalized = [];
+  for (const row of rows || []) {
+    const n = row && row.rowKey ? row : normalizeUsageRow(row);
+    if (n) normalized.push(n);
+  }
+
+  const legacyTurnIds = new Set();
+  for (const row of normalized) {
+    if (row.source === 'legacy' && row.turnId) legacyTurnIds.add(row.turnId);
+  }
+
+  const seenRowKeys = new Set();
+  const out = [];
+  for (const row of normalized) {
+    if (row.source === 'runtime' && row.turnId && legacyTurnIds.has(row.turnId)) continue;
+    if (seenRowKeys.has(row.rowKey)) continue;
+    seenRowKeys.add(row.rowKey);
+    out.push(row);
+  }
+  return out;
+}
+
+function queryTokenUsageTable(db, tableName, sourceTag) {
+  if (!tableExists(db, tableName)) return [];
+  // Only token/accounting columns — no agent_name, framework_type, or raw payload.
+  // Prefer selecting id when present so multi-step turns stay distinct even if
+  // token counters collide. Fall back without id for very old schemas.
+  const withId = `SELECT id, session_id, turn_id, model, ts,
+                         input_tokens, output_tokens, reasoning_tokens,
+                         cache_read_tokens, cache_write_tokens, cost_usd
+                  FROM ${tableName}`;
+  const withoutId = `SELECT session_id, turn_id, model, ts,
+                            input_tokens, output_tokens, reasoning_tokens,
+                            cache_read_tokens, cache_write_tokens, cost_usd
+                     FROM ${tableName}`;
+  let rows;
+  try {
+    rows = db.prepare(withId).all();
+  } catch (_) {
+    try {
+      rows = db.prepare(withoutId).all();
+    } catch (__) {
+      return [];
+    }
+  }
+  return (rows || []).map((row) => normalizeUsageRow({ ...row, _source: sourceTag })).filter(Boolean);
+}
+
+function readRowsFromDbPath(dbPath, tableName, sourceTag, sqliteMod) {
+  if (!dbPath || !fs.existsSync(dbPath)) return [];
+  if (!sqliteMod) return [];
+  let db;
+  try {
+    db = openReadOnlyDb(dbPath, sqliteMod);
+    return queryTokenUsageTable(db, tableName, sourceTag);
+  } catch (_) {
+    return [];
+  } finally {
+    if (db) {
+      try { db.close(); } catch (_) { /* ignore */ }
+    }
+  }
+}
+
+/**
+ * Collect normalized, deduped usage rows from the MiniMax data root.
+ * Injectable seams: options.rows (skip I/O), options.sqlite, options.homeDir/env.
+ */
+function collectMinimaxRows(options = {}) {
+  if (Array.isArray(options.rows)) {
+    return dedupeUsageRows(options.rows.map((row) => (row && row.dedupeKey ? row : normalizeUsageRow(row))));
+  }
+  const sqliteMod = options.sqlite !== undefined ? options.sqlite : sqlite;
+  if (!sqliteMod) return [];
+  const homeDir = resolveMinimaxHome(options);
+  const legacyRows = readRowsFromDbPath(legacyDbPath(homeDir), 'token_usage', 'legacy', sqliteMod);
+  const runtimeRows = readRowsFromDbPath(runtimeDbPath(homeDir), 'local_runtime_token_usage', 'runtime', sqliteMod);
+  // Within each store keep multi-step rows; cross-store legacy wins by turn_id.
+  return dedupeUsageRows([...legacyRows, ...runtimeRows]);
+}
+
+function windowStartMs(windows) {
+  return Math.max(0, timestampMs(windows.todayStart), timestampMs(windows.monthStart), timestampMs(windows.allTimeSince));
+}
+
+function localDateKey(timestamp) {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '';
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Build a tokscale-compatible JSON object from MiniMax usage rows.
+ */
+function buildTokscaleJson(windows = {}, options = {}) {
+  const sinceMs = windowStartMs(windows);
+  const allRows = collectMinimaxRows(options).filter((row) => {
+    if (!sinceMs) return true;
+    if (!row.createdAt) return options.includeUndated === true;
+    return row.createdAt >= sinceMs;
+  });
+
+  const bySessionModel = new Map();
+  for (const row of allRows) {
+    const key = `${row.sessionId || 'unknown'}\u0000${row.model}`;
+    if (!bySessionModel.has(key)) {
+      bySessionModel.set(key, {
+        sessionId: row.sessionId || 'unknown',
+        model: row.model,
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        reasoning: 0,
+        messages: 0,
+        cost: 0,
+        startedAt: 0,
+        lastUsedAt: 0
+      });
+    }
+    const m = bySessionModel.get(key);
+    m.input += row.input;
+    m.output += row.output;
+    m.cacheRead += row.cacheRead;
+    m.cacheWrite += row.cacheWrite;
+    m.reasoning += row.reasoning;
+    m.messages += Number(row.messages || 1);
+    m.cost += numberValue(row.cost);
+    if (row.createdAt && (!m.startedAt || row.createdAt < m.startedAt)) m.startedAt = row.createdAt;
+    if (row.createdAt > m.lastUsedAt) m.lastUsedAt = row.createdAt;
+  }
+
+  const entries = [];
+  let allInput = 0;
+  let allOutput = 0;
+  let allCacheRead = 0;
+  let allCacheWrite = 0;
+  let allMessages = 0;
+  let allCost = 0;
+
+  for (const m of bySessionModel.values()) {
+    entries.push({
+      client: CLIENT_ID,
+      mergedClients: null,
+      sessionId: m.sessionId,
+      model: m.model,
+      provider: CLIENT_ID,
+      input: m.input,
+      output: m.output,
+      cacheRead: m.cacheRead,
+      cacheWrite: m.cacheWrite,
+      reasoning: m.reasoning,
+      messageCount: m.messages,
+      cost: m.cost,
+      startedAt: m.startedAt ? new Date(m.startedAt).toISOString() : '',
+      lastUsedAt: m.lastUsedAt ? new Date(m.lastUsedAt).toISOString() : '',
+      performance: null
+    });
+    allInput += m.input;
+    allOutput += m.output;
+    allCacheRead += m.cacheRead;
+    allCacheWrite += m.cacheWrite;
+    allMessages += m.messages;
+    allCost += m.cost;
+  }
+
+  return {
+    groupBy: 'client,session,model',
+    entries,
+    totalInput: allInput,
+    totalOutput: allOutput,
+    totalCacheRead: allCacheRead,
+    totalCacheWrite: allCacheWrite,
+    totalMessages: allMessages,
+    totalCost: allCost,
+    processingTimeMs: 0
+  };
+}
+
+function buildMinimaxHistoryGraph(options = {}) {
+  const byDate = new Map();
+  const rows = collectMinimaxRows(options);
+  for (const row of rows) {
+    const date = row.createdAt ? localDateKey(row.createdAt) : '';
+    if (!date) continue;
+    let day = byDate.get(date);
+    if (!day) {
+      day = { date, clients: [] };
+      byDate.set(date, day);
+    }
+    const modelId = String(row.model || 'unknown').toLowerCase();
+    let client = day.clients.find((entry) => entry.modelId === modelId);
+    if (!client) {
+      client = {
+        client: CLIENT_ID,
+        modelId,
+        tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+        cost: 0,
+        messages: 0
+      };
+      day.clients.push(client);
+    }
+    client.tokens.input += row.input;
+    client.tokens.output += row.output;
+    client.tokens.cacheRead += row.cacheRead;
+    client.tokens.cacheWrite += row.cacheWrite;
+    client.tokens.reasoning += row.reasoning;
+    client.cost += numberValue(row.cost);
+    client.messages += 1;
+  }
+  return { contributions: [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date)) };
+}
+
+function buildMinimaxPeriods(options = {}) {
+  const now = options.now ? new Date(options.now) : new Date();
+  const rows = Array.isArray(options.rows) ? dedupeUsageRows(options.rows) : collectMinimaxRows(options);
+  const buildOptions = { rows, sqlite: options.sqlite, homeDir: options.homeDir, env: options.env };
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0).getTime();
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1, 0, 0, 0, 0).getTime();
+  return {
+    today: buildTokscaleJson({ todayStart }, buildOptions),
+    month: buildTokscaleJson({ monthStart }, buildOptions),
+    allTime: buildTokscaleJson({ allTimeSince: options.allTimeSince }, { ...buildOptions, includeUndated: true })
+  };
+}
+
+module.exports = {
+  CLIENT_ID,
+  resolveMinimaxHome,
+  legacyDbPath,
+  runtimeDbPath,
+  normalizeUsageRow,
+  dedupeUsageRows,
+  collectMinimaxRows,
+  buildTokscaleJson,
+  buildMinimaxHistoryGraph,
+  buildMinimaxPeriods
+};

--- a/src/shared/promaUsage.js
+++ b/src/shared/promaUsage.js
@@ -14,33 +14,18 @@ const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 const { createHash } = require('node:crypto');
+const {
+  numberValue,
+  timestampMs,
+  normalizedModelId,
+  localDateKey,
+  localPeriodBounds
+} = require('./localUsageHelpers');
 
 const PROMA_ROOT = path.join(os.homedir(), '.proma', 'agent-sessions');
 
-function numberValue(value) {
-  const n = Number(value || 0);
-  return Number.isFinite(n) ? n : 0;
-}
-
-function timestampMs(value) {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return value > 0 && value < 1e12 ? value * 1000 : value;
-  }
-  if (typeof value === 'string' && value.trim()) {
-    const numeric = Number(value);
-    if (Number.isFinite(numeric)) return numeric > 0 && numeric < 1e12 ? numeric * 1000 : numeric;
-    const parsed = Date.parse(value);
-    return Number.isNaN(parsed) ? 0 : parsed;
-  }
-  return 0;
-}
-
 function rowTotal(row) {
   return row.input + row.output + row.cacheRead + row.cacheWrite;
-}
-
-function normalizedModelId(value) {
-  return String(value || '').trim().toLowerCase();
 }
 
 // Cost is an estimate from a model-price catalog, never a provider invoice.
@@ -262,15 +247,6 @@ function buildTokscaleJson(windows = {}, options = {}) {
   };
 }
 
-function localDateKey(timestamp) {
-  const date = new Date(timestamp);
-  if (Number.isNaN(date.getTime())) return '';
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
-
 // Return raw graph-compatible contributions so collector.js can merge this
 // local adapter with tokscale's graph output through the shared history core.
 function buildPromaHistoryGraph(options = {}) {
@@ -314,11 +290,9 @@ function buildPromaHistoryGraph(options = {}) {
  * @param {{ now?: Date | number | string, allTimeSince?: number | string, roots?: string[] }} options
  */
 function buildPromaPeriods(options = {}) {
-  const now = options.now ? new Date(options.now) : new Date();
+  const { todayStart, monthStart } = localPeriodBounds(options.now);
   const rows = Array.isArray(options.rows) ? options.rows : collectPromaRows(options);
   const buildOptions = { rows, pricingByModel: options.pricingByModel };
-  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0).getTime();
-  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1, 0, 0, 0, 0).getTime();
 
   return {
     today: buildTokscaleJson({ todayStart }, buildOptions),

--- a/src/shared/usage.js
+++ b/src/shared/usage.js
@@ -133,6 +133,7 @@ function normalizeClientName(value) {
   if (raw.includes('codebuddy')) return 'codebuddy';
   if (raw.includes('workbuddy')) return 'workbuddy';
   if (raw.includes('proma')) return 'proma';
+  if (raw.includes('minimax')) return 'minimax';
   if (raw.includes('opencode')) return 'opencode';
   if (raw.includes('openclaw') || raw.includes('clawd') || raw.includes('moltbot') || raw.includes('moldbot')) return 'openclaw';
   return raw.replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '') || null;

--- a/src/shared/wslUsage.js
+++ b/src/shared/wslUsage.js
@@ -4,6 +4,7 @@ const fs = require('node:fs');
 const { execFileSync } = require('node:child_process');
 const { emptyPeriod, extractUsageFromTokscale, mergePeriods } = require('./usage');
 const { buildPromaPeriods, collectPromaRows } = require('./promaUsage');
+const { buildMinimaxPeriods, collectMinimaxRows } = require('./minimaxUsage');
 
 const LXSS_KEY = 'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss';
 
@@ -44,7 +45,10 @@ const WSL_DATA_MARKERS = [
   '.config/kiro/User/globalStorage/kiro.kiroagent',
   '.codebuddy/projects',
   '.workbuddy',
-  '.proma/agent-sessions'
+  '.proma/agent-sessions',
+  '.minimax',
+  '.minimax/sqlite.db',
+  '.minimax/v2/sqlite/runtime-state.sqlite'
 ];
 
 // Maps every WSL_DATA_MARKERS entry to the tracked-client id that owns it, so a
@@ -84,7 +88,10 @@ const MARKER_CLIENTS = {
   '.config/kiro/User/globalStorage/kiro.kiroagent': 'kiro',
   '.codebuddy/projects': 'codebuddy',
   '.workbuddy': 'workbuddy',
-  '.proma/agent-sessions': 'proma'
+  '.proma/agent-sessions': 'proma',
+  '.minimax': 'minimax',
+  '.minimax/sqlite.db': 'minimax',
+  '.minimax/v2/sqlite/runtime-state.sqlite': 'minimax'
 };
 
 // Clients whose tokscale `--home` scan can fall back to a HOST-native database
@@ -226,6 +233,8 @@ async function collectWslUsage(options = {}, deps = {}) {
   const { clients, trackedClients = clients, allTimeSince, commandTimeoutMs, now, runTokscale, logger, decoratePeriods } = options;
   const buildProma = options.buildPromaPeriods || buildPromaPeriods;
   const collectProma = options.collectPromaRows || collectPromaRows;
+  const buildMinimax = options.buildMinimaxPeriods || buildMinimaxPeriods;
+  const collectMinimax = options.collectMinimaxRows || collectMinimaxRows;
   const existsSync = deps.existsSync || fs.existsSync;
   const readdirSync = deps.readdirSync || fs.readdirSync;
   const bundle = emptyWslBundle();
@@ -266,6 +275,26 @@ async function collectWslUsage(options = {}, deps = {}) {
         bundle.allTime = mergePeriods(bundle.allTime, extractUsageFromTokscale(proma.allTime));
       } catch (error) {
         if (typeof logger === 'function') logger(`wsl Proma usage parse failed for ${home}: ${error.message}`);
+      }
+    }
+    // MiniMax Code is also parse-local (not a tokscale client). Isolate the
+    // WSL home's ~/.minimax so host MiniMax usage is not double-counted.
+    if (tracked.has('minimax') && homeDataClients.includes('minimax')) {
+      try {
+        const minimaxOptions = {
+          now,
+          allTimeSince,
+          homeDir: wslHomePath(home, '.minimax')
+        };
+        if (typeof collectMinimax === 'function') {
+          minimaxOptions.rows = collectMinimax(minimaxOptions);
+        }
+        const minimax = buildMinimax(minimaxOptions);
+        bundle.today = mergePeriods(bundle.today, extractUsageFromTokscale(minimax.today));
+        bundle.month = mergePeriods(bundle.month, extractUsageFromTokscale(minimax.month));
+        bundle.allTime = mergePeriods(bundle.allTime, extractUsageFromTokscale(minimax.allTime));
+      } catch (error) {
+        if (typeof logger === 'function') logger(`wsl MiniMax usage parse failed for ${home}: ${error.message}`);
       }
     }
     // Pass the requested clients through, dropping only a host-fallback-gated

--- a/tests/shared/clientTracking.test.js
+++ b/tests/shared/clientTracking.test.js
@@ -42,7 +42,8 @@ test('KNOWN_CLIENTS is a superset of DEFAULT_CLIENTS and still includes opt-in m
 });
 
 test('default tracked clients are accepted by bundled tokscale', () => {
-  const locallyParsedClients = new Set(['proma']);
+  // Parse-local clients (no tokscale --client value): proma + minimax (MiniMax Code).
+  const locallyParsedClients = new Set(['proma', 'minimax']);
   const result = spawnSync(process.execPath, [require.resolve('tokscale/bin.js'), '--help'], { encoding: 'utf8' });
   assert.equal(result.status, 0, result.stderr || result.stdout);
   const help = `${result.stdout || ''}\n${result.stderr || ''}`;
@@ -51,6 +52,11 @@ test('default tracked clients are accepted by bundled tokscale', () => {
   const supported = new Set(possibleValues[1].split(',').map((client) => client.trim()).filter(Boolean));
   const unsupported = DEFAULT_CLIENTS.split(',').filter((client) => !supported.has(client) && !locallyParsedClients.has(client));
   assert.deepEqual(unsupported, []);
+});
+
+test('minimax is default-tracked as a parse-local client', () => {
+  assert.ok(DEFAULT_CLIENTS.split(',').includes('minimax'), 'minimax should be tracked by default');
+  assert.ok(KNOWN_CLIENTS.split(',').includes('minimax'), 'minimax must be a known client');
 });
 
 test('clientsCsvForSetting preserves explicit empty tracked-tool selection', () => {

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -323,11 +323,17 @@ test('watchPathsForClients watches the Hermes home dir so new state.db sidecars 
 
 test('watchIgnoreMatcher prunes the Hermes runtime but keeps the state.db family and the watch root', () => {
   const tmp = withTmpHome([path.join('.hermes', 'hermes-agent', 'node_modules')]);
+  // Seed a root state.db so resolveHermesHome prefers ~/.hermes over a real
+  // %LOCALAPPDATA%\hermes install on the developer machine (Windows).
+  fs.writeFileSync(path.join(tmp, '.hermes', 'state.db'), '');
   const originalHomedir = os.homedir;
   const previousHermesHome = process.env.HERMES_HOME;
+  const previousLocalAppData = process.env.LOCALAPPDATA;
   os.homedir = () => tmp;
   try {
     delete process.env.HERMES_HOME;
+    // Isolate from the host's native Hermes install under %LOCALAPPDATA%.
+    process.env.LOCALAPPDATA = path.join(tmp, 'AppData', 'Local');
     const { watchIgnoreMatcher } = freshCollector();
     const ignored = watchIgnoreMatcher('claude,hermes');
     const hermes = path.join(tmp, '.hermes');
@@ -347,6 +353,52 @@ test('watchIgnoreMatcher prunes the Hermes runtime but keeps the state.db family
     os.homedir = originalHomedir;
     if (previousHermesHome === undefined) delete process.env.HERMES_HOME;
     else process.env.HERMES_HOME = previousHermesHome;
+    if (previousLocalAppData === undefined) delete process.env.LOCALAPPDATA;
+    else process.env.LOCALAPPDATA = previousLocalAppData;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('watchIgnoreMatcher prunes MiniMax sessions/agents but keeps usage SQLite files', () => {
+  const tmp = withTmpHome([
+    path.join('.minimax', 'sessions', 'mvs_abc'),
+    path.join('.minimax', 'agents', 'mavis'),
+    path.join('.minimax', 'v2', 'sqlite')
+  ]);
+  fs.writeFileSync(path.join(tmp, '.minimax', 'sqlite.db'), '');
+  fs.writeFileSync(path.join(tmp, '.minimax', 'v2', 'sqlite', 'runtime-state.sqlite'), '');
+  const originalHomedir = os.homedir;
+  const previousMinimaxHome = process.env.MINIMAX_HOME;
+  const previousMavisHome = process.env.MAVIS_HOME;
+  os.homedir = () => tmp;
+  try {
+    delete process.env.MINIMAX_HOME;
+    delete process.env.MAVIS_HOME;
+    const { watchIgnoreMatcher, watchPathsForClients } = freshCollector();
+    const paths = watchPathsForClients('minimax');
+    const minimaxHome = path.join(tmp, '.minimax');
+    assert.ok(paths.includes(minimaxHome));
+    assert.ok(paths.includes(path.join(minimaxHome, 'v2', 'sqlite')));
+    const ignored = watchIgnoreMatcher('minimax');
+    assert.equal(typeof ignored, 'function');
+    // Watch roots + usage DB family stay visible.
+    assert.equal(ignored(minimaxHome), false);
+    assert.equal(ignored(path.join(minimaxHome, 'sqlite.db')), false);
+    assert.equal(ignored(path.join(minimaxHome, 'sqlite.db-wal')), false);
+    assert.equal(ignored(path.join(minimaxHome, 'v2')), false);
+    assert.equal(ignored(path.join(minimaxHome, 'v2', 'sqlite')), false);
+    assert.equal(ignored(path.join(minimaxHome, 'v2', 'sqlite', 'runtime-state.sqlite')), false);
+    // Conversation / agent trees are pruned (not polled, not opened).
+    assert.equal(ignored(path.join(minimaxHome, 'sessions')), true);
+    assert.equal(ignored(path.join(minimaxHome, 'sessions', 'mvs_abc')), true);
+    assert.equal(ignored(path.join(minimaxHome, 'agents', 'mavis')), true);
+  } finally {
+    os.homedir = originalHomedir;
+    if (previousMinimaxHome === undefined) delete process.env.MINIMAX_HOME;
+    else process.env.MINIMAX_HOME = previousMinimaxHome;
+    if (previousMavisHome === undefined) delete process.env.MAVIS_HOME;
+    else process.env.MAVIS_HOME = previousMavisHome;
     delete require.cache[collectorPath];
     fs.rmSync(tmp, { recursive: true, force: true });
   }

--- a/tests/shared/minimaxUsage.test.js
+++ b/tests/shared/minimaxUsage.test.js
@@ -54,6 +54,38 @@ function row({
   });
 }
 
+test('normalizedModelId lowercases model ids so casing does not split buckets', () => {
+  const a = row({ turnId: 't1', model: 'minimax/MiniMax-M3', input: 10, source: 'legacy' });
+  const b = row({ turnId: 't2', model: 'minimax/minimax-m3', input: 5, source: 'legacy' });
+  const usage = extractUsageFromTokscale(buildTokscaleJson({}, { rows: [a, b] }));
+  assert.equal(Object.keys(usage.models).length, 1);
+  assert.equal(usage.models['minimax/minimax-m3'], 15);
+});
+
+test('dedupeUsageRows re-normalizes prebuilt rows so missing source still applies legacy-wins', () => {
+  // Simulate a pre-normalized legacy row that only has field aliases (no source).
+  const legacyLike = {
+    sessionId: 's1',
+    turnId: 'shared',
+    model: 'minimax/M3',
+    createdAt: localMs(2026, 6, 9, 12, 0),
+    input: 100,
+    output: 0,
+    reasoning: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    cost: 0,
+    source: 'legacy',
+    rowKey: 'prebuilt-legacy'
+  };
+  const runtime = row({ turnId: 'shared', input: 999, source: 'runtime' });
+  const deduped = dedupeUsageRows([legacyLike, runtime]);
+  assert.equal(deduped.length, 1);
+  assert.equal(deduped[0].source, 'legacy');
+  assert.equal(deduped[0].model, 'minimax/m3');
+  assert.equal(deduped[0].input, 100);
+});
+
 test('normalizeUsageRow maps MiniMax token_usage columns and ignores reasoning in total', () => {
   const normalized = normalizeUsageRow({
     id: 42,

--- a/tests/shared/minimaxUsage.test.js
+++ b/tests/shared/minimaxUsage.test.js
@@ -1,0 +1,358 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  CLIENT_ID,
+  normalizeUsageRow,
+  dedupeUsageRows,
+  collectMinimaxRows,
+  buildTokscaleJson,
+  buildMinimaxPeriods,
+  buildMinimaxHistoryGraph,
+  resolveMinimaxHome,
+  legacyDbPath,
+  runtimeDbPath
+} = require('../../src/shared/minimaxUsage');
+const { extractUsageFromTokscale, mergePeriods } = require('../../src/shared/usage');
+const { LOCALLY_PARSED_CLIENTS } = require('../../src/shared/collector');
+
+// Local wall-clock helpers so period windows are timezone-stable across CI hosts.
+function localMs(year, monthIndex, day, hour = 12, minute = 0) {
+  return new Date(year, monthIndex, day, hour, minute, 0, 0).getTime();
+}
+
+function row({
+  sessionId = 'mvs_test',
+  turnId = '',
+  model = 'minimax/MiniMax-M3',
+  ts = localMs(2026, 6, 9, 12, 0),
+  input = 0,
+  output = 0,
+  reasoning = 0,
+  cacheRead = 0,
+  cacheWrite = 0,
+  cost = 0,
+  source = 'legacy'
+} = {}) {
+  return normalizeUsageRow({
+    session_id: sessionId,
+    turn_id: turnId,
+    model,
+    ts,
+    input_tokens: input,
+    output_tokens: output,
+    reasoning_tokens: reasoning,
+    cache_read_tokens: cacheRead,
+    cache_write_tokens: cacheWrite,
+    cost_usd: cost,
+    _source: source
+  });
+}
+
+test('normalizeUsageRow maps MiniMax token_usage columns and ignores reasoning in total', () => {
+  const normalized = normalizeUsageRow({
+    id: 42,
+    session_id: 'mvs_1',
+    turn_id: 'turn-a',
+    model: 'minimax/MiniMax-M3',
+    ts: 1784033553109,
+    input_tokens: 100,
+    output_tokens: 20,
+    reasoning_tokens: 5,
+    cache_read_tokens: 50,
+    cache_write_tokens: 10,
+    cost_usd: 0.01,
+    _source: 'runtime'
+  });
+  assert.equal(normalized.sessionId, 'mvs_1');
+  assert.equal(normalized.turnId, 'turn-a');
+  assert.equal(normalized.input, 100);
+  assert.equal(normalized.output, 20);
+  assert.equal(normalized.reasoning, 5);
+  assert.equal(normalized.cacheRead, 50);
+  assert.equal(normalized.cacheWrite, 10);
+  assert.equal(normalized.total, 180); // 100+20+50+10 — reasoning not added
+  // row identity is per-step (id), never turn_id alone
+  assert.equal(normalized.rowKey, 'runtime:id:42');
+  assert.equal(normalized.dedupeKey, normalized.rowKey);
+  // Least privilege: agent/framework never retained on the row object
+  assert.equal(normalized.agentName, undefined);
+  assert.equal(normalized.frameworkType, undefined);
+});
+
+test('dedupeUsageRows drops runtime turn_id already present in legacy (legacy wins)', () => {
+  const legacy = row({ turnId: 'shared-turn', input: 100, output: 10, source: 'legacy' });
+  const runtime = row({ turnId: 'shared-turn', input: 100, output: 10, source: 'runtime', ts: localMs(2026, 6, 9, 12, 1) });
+  const onlyRuntime = row({ turnId: 'runtime-only', input: 40, output: 2, source: 'runtime' });
+  const deduped = dedupeUsageRows([legacy, runtime, onlyRuntime]);
+  assert.equal(deduped.length, 2);
+  assert.equal(deduped[0].source, 'legacy');
+  assert.equal(deduped[1].turnId, 'runtime-only');
+  const total = deduped.reduce((sum, r) => sum + r.total, 0);
+  assert.equal(total, 110 + 42);
+});
+
+test('same-store multi-step same turn_id must SUM (live runtime shape)', () => {
+  // Live local_runtime_token_usage: one turn_id owns many model-call rows with
+  // different id/ts/token totals. Collapsing to first-wins undercounts ~10M tokens.
+  const turnId = 'turn_task_bg_example';
+  const steps = [
+    row({ turnId, input: 18401, output: 398, cacheRead: 242, source: 'runtime', ts: localMs(2026, 6, 9, 12, 0) }),
+    row({ turnId, input: 198, output: 42, cacheRead: 19027, source: 'runtime', ts: localMs(2026, 6, 9, 12, 1) }),
+    row({ turnId, input: 123, output: 37, cacheRead: 19253, source: 'runtime', ts: localMs(2026, 6, 9, 12, 2) })
+  ];
+  // Distinct step totals: 19041 + 19267 + 19413 = 57721
+  const expected = steps.reduce((sum, r) => sum + r.total, 0);
+  assert.equal(expected, 57721);
+  const deduped = dedupeUsageRows(steps);
+  assert.equal(deduped.length, 3, 'all multi-step rows must survive');
+  assert.equal(deduped.reduce((sum, r) => sum + r.total, 0), expected);
+
+  const usage = extractUsageFromTokscale(buildTokscaleJson({}, { rows: steps }));
+  assert.equal(usage.clients.minimax, expected);
+  assert.equal(usage.totalTokens, expected);
+});
+
+test('legacy multi-step same turn_id also sums; runtime clones of that turn are dropped', () => {
+  const turnId = 'turn-migrated';
+  const legacySteps = [
+    row({ turnId, input: 50, output: 5, source: 'legacy', ts: localMs(2026, 6, 9, 10, 0) }),
+    row({ turnId, input: 20, output: 3, source: 'legacy', ts: localMs(2026, 6, 9, 10, 1) })
+  ];
+  const runtimeCloneSteps = [
+    row({ turnId, input: 50, output: 5, source: 'runtime', ts: localMs(2026, 6, 9, 10, 0) }),
+    row({ turnId, input: 20, output: 3, source: 'runtime', ts: localMs(2026, 6, 9, 10, 1) }),
+    row({ turnId, input: 999, output: 1, source: 'runtime', ts: localMs(2026, 6, 9, 10, 2) })
+  ];
+  const usage = extractUsageFromTokscale(buildTokscaleJson({}, {
+    rows: [...legacySteps, ...runtimeCloneSteps]
+  }));
+  // Only legacy steps: 55 + 23 = 78 — not runtime's extra 1000
+  assert.equal(usage.clients.minimax, 78);
+});
+
+test('dedupeUsageRows collapses only exact row clones when turn_id is empty', () => {
+  const a = row({ turnId: '', sessionId: 's1', ts: 1000, input: 10, output: 1, source: 'runtime' });
+  const b = row({ turnId: '', sessionId: 's1', ts: 1000, input: 10, output: 1, source: 'runtime' });
+  const c = row({ turnId: '', sessionId: 's1', ts: 1000, input: 11, output: 1, source: 'runtime' });
+  assert.equal(dedupeUsageRows([a, b, c]).length, 2);
+});
+
+test('empty / missing home yields empty usage without throw', () => {
+  const missing = path.join(os.tmpdir(), `minimax-missing-${Date.now()}`);
+  const rows = collectMinimaxRows({ homeDir: missing });
+  assert.deepEqual(rows, []);
+  const periods = buildMinimaxPeriods({ homeDir: missing, now: '2026-07-09T12:00:00.000Z' });
+  const usage = extractUsageFromTokscale(periods.allTime);
+  assert.equal(usage.totalTokens, 0);
+  assert.equal(usage.clients.minimax, undefined);
+});
+
+test('single-store multi-model rows aggregate under client minimax', () => {
+  const rows = [
+    row({ sessionId: 's1', turnId: 't1', model: 'minimax/MiniMax-M3', input: 100, output: 20, cacheRead: 30, ts: localMs(2026, 6, 9, 10, 0) }),
+    row({ sessionId: 's1', turnId: 't2', model: 'minimax/MiniMax-M2.7', input: 40, output: 5, ts: localMs(2026, 6, 9, 11, 0) }),
+    row({ sessionId: 's2', turnId: 't3', model: 'minimax/MiniMax-M3', input: 10, output: 1, ts: localMs(2026, 6, 8, 10, 0) })
+  ];
+  const periods = buildMinimaxPeriods({
+    now: new Date(2026, 6, 9, 13, 0, 0, 0),
+    allTimeSince: '2026-01-01',
+    rows
+  });
+  const today = extractUsageFromTokscale(periods.today);
+  const allTime = extractUsageFromTokscale(periods.allTime);
+
+  // today: 100+20+30 + 40+5 = 195
+  assert.equal(today.clients.minimax, 195);
+  assert.equal(today.totalTokens, 195);
+  assert.ok(Object.keys(today.models).some((k) => k.toLowerCase().includes('m3')));
+  // allTime includes yesterday's 11
+  assert.equal(allTime.clients.minimax, 206);
+  assert.equal(CLIENT_ID, 'minimax');
+  for (const entry of periods.today.entries) {
+    assert.equal(entry.client, 'minimax');
+  }
+});
+
+test('dual-store fixture with shared turn does not double-count through shipped aggregation', () => {
+  const sharedTurn = 'turn-shared-1';
+  const rows = [
+    row({ turnId: sharedTurn, input: 80, output: 20, cacheRead: 100, source: 'legacy', ts: localMs(2026, 6, 9, 12, 0) }),
+    // runtime multi-step for the same turn_id must be fully dropped (legacy wins)
+    row({ turnId: sharedTurn, input: 80, output: 20, cacheRead: 100, source: 'runtime', ts: localMs(2026, 6, 9, 12, 0) }),
+    row({ turnId: sharedTurn, input: 1, output: 1, source: 'runtime', ts: localMs(2026, 6, 9, 12, 1) }),
+    row({ turnId: 'turn-runtime-only', input: 15, output: 5, source: 'runtime', ts: localMs(2026, 6, 9, 12, 30) })
+  ];
+  const periods = buildMinimaxPeriods({ now: new Date(2026, 6, 9, 18, 0, 0, 0), allTimeSince: '2026-01-01', rows });
+  const usage = extractUsageFromTokscale(periods.today);
+  // shared legacy once (200) + runtime-only (20) = 220 — not 422
+  assert.equal(usage.clients.minimax, 220);
+  assert.equal(usage.totalTokens, 220);
+});
+
+test('period windows filter by local day boundaries using injected now', () => {
+  const rows = [
+    row({ turnId: 'old', ts: localMs(2026, 6, 8, 23, 0), input: 100 }),
+    row({ turnId: 'new', ts: localMs(2026, 6, 9, 1, 0), input: 40, output: 2 })
+  ];
+  const periods = buildMinimaxPeriods({ now: new Date(2026, 6, 9, 12, 0, 0, 0), allTimeSince: '2026-01-01', rows });
+  const today = extractUsageFromTokscale(periods.today);
+  const month = extractUsageFromTokscale(periods.month);
+  assert.equal(today.clients.minimax, 42);
+  assert.equal(month.clients.minimax, 142);
+});
+
+test('history graph attributes days to minimax client id', () => {
+  const graph = buildMinimaxHistoryGraph({
+    rows: [
+      row({ turnId: 'a', ts: localMs(2026, 6, 9, 10, 0), input: 10, output: 1 }),
+      row({ turnId: 'b', ts: localMs(2026, 6, 9, 11, 0), input: 5, output: 2 })
+    ]
+  });
+  assert.ok(graph.contributions.length >= 1);
+  for (const day of graph.contributions) {
+    for (const c of day.clients) {
+      assert.equal(c.client, 'minimax');
+    }
+  }
+});
+
+test('resolveMinimaxHome respects MINIMAX_HOME then MAVIS_HOME then default', () => {
+  const custom = path.join(os.tmpdir(), 'custom-minimax-home');
+  assert.equal(resolveMinimaxHome({ env: { MINIMAX_HOME: custom } }), path.resolve(custom));
+  assert.equal(resolveMinimaxHome({ env: { MAVIS_HOME: custom, HOME: '/tmp/x' } }), path.resolve(custom));
+  const def = resolveMinimaxHome({ env: { HOME: '/tmp/userhome', USERPROFILE: '' } });
+  assert.equal(def, path.join('/tmp/userhome', '.minimax'));
+  assert.equal(legacyDbPath(custom), path.join(custom, 'sqlite.db'));
+  assert.equal(runtimeDbPath(custom), path.join(custom, 'v2', 'sqlite', 'runtime-state.sqlite'));
+});
+
+test('minimax is a locally-parsed client (excluded from tokscale CSV path)', () => {
+  assert.ok(LOCALLY_PARSED_CLIENTS.has('minimax'));
+  assert.ok(LOCALLY_PARSED_CLIENTS.has('proma'));
+});
+
+test('minimax client id is never confused with opencode in shipped extraction', () => {
+  const minimaxJson = buildTokscaleJson({}, { rows: [row({ turnId: 'm1', input: 10 })] });
+  assert.equal(minimaxJson.entries[0].client, 'minimax');
+  const usage = extractUsageFromTokscale(minimaxJson);
+  assert.equal(usage.clients.minimax, 10);
+  assert.equal(usage.clients.opencode, undefined);
+});
+
+test('mergePeriods keeps minimax separate from opencode', () => {
+  const minimaxPeriod = extractUsageFromTokscale(buildTokscaleJson({}, {
+    rows: [row({ turnId: 'm1', input: 50, output: 5 })]
+  }));
+  const opencodePeriod = {
+    totalTokens: 30,
+    costUsd: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    outputTokens: 0,
+    clients: { opencode: 30 },
+    clientCosts: {},
+    clientCacheReads: {},
+    clientCacheWrites: {},
+    clientOutputs: {},
+    models: {},
+    modelCosts: {},
+    modelCacheReads: {},
+    modelCacheWrites: {},
+    modelOutputs: {},
+    clientModels: {},
+    clientModelCosts: {},
+    projects: Object.create(null),
+    sessions: {}
+  };
+  const merged = mergePeriods(opencodePeriod, minimaxPeriod);
+  assert.equal(merged.clients.opencode, 30);
+  assert.equal(merged.clients.minimax, 55);
+  assert.equal(merged.totalTokens, 85);
+});
+
+test('real-shaped sqlite fixture path is readable by collectMinimaxRows when present', () => {
+  // Build a tiny on-disk dual-store fixture and drive the real SQLite path.
+  let DatabaseSync;
+  try {
+    ({ DatabaseSync } = require('node:sqlite'));
+  } catch (_) {
+    return; // skip if node:sqlite unavailable
+  }
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'minimax-fixture-'));
+  const legacyPath = legacyDbPath(root);
+  const runtimePath = runtimeDbPath(root);
+  fs.mkdirSync(path.dirname(runtimePath), { recursive: true });
+
+  const legacy = new DatabaseSync(legacyPath);
+  legacy.exec(`CREATE TABLE token_usage (
+    id INTEGER PRIMARY KEY, session_id TEXT, agent_name TEXT, framework_type TEXT,
+    turn_id TEXT, model TEXT, ts INTEGER, input_tokens INTEGER, output_tokens INTEGER,
+    reasoning_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER, cost_usd REAL, raw TEXT
+  )`);
+  legacy.prepare(`INSERT INTO token_usage
+    (session_id, agent_name, framework_type, turn_id, model, ts, input_tokens, output_tokens,
+     reasoning_tokens, cache_read_tokens, cache_write_tokens, cost_usd)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    'mvs_a', 'mavis', 'opencode', 'turn-shared', 'minimax/MiniMax-M3',
+    localMs(2026, 6, 9, 12, 0), 100, 10, 0, 20, 0, 0.01
+  );
+  legacy.close();
+
+  const runtime = new DatabaseSync(runtimePath);
+  runtime.exec(`CREATE TABLE local_runtime_token_usage (
+    id INTEGER PRIMARY KEY, session_id TEXT, agent_name TEXT, framework_type TEXT,
+    turn_id TEXT, model TEXT, ts INTEGER, input_tokens INTEGER, output_tokens INTEGER,
+    reasoning_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER, cost_usd REAL, raw TEXT
+  )`);
+  // Same turn_id as legacy — entire runtime turn must drop (even multi-step).
+  runtime.prepare(`INSERT INTO local_runtime_token_usage
+    (session_id, agent_name, framework_type, turn_id, model, ts, input_tokens, output_tokens,
+     reasoning_tokens, cache_read_tokens, cache_write_tokens, cost_usd)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    'mvs_a', 'mavis', 'pi-agent', 'turn-shared', 'minimax/MiniMax-M3',
+    localMs(2026, 6, 9, 12, 0), 100, 10, 0, 20, 0, 0.01
+  );
+  runtime.prepare(`INSERT INTO local_runtime_token_usage
+    (session_id, agent_name, framework_type, turn_id, model, ts, input_tokens, output_tokens,
+     reasoning_tokens, cache_read_tokens, cache_write_tokens, cost_usd)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    'mvs_a', 'mavis', 'pi-agent', 'turn-shared', 'minimax/MiniMax-M3',
+    localMs(2026, 6, 9, 12, 1), 50, 5, 0, 0, 0, 0
+  );
+  // Runtime-only turn with TWO steps that must both count.
+  runtime.prepare(`INSERT INTO local_runtime_token_usage
+    (session_id, agent_name, framework_type, turn_id, model, ts, input_tokens, output_tokens,
+     reasoning_tokens, cache_read_tokens, cache_write_tokens, cost_usd)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    'mvs_b', 'coder', 'pi-agent', 'turn-only-runtime', 'minimax/MiniMax-M3',
+    localMs(2026, 6, 9, 13, 0), 30, 5, 0, 0, 0, 0
+  );
+  runtime.prepare(`INSERT INTO local_runtime_token_usage
+    (session_id, agent_name, framework_type, turn_id, model, ts, input_tokens, output_tokens,
+     reasoning_tokens, cache_read_tokens, cache_write_tokens, cost_usd)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    'mvs_b', 'coder', 'pi-agent', 'turn-only-runtime', 'minimax/MiniMax-M3',
+    localMs(2026, 6, 9, 13, 1), 10, 2, 0, 0, 0, 0
+  );
+  runtime.close();
+
+  const periods = buildMinimaxPeriods({
+    homeDir: root,
+    now: new Date(2026, 6, 9, 18, 0, 0, 0),
+    allTimeSince: '2026-01-01'
+  });
+  const usage = extractUsageFromTokscale(periods.today);
+  // legacy shared 130 + runtime-only steps 35+12 = 177
+  assert.equal(usage.clients.minimax, 177);
+  assert.equal(usage.totalTokens, 177);
+
+  try {
+    fs.rmSync(root, { recursive: true, force: true });
+  } catch (_) { /* ignore */ }
+});

--- a/tests/shared/wslUsage.test.js
+++ b/tests/shared/wslUsage.test.js
@@ -37,6 +37,13 @@ test('homeHasData maps Proma agent sessions to proma', () => {
   assert.deepEqual(ids, ['proma']);
 });
 
+test('homeHasData maps MiniMax data root to minimax', () => {
+  const home = '\\\\wsl$\\Ubuntu\\home\\u';
+  const present = new Set([`${home}\\.minimax\\sqlite.db`]);
+  const ids = homeHasData(home, (p) => present.has(p));
+  assert.deepEqual(ids, ['minimax']);
+});
+
 test('homeHasData maps VS Code Copilot workspace storage to copilot', () => {
   const home = '\\\\wsl$\\Ubuntu\\home\\u';
   const workspaceRoot = `${home}\\.config\\Code\\User\\workspaceStorage`;
@@ -397,6 +404,41 @@ test('collectWslUsage parses Proma-only WSL homes without calling tokscale', asy
   assert.equal(bundle.today.clients.proma, 10);
   assert.equal(bundle.month.clients.proma, 20);
   assert.equal(bundle.allTime.clients.proma, 30);
+});
+
+test('collectWslUsage parses MiniMax-only WSL homes without calling tokscale', async () => {
+  const home = '\\\\wsl$\\Ubuntu\\home\\u';
+  const now = new Date('2026-07-10T08:00:00.000Z');
+  let minimaxOptions = null;
+  const { bundle, detected } = await collectWslUsage(
+    {
+      clients: '',
+      trackedClients: 'minimax',
+      allTimeSince: '2025-01-01',
+      commandTimeoutMs: 1000,
+      now,
+      buildMinimaxPeriods: (options) => {
+        minimaxOptions = options;
+        return {
+          today: { entries: [{ client: 'minimax', model: 'minimax/m3', input: 7, output: 3 }] },
+          month: { entries: [{ client: 'minimax', model: 'minimax/m3', input: 15 }] },
+          allTime: { entries: [{ client: 'minimax', model: 'minimax/m3', input: 40 }] }
+        };
+      }
+    },
+    {
+      platform: 'win32',
+      exec: (cmd) => (cmd === 'reg' ? 'Lxss' : 'Ubuntu\n'),
+      readdirSync: () => ['u'],
+      existsSync: (p) => p === `${home}\\.minimax` || p === `${home}\\.minimax\\sqlite.db`
+    }
+  );
+  assert.deepEqual(detected, ['minimax']);
+  assert.equal(minimaxOptions.homeDir, `${home}\\.minimax`);
+  assert.equal(minimaxOptions.now, now);
+  assert.equal(bundle.today.clients.minimax, 10);
+  assert.equal(bundle.month.clients.minimax, 15);
+  assert.equal(bundle.allTime.clients.minimax, 40);
 });
 
 test('collectWslUsage applies the cached Proma price to WSL rows', async () => {

--- a/worker/src/shared/usage.js
+++ b/worker/src/shared/usage.js
@@ -136,6 +136,7 @@ function normalizeClientName(value) {
   if (raw.includes('codebuddy')) return 'codebuddy';
   if (raw.includes('workbuddy')) return 'workbuddy';
   if (raw.includes('proma')) return 'proma';
+  if (raw.includes('minimax')) return 'minimax';
   if (raw.includes('opencode')) return 'opencode';
   if (raw.includes('openclaw') || raw.includes('clawd') || raw.includes('moltbot') || raw.includes('moldbot')) return 'openclaw';
   return raw.replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '') || null;


### PR DESCRIPTION
## Summary
- Add parse-local MiniMax Code usage tracking (same pipeline as Proma): read `~/.minimax` `token_usage` + `v2/sqlite/runtime-state.sqlite` `local_runtime_token_usage`, emit tokscale-shaped JSON, merge into today/month/allTime.
- Client id is `minimax` (not OpenCode). Multi-step rows under the same `turn_id` **sum** within a store; cross-store overlaps drop runtime turns already present in legacy.
- Wire default tracking, watch paths, UI/Discord labels, and README tables. Existing MiniMax **limits** API path is unchanged.
- Privacy hardening: SELECT only accounting columns (no agent/raw); chokidar ignores `sessions/` / `agents/` under `~/.minimax` and only keeps usage SQLite (+ WAL/SHM).

## Notes / known semantics
- `messageCount` counts agent/API **steps** (DB rows), not user chat turns.
- `cost` comes from DB `cost_usd` (runtime rows may be 0).
- Enabling both `minimax` and `opencode` could double-count if the same work also landed in OpenCode's DB.
- Override data root with `MINIMAX_HOME` / `MAVIS_HOME` if needed.

## Test plan
- [x] `node --test tests/shared/minimaxUsage.test.js tests/shared/collectorLoadGuards.test.js tests/shared/clientTracking.test.js`
- [x] Live `collectUsageOnce({ clients: 'minimax' })` against `~/.minimax` shows non-zero `clients.minimax`
- [x] Dual-store multi-step fixture: same `turn_id` sums within store; legacy wins cross-store
- [x] Watch ignore: sessions/agents pruned; sqlite.db + runtime-state.sqlite kept
- [ ] Manual: open widget, confirm MiniMax Code row under usage breakdown

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add MiniMax Code local usage tracking by parsing `~/.minimax` SQLite databases and merging results into today, month, and all‑time. Now works under WSL and shows “MiniMax Code” in the UI; the existing limits API path is unchanged.

- **New Features**
  - Parse `sqlite.db` (`token_usage`) and `v2/sqlite/runtime-state.sqlite` (`local_runtime_token_usage`) and emit tokscale‑shaped JSON with client id `minimax`.
  - Sum multi‑step rows under the same `turn_id` within a store; if a `turn_id` exists in legacy, drop matching runtime rows (legacy wins).
  - Integrate into period scans and history; exclude `minimax` from tokscale `--client` and merge like `proma`. Includes WSL homes, isolating each distro’s `~/.minimax`.
  - Privacy-safe watching: only track `sqlite.db*` and `runtime-state.sqlite*`; ignore `sessions/` and `agents/`.
  - UI/docs: add “MiniMax Code” labels, enable `minimax` by default, update `.env.example` and READMEs. Supports `MINIMAX_HOME`/`MAVIS_HOME` overrides.

- **Refactors / Fixes**
  - Lowercase model ids to avoid split buckets.
  - Always re-normalize rows so dedupe preserves `source` and applies legacy‑wins reliably.
  - Extract shared local‑usage helpers reused by `proma` and `minimax`.

<sup>Written for commit b10f9e279b0aba55735a418afc7c564560cd2b0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

