### PR TITLE
fix(home): reload activity history across midnight and on refresh

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -2823,7 +2823,11 @@ async function writeExportTo(dir, periods, options = {}) {
 
 async function fetchStats(options = {}) {
   const force = Boolean(options?.force);
-  const tickOptions = force ? { forceLimits: true } : {};
+  // forceHistory stays independent of `force` on purpose: tool settings, account
+  // sign-ins and limits actions all refresh with { force: true }, so folding the
+  // history rescan into it would spawn the expensive `tokscale graph` on each one.
+  // Only the manual refresh button opts in.
+  const tickOptions = force ? { forceLimits: true, forceHistory: Boolean(options?.forceHistory) } : {};
   if (mode === 'local') {
     if (force && localCollectorHandle) await localCollectorHandle.tick('manual', tickOptions);
     if (localStats) return localStats;

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -4187,6 +4187,7 @@ async function refreshStats(options = {}) {
       // a retry budget that an earlier outage may have exhausted.
       clearTimeout(state.homeHistoryRetryTimer);
       state.homeHistoryRetryTimer = null;
+      state.homeHistoryLoadedSignature = '';
       state.homeHistoryRetrySignature = '';
       state.homeHistoryRetries = 0;
       state.homeHistorySignature = '';

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -3095,9 +3095,11 @@ async function loadHomeHistory() {
   try {
     // Only ever one fetch in flight (homeHistoryBusy), so the response is the freshest
     // history at invoke time and can be taken as-is — no older reply can land on top of
-    // a newer one. If the collector produced a newer history while this was in flight,
-    // the signature recorded above no longer matches state.stats, so the re-render below
-    // re-enters here and pulls it; a mid-fetch change is never left stranded.
+    // a newer one. The signature is recorded before the await on purpose: it stops a
+    // failed or empty fetch from re-triggering on the very next render (renderHome runs
+    // loadHomeHistory every render), which is the #39 spin loop. Recovery is by the next
+    // signature move instead — a newer history arriving mid-fetch, or any later stats
+    // change, no longer matches, so the re-render below re-enters and pulls it.
     state.homeHistory = await window.tokenMonitor.getDashboardHistory();
   } catch (error) {
     console.log(`[home] history failed: ${error.message}`);

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -202,6 +202,8 @@ function normalizeInitialViewValue(value, allowed, fallback) {
 }
 
 const state = { period: normalizeInitialViewValue(initialViewState.period, viewPeriodValues, 'today'), appUpdate: null, breakdown: normalizeInitialViewValue(initialViewState.breakdown, viewBreakdownValues, 'home'), viewSwitcherOpen: false, viewSwitcherHasOpened: false, resetCreditsTooltipHasOpened: false, resetCreditsTooltipActive: false, resetCreditsTooltipRenderPending: false, settings: null, stats: null, homeHistory: null, homeHistoryBusy: false, homeHistoryRequested: false, homeHistorySignature: '', homeHistoryRetries: 0, homeHistoryRetryTimer: null, homeActivityScrollLeft: null, homeActivityFollowEnd: true, homeActivityResizeObserver: null, serviceStatus: null, serviceStatusBusy: false, serviceProvidersExpanded: false, trendSettingsExpanded: false, trendsActivating: false, homeSettingsExpanded: false, homeLimitSettingsExpanded: false, serviceStatusTicker: null, refreshTimer: null, refreshBusy: false, refreshFeedbackTimer: null, currentTotal: 0, rowSignature: '', streamConnected: false, streamFailure: null, mode: 'idle', appInfo: null, tokscaleStatus: null, tokscaleCheck: null, tokscaleBusy: false, hubInfo: null, cursorAccount: { status: null, error: '' }, cursorAccountExpanded: false, codexAccountExpanded: false, codexAccountError: '', codexSignInBusy: false, codexSignInFlowId: '', codexLoginUrl: '', codexLoginStatus: '', codexLoginOutput: '', codexActiveAccount: null, codexPendingActiveAccount: null, codexPendingActiveAccountUntil: 0, codexPendingActiveAccountTimer: null, codexSystemSwitchingAccountId: '', codexSystemSwitchErrorAccountId: '', codexSystemSwitchError: '', codexSwitchPopoverHasOpened: false, codexSwitchPopoverActive: false, codexSwitchPopoverRenderPending: false, customPricingExpanded: false, opencodeProfileCount: 0, opencodeCookieExpanded: false, deepseekAccountExpanded: false, deepseekPendingCheckSince: 0, minimaxAccountExpanded: false, minimaxPendingCheckSince: 0, zaiAccountExpanded: false, zaiPendingCheckSince: 0, zaiteamAccountExpanded: false, zaiteamPendingCheckSince: 0, volcengineAccountExpanded: false, volcenginePendingCheckSince: 0, qoderAccountExpanded: false, qoderPendingCheckSince: 0, kimiAccountExpanded: false, kimiPendingCheckSince: 0, ollamaAccountExpanded: false, ollamaPendingCheckSince: 0, mimoAccountExpanded: false, mimoAccountError: '', copilotAccountExpanded: false, copilotManualExpanded: false, copilotPendingCheckSince: 0, copilotSignInBusy: false, copilotSignInCancelable: false, copilotSignInFlowId: '', copilotAuthorizeMessage: '', copilotLoginStatus: '', copilotErrorMessage: '', floatingBubble: initialFloatingBubble, suppressInitialNumberAnimation: window.__TOKEN_MONITOR_SUPPRESS_INITIAL_NUMBER_ANIMATION__ === true, openSession: null, detailSort: 'time', recordingWindowShortcut: false, windowShortcutInvalid: false };
+state.homeHistoryLoadedSignature = '';
+state.homeHistoryRetrySignature = '';
 state.appUpdateNotesPresentedVersion = '';
 state.periodMotionActive = false;
 state.animateBarsFromZero = false;
@@ -3098,24 +3100,43 @@ async function loadHomeHistory() {
   // recovered by the bounded timer-driven retry in the finally block instead, not by
   // render — so Home is not stranded on the 30-day preview until the history genuinely
   // changes, which for an account with history but no current activity might be never.
+  const requestSignature = homeOverviewApi.homeHistorySignature(state.stats);
   const previewHadDays = homeOverviewApi.historyHasDays(state.stats?.historyPreview);
+  if (state.homeHistoryRetrySignature !== requestSignature) {
+    clearTimeout(state.homeHistoryRetryTimer);
+    state.homeHistoryRetryTimer = null;
+    state.homeHistoryRetrySignature = requestSignature;
+    state.homeHistoryRetries = 0;
+  }
   state.homeHistoryRequested = true;
-  state.homeHistorySignature = homeOverviewApi.homeHistorySignature(state.stats);
+  state.homeHistorySignature = requestSignature;
   state.homeHistoryBusy = true;
+  let resolved = false;
+  let fetchedHistory = null;
   try {
     // Only ever one fetch in flight (homeHistoryBusy), so the response is the freshest
     // history at invoke time and can be taken as-is — no older reply can land on top of
     // a newer one.
-    state.homeHistory = await window.tokenMonitor.getDashboardHistory();
+    fetchedHistory = await window.tokenMonitor.getDashboardHistory();
+    resolved = true;
   } catch (error) {
     console.log(`[home] history failed: ${error.message}`);
   } finally {
     state.homeHistoryBusy = false;
-    const loadedDays = homeOverviewApi.historyHasDays(state.homeHistory);
-    if (loadedDays) {
+    const outcome = homeOverviewApi.homeHistoryFetchOutcome({
+      resolved,
+      history: fetchedHistory,
+      previewHasDays: previewHadDays
+    });
+    if (outcome.accepted) {
+      state.homeHistory = fetchedHistory;
+      state.homeHistoryLoadedSignature = requestSignature;
       state.homeHistoryRetries = 0;
+      state.homeHistoryRetrySignature = '';
+      clearTimeout(state.homeHistoryRetryTimer);
+      state.homeHistoryRetryTimer = null;
     } else if (homeOverviewApi.shouldRetryHomeHistory({
-      loadedDays,
+      loadedDays: outcome.loadedDays,
       previewHasDays: previewHadDays,
       retries: state.homeHistoryRetries,
       maxRetries: HOME_HISTORY_MAX_RETRIES
@@ -3124,11 +3145,12 @@ async function loadHomeHistory() {
       clearTimeout(state.homeHistoryRetryTimer);
       state.homeHistoryRetryTimer = setTimeout(() => {
         state.homeHistoryRetryTimer = null;
-        // Skip if a later success already populated Home in the meantime.
-        if (!homeOverviewApi.historyHasDays(state.homeHistory)) {
-          state.homeHistorySignature = '';
-          void loadHomeHistory();
-        }
+        // Stale display data is not proof that this signature loaded. Retry only
+        // while the target is still current and no later request accepted it.
+        if (state.homeHistoryLoadedSignature === requestSignature) return;
+        if (homeOverviewApi.homeHistorySignature(state.stats) !== requestSignature) return;
+        state.homeHistorySignature = '';
+        void loadHomeHistory();
       }, HOME_HISTORY_RETRY_MS);
     }
     if (state.breakdown === 'home') render();
@@ -4159,6 +4181,16 @@ async function refreshStats(options = {}) {
   }
   try {
     state.stats = overlayAllTimeSessions(await window.tokenMonitor.getStats(options));
+    if (options.forceHistory === true) {
+      // A manual history rescan is an explicit retry boundary. Let Home request the
+      // corresponding full payload even when its revision is unchanged, and restore
+      // a retry budget that an earlier outage may have exhausted.
+      clearTimeout(state.homeHistoryRetryTimer);
+      state.homeHistoryRetryTimer = null;
+      state.homeHistoryRetrySignature = '';
+      state.homeHistoryRetries = 0;
+      state.homeHistorySignature = '';
+    }
     applyCodexActiveAccountFromStats();
     setStatus(statusTextFor(state.mode, state.streamConnected));
     render();

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -201,7 +201,7 @@ function normalizeInitialViewValue(value, allowed, fallback) {
   return allowed.has(raw) ? raw : fallback;
 }
 
-const state = { period: normalizeInitialViewValue(initialViewState.period, viewPeriodValues, 'today'), appUpdate: null, breakdown: normalizeInitialViewValue(initialViewState.breakdown, viewBreakdownValues, 'home'), viewSwitcherOpen: false, viewSwitcherHasOpened: false, resetCreditsTooltipHasOpened: false, resetCreditsTooltipActive: false, resetCreditsTooltipRenderPending: false, settings: null, stats: null, homeHistory: null, homeHistoryBusy: false, homeHistoryRequested: false, homeHistorySignature: '', homeActivityScrollLeft: null, homeActivityFollowEnd: true, homeActivityResizeObserver: null, serviceStatus: null, serviceStatusBusy: false, serviceProvidersExpanded: false, trendSettingsExpanded: false, trendsActivating: false, homeSettingsExpanded: false, homeLimitSettingsExpanded: false, serviceStatusTicker: null, refreshTimer: null, refreshBusy: false, refreshFeedbackTimer: null, currentTotal: 0, rowSignature: '', streamConnected: false, streamFailure: null, mode: 'idle', appInfo: null, tokscaleStatus: null, tokscaleCheck: null, tokscaleBusy: false, hubInfo: null, cursorAccount: { status: null, error: '' }, cursorAccountExpanded: false, codexAccountExpanded: false, codexAccountError: '', codexSignInBusy: false, codexSignInFlowId: '', codexLoginUrl: '', codexLoginStatus: '', codexLoginOutput: '', codexActiveAccount: null, codexPendingActiveAccount: null, codexPendingActiveAccountUntil: 0, codexPendingActiveAccountTimer: null, codexSystemSwitchingAccountId: '', codexSystemSwitchErrorAccountId: '', codexSystemSwitchError: '', codexSwitchPopoverHasOpened: false, codexSwitchPopoverActive: false, codexSwitchPopoverRenderPending: false, customPricingExpanded: false, opencodeProfileCount: 0, opencodeCookieExpanded: false, deepseekAccountExpanded: false, deepseekPendingCheckSince: 0, minimaxAccountExpanded: false, minimaxPendingCheckSince: 0, zaiAccountExpanded: false, zaiPendingCheckSince: 0, zaiteamAccountExpanded: false, zaiteamPendingCheckSince: 0, volcengineAccountExpanded: false, volcenginePendingCheckSince: 0, qoderAccountExpanded: false, qoderPendingCheckSince: 0, kimiAccountExpanded: false, kimiPendingCheckSince: 0, ollamaAccountExpanded: false, ollamaPendingCheckSince: 0, mimoAccountExpanded: false, mimoAccountError: '', copilotAccountExpanded: false, copilotManualExpanded: false, copilotPendingCheckSince: 0, copilotSignInBusy: false, copilotSignInCancelable: false, copilotSignInFlowId: '', copilotAuthorizeMessage: '', copilotLoginStatus: '', copilotErrorMessage: '', floatingBubble: initialFloatingBubble, suppressInitialNumberAnimation: window.__TOKEN_MONITOR_SUPPRESS_INITIAL_NUMBER_ANIMATION__ === true, openSession: null, detailSort: 'time', recordingWindowShortcut: false, windowShortcutInvalid: false };
+const state = { period: normalizeInitialViewValue(initialViewState.period, viewPeriodValues, 'today'), appUpdate: null, breakdown: normalizeInitialViewValue(initialViewState.breakdown, viewBreakdownValues, 'home'), viewSwitcherOpen: false, viewSwitcherHasOpened: false, resetCreditsTooltipHasOpened: false, resetCreditsTooltipActive: false, resetCreditsTooltipRenderPending: false, settings: null, stats: null, homeHistory: null, homeHistoryBusy: false, homeHistoryRequested: false, homeHistorySignature: '', homeHistoryRetries: 0, homeHistoryRetryTimer: null, homeActivityScrollLeft: null, homeActivityFollowEnd: true, homeActivityResizeObserver: null, serviceStatus: null, serviceStatusBusy: false, serviceProvidersExpanded: false, trendSettingsExpanded: false, trendsActivating: false, homeSettingsExpanded: false, homeLimitSettingsExpanded: false, serviceStatusTicker: null, refreshTimer: null, refreshBusy: false, refreshFeedbackTimer: null, currentTotal: 0, rowSignature: '', streamConnected: false, streamFailure: null, mode: 'idle', appInfo: null, tokscaleStatus: null, tokscaleCheck: null, tokscaleBusy: false, hubInfo: null, cursorAccount: { status: null, error: '' }, cursorAccountExpanded: false, codexAccountExpanded: false, codexAccountError: '', codexSignInBusy: false, codexSignInFlowId: '', codexLoginUrl: '', codexLoginStatus: '', codexLoginOutput: '', codexActiveAccount: null, codexPendingActiveAccount: null, codexPendingActiveAccountUntil: 0, codexPendingActiveAccountTimer: null, codexSystemSwitchingAccountId: '', codexSystemSwitchErrorAccountId: '', codexSystemSwitchError: '', codexSwitchPopoverHasOpened: false, codexSwitchPopoverActive: false, codexSwitchPopoverRenderPending: false, customPricingExpanded: false, opencodeProfileCount: 0, opencodeCookieExpanded: false, deepseekAccountExpanded: false, deepseekPendingCheckSince: 0, minimaxAccountExpanded: false, minimaxPendingCheckSince: 0, zaiAccountExpanded: false, zaiPendingCheckSince: 0, zaiteamAccountExpanded: false, zaiteamPendingCheckSince: 0, volcengineAccountExpanded: false, volcenginePendingCheckSince: 0, qoderAccountExpanded: false, qoderPendingCheckSince: 0, kimiAccountExpanded: false, kimiPendingCheckSince: 0, ollamaAccountExpanded: false, ollamaPendingCheckSince: 0, mimoAccountExpanded: false, mimoAccountError: '', copilotAccountExpanded: false, copilotManualExpanded: false, copilotPendingCheckSince: 0, copilotSignInBusy: false, copilotSignInCancelable: false, copilotSignInFlowId: '', copilotAuthorizeMessage: '', copilotLoginStatus: '', copilotErrorMessage: '', floatingBubble: initialFloatingBubble, suppressInitialNumberAnimation: window.__TOKEN_MONITOR_SUPPRESS_INITIAL_NUMBER_ANIMATION__ === true, openSession: null, detailSort: 'time', recordingWindowShortcut: false, windowShortcutInvalid: false };
 state.appUpdateNotesPresentedVersion = '';
 state.periodMotionActive = false;
 state.animateBarsFromZero = false;
@@ -3082,6 +3082,9 @@ function openViewFromTray(viewId) {
   renderBreakdownChange(viewId, { allowHidden: true });
 }
 
+const HOME_HISTORY_MAX_RETRIES = 3;
+const HOME_HISTORY_RETRY_MS = 4000;
+
 async function loadHomeHistory() {
   if (state.homeHistoryBusy || !window.tokenMonitor.getDashboardHistory) return;
   if (!homeOverviewApi.shouldFetchHomeHistory({
@@ -3089,22 +3092,45 @@ async function loadHomeHistory() {
     stats: state.stats,
     lastSignature: state.homeHistorySignature
   })) return;
+  // The signature is recorded before the await on purpose: it stops a failed or empty
+  // fetch from re-firing on the very next render (renderHome runs loadHomeHistory every
+  // render), which is the #39 spin loop. A transient failure or a raced empty result is
+  // recovered by the bounded timer-driven retry in the finally block instead, not by
+  // render — so Home is not stranded on the 30-day preview until the history genuinely
+  // changes, which for an account with history but no current activity might be never.
+  const previewHadDays = homeOverviewApi.historyHasDays(state.stats?.historyPreview);
   state.homeHistoryRequested = true;
   state.homeHistorySignature = homeOverviewApi.homeHistorySignature(state.stats);
   state.homeHistoryBusy = true;
   try {
     // Only ever one fetch in flight (homeHistoryBusy), so the response is the freshest
     // history at invoke time and can be taken as-is — no older reply can land on top of
-    // a newer one. The signature is recorded before the await on purpose: it stops a
-    // failed or empty fetch from re-triggering on the very next render (renderHome runs
-    // loadHomeHistory every render), which is the #39 spin loop. Recovery is by the next
-    // signature move instead — a newer history arriving mid-fetch, or any later stats
-    // change, no longer matches, so the re-render below re-enters and pulls it.
+    // a newer one.
     state.homeHistory = await window.tokenMonitor.getDashboardHistory();
   } catch (error) {
     console.log(`[home] history failed: ${error.message}`);
   } finally {
     state.homeHistoryBusy = false;
+    const loadedDays = homeOverviewApi.historyHasDays(state.homeHistory);
+    if (loadedDays) {
+      state.homeHistoryRetries = 0;
+    } else if (homeOverviewApi.shouldRetryHomeHistory({
+      loadedDays,
+      previewHasDays: previewHadDays,
+      retries: state.homeHistoryRetries,
+      maxRetries: HOME_HISTORY_MAX_RETRIES
+    })) {
+      state.homeHistoryRetries += 1;
+      clearTimeout(state.homeHistoryRetryTimer);
+      state.homeHistoryRetryTimer = setTimeout(() => {
+        state.homeHistoryRetryTimer = null;
+        // Skip if a later success already populated Home in the meantime.
+        if (!homeOverviewApi.historyHasDays(state.homeHistory)) {
+          state.homeHistorySignature = '';
+          void loadHomeHistory();
+        }
+      }, HOME_HISTORY_RETRY_MS);
+    }
     if (state.breakdown === 'home') render();
   }
 }

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -201,7 +201,7 @@ function normalizeInitialViewValue(value, allowed, fallback) {
   return allowed.has(raw) ? raw : fallback;
 }
 
-const state = { period: normalizeInitialViewValue(initialViewState.period, viewPeriodValues, 'today'), appUpdate: null, breakdown: normalizeInitialViewValue(initialViewState.breakdown, viewBreakdownValues, 'home'), viewSwitcherOpen: false, viewSwitcherHasOpened: false, resetCreditsTooltipHasOpened: false, resetCreditsTooltipActive: false, resetCreditsTooltipRenderPending: false, settings: null, stats: null, homeHistory: null, homeHistoryBusy: false, homeHistoryRequested: false, homeHistoryPreviewKey: '', homeActivityScrollLeft: null, homeActivityFollowEnd: true, homeActivityResizeObserver: null, serviceStatus: null, serviceStatusBusy: false, serviceProvidersExpanded: false, trendSettingsExpanded: false, trendsActivating: false, homeSettingsExpanded: false, homeLimitSettingsExpanded: false, serviceStatusTicker: null, refreshTimer: null, refreshBusy: false, refreshFeedbackTimer: null, currentTotal: 0, rowSignature: '', streamConnected: false, streamFailure: null, mode: 'idle', appInfo: null, tokscaleStatus: null, tokscaleCheck: null, tokscaleBusy: false, hubInfo: null, cursorAccount: { status: null, error: '' }, cursorAccountExpanded: false, codexAccountExpanded: false, codexAccountError: '', codexSignInBusy: false, codexSignInFlowId: '', codexLoginUrl: '', codexLoginStatus: '', codexLoginOutput: '', codexActiveAccount: null, codexPendingActiveAccount: null, codexPendingActiveAccountUntil: 0, codexPendingActiveAccountTimer: null, codexSystemSwitchingAccountId: '', codexSystemSwitchErrorAccountId: '', codexSystemSwitchError: '', codexSwitchPopoverHasOpened: false, codexSwitchPopoverActive: false, codexSwitchPopoverRenderPending: false, customPricingExpanded: false, opencodeProfileCount: 0, opencodeCookieExpanded: false, deepseekAccountExpanded: false, deepseekPendingCheckSince: 0, minimaxAccountExpanded: false, minimaxPendingCheckSince: 0, zaiAccountExpanded: false, zaiPendingCheckSince: 0, zaiteamAccountExpanded: false, zaiteamPendingCheckSince: 0, volcengineAccountExpanded: false, volcenginePendingCheckSince: 0, qoderAccountExpanded: false, qoderPendingCheckSince: 0, kimiAccountExpanded: false, kimiPendingCheckSince: 0, ollamaAccountExpanded: false, ollamaPendingCheckSince: 0, mimoAccountExpanded: false, mimoAccountError: '', copilotAccountExpanded: false, copilotManualExpanded: false, copilotPendingCheckSince: 0, copilotSignInBusy: false, copilotSignInCancelable: false, copilotSignInFlowId: '', copilotAuthorizeMessage: '', copilotLoginStatus: '', copilotErrorMessage: '', floatingBubble: initialFloatingBubble, suppressInitialNumberAnimation: window.__TOKEN_MONITOR_SUPPRESS_INITIAL_NUMBER_ANIMATION__ === true, openSession: null, detailSort: 'time', recordingWindowShortcut: false, windowShortcutInvalid: false };
+const state = { period: normalizeInitialViewValue(initialViewState.period, viewPeriodValues, 'today'), appUpdate: null, breakdown: normalizeInitialViewValue(initialViewState.breakdown, viewBreakdownValues, 'home'), viewSwitcherOpen: false, viewSwitcherHasOpened: false, resetCreditsTooltipHasOpened: false, resetCreditsTooltipActive: false, resetCreditsTooltipRenderPending: false, settings: null, stats: null, homeHistory: null, homeHistoryBusy: false, homeHistoryRequested: false, homeHistorySignature: '', homeActivityScrollLeft: null, homeActivityFollowEnd: true, homeActivityResizeObserver: null, serviceStatus: null, serviceStatusBusy: false, serviceProvidersExpanded: false, trendSettingsExpanded: false, trendsActivating: false, homeSettingsExpanded: false, homeLimitSettingsExpanded: false, serviceStatusTicker: null, refreshTimer: null, refreshBusy: false, refreshFeedbackTimer: null, currentTotal: 0, rowSignature: '', streamConnected: false, streamFailure: null, mode: 'idle', appInfo: null, tokscaleStatus: null, tokscaleCheck: null, tokscaleBusy: false, hubInfo: null, cursorAccount: { status: null, error: '' }, cursorAccountExpanded: false, codexAccountExpanded: false, codexAccountError: '', codexSignInBusy: false, codexSignInFlowId: '', codexLoginUrl: '', codexLoginStatus: '', codexLoginOutput: '', codexActiveAccount: null, codexPendingActiveAccount: null, codexPendingActiveAccountUntil: 0, codexPendingActiveAccountTimer: null, codexSystemSwitchingAccountId: '', codexSystemSwitchErrorAccountId: '', codexSystemSwitchError: '', codexSwitchPopoverHasOpened: false, codexSwitchPopoverActive: false, codexSwitchPopoverRenderPending: false, customPricingExpanded: false, opencodeProfileCount: 0, opencodeCookieExpanded: false, deepseekAccountExpanded: false, deepseekPendingCheckSince: 0, minimaxAccountExpanded: false, minimaxPendingCheckSince: 0, zaiAccountExpanded: false, zaiPendingCheckSince: 0, zaiteamAccountExpanded: false, zaiteamPendingCheckSince: 0, volcengineAccountExpanded: false, volcenginePendingCheckSince: 0, qoderAccountExpanded: false, qoderPendingCheckSince: 0, kimiAccountExpanded: false, kimiPendingCheckSince: 0, ollamaAccountExpanded: false, ollamaPendingCheckSince: 0, mimoAccountExpanded: false, mimoAccountError: '', copilotAccountExpanded: false, copilotManualExpanded: false, copilotPendingCheckSince: 0, copilotSignInBusy: false, copilotSignInCancelable: false, copilotSignInFlowId: '', copilotAuthorizeMessage: '', copilotLoginStatus: '', copilotErrorMessage: '', floatingBubble: initialFloatingBubble, suppressInitialNumberAnimation: window.__TOKEN_MONITOR_SUPPRESS_INITIAL_NUMBER_ANIMATION__ === true, openSession: null, detailSort: 'time', recordingWindowShortcut: false, windowShortcutInvalid: false };
 state.appUpdateNotesPresentedVersion = '';
 state.periodMotionActive = false;
 state.animateBarsFromZero = false;
@@ -3085,15 +3085,19 @@ function openViewFromTray(viewId) {
 async function loadHomeHistory() {
   if (state.homeHistoryBusy || !window.tokenMonitor.getDashboardHistory) return;
   if (!homeOverviewApi.shouldFetchHomeHistory({
-    homeHistory: state.homeHistory,
     requested: state.homeHistoryRequested,
-    preview: state.stats?.historyPreview,
-    lastPreviewKey: state.homeHistoryPreviewKey
+    stats: state.stats,
+    lastSignature: state.homeHistorySignature
   })) return;
   state.homeHistoryRequested = true;
-  state.homeHistoryPreviewKey = homeOverviewApi.historyPreviewKey(state.stats?.historyPreview);
+  state.homeHistorySignature = homeOverviewApi.homeHistorySignature(state.stats);
   state.homeHistoryBusy = true;
   try {
+    // Only ever one fetch in flight (homeHistoryBusy), so the response is the freshest
+    // history at invoke time and can be taken as-is — no older reply can land on top of
+    // a newer one. If the collector produced a newer history while this was in flight,
+    // the signature recorded above no longer matches state.stats, so the re-render below
+    // re-enters here and pulls it; a mid-fetch change is never left stranded.
     state.homeHistory = await window.tokenMonitor.getDashboardHistory();
   } catch (error) {
     console.log(`[home] history failed: ${error.message}`);
@@ -3803,10 +3807,11 @@ function renderHomeTrendsModule() {
     body.append(empty);
     return module;
   }
-  // homeHistory is fetched once and frozen, so its today bucket lags the live headline
-  // total; patch today's tokens with the live period total (like the trends sparkline's
+  // The snapshot's today bucket lags the live headline total between history ticks;
+  // patch today's tokens with the live period total (like the trends sparkline's
   // patchTodayBar) so the heatmap and trend line match the number shown above them.
-  const today = new Date().toISOString().slice(0, 10);
+  // The key must be the LOCAL day: the period being patched in is local-day scoped.
+  const today = charts.localDayKey();
   const todayPeriod = state.stats?.periods?.today;
   const points = homeOverviewApi.patchDailyToday(rawDaily, today, Number(todayPeriod?.totalTokens || 0), Number(todayPeriod?.costUsd || 0));
   const activityLayout = homeOverviewApi.homeActivityHeatmapLayout();
@@ -6743,7 +6748,10 @@ els.openRepositoryButton?.addEventListener('click', () => window.tokenMonitor.op
 els.reportIssueButton?.addEventListener('click', () => window.tokenMonitor.openExternal?.(TOKEN_MONITOR_ISSUES_URL));
 els.refreshButton.addEventListener('click', () => {
   if (state.breakdown === 'status') refreshStatusViewManually().catch(() => {});
-  else refreshStats({ force: true, feedback: true });
+  // Only this button asks for a history rescan: `{ force: true }` is used all over the
+  // settings/account flows, and folding history into it would re-run the expensive
+  // `tokscale graph` on every one of them.
+  else refreshStats({ force: true, forceHistory: true, feedback: true });
 });
 els.minButton.addEventListener('click', () => window.tokenMonitor.minimize());
 els.closeButton.addEventListener('click', () => window.tokenMonitor.close());

--- a/src/electron/renderer/dashboard.js
+++ b/src/electron/renderer/dashboard.js
@@ -249,7 +249,9 @@ function formatCostCompact(usd) {
 }
 function shortDate(key) { const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(String(key)); return m ? `${Number(m[2])}/${Number(m[3])}` : String(key); }
 function axisEvery(list) { return Math.max(1, Math.ceil(list.length / 9)); }
-function todayKey() { return new Date().toISOString().slice(0, 10); }
+// Local, not UTC: the heatmap's day cells are local-day scoped, so a UTC "today"
+// shifted the whole rolling year by a day for non-UTC users (#177).
+function todayKey() { return charts.localDayKey(); }
 function daysBetween(a, b) {
   return Math.round((Date.parse(`${String(b).slice(0, 10)}T00:00:00Z`) - Date.parse(`${String(a).slice(0, 10)}T00:00:00Z`)) / 86400000);
 }

--- a/src/electron/renderer/homeOverview.js
+++ b/src/electron/renderer/homeOverview.js
@@ -350,6 +350,18 @@
     return Number(retries || 0) < Number(maxRetries || 0);
   }
 
+  // Keep the result of this request separate from any older full history still used
+  // for display. A rejected request must not look successful merely because the
+  // previous snapshot had days, and a raced empty result must not replace useful
+  // stale data while the live preview proves history still exists.
+  function homeHistoryFetchOutcome({ resolved, history, previewHasDays } = {}) {
+    const loadedDays = Boolean(resolved) && historyHasDays(history);
+    return {
+      loadedDays,
+      accepted: Boolean(resolved) && (loadedDays || !previewHasDays)
+    };
+  }
+
   function homeActivityWheelRoute(event) {
     if (event?.shiftKey) return 'activity-horizontal';
     const deltaX = Math.abs(Number(event?.deltaX || 0));
@@ -397,6 +409,7 @@
     homeHistorySignature,
     shouldFetchHomeHistory,
     shouldRetryHomeHistory,
+    homeHistoryFetchOutcome,
     homeActivityHeatmapLayout,
     homeActivityWheelRoute,
     homeActivityScrollTarget,

--- a/src/electron/renderer/homeOverview.js
+++ b/src/electron/renderer/homeOverview.js
@@ -304,17 +304,29 @@
     return `${daily.length}:${last.date || ''}:${last.tokens || 0}`;
   }
 
-  // Whether loadHomeHistory should (re)fetch the full history. The first fetch can
-  // race the local collector at cold start and return empty; don't let that stick —
-  // refetch once the stats preview confirms history exists, but only when the preview
-  // has actually changed since the last attempt (so one bad fetch can't loop), stop
-  // once we hold the full data, and never poll a genuinely zero-usage account (#39).
-  function shouldFetchHomeHistory({ homeHistory, requested, preview, lastPreviewKey } = {}) {
-    if (historyHasDays(homeHistory)) return false;
+  // Identity of the history the held snapshot was fetched for. Mirrors main's
+  // statsHistoryRevision: prefer the real revision, fall back to the preview tail
+  // for an older hub that predates revisions. The revision only moves when the
+  // collector actually produces a different history (carry-forward keeps it stable
+  // between the gated history ticks), so keying refetches on it costs no extra
+  // `tokscale graph` runs.
+  function homeHistorySignature(stats) {
+    const revision = String(stats?.historyRevision || '').trim();
+    return revision || historyPreviewKey(stats?.historyPreview);
+  }
+
+  // Whether loadHomeHistory should (re)fetch the full history. Home used to freeze
+  // the first non-empty result for the whole renderer session, so a snapshot taken
+  // before midnight kept showing yesterday at its startup value (0 for a day that
+  // had not happened yet) until the app restarted (#177). Refetch whenever the
+  // history signature moves; a failed/empty fetch leaves the recorded signature
+  // untouched, so it still can't spin the render→fetch loop, and a genuinely
+  // zero-usage account with nothing to fetch is still never polled (#39).
+  function shouldFetchHomeHistory({ requested, stats, lastSignature } = {}) {
     if (!requested) return true;
-    const key = historyPreviewKey(preview);
-    if (!key) return false;
-    return key !== lastPreviewKey;
+    const signature = homeHistorySignature(stats);
+    if (!signature) return false;
+    return signature !== lastSignature;
   }
 
   function homeActivityWheelRoute(event) {
@@ -360,6 +372,7 @@
     pickHomeHistory,
     patchDailyToday,
     historyPreviewKey,
+    homeHistorySignature,
     shouldFetchHomeHistory,
     homeActivityHeatmapLayout,
     homeActivityWheelRoute,

--- a/src/electron/renderer/homeOverview.js
+++ b/src/electron/renderer/homeOverview.js
@@ -335,6 +335,21 @@
     return signature !== lastSignature;
   }
 
+  // After a fetch settles, whether loadHomeHistory should schedule a bounded retry.
+  // The signature is recorded before the fetch to keep a failed attempt from
+  // re-firing every render (the #39 spin), which means a transient failure or a
+  // raced empty result would otherwise strand Home on the 30-day preview until the
+  // history genuinely changes or the app restarts — a real gap for an account with
+  // history but no current activity, since its revision never moves. So: if the
+  // fetch produced no days but the live preview says days exist, retry up to a cap.
+  // A genuinely zero-usage account (no preview days) is never retried, so this cannot
+  // reintroduce the render→fetch loop.
+  function shouldRetryHomeHistory({ loadedDays, previewHasDays, retries, maxRetries } = {}) {
+    if (loadedDays) return false;
+    if (!previewHasDays) return false;
+    return Number(retries || 0) < Number(maxRetries || 0);
+  }
+
   function homeActivityWheelRoute(event) {
     if (event?.shiftKey) return 'activity-horizontal';
     const deltaX = Math.abs(Number(event?.deltaX || 0));
@@ -378,8 +393,10 @@
     pickHomeHistory,
     patchDailyToday,
     historyPreviewKey,
+    historyHasDays,
     homeHistorySignature,
     shouldFetchHomeHistory,
+    shouldRetryHomeHistory,
     homeActivityHeatmapLayout,
     homeActivityWheelRoute,
     homeActivityScrollTarget,

--- a/src/electron/renderer/homeOverview.js
+++ b/src/electron/renderer/homeOverview.js
@@ -305,14 +305,20 @@
   }
 
   // Identity of the history the held snapshot was fetched for. Mirrors main's
-  // statsHistoryRevision: prefer the real revision, fall back to the preview tail
-  // for an older hub that predates revisions. The revision only moves when the
-  // collector actually produces a different history (carry-forward keeps it stable
-  // between the gated history ticks), so keying refetches on it costs no extra
+  // statsHistoryRevision so Home invalidates on exactly the changes the standalone
+  // dashboard does: prefer the real revision, and for an older hub that predates
+  // revisions fall back to the WHOLE preview, not just its daily tail — a tail key
+  // (`length:lastDate:lastTokens`) misses a change to a non-tail day, a cost, an
+  // active-time, or a monthly total, so a backfill of an earlier day would never
+  // reach Home. Empty preview still collapses to '' so a genuinely zero-usage
+  // account is never polled (#39). The revision only moves when the collector
+  // actually produces a different history (carry-forward keeps it stable between
+  // the gated history ticks), so keying refetches on it costs no extra
   // `tokscale graph` runs.
   function homeHistorySignature(stats) {
     const revision = String(stats?.historyRevision || '').trim();
-    return revision || historyPreviewKey(stats?.historyPreview);
+    if (revision) return revision;
+    return stats?.historyPreview?.daily?.length ? JSON.stringify(stats.historyPreview) : '';
   }
 
   // Whether loadHomeHistory should (re)fetch the full history. Home used to freeze

--- a/src/electron/renderer/usageCharts.js
+++ b/src/electron/renderer/usageCharts.js
@@ -16,6 +16,23 @@
     return total;
   }
 
+  // Wall-clock "today" as a LOCAL day key. Day cells and the live period totals
+  // patched into them are both local-day scoped (the collector keys periods with
+  // localTodayKey), so reading today off toISOString() — which is UTC — pasted the
+  // local today's tokens onto the UTC day: at UTC+8 that is the *previous* day's
+  // cell between 00:00 and 07:59 local, blanking yesterday every morning (#177).
+  // Built from the local getters rather than a locale-formatted string so the key
+  // stays YYYY-MM-DD regardless of the user's locale.
+  function localDayKey(date = new Date()) {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  }
+
+  // Day keys are compared and stepped as plain calendar strings, so the arithmetic
+  // below stays UTC-anchored on purpose: it operates on an already-correct key and
+  // never reads the wall clock.
   function addDaysUTC(key, delta) {
     return new Date(Date.parse(`${key}T00:00:00Z`) + delta * 86400000).toISOString().slice(0, 10);
   }
@@ -186,7 +203,7 @@
   }
 
   function rollingYearHeatmap(daily, options) {
-    const o = Object.assign({ endDate: new Date().toISOString().slice(0, 10), cell: 8, gap: 3 }, options || {});
+    const o = Object.assign({ endDate: localDayKey(), cell: 8, gap: 3 }, options || {});
     const endDate = String(o.endDate).slice(0, 10);
     const end = new Date(`${endDate}T00:00:00Z`);
     const startDate = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth() - 11, 1)).toISOString().slice(0, 10);
@@ -543,7 +560,7 @@
   }
 
   return {
-    weekStartKey, dailyBarsChart, candleChart, contribHeatmap, rollingYearHeatmap, statsCards, sparklinePreview,
+    localDayKey, weekStartKey, dailyBarsChart, candleChart, contribHeatmap, rollingYearHeatmap, statsCards, sparklinePreview,
     areaLineChart, areaLineSvg,
     selectPreviewSeries, patchTodayBar, sparklineSvg,
     clientColors, fallbackModelColors, modelVendorFor, modelColor, clampDaily,

--- a/tests/electron/activityDateKey.test.js
+++ b/tests/electron/activityDateKey.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+// Pin the zone before anything reads the clock: these cases are about the
+// local-vs-UTC day boundary, so they must not inherit the CI machine's zone.
+// node --test runs every test file in its own process, so this cannot leak.
+process.env.TZ = 'Asia/Shanghai'; // UTC+8, no DST
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const charts = require('../../src/electron/renderer/usageCharts');
+
+// 02:00 local on 2026-07-17 at UTC+8 is still 2026-07-16 in UTC — the exact window
+// (00:00–07:59 local) that made the activity heatmap paint the live "today" total
+// onto yesterday's cell, blanking a day that had real usage (#177).
+const EARLY_MORNING_UTC8 = new Date('2026-07-16T18:00:00Z');
+
+test('localDayKey returns the local day inside the UTC+8 early-morning window (#177)', () => {
+  assert.equal(charts.localDayKey(EARLY_MORNING_UTC8), '2026-07-17');
+  // The regression this replaces: a UTC-derived key names the previous day, so the
+  // local today's period total was patched onto yesterday's cell.
+  assert.equal(EARLY_MORNING_UTC8.toISOString().slice(0, 10), '2026-07-16');
+});
+
+test('localDayKey rolls the year/month with the local day, not the UTC one (#177)', () => {
+  // 02:00 local on 2027-01-01 at UTC+8 is still 2026-12-31 in UTC, so every component
+  // differs at once — this is what pins all three getters to their local variants.
+  const newYear = new Date('2026-12-31T18:00:00Z');
+  assert.equal(charts.localDayKey(newYear), '2027-01-01');
+  assert.equal(newYear.toISOString().slice(0, 10), '2026-12-31');
+});
+
+test('localDayKey agrees with UTC once the local and UTC day line up again', () => {
+  // 12:00 local = 04:00Z the same day; outside the window both agree.
+  const midday = new Date('2026-07-17T04:00:00Z');
+  assert.equal(charts.localDayKey(midday), '2026-07-17');
+  assert.equal(charts.localDayKey(midday), midday.toISOString().slice(0, 10));
+});
+
+test('localDayKey zero-pads and never depends on locale formatting', () => {
+  // 09:00 local on 2026-01-05 → single-digit month and day.
+  assert.equal(charts.localDayKey(new Date('2026-01-05T01:00:00Z')), '2026-01-05');
+  assert.match(charts.localDayKey(), /^\d{4}-\d{2}-\d{2}$/);
+});
+
+test('the rolling-year heatmap ends on the local day by default', () => {
+  const heat = charts.rollingYearHeatmap([], {});
+  assert.equal(heat.cells[heat.cells.length - 1].date, charts.localDayKey());
+});
+
+test('activity views derive today from the local day key, not toISOString (#177)', () => {
+  const rendererDir = path.join(__dirname, '../../src/electron/renderer');
+  for (const file of ['app.js', 'dashboard.js', 'usageCharts.js']) {
+    const source = fs.readFileSync(path.join(rendererDir, file), 'utf8');
+    // Key arithmetic on an already-correct key stays UTC-anchored (addDaysUTC,
+    // month-start math); what must never come back is reading the wall clock in UTC.
+    assert.ok(
+      !/new Date\(\)\.toISOString\(\)\.slice\(0, ?10\)/.test(source),
+      `${file} must derive today from localDayKey(), not new Date().toISOString()`
+    );
+  }
+});

--- a/tests/electron/controlLayoutSwap.test.js
+++ b/tests/electron/controlLayoutSwap.test.js
@@ -157,7 +157,9 @@ test('refresh button exposes busy, success, and error feedback states', () => {
   assert.match(body, /setRefreshButtonState\('refreshing'/, 'feedback refresh starts button feedback immediately');
   assert.match(body, /settleRefreshButtonState\('refreshed'/, 'feedback refresh shows success feedback');
   assert.match(body, /settleRefreshButtonState\('error'/, 'feedback refresh shows error feedback');
-  assert.match(app, /refreshStats\(\{ force: true, feedback: true \}\)/, 'Reload click opts into button feedback');
+  // Intent is the feedback opt-in, not the exact flag list (the Reload click also
+  // forces a history rescan — see refreshForceHistory.test.js).
+  assert.match(app, /refreshStats\(\{[^}]*feedback: true[^}]*\}\)/, 'Reload click opts into button feedback');
 
   assert.doesNotMatch(cssRule(css, '.refresh-button.is-refreshing'), /cursor:\s*progress/, 'loading state should not alter the pointer cursor');
   assert.equal(declaration(cssRule(css, '.refresh-button:disabled'), 'cursor'), 'default', 'disabled refresh keeps the normal arrow cursor');

--- a/tests/electron/homeOverview.test.js
+++ b/tests/electron/homeOverview.test.js
@@ -21,7 +21,8 @@ const {
   historyPreviewKey,
   homeHistorySignature,
   shouldFetchHomeHistory,
-  shouldRetryHomeHistory
+  shouldRetryHomeHistory,
+  homeHistoryFetchOutcome
 } = require('../../src/electron/renderer/homeOverview');
 
 const historyWithDays = { daily: [{ date: '2026-06-01', tokens: 10, cost: 1 }], monthly: [], summary: {} };
@@ -500,6 +501,8 @@ test('loadHomeHistory wires the bounded retry through a timer, not a render', ()
   assert.match(body, /shouldRetryHomeHistory\(/, 'retry decision is delegated to the guarded predicate');
   assert.match(body, /setTimeout\(/, 'the retry is timer-driven so it cannot re-enter on every render');
   assert.match(body, /homeHistoryRetries \+= 1/, 'the retry counter advances toward the cap');
+  assert.match(body, /homeHistoryRetrySignature !== requestSignature[\s\S]*?homeHistoryRetries = 0/, 'a new signature receives a fresh retry budget');
+  assert.match(body, /homeHistoryLoadedSignature === requestSignature/, 'stale display history cannot suppress a retry');
 });
 
 test('historyPreviewKey is empty for no days and changes as the daily tail moves', () => {
@@ -587,6 +590,37 @@ test('shouldRetryHomeHistory never retries a genuinely zero-usage account (#39)'
   // No preview days means there is nothing to load, so retrying would just poll — and
   // could reintroduce the render→fetch loop. Suppress it regardless of the counter.
   assert.equal(shouldRetryHomeHistory({ loadedDays: false, previewHasDays: false, retries: 0, maxRetries: 3 }), false);
+});
+
+test('homeHistoryFetchOutcome does not mistake stale display history for a successful request', () => {
+  // The rejected request produced no value. Passing the old snapshot here proves
+  // that it cannot make this attempt look loaded merely because it still has days.
+  assert.deepEqual(homeHistoryFetchOutcome({
+    resolved: false,
+    history: historyWithDays,
+    previewHasDays: true
+  }), { loadedDays: false, accepted: false });
+});
+
+test('homeHistoryFetchOutcome preserves stale history across a raced empty result', () => {
+  assert.deepEqual(homeHistoryFetchOutcome({
+    resolved: true,
+    history: emptyHistory,
+    previewHasDays: true
+  }), { loadedDays: false, accepted: false });
+  assert.deepEqual(homeHistoryFetchOutcome({
+    resolved: true,
+    history: historyWithDays,
+    previewHasDays: true
+  }), { loadedDays: true, accepted: true });
+});
+
+test('homeHistoryFetchOutcome accepts an empty result for a zero-usage account', () => {
+  assert.deepEqual(homeHistoryFetchOutcome({
+    resolved: true,
+    history: emptyHistory,
+    previewHasDays: false
+  }), { loadedDays: false, accepted: true });
 });
 
 test('shouldFetchHomeHistory never polls a zero-usage account', () => {

--- a/tests/electron/homeOverview.test.js
+++ b/tests/electron/homeOverview.test.js
@@ -500,15 +500,29 @@ test('historyPreviewKey is empty for no days and changes as the daily tail moves
   assert.notEqual(historyPreviewKey({ daily: [{ date: '2026-06-02', tokens: 99 }] }), key);
 });
 
-test('homeHistorySignature prefers the revision and falls back to the preview tail', () => {
+test('homeHistorySignature prefers the revision and falls back to the whole preview', () => {
   assert.equal(homeHistorySignature({ historyRevision: 'abc123', historyPreview: historyWithDays }), 'abc123');
-  // An older hub that predates revisions still has to be able to move the signature.
+  // An older hub that predates revisions falls back to the full preview, mirroring
+  // main's statsHistoryRevision, so any field change moves the signature.
   assert.equal(
     homeHistorySignature({ historyPreview: historyWithDays }),
-    historyPreviewKey(historyWithDays)
+    JSON.stringify(historyWithDays)
   );
   assert.equal(homeHistorySignature(null), '');
   assert.equal(homeHistorySignature({ historyRevision: '   ' , historyPreview: emptyHistory }), '');
+});
+
+test('homeHistorySignature (revision-less) moves on a non-tail change the tail key would miss', () => {
+  // The daily tail (length:lastDate:lastTokens) is identical across these, but an
+  // earlier day's cost/tokens and a monthly total differ — a backfill of an older
+  // day. Home must still invalidate, which the tail key could not detect.
+  const base = { daily: [{ date: '2026-06-01', tokens: 0, cost: 0 }, { date: '2026-06-02', tokens: 10, cost: 1 }], monthly: [{ month: '2026-06', tokens: 10 }], summary: {} };
+  const backfilled = { daily: [{ date: '2026-06-01', tokens: 500, cost: 5 }, { date: '2026-06-02', tokens: 10, cost: 1 }], monthly: [{ month: '2026-06', tokens: 510 }], summary: {} };
+  assert.equal(historyPreviewKey(base), historyPreviewKey(backfilled)); // tail key is blind to it
+  assert.notEqual(
+    homeHistorySignature({ historyPreview: base }),
+    homeHistorySignature({ historyPreview: backfilled })
+  );
 });
 
 test('shouldFetchHomeHistory fetches on the first request', () => {

--- a/tests/electron/homeOverview.test.js
+++ b/tests/electron/homeOverview.test.js
@@ -20,7 +20,8 @@ const {
   patchDailyToday,
   historyPreviewKey,
   homeHistorySignature,
-  shouldFetchHomeHistory
+  shouldFetchHomeHistory,
+  shouldRetryHomeHistory
 } = require('../../src/electron/renderer/homeOverview');
 
 const historyWithDays = { daily: [{ date: '2026-06-01', tokens: 10, cost: 1 }], monthly: [], summary: {} };
@@ -491,6 +492,16 @@ test('renderHomeTrendsModule patches the activity today cell with the live perio
   assert.match(match[1], /patchDailyToday\([\s\S]*?totalTokens/);
 });
 
+test('loadHomeHistory wires the bounded retry through a timer, not a render', () => {
+  const rendererSource = fs.readFileSync(path.join(__dirname, '../../src/electron/renderer/app.js'), 'utf8');
+  const match = rendererSource.match(/async function loadHomeHistory\(\) \{([\s\S]*?)\n\}/);
+  assert.ok(match, 'loadHomeHistory exists');
+  const body = match[1];
+  assert.match(body, /shouldRetryHomeHistory\(/, 'retry decision is delegated to the guarded predicate');
+  assert.match(body, /setTimeout\(/, 'the retry is timer-driven so it cannot re-enter on every render');
+  assert.match(body, /homeHistoryRetries \+= 1/, 'the retry counter advances toward the cap');
+});
+
 test('historyPreviewKey is empty for no days and changes as the daily tail moves', () => {
   assert.equal(historyPreviewKey(null), '');
   assert.equal(historyPreviewKey(emptyHistory), '');
@@ -558,6 +569,24 @@ test('shouldFetchHomeHistory refetches once the collector produces a newer histo
     stats: { historyPreview: { daily: [{ date: '2026-06-02', tokens: 42 }] } },
     lastSignature: historyPreviewKey(historyWithDays)
   }), true);
+});
+
+test('shouldRetryHomeHistory retries a failed first load when the preview has days', () => {
+  // Account has history but no current activity, so its revision never moves; a
+  // transient first-load failure must still recover without waiting for a real change.
+  assert.equal(shouldRetryHomeHistory({ loadedDays: false, previewHasDays: true, retries: 0, maxRetries: 3 }), true);
+  assert.equal(shouldRetryHomeHistory({ loadedDays: false, previewHasDays: true, retries: 2, maxRetries: 3 }), true);
+});
+
+test('shouldRetryHomeHistory stops at the cap and after a success', () => {
+  assert.equal(shouldRetryHomeHistory({ loadedDays: false, previewHasDays: true, retries: 3, maxRetries: 3 }), false);
+  assert.equal(shouldRetryHomeHistory({ loadedDays: true, previewHasDays: true, retries: 0, maxRetries: 3 }), false);
+});
+
+test('shouldRetryHomeHistory never retries a genuinely zero-usage account (#39)', () => {
+  // No preview days means there is nothing to load, so retrying would just poll — and
+  // could reintroduce the render→fetch loop. Suppress it regardless of the counter.
+  assert.equal(shouldRetryHomeHistory({ loadedDays: false, previewHasDays: false, retries: 0, maxRetries: 3 }), false);
 });
 
 test('shouldFetchHomeHistory never polls a zero-usage account', () => {

--- a/tests/electron/homeOverview.test.js
+++ b/tests/electron/homeOverview.test.js
@@ -19,6 +19,7 @@ const {
   pickHomeHistory,
   patchDailyToday,
   historyPreviewKey,
+  homeHistorySignature,
   shouldFetchHomeHistory
 } = require('../../src/electron/renderer/homeOverview');
 
@@ -499,41 +500,54 @@ test('historyPreviewKey is empty for no days and changes as the daily tail moves
   assert.notEqual(historyPreviewKey({ daily: [{ date: '2026-06-02', tokens: 99 }] }), key);
 });
 
+test('homeHistorySignature prefers the revision and falls back to the preview tail', () => {
+  assert.equal(homeHistorySignature({ historyRevision: 'abc123', historyPreview: historyWithDays }), 'abc123');
+  // An older hub that predates revisions still has to be able to move the signature.
+  assert.equal(
+    homeHistorySignature({ historyPreview: historyWithDays }),
+    historyPreviewKey(historyWithDays)
+  );
+  assert.equal(homeHistorySignature(null), '');
+  assert.equal(homeHistorySignature({ historyRevision: '   ' , historyPreview: emptyHistory }), '');
+});
+
 test('shouldFetchHomeHistory fetches on the first request', () => {
-  assert.equal(shouldFetchHomeHistory({ homeHistory: null, requested: false, preview: null }), true);
+  assert.equal(shouldFetchHomeHistory({ requested: false, stats: null }), true);
 });
 
 test('shouldFetchHomeHistory refetches when an empty result raced the collector', () => {
-  // Requested once during the race (preview was empty → lastPreviewKey ''), but the
-  // preview now shows history exists — fetch again instead of sticking on the empty result.
+  // Requested once during the race (no stats yet → lastSignature ''), but stats now
+  // show history exists — fetch again instead of sticking on the empty result.
   assert.equal(shouldFetchHomeHistory({
-    homeHistory: emptyHistory, requested: true, preview: historyWithDays, lastPreviewKey: ''
+    requested: true, stats: { historyRevision: 'rev-1' }, lastSignature: ''
   }), true);
 });
 
-test('shouldFetchHomeHistory does not refetch against the preview it already tried', () => {
+test('shouldFetchHomeHistory does not refetch against the history it already tried', () => {
   // A failed/empty full-history fetch must not loop: loadHomeHistory's finally always
-  // re-renders Home, so refetching the same preview state would spin the IPC path.
-  const key = historyPreviewKey(historyWithDays);
+  // re-renders Home, so refetching the same history state would spin the IPC path.
   assert.equal(shouldFetchHomeHistory({
-    homeHistory: emptyHistory, requested: true, preview: historyWithDays, lastPreviewKey: key
+    requested: true, stats: { historyRevision: 'rev-1' }, lastSignature: 'rev-1'
   }), false);
 });
 
-test('shouldFetchHomeHistory retries once the preview changes after a failed attempt', () => {
-  const staleKey = historyPreviewKey(historyWithDays);
-  const newerPreview = { daily: [{ date: '2026-06-02', tokens: 42 }] };
+test('shouldFetchHomeHistory refetches once the collector produces a newer history (#177)', () => {
+  // Home used to freeze the first non-empty snapshot for the whole renderer session, so
+  // a snapshot taken before midnight kept rendering yesterday at its startup value until
+  // the app was restarted. Holding data must not block a refetch any more.
   assert.equal(shouldFetchHomeHistory({
-    homeHistory: emptyHistory, requested: true, preview: newerPreview, lastPreviewKey: staleKey
+    requested: true, stats: { historyRevision: 'rev-2' }, lastSignature: 'rev-1'
+  }), true);
+  // Same for a revision-less hub, via the preview tail fallback.
+  assert.equal(shouldFetchHomeHistory({
+    requested: true,
+    stats: { historyPreview: { daily: [{ date: '2026-06-02', tokens: 42 }] } },
+    lastSignature: historyPreviewKey(historyWithDays)
   }), true);
 });
 
-test('shouldFetchHomeHistory stops once the full history is held', () => {
-  assert.equal(shouldFetchHomeHistory({ homeHistory: historyWithDays, requested: true, preview: historyWithDays }), false);
-});
-
 test('shouldFetchHomeHistory never polls a zero-usage account', () => {
-  // Requested once, still no preview data — nothing to fetch, so don't poll on every render.
-  assert.equal(shouldFetchHomeHistory({ homeHistory: emptyHistory, requested: true, preview: emptyHistory }), false);
-  assert.equal(shouldFetchHomeHistory({ homeHistory: null, requested: true, preview: null }), false);
+  // Requested once, still nothing to identify a history by — don't poll on every render.
+  assert.equal(shouldFetchHomeHistory({ requested: true, stats: { historyPreview: emptyHistory } }), false);
+  assert.equal(shouldFetchHomeHistory({ requested: true, stats: null }), false);
 });

--- a/tests/electron/refreshForceHistory.test.js
+++ b/tests/electron/refreshForceHistory.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+// main.js requires electron at the top level, so it cannot be loaded here; these
+// guard the wiring at the source level instead (same approach as the
+// renderHomeTrendsModule guard in homeOverview.test.js).
+const rendererSource = fs.readFileSync(path.join(__dirname, '../../src/electron/renderer/app.js'), 'utf8');
+const mainSource = fs.readFileSync(path.join(__dirname, '../../src/electron/main.js'), 'utf8');
+
+test('the manual refresh button asks for a history rescan', () => {
+  const handler = rendererSource.match(/els\.refreshButton\.addEventListener\('click',[\s\S]*?\n\}\);/);
+  assert.ok(handler, 'refresh button handler exists');
+  assert.match(handler[0], /refreshStats\(\{[^}]*forceHistory: true[^}]*\}\)/);
+});
+
+test('only the manual refresh button drags history along with force (#177)', () => {
+  // Tool settings, account sign-ins and limits actions all call refreshStats({ force: true });
+  // folding history into plain `force` would re-run the expensive `tokscale graph` on each.
+  const calls = rendererSource.match(/refreshStats\(\{[^}]*\}\)/g) || [];
+  const withHistory = calls.filter((call) => call.includes('forceHistory'));
+  assert.equal(withHistory.length, 1, `exactly one refreshStats call may force history, got: ${withHistory.join(', ')}`);
+  // ...and it is the manual button's (the only call that drives the button feedback).
+  assert.match(withHistory[0], /feedback: true/);
+});
+
+test('fetchStats reads forceHistory independently of force', () => {
+  const fetchStats = mainSource.match(/async function fetchStats\(options = \{\}\) \{([\s\S]*?)\n {2}if \(mode === 'local'\)/);
+  assert.ok(fetchStats, 'fetchStats exists');
+  const head = fetchStats[1];
+  // The tick option must come from its own flag, never be aliased to `force`.
+  assert.match(head, /forceHistory: Boolean\(options\?\.forceHistory\)/);
+  assert.doesNotMatch(head, /forceHistory: force\b/);
+  assert.doesNotMatch(head, /forceHistory: true/);
+});

--- a/tests/electron/refreshForceHistory.test.js
+++ b/tests/electron/refreshForceHistory.test.js
@@ -27,6 +27,16 @@ test('only the manual refresh button drags history along with force (#177)', () 
   assert.match(withHistory[0], /feedback: true/);
 });
 
+test('a forced history refresh restores the Home full-history retry budget', () => {
+  const refreshStats = rendererSource.match(/async function refreshStats\(options = \{\}\) \{([\s\S]*?)\n\}\n\nasync function refreshStatusViewManually/);
+  assert.ok(refreshStats, 'refreshStats exists');
+  const body = refreshStats[1];
+  assert.match(body, /options\.forceHistory === true/);
+  assert.match(body, /homeHistoryRetrySignature = ''/);
+  assert.match(body, /homeHistoryRetries = 0/);
+  assert.match(body, /homeHistorySignature = ''/);
+});
+
 test('fetchStats reads forceHistory independently of force', () => {
   const fetchStats = mainSource.match(/async function fetchStats\(options = \{\}\) \{([\s\S]*?)\n {2}if \(mode === 'local'\)/);
   assert.ok(fetchStats, 'fetchStats exists');

--- a/tests/electron/refreshForceHistory.test.js
+++ b/tests/electron/refreshForceHistory.test.js
@@ -32,6 +32,7 @@ test('a forced history refresh restores the Home full-history retry budget', () 
   assert.ok(refreshStats, 'refreshStats exists');
   const body = refreshStats[1];
   assert.match(body, /options\.forceHistory === true/);
+  assert.match(body, /homeHistoryLoadedSignature = ''/);
   assert.match(body, /homeHistoryRetrySignature = ''/);
   assert.match(body, /homeHistoryRetries = 0/);
   assert.match(body, /homeHistorySignature = ''/);


### PR DESCRIPTION
## Summary

The home activity heatmap fetched the full history once per renderer session and then froze it, so a snapshot taken before midnight kept rendering yesterday at its startup value — 0 for a day that hadn't happened yet — while only the live patch kept today current. After midnight the patch moved on to the new day and yesterday fell back to that stale 0. No refresh could fix it, because holding data was itself the condition that blocked every refetch; only restarting the app reloaded the history. That is the "yesterday shows 0, refresh doesn't help, restart brings it back" report in #177.

Two more defects surfaced while tracing it:

- The manual refresh button never asked for a history rescan — `fetchStats` only ever passed `forceLimits` — so even a forced tick left the history on its 15-minute interval.
- Both activity views derived "today" from `new Date().toISOString()`, which is UTC, while the period totals patched into them are local-day scoped (`localTodayKey`). At UTC+8 that pasted the local today's total onto the previous day's cell between 00:00 and 07:59 local, blanking a day that had real usage. The standalone dashboard only shifted its rolling-year boundary, since it does no live patching.

## Changes

- **Home refetches on `historyRevision`** — `shouldFetchHomeHistory` keys off the history signature instead of "do we already hold data". It falls back to the preview tail for an older hub that predates revisions, mirroring main's `statsHistoryRevision`. A failed or empty fetch leaves the recorded signature untouched, so it still cannot spin the render→fetch loop, and a zero-usage account is still never polled (#39). The revision only moves when the collector actually produces a different history, so this costs no extra `tokscale graph` runs.
- **`forceHistory` is independent of `force`** — only the manual refresh button opts in. Tool settings, account sign-ins and limits actions all refresh with `{ force: true }`, and folding the rescan into that would spawn the expensive `tokscale graph` on every one of them. The collector already accepted the tick option; nothing ever set it.
- **Local day keys** — new `charts.localDayKey()`, built from `getFullYear`/`getMonth`/`getDate` rather than locale formatting, used by the home trends module, the dashboard's `todayKey()`, and `rollingYearHeatmap`'s default `endDate`. Day-key arithmetic (`addDaysUTC`, the month-start math) stays UTC-anchored on purpose: it operates on an already-correct key and never reads the wall clock.

Worth noting as a side effect: because the refresh button now moves the history revision, the standalone dashboard reloads along with it — previously it could only wait out the 15-minute interval.

## Verification

- `npm run verify` (lint + 1371 tests) green.
- New `tests/electron/activityDateKey.test.js` pins `TZ=Asia/Shanghai` and asserts against fixed instants, so the cases never inherit the CI machine's zone. It includes the UTC+8 New Year crossing, where year, month and day all differ at once.
- New `tests/electron/refreshForceHistory.test.js` guards that exactly one `refreshStats` call may force history, and that `fetchStats` never aliases it to `force`.
- Every new guard was mutation-checked: reintroducing the freeze, reverting either view's day key to UTC, dropping `forceHistory` from the button, and aliasing it to `force` each fail the intended test. That pass found a real hole — with only the July dates, `getFullYear → getUTCFullYear` slipped through unnoticed; the year-boundary case closed it and all three local getters are now independently covered.
- Two existing tests were adjusted rather than worked around: `homeOverview.test.js` had a case asserting the frozen behaviour as contract (`stops once the full history is held`), now rewritten around the revision; `controlLayoutSwap.test.js` pinned the refresh button's exact flag list, loosened to the feedback opt-in it was actually testing.

`Refs #177` rather than `Fixes` — this covers the cross-midnight and refresh half only. The grey April–May cells in that thread have a separate cause and are not addressed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reloads the Home activity history when it changes (including across midnight), recovers from transient failures with a bounded, signature-scoped retry, and refreshes on manual reload. Switches “today” to the local day so cells align with totals. Refs #177.

- **Bug Fixes**
  - Home refetches when the history signature changes: prefers `historyRevision`; for revision‑less hubs falls back to the full `historyPreview` (not just the daily tail), matching main’s `statsHistoryRevision`; avoids loops and never polls zero‑usage.
  - Adds a timer‑driven, bounded retry when a history load returns no days but the preview shows days; retries are scoped to the requested signature, stale history is kept, and a raced empty result won’t overwrite it.
  - Manual refresh now requests a history rescan via `forceHistory` (kept independent from `force` and forwarded in `main.fetchStats`); it also resets Home’s retry budget and clears the loaded‑history signature so a failed request gets its retries even if the revision hasn’t moved.
  - Use `charts.localDayKey()` for “today” in Home and Dashboard; the rolling‑year heatmap ends on the local day by default.

<sup>Written for commit 2ab5f5c5e3b981bcb220b247060fc306fcbcd7c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

