### PR TITLE
fix(widget): improve floating bubble contrast

### DIFF
--- a/src/electron/floatingBubble.js
+++ b/src/electron/floatingBubble.js
@@ -18,9 +18,8 @@ function canUseFloatingBubble(settings = {}) {
     settings.windowBehavior !== 'desktop';
 }
 
-function floatingBubbleNativeGlassEnabled(settings = {}, state = {}, platform = process.platform) {
-  if (platform === 'win32' && state?.collapsed === true) return false;
-  return settings?.systemGlass !== false && state?.collapsed !== true;
+function floatingBubbleNativeGlassEnabled(settings = {}) {
+  return settings?.systemGlass !== false;
 }
 
 function floatingBubbleCollapsedArea(display, platform = process.platform) {
@@ -36,7 +35,7 @@ function floatingBubbleWindowChrome(platform = process.platform, collapsed = fal
   if (platform !== 'win32' || collapsed !== true) return {};
   return {
     hasShadow: false,
-    roundedCorners: false,
+    roundedCorners: true,
     thickFrame: false
   };
 }

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -1562,7 +1562,7 @@ function applyWindowSettings() {
 }
 
 function nativeBlurEnabled(source = settings) {
-  return floatingBubbleNativeGlassEnabled(source, floatingBubbleState, process.platform);
+  return floatingBubbleNativeGlassEnabled(source);
 }
 
 function keepNativeBlurActive() {
@@ -3292,7 +3292,7 @@ function createWindow(boundsOverride, options = {}) {
   });
   mainWindow = win;
   mainWindowChrome = { collapsedFloatingBubble };
-  applyWindowsChrome(win, { round: !collapsedFloatingBubble });
+  applyWindowsChrome(win, { round: true });
   win.webContents.setWindowOpenHandler(({ url }) => {
     if (isAllowedExternalUrl(url)) shell.openExternal(url);
     return { action: 'deny' };
@@ -3332,11 +3332,14 @@ function createWindow(boundsOverride, options = {}) {
   loadWindowFile(win, {
     waitForContent: options.waitForContent === true,
     inactive: options.inactive === true,
-    query: floatingBubbleInitialRendererQuery(floatingBubbleState, {
-      collapsedWindow: collapsedFloatingBubble,
-      suppressInitialNumberAnimation: options.suppressInitialNumberAnimation === true,
-      viewState: rendererViewState
-    })
+    query: {
+      ...floatingBubbleInitialRendererQuery(floatingBubbleState, {
+        collapsedWindow: collapsedFloatingBubble,
+        suppressInitialNumberAnimation: options.suppressInitialNumberAnimation === true,
+        viewState: rendererViewState
+      }),
+      ...(settings?.systemGlass === false ? { systemGlassDisabled: '1' } : {})
+    }
   });
 }
 

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -4246,6 +4246,8 @@ function applyAppearanceSettings(settings) {
   const opacity = clamp(settings?.glassOpacity ?? 68, 0, 100) / 100;
   const depth = clamp(settings?.glassBlur ?? 32, 0, 100) / 100;
   document.documentElement.style.setProperty('--glass-alpha', opacity.toFixed(2));
+  document.documentElement.style.setProperty('--bubble-alpha', (0.62 + opacity * 0.22).toFixed(2));
+  document.documentElement.style.setProperty('--bubble-blur', settings?.systemGlass === false ? '0px' : `${Math.round(10 + depth * 24)}px`);
   document.documentElement.style.setProperty('--line-alpha', (0.1 + depth * 0.09).toFixed(3));
   document.documentElement.style.setProperty('--line-strong-alpha', (0.18 + depth * 0.14).toFixed(3));
   document.documentElement.style.setProperty('--control-alpha', (0.03 + depth * 0.045).toFixed(3));
@@ -4687,7 +4689,10 @@ function renderFloatingBubbleContent() {
   const mode = state.settings?.floatingBubbleContent || 'icon';
   if (window.TokenMonitorTrayText.isGeneratedTrayIconMode(mode)) {
     const dataUrl = state.stats
-      ? trayDataUrlForMode(mode, 44, BUBBLE_BARS_COLORS, { contentOnly: mode === 'barsAllSessions' || mode === 'limitsAllSessions' })
+      ? trayDataUrlForMode(mode, 44, BUBBLE_BARS_COLORS, {
+          contentOnly: mode === 'barsAllSessions' || mode === 'limitsAllSessions',
+          providerBackdrop: true
+        })
       : null;
     if (dataUrl) {
       el.classList.add('bars');
@@ -6968,7 +6973,16 @@ function roundedRectPath(ctx, x, y, w, h, r) {
 const trayProviderImages = {};
 const trayProviderIconDeliveryGuard = window.TokenMonitorTrayProviderIcons.createTrayProviderIconDeliveryGuard();
 
-function renderBarsIcon(stats, height = 44, picker = pickWorstProvider, colors = {}) {
+function drawProviderImage(ctx, image, x, y, size, backdrop = false) {
+  if (backdrop) {
+    roundedRectPath(ctx, x, y, size, size, Math.max(2, Math.round(size * 0.24)));
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.9)';
+    ctx.fill();
+  }
+  ctx.drawImage(image, x, y, size, size);
+}
+
+function renderBarsIcon(stats, height = 44, picker = pickWorstProvider, colors = {}, options = {}) {
   const trackColor = colors.track || 'rgba(0, 0, 0, 0.32)';
   const fillColor = colors.fill || 'rgba(0, 0, 0, 1)';
   const selection = picker(stats);
@@ -6985,7 +6999,7 @@ function renderBarsIcon(stats, height = 44, picker = pickWorstProvider, colors =
   ctx.clearRect(0, 0, layout.width, layout.height);
 
   if (providerImage) {
-    ctx.drawImage(providerImage, layout.padX, layout.iconY, layout.iconSize, layout.iconSize);
+    drawProviderImage(ctx, providerImage, layout.padX, layout.iconY, layout.iconSize, options.providerBackdrop === true);
   }
 
   function drawBar(y, percent) {
@@ -7112,7 +7126,7 @@ function renderLimitSessionsIcon(stats, height = 44, configOrder, colors = {}, o
   const centerY = height / 2;
   entries.forEach((entry, index) => {
     if (entry.image) {
-      ctx.drawImage(entry.image, x, layout.iconY, iconSize, iconSize);
+      drawProviderImage(ctx, entry.image, x, layout.iconY, iconSize, options.providerBackdrop === true);
       x += iconSize + gap;
     }
     ctx.fillText(entry.text, x, centerY + 1);
@@ -7128,7 +7142,7 @@ function renderLimitSessionsIcon(stats, height = 44, configOrder, colors = {}, o
 function barsDataUrlForMode(mode, size = 44, colors, options = {}) {
   if (mode === 'barsAllSessions') return renderAllSessionsIcon(state.stats, size, configuredLimitProviderOrder(), colors, options);
   const pickers = { barsSession: pickWorstSessionProvider, barsWeekly: pickWorstWeeklyProvider };
-  return renderBarsIcon(state.stats, size, pickers[mode] || pickWorstProvider, colors);
+  return renderBarsIcon(state.stats, size, pickers[mode] || pickWorstProvider, colors, options);
 }
 
 function trayDataUrlForMode(mode, size = 44, colors, options = {}) {

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -7030,14 +7030,14 @@ function pickConfiguredSessionProviders(stats, configOrder) {
   });
 }
 
-function renderAllSessionsIcon(stats, height = 44, configOrder, colors = {}) {
+function renderAllSessionsIcon(stats, height = 44, configOrder, colors = {}, options = {}) {
   const trackColor = colors.track || 'rgba(0, 0, 0, 0.32)';
   const fillColor = colors.fill || 'rgba(0, 0, 0, 1)';
   const picks = pickConfiguredSessionProviders(stats, configOrder);
   if (picks.length === 0) return null;
   // With one tool, preserve its canonical pair; a lone weekly/billing window is
   // promoted to the top lane and the lower lane remains an empty track.
-  if (picks.length === 1) return renderBarsIcon(stats, height, () => picks[0], colors);
+  if (picks.length === 1) return renderBarsIcon(stats, height, () => picks[0], colors, options);
 
   const { trayBarFillWidth, trayBarsLayout } = window.TokenMonitorTrayBars;
   const layout = trayBarsLayout(height, { contentOnly: true });

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -4245,13 +4245,13 @@ function applyControlLayout(settingsInTitlebar) {
 function applyAppearanceSettings(settings) {
   const opacity = clamp(settings?.glassOpacity ?? 68, 0, 100) / 100;
   const depth = clamp(settings?.glassBlur ?? 32, 0, 100) / 100;
+  const systemGlassDisabled = settings?.systemGlass === false;
   document.documentElement.style.setProperty('--glass-alpha', opacity.toFixed(2));
-  document.documentElement.style.setProperty('--bubble-alpha', (0.62 + opacity * 0.22).toFixed(2));
-  document.documentElement.style.setProperty('--bubble-blur', settings?.systemGlass === false ? '0px' : `${Math.round(10 + depth * 24)}px`);
   document.documentElement.style.setProperty('--line-alpha', (0.1 + depth * 0.09).toFixed(3));
   document.documentElement.style.setProperty('--line-strong-alpha', (0.18 + depth * 0.14).toFixed(3));
   document.documentElement.style.setProperty('--control-alpha', (0.03 + depth * 0.045).toFixed(3));
   document.documentElement.style.setProperty('--highlight-alpha', (0.045 + depth * 0.06).toFixed(3));
+  document.documentElement.classList.toggle('system-glass-disabled', systemGlassDisabled);
   applyReduceMotionPreference(settings?.reduceMotion);
   // Only full settings objects carry themeColors; glass/zoom preview patches
   // omit it, so we must not wipe theme overrides mid-slider-drag.
@@ -4677,11 +4677,19 @@ function normalizeWindowToggleShortcutValue(value) {
   return windowShortcutApi.normalizeWindowToggleShortcut(value);
 }
 
-const BUBBLE_CONTENT_MIN_W = 18;
+const BUBBLE_CONTENT_MIN_W = 34;
 const BUBBLE_CONTENT_HEIGHT = 34;
 const BUBBLE_CONTENT_PAD_X = 10;
-// The tray bars are black (a macOS menu-bar template); on the bubble's dark glass they need light ink.
-const BUBBLE_BARS_COLORS = { track: 'rgba(255, 255, 255, 0.22)', fill: 'rgba(255, 255, 255, 0.92)' };
+
+function floatingBubbleGeneratedColors() {
+  const text = resolvedThemeColor('text');
+  const rgb = themePresetsApi.hexToRgbTriplet(text);
+  return {
+    track: `rgba(${rgb}, 0.22)`,
+    fill: `rgba(${rgb}, 0.92)`,
+    text: `rgba(${rgb}, 0.92)`
+  };
+}
 
 function renderFloatingBubbleContent() {
   const el = els.floatingBubbleContent;
@@ -4689,9 +4697,9 @@ function renderFloatingBubbleContent() {
   const mode = state.settings?.floatingBubbleContent || 'icon';
   if (window.TokenMonitorTrayText.isGeneratedTrayIconMode(mode)) {
     const dataUrl = state.stats
-      ? trayDataUrlForMode(mode, 44, BUBBLE_BARS_COLORS, {
+      ? trayDataUrlForMode(mode, 44, floatingBubbleGeneratedColors(), {
           contentOnly: mode === 'barsAllSessions' || mode === 'limitsAllSessions',
-          providerBackdrop: true
+          providerContrastHalo: true
         })
       : null;
     if (dataUrl) {
@@ -6973,11 +6981,14 @@ function roundedRectPath(ctx, x, y, w, h, r) {
 const trayProviderImages = {};
 const trayProviderIconDeliveryGuard = window.TokenMonitorTrayProviderIcons.createTrayProviderIconDeliveryGuard();
 
-function drawProviderImage(ctx, image, x, y, size, backdrop = false) {
-  if (backdrop) {
-    roundedRectPath(ctx, x, y, size, size, Math.max(2, Math.round(size * 0.24)));
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.9)';
-    ctx.fill();
+function drawProviderImage(ctx, image, x, y, size, contrastHalo = false) {
+  if (contrastHalo) {
+    const lightSurface = themePresetsApi.isLightHex(resolvedThemeColor('bg'));
+    ctx.save();
+    ctx.shadowColor = lightSurface ? 'rgba(0, 0, 0, 0.58)' : 'rgba(255, 255, 255, 0.82)';
+    ctx.shadowBlur = Math.max(2, Math.round(size * 0.1));
+    ctx.drawImage(image, x, y, size, size);
+    ctx.restore();
   }
   ctx.drawImage(image, x, y, size, size);
 }
@@ -6999,7 +7010,7 @@ function renderBarsIcon(stats, height = 44, picker = pickWorstProvider, colors =
   ctx.clearRect(0, 0, layout.width, layout.height);
 
   if (providerImage) {
-    drawProviderImage(ctx, providerImage, layout.padX, layout.iconY, layout.iconSize, options.providerBackdrop === true);
+    drawProviderImage(ctx, providerImage, layout.padX, layout.iconY, layout.iconSize, options.providerContrastHalo === true);
   }
 
   function drawBar(y, percent) {
@@ -7126,7 +7137,7 @@ function renderLimitSessionsIcon(stats, height = 44, configOrder, colors = {}, o
   const centerY = height / 2;
   entries.forEach((entry, index) => {
     if (entry.image) {
-      drawProviderImage(ctx, entry.image, x, layout.iconY, iconSize, options.providerBackdrop === true);
+      drawProviderImage(ctx, entry.image, x, layout.iconY, iconSize, options.providerContrastHalo === true);
       x += iconSize + gap;
     }
     ctx.fillText(entry.text, x, centerY + 1);

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -4282,6 +4282,7 @@ function applyAppearanceSettings(settings) {
 
 const themePresetsApi = window.TokenMonitorThemePresets;
 let themeCodeFeedbackGeneration = 0;
+let appliedThemeOverrides = {};
 // Snapshot of the canonical brand colours, taken before any override is
 // applied. clientColors is mutated in place (other modules hold the same
 // reference), so this is the source of truth for "reset to brand".
@@ -4310,11 +4311,13 @@ function matchingThemePresetId(overrides) {
 }
 
 function applyThemeColors(overrides) {
+  appliedThemeOverrides = themePresetsApi.normalizeOverrides(overrides, themePresetsApi.INTERFACE_COLOR_KEYS);
   const root = document.documentElement.style;
-  for (const { name, value } of themePresetsApi.themeCssVarEntries(overrides)) {
+  for (const { name, value } of themePresetsApi.themeCssVarEntries(appliedThemeOverrides)) {
     if (value) root.setProperty(name, value);
     else root.removeProperty(name);
   }
+  renderFloatingBubbleContent();
 }
 
 function applyVendorColorOverrides(overrides) {
@@ -4324,8 +4327,7 @@ function applyVendorColorOverrides(overrides) {
 
 // Current resolved palette value for an interface colour key.
 function resolvedThemeColor(key) {
-  const clean = themePresetsApi.normalizeOverrides(state.settings?.themeColors, themePresetsApi.INTERFACE_COLOR_KEYS);
-  return clean[key] || themePresetsApi.DEFAULT_THEME[key];
+  return appliedThemeOverrides[key] || themePresetsApi.DEFAULT_THEME[key];
 }
 
 function buildAppearanceColorControls() {

--- a/src/electron/renderer/floatingBubbleBoot.js
+++ b/src/electron/renderer/floatingBubbleBoot.js
@@ -7,6 +7,9 @@
     document.documentElement.classList.add(`floating-bubble-collapsed-${side}`);
     window.__TOKEN_MONITOR_INITIAL_FLOATING_BUBBLE__ = { collapsed: true, side };
   }
+  if (query.get('systemGlassDisabled') === '1') {
+    document.documentElement.classList.add('system-glass-disabled');
+  }
   const period = query.get('period');
   const breakdown = query.get('breakdown');
   const viewState = {};

--- a/src/electron/renderer/styles.css
+++ b/src/electron/renderer/styles.css
@@ -11,13 +11,17 @@
   --panel-rgb: 16, 21, 30;
   --sunken-rgb: 4, 8, 13;
   --glass-alpha: 0.68;
-  --bubble-alpha: 0.78;
-  --bubble-blur: 18px;
   --line-alpha: 0.138;
   --line-strong-alpha: 0.238;
   --control-alpha: 0.049;
   --highlight-alpha: 0.07;
   --glass: rgba(var(--glass-rgb), var(--glass-alpha));
+  --glass-surface:
+    linear-gradient(180deg, rgba(var(--overlay-rgb), var(--highlight-alpha)), rgba(var(--overlay-rgb), 0.022)),
+    linear-gradient(135deg, rgba(var(--overlay-rgb), 0.035), rgba(0, 0, 0, 0.09)),
+    var(--glass);
+  --glass-filter: blur(32px) saturate(115%);
+  --floating-bubble-radius: 17px;
   --glass-strong: rgba(31, 35, 41, 0.56);
   --glass-soft: rgba(var(--overlay-rgb), 0.05);
   --line: rgba(var(--line-rgb), var(--line-alpha));
@@ -73,13 +77,10 @@ input, textarea, [contenteditable="true"] {
   border: 1px solid var(--line-strong);
   border-radius: 14px;
   clip-path: inset(0 round 14px);
-  background:
-    linear-gradient(180deg, rgba(var(--overlay-rgb), var(--highlight-alpha)), rgba(var(--overlay-rgb), 0.022)),
-    linear-gradient(135deg, rgba(var(--overlay-rgb), 0.035), rgba(0, 0, 0, 0.09)),
-    var(--glass);
+  background: var(--glass-surface);
   box-shadow: 0 22px 55px var(--shadow), inset 0 1px 0 rgba(var(--overlay-rgb), 0.13);
-  -webkit-backdrop-filter: blur(32px) saturate(115%);
-  backdrop-filter: blur(32px) saturate(115%);
+  -webkit-backdrop-filter: var(--glass-filter);
+  backdrop-filter: var(--glass-filter);
 }
 html.is-windows, html.is-windows body {
   border-radius: 8px;
@@ -121,15 +122,23 @@ html.is-mac-legacy .shell {
   width: 100%;
   height: 100%;
   padding: 0;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(15, 18, 24, var(--bubble-alpha));
-  color: #f7f9fb;
+  overflow: hidden;
+  border: 0;
+  border-radius: var(--floating-bubble-radius);
+  background: var(--glass-surface);
+  color: var(--number);
   cursor: grab;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14), inset 0 0 0 1px rgba(0, 0, 0, 0.16);
+  box-shadow: inset 0 1px 0 rgba(var(--overlay-rgb), 0.13);
   outline: none;
-  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.72);
-  -webkit-backdrop-filter: blur(var(--bubble-blur)) saturate(130%);
-  backdrop-filter: blur(var(--bubble-blur)) saturate(130%);
+  -webkit-backdrop-filter: var(--glass-filter);
+  backdrop-filter: var(--glass-filter);
+}
+.system-glass-disabled .floating-bubble-tab {
+  box-shadow:
+    inset 0 0 0 1px var(--line-strong),
+    inset 0 1px 0 rgba(var(--overlay-rgb), 0.13);
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
 }
 .floating-bubble-tab span {
   display: block;
@@ -157,11 +166,11 @@ body.floating-bubble-collapsed-right {
 }
 html.floating-bubble-collapsed-left,
 body.floating-bubble-collapsed-left {
-  border-radius: 0;
+  border-radius: var(--floating-bubble-radius);
 }
 html.floating-bubble-collapsed-right,
 body.floating-bubble-collapsed-right {
-  border-radius: 0;
+  border-radius: var(--floating-bubble-radius);
 }
 html.floating-bubble-collapsed-left body .shell,
 html.floating-bubble-collapsed-right body .shell,
@@ -173,12 +182,22 @@ body.floating-bubble-collapsed-right .shell {
 html.floating-bubble-collapsed-left body .floating-bubble-tab,
 body.floating-bubble-collapsed-left .floating-bubble-tab {
   display: flex;
-  border-radius: 0;
+  border-radius: var(--floating-bubble-radius);
 }
 html.floating-bubble-collapsed-right body .floating-bubble-tab,
 body.floating-bubble-collapsed-right .floating-bubble-tab {
   display: flex;
-  border-radius: 0;
+  border-radius: var(--floating-bubble-radius);
+}
+html.is-windows.floating-bubble-collapsed-left,
+html.is-windows.floating-bubble-collapsed-right,
+html.is-windows body.floating-bubble-collapsed-left,
+html.is-windows body.floating-bubble-collapsed-right,
+html.is-windows.floating-bubble-collapsed-left body .floating-bubble-tab,
+html.is-windows.floating-bubble-collapsed-right body .floating-bubble-tab,
+body.is-windows.floating-bubble-collapsed-left .floating-bubble-tab,
+body.is-windows.floating-bubble-collapsed-right .floating-bubble-tab {
+  border-radius: 8px;
 }
 .floating-bubble-tab:hover {
   color: var(--text);

--- a/src/electron/renderer/styles.css
+++ b/src/electron/renderer/styles.css
@@ -11,6 +11,8 @@
   --panel-rgb: 16, 21, 30;
   --sunken-rgb: 4, 8, 13;
   --glass-alpha: 0.68;
+  --bubble-alpha: 0.78;
+  --bubble-blur: 18px;
   --line-alpha: 0.138;
   --line-strong-alpha: 0.238;
   --control-alpha: 0.049;
@@ -119,14 +121,15 @@ html.is-mac-legacy .shell {
   width: 100%;
   height: 100%;
   padding: 0;
-  border: 0;
-  background: transparent;
-  color: var(--green);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(15, 18, 24, var(--bubble-alpha));
+  color: #f7f9fb;
   cursor: grab;
-  box-shadow: none;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14), inset 0 0 0 1px rgba(0, 0, 0, 0.16);
   outline: none;
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.72);
+  -webkit-backdrop-filter: blur(var(--bubble-blur)) saturate(130%);
+  backdrop-filter: blur(var(--bubble-blur)) saturate(130%);
 }
 .floating-bubble-tab span {
   display: block;
@@ -150,11 +153,7 @@ html.floating-bubble-collapsed-left,
 body.floating-bubble-collapsed-left,
 html.floating-bubble-collapsed-right,
 body.floating-bubble-collapsed-right {
-  background:
-    linear-gradient(180deg, rgba(var(--overlay-rgb), var(--highlight-alpha)), rgba(var(--overlay-rgb), 0.022)),
-    linear-gradient(135deg, rgba(var(--overlay-rgb), 0.035), rgba(0, 0, 0, 0.09)),
-    var(--glass),
-    rgb(var(--glass-rgb));
+  background: transparent;
 }
 html.floating-bubble-collapsed-left,
 body.floating-bubble-collapsed-left {

--- a/src/electron/windowsChrome.js
+++ b/src/electron/windowsChrome.js
@@ -53,8 +53,8 @@ function setUintAttribute(api, hwnd, attribute, value) {
   api.DwmSetWindowAttribute(hwnd, attribute, buf, 4);
 }
 
-// `round` is skipped for the docked floating bubble, whose inner edge must stay
-// square against the screen edge.
+// The collapsed floating bubble can be dragged anywhere, so it keeps the same
+// anti-aliased DWM rounding as the expanded widget.
 function applyWindowsChrome(win, { round = false } = {}) {
   if (process.platform !== 'win32') return;
   if (!win || win.isDestroyed?.()) return;

--- a/tests/electron/floatingBubble.test.js
+++ b/tests/electron/floatingBubble.test.js
@@ -26,6 +26,7 @@ const windowsDisplay = {
   workArea: { x: 0, y: 0, width: 1840, height: 1040 }
 };
 const stylesPath = path.join(__dirname, '..', '..', 'src', 'electron', 'renderer', 'styles.css');
+const appPath = path.join(__dirname, '..', '..', 'src', 'electron', 'renderer', 'app.js');
 const indexPath = path.join(__dirname, '..', '..', 'src', 'electron', 'renderer', 'index.html');
 const bootPath = path.join(__dirname, '..', '..', 'src', 'electron', 'renderer', 'floatingBubbleBoot.js');
 
@@ -378,6 +379,7 @@ test('dragFloatingBubbleBounds anchors the mini-window to the OS cursor point', 
 
 test('floating bubble collapsed styles fill the mini window with app glass styling', () => {
   const css = fs.readFileSync(stylesPath, 'utf8');
+  const app = fs.readFileSync(appPath, 'utf8');
   const html = fs.readFileSync(indexPath, 'utf8');
   const boot = fs.readFileSync(bootPath, 'utf8');
   assert.ok(html.indexOf('floatingBubbleBoot.js') < html.indexOf('styles.css'));
@@ -390,12 +392,16 @@ test('floating bubble collapsed styles fill the mini window with app glass styli
   assert.match(css, /html\.floating-bubble-collapsed-right,\s*body\.floating-bubble-collapsed-right/);
   const collapsedBlock = cssBlock(css, 'html\\.floating-bubble-collapsed-left,\\s*body\\.floating-bubble-collapsed-left,\\s*html\\.floating-bubble-collapsed-right,\\s*body\\.floating-bubble-collapsed-right');
   const tabBlock = cssBlock(css, '\\.floating-bubble-tab');
-  assert.match(collapsedBlock, /rgb\(var\(--glass-rgb\)\);/);
+  assert.match(collapsedBlock, /background:\s*transparent;/);
   assert.match(tabBlock, /appearance:\s*none;/);
-  assert.match(tabBlock, /border:\s*0;/);
-  assert.match(tabBlock, /background:\s*transparent;/);
-  assert.match(tabBlock, /box-shadow:\s*none;/);
-  assert.match(tabBlock, /backdrop-filter:\s*none;/);
+  assert.match(tabBlock, /border:\s*1px solid rgba\(255, 255, 255, 0\.2\);/);
+  assert.match(tabBlock, /background:\s*rgba\(15, 18, 24, var\(--bubble-alpha\)\);/);
+  assert.match(tabBlock, /color:\s*#f7f9fb;/);
+  assert.match(tabBlock, /backdrop-filter:\s*blur\(var\(--bubble-blur\)\) saturate\(130%\);/);
+  assert.match(css, /--bubble-alpha:\s*0\.78;/);
+  assert.match(css, /--bubble-blur:\s*18px;/);
+  assert.match(app, /--bubble-alpha', \(0\.62 \+ opacity \* 0\.22\)\.toFixed\(2\)/);
+  assert.match(app, /--bubble-blur', settings\?\.systemGlass === false \? '0px'/);
   assert.match(css, /html\.floating-bubble-collapsed-left body \.shell,\s*html\.floating-bubble-collapsed-right body \.shell/);
   assert.match(css, /html\.floating-bubble-collapsed-left body \.floating-bubble-tab/);
   assert.match(css, /html\.floating-bubble-collapsed-left,\s*body\.floating-bubble-collapsed-left\s*\{[\s\S]*border-radius:\s*0;/);

--- a/tests/electron/floatingBubble.test.js
+++ b/tests/electron/floatingBubble.test.js
@@ -43,26 +43,9 @@ test('floating bubble is available only for enabled movable window modes', () =>
   assert.equal(canUseFloatingBubble({ floatingBubbleEnabled: true, windowBehavior: 'floating', trayMode: true }), false);
 });
 
-test('floating bubble disables native system glass while collapsed', () => {
-  assert.equal(floatingBubbleNativeGlassEnabled({ systemGlass: true }, { collapsed: false }), true);
-  assert.equal(floatingBubbleNativeGlassEnabled({ systemGlass: true }, { collapsed: true }), false);
-  assert.equal(floatingBubbleNativeGlassEnabled({ systemGlass: false }, { collapsed: false }), false);
-  assert.equal(
-    floatingBubbleNativeGlassEnabled({ systemGlass: true, floatingBubbleEnabled: true }, { collapsed: false }, 'win32'),
-    true
-  );
-  assert.equal(
-    floatingBubbleNativeGlassEnabled({ systemGlass: false, floatingBubbleEnabled: true }, { collapsed: false }, 'win32'),
-    false
-  );
-  assert.equal(
-    floatingBubbleNativeGlassEnabled({ systemGlass: true, floatingBubbleEnabled: true }, { collapsed: true }, 'win32'),
-    false
-  );
-  assert.equal(
-    floatingBubbleNativeGlassEnabled({ systemGlass: true, floatingBubbleEnabled: true }, { collapsed: false }, 'darwin'),
-    true
-  );
+test('floating bubble native glass follows the system glass setting', () => {
+  assert.equal(floatingBubbleNativeGlassEnabled({ systemGlass: true }), true);
+  assert.equal(floatingBubbleNativeGlassEnabled({ systemGlass: false }), false);
 });
 
 test('floatingBubbleCollapsedArea uses physical display bounds on Windows', () => {
@@ -76,7 +59,7 @@ test('floatingBubbleCollapsedArea uses physical display bounds on Windows', () =
 test('floatingBubbleWindowChrome removes Windows native frame only for collapsed mini-window', () => {
   assert.deepEqual(floatingBubbleWindowChrome('win32', true), {
     hasShadow: false,
-    roundedCorners: false,
+    roundedCorners: true,
     thickFrame: false
   });
   assert.deepEqual(floatingBubbleWindowChrome('win32', false), {});
@@ -394,17 +377,22 @@ test('floating bubble collapsed styles fill the mini window with app glass styli
   const tabBlock = cssBlock(css, '\\.floating-bubble-tab');
   assert.match(collapsedBlock, /background:\s*transparent;/);
   assert.match(tabBlock, /appearance:\s*none;/);
-  assert.match(tabBlock, /border:\s*1px solid rgba\(255, 255, 255, 0\.2\);/);
-  assert.match(tabBlock, /background:\s*rgba\(15, 18, 24, var\(--bubble-alpha\)\);/);
-  assert.match(tabBlock, /color:\s*#f7f9fb;/);
-  assert.match(tabBlock, /backdrop-filter:\s*blur\(var\(--bubble-blur\)\) saturate\(130%\);/);
-  assert.match(css, /--bubble-alpha:\s*0\.78;/);
-  assert.match(css, /--bubble-blur:\s*18px;/);
-  assert.match(app, /--bubble-alpha', \(0\.62 \+ opacity \* 0\.22\)\.toFixed\(2\)/);
-  assert.match(app, /--bubble-blur', settings\?\.systemGlass === false \? '0px'/);
+  assert.match(tabBlock, /border:\s*0;/);
+  assert.match(tabBlock, /border-radius:\s*var\(--floating-bubble-radius\);/);
+  assert.match(app, /const BUBBLE_CONTENT_MIN_W = 34;/);
+  assert.match(tabBlock, /background:\s*var\(--glass-surface\);/);
+  assert.match(tabBlock, /color:\s*var\(--number\);/);
+  assert.match(tabBlock, /backdrop-filter:\s*var\(--glass-filter\);/);
+  assert.match(css, /\.system-glass-disabled \.floating-bubble-tab\s*\{[\s\S]*backdrop-filter:\s*none;/);
+  assert.match(app, /classList\.toggle\('system-glass-disabled', systemGlassDisabled\)/);
+  assert.match(boot, /query\.get\('systemGlassDisabled'\) === '1'/);
+  assert.match(css, /--glass-surface:\s*[\s\S]*var\(--glass\);/);
+  assert.match(css, /--glass-filter:\s*blur\(32px\) saturate\(115%\);/);
+  assert.doesNotMatch(css, /--bubble-(?:alpha|blur)/);
+  assert.doesNotMatch(app, /--bubble-(?:alpha|blur)/);
   assert.match(css, /html\.floating-bubble-collapsed-left body \.shell,\s*html\.floating-bubble-collapsed-right body \.shell/);
   assert.match(css, /html\.floating-bubble-collapsed-left body \.floating-bubble-tab/);
-  assert.match(css, /html\.floating-bubble-collapsed-left,\s*body\.floating-bubble-collapsed-left\s*\{[\s\S]*border-radius:\s*0;/);
+  assert.match(css, /html\.floating-bubble-collapsed-left,\s*body\.floating-bubble-collapsed-left\s*\{[\s\S]*border-radius:\s*var\(--floating-bubble-radius\);/);
 });
 
 test('floatingBubbleCollapsePlan honors a custom handle size', () => {

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -367,9 +367,12 @@ test('limit percent tray mode renders provider icons into a generated tray image
   assert.match(renderLimitSessionsIcon, /secondaryWindow/);
   assert.match(renderLimitSessionsIcon, /trayProviderImages\[pick\.providerRecord\.provider\]/);
   assert.match(renderLimitSessionsIcon, /drawProviderImage\(ctx, entry\.image/);
-  assert.match(drawProviderImage, /rgba\(255, 255, 255, 0\.9\)/);
-  assert.match(drawProviderImage, /roundedRectPath\(ctx, x, y, size, size/);
-  assert.match(app, /providerBackdrop:\s*true/);
+  assert.match(drawProviderImage, /shadowColor/);
+  assert.match(drawProviderImage, /shadowBlur/);
+  assert.doesNotMatch(drawProviderImage, /fillRect|\.fill\(/);
+  assert.match(app, /providerContrastHalo:\s*true/);
+  assert.match(app, /function floatingBubbleGeneratedColors\(\)/);
+  assert.match(app, /resolvedThemeColor\('text'\)/);
   assert.match(renderLimitSessionsIcon, /`500 \$\{fontSize\}px/);
   assert.match(renderLimitSessionsIcon, /formatPercent\(limitFillPercent/);
   assert.match(renderLimitSessionsIcon, /·/);

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -373,6 +373,9 @@ test('limit percent tray mode renders provider icons into a generated tray image
   assert.match(app, /providerContrastHalo:\s*true/);
   assert.match(app, /function floatingBubbleGeneratedColors\(\)/);
   assert.match(app, /resolvedThemeColor\('text'\)/);
+  assert.match(app, /appliedThemeOverrides = themePresetsApi\.normalizeOverrides\(overrides/);
+  assert.match(app, /function applyThemeColors\(overrides\)[\s\S]*renderFloatingBubbleContent\(\);/);
+  assert.match(app, /function resolvedThemeColor\(key\)[\s\S]*appliedThemeOverrides\[key\]/);
   assert.match(renderLimitSessionsIcon, /`500 \$\{fontSize\}px/);
   assert.match(renderLimitSessionsIcon, /formatPercent\(limitFillPercent/);
   assert.match(renderLimitSessionsIcon, /·/);

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -347,6 +347,8 @@ test('tray primary-limit modes use the shared provider-aware resolver', () => {
   assert.match(renderBars, /secondaryWindow/);
   assert.doesNotMatch(renderBars, /\.find\(\(w\) => w\.kind/);
   assert.match(renderAllSessions, /trayBarsLayout\(height, \{ contentOnly: true \}\)/);
+  assert.match(renderAllSessions, /function renderAllSessionsIcon\(stats, height = 44, configOrder, colors = \{\}, options = \{\}\)/);
+  assert.match(renderAllSessions, /picks\.length === 1\) return renderBarsIcon\(stats, height, \(\) => picks\[0\], colors, options\)/);
 });
 
 test('limit percent tray mode renders provider icons into a generated tray image', () => {

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -353,6 +353,7 @@ test('limit percent tray mode renders provider icons into a generated tray image
   const app = readRendererFile('app.js');
   const main = fs.readFileSync(path.join(__dirname, '../../src/electron/main.js'), 'utf8');
   const renderLimitSessionsIcon = functionBody(app, 'renderLimitSessionsIcon', 'barsDataUrlForMode');
+  const drawProviderImage = functionBody(app, 'drawProviderImage', 'renderBarsIcon');
   const maybeUpdateBarsIcon = functionBody(app, 'maybeUpdateBarsIcon', 'loadImage');
   const updateTrayDisplay = functionBody(main, 'updateTrayDisplay', 'sendStatus');
 
@@ -363,6 +364,10 @@ test('limit percent tray mode renders provider icons into a generated tray image
   assert.match(renderLimitSessionsIcon, /primaryWindow/);
   assert.match(renderLimitSessionsIcon, /secondaryWindow/);
   assert.match(renderLimitSessionsIcon, /trayProviderImages\[pick\.providerRecord\.provider\]/);
+  assert.match(renderLimitSessionsIcon, /drawProviderImage\(ctx, entry\.image/);
+  assert.match(drawProviderImage, /rgba\(255, 255, 255, 0\.9\)/);
+  assert.match(drawProviderImage, /roundedRectPath\(ctx, x, y, size, size/);
+  assert.match(app, /providerBackdrop:\s*true/);
   assert.match(renderLimitSessionsIcon, /`500 \$\{fontSize\}px/);
   assert.match(renderLimitSessionsIcon, /formatPercent\(limitFillPercent/);
   assert.match(renderLimitSessionsIcon, /·/);


### PR DESCRIPTION
## Summary

- Give the collapsed Floating Bubble a dedicated translucent contrast surface with blur, border, and text shadow so its content stays readable over light and dark wallpapers.
- Keep the surface responsive to the existing glass opacity, blur depth, and system glass settings while enforcing a minimum readable tint.
- Draw provider icons over a light backing only in generated Floating Bubble content, preserving dark assets such as Codex without changing tray icon rendering.

## Root cause

The collapsed bubble explicitly disables native system glass, while its generated limit text is rendered in light ink and some provider assets are nearly black. Depending on the wallpaper, either the text or provider icon could disappear. The fix gives the bubble its own reliable contrast layer and handles dark provider artwork independently of the text colour.

Fixes #184

## Testing

- `node --test tests/electron/floatingBubble.test.js tests/electron/limitProviderPresentation.test.js`
- `npm run verify` (with isolated `HOME`, `USERPROFILE`, `APPDATA`, and `LOCALAPPDATA` so local Copilot/Hermes data does not leak into filesystem guard tests)

## Visual reference

The dark- and light-wallpaper failure cases are attached to #184: https://github.com/Javis603/token-monitor/issues/184

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves readability of the collapsed Floating Bubble by aligning it with the app’s glass appearance and adding a reliable contrast surface so text and provider icons stay visible on any wallpaper. Fixes #184.

- **Bug Fixes**
  - Adopted shared app glass variables `--glass-surface` and `--glass-filter`; native blur now follows the `systemGlass` setting exactly, disabling blur via a `.system-glass-disabled` class when off (applied at boot through a query flag).
  - Generated bubble content now uses the active theme text color and re-renders during theme previews; provider icons draw with a subtle contrast halo across bars/limits/all-sessions modes (including single-provider). Tray icon behavior is unchanged.
  - Collapsed bubble keeps a transparent window background; the tab has rounded corners, the app glass surface, an inset highlight, and uses theme `--number` text color. Windows DWM rounding is enabled for the mini-window, and the content’s minimum width is increased to 34px to avoid clipping.
  - Updated tests for new CSS variables/classes, early `.system-glass-disabled` boot wiring, theme preview sync, single-provider pass‑through, and the icon draw helper.

<sup>Written for commit 1e73f819f61d8ae11bab050c968bf14ee211bdf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

