### PR TITLE
fix(collector): decouple session timestamps from project tracking

### DIFF
--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -380,6 +380,9 @@ function sessionTimestampMap(periods, home = os.homedir(), deps = {}) {
   const metadata = deps.metadataCache || new Map();
   const resolvedSessionKeys = deps.resolvedSessionKeys || new Set();
   const attemptedSessionKeys = deps.attemptedSessionKeys || new Set();
+  // Timestamps are always backfilled (the session view sorts by recency); project
+  // identity is the part gated by the Projects opt-out (issue #182).
+  const resolveProjects = deps.resolveProjects !== false;
   const byClient = new Map();
   for (const ref of refs.values()) {
     const key = `${ref.client}:${ref.sessionId}`;
@@ -392,7 +395,7 @@ function sessionTimestampMap(periods, home = os.homedir(), deps = {}) {
   const applyFile = (client, sessionId, filePath) => {
     const startedAt = timestampFromSessionId(sessionId);
     const lastUsedAt = lastJsonlTimestamp(filePath) || startedAt;
-    const identity = projectIdentity(projectPathFromJsonl(filePath));
+    const identity = resolveProjects ? projectIdentity(projectPathFromJsonl(filePath)) : {};
     const key = `${client}:${sessionId}`;
     metadata.set(key, { startedAt, lastUsedAt, ...identity });
     if (identity.projectId) resolvedSessionKeys.add(key);
@@ -407,7 +410,7 @@ function sessionTimestampMap(periods, home = os.homedir(), deps = {}) {
     for (const [sessionId, meta] of readOpencodeMeta(opencodeIds)) {
       const startedAt = meta.startedAt || '';
       const lastUsedAt = meta.lastUsedAt || startedAt;
-      const identity = projectIdentity(meta.projectPath);
+      const identity = resolveProjects ? projectIdentity(meta.projectPath) : {};
       const key = `opencode:${sessionId}`;
       if (startedAt || lastUsedAt || identity.projectId) metadata.set(key, { startedAt, lastUsedAt, ...identity });
       if (identity.projectId) resolvedSessionKeys.add(key);
@@ -592,7 +595,7 @@ async function collectUsageOnce(options) {
   const decorateLocalPeriods = (periods, { retryMisses = false } = {}) => applySessionTimestamps(
     periods,
     options.homeDir || os.homedir(),
-    { ...localSessionMetadataDeps, retryMisses }
+    { ...localSessionMetadataDeps, retryMisses, resolveProjects: projectsEnabled }
   );
   // tokscale doesn't know about Proma yet — filter it out of the subprocess
   // calls so --client doesn't reject an unknown value. Proma is parsed
@@ -647,28 +650,30 @@ async function collectUsageOnce(options) {
       // is what let the issue #15 self-trigger loop spike tokscale past 500% CPU.
       const todayJson = await runTokscaleFn({ clients: tokscaleClients, flags: ['--today'], commandTimeoutMs });
       today = extractUsageFromTokscale(todayJson);
-      if (projectsEnabled && typeof options.onProgress === 'function') decorateLocalPeriods({ today });
+      if (typeof options.onProgress === 'function') decorateLocalPeriods({ today });
       try { if (typeof options.onProgress === 'function') options.onProgress({ today, updatedAt: new Date().toISOString() }); } catch (_) {}
       const monthJson = await runTokscaleFn({ clients: tokscaleClients, flags: ['--month'], commandTimeoutMs });
       month = extractUsageFromTokscale(monthJson);
-      if (projectsEnabled && typeof options.onProgress === 'function') decorateLocalPeriods({ today, month });
+      if (typeof options.onProgress === 'function') decorateLocalPeriods({ today, month });
       try { if (typeof options.onProgress === 'function') options.onProgress({ today, month, updatedAt: new Date().toISOString() }); } catch (_) {}
       const allTimeJson = await runTokscaleFn({ clients: tokscaleClients, flags: ['--since', allTimeSince], commandTimeoutMs });
       allTime = extractUsageFromTokscale(allTimeJson);
     }
-    if (projectsEnabled) {
-      if (anchorUsed) {
-        // Watch tick: `today` is a fresh scan and must be decorated, but month/
-        // allTime are derived from the last full-scan anchor and already carry each
-        // session's project label + timestamps through applyPeriodDelta. Decorating
-        // them again would re-stat every historical session file every few seconds
-        // (the perceived UI stutter). Decorate only today, then propagate its freshly
-        // resolved identities onto sessions that started today (absent from the anchor).
-        decorateLocalPeriods({ today }, { retryMisses: true });
-        propagateTodayProjects(today, [month, allTime]);
-      } else {
-        decorateLocalPeriods({ today, month, allTime }, { retryMisses: true });
-      }
+    // Always decorate: session timestamps drive the recency sort regardless of the
+    // Projects opt-out (issue #182). decorateLocalPeriods gates only project identity
+    // on projectsEnabled, so opting out still costs the timestamp backfill and nothing
+    // more.
+    if (anchorUsed) {
+      // Watch tick: `today` is a fresh scan and must be decorated, but month/
+      // allTime are derived from the last full-scan anchor and already carry each
+      // session's project label + timestamps through applyPeriodDelta. Decorating
+      // them again would re-stat every historical session file every few seconds
+      // (the perceived UI stutter). Decorate only today, then propagate its freshly
+      // resolved identities onto sessions that started today (absent from the anchor).
+      decorateLocalPeriods({ today }, { retryMisses: true });
+      propagateTodayProjects(today, [month, allTime]);
+    } else {
+      decorateLocalPeriods({ today, month, allTime }, { retryMisses: true });
     }
     if (promaPeriods && !anchorUsed) {
       today = mergePeriods(today, promaPeriods.today);
@@ -706,7 +711,7 @@ async function collectUsageOnce(options) {
           pricingRevision: options.pricingRevision
         }),
         logger: options.logger,
-        decoratePeriods: projectsEnabled ? (periods, home) => applySessionTimestamps(periods, home, { scopedHome: true }) : undefined
+        decoratePeriods: (periods, home) => applySessionTimestamps(periods, home, { scopedHome: true, resolveProjects: projectsEnabled })
       });
       wslBundle = wslResult.bundle;
       wslDetected = wslResult.detected;
@@ -726,7 +731,7 @@ async function collectUsageOnce(options) {
           pricingRevision: options.pricingRevision
         }),
         logger: options.logger,
-        decoratePeriods: projectsEnabled ? (periods, home) => applySessionTimestamps(periods, home, { scopedHome: true }) : undefined
+        decoratePeriods: (periods, home) => applySessionTimestamps(periods, home, { scopedHome: true, resolveProjects: projectsEnabled })
       });
       wslBundle = wslResult.bundle;
       wslDetected = wslResult.detected;

--- a/tests/shared/collectorProgressiveLoading.test.js
+++ b/tests/shared/collectorProgressiveLoading.test.js
@@ -141,12 +141,37 @@ test('disabling project tracking skips local metadata attribution', async () => 
       projectsEnabled: false, limitsEnabled: false, historyEnabled: false,
       runTokscale: async () => ({ entries: [{ client: 'claude', sessionId: 's1', model: 'm', input: 1 }] }),
       collectWslUsage: async (options) => {
-        assert.equal(options.decoratePeriods, undefined);
+        // Timestamps still need backfilling with projects off, so the decorator is
+        // provided; it just resolves no project identity.
+        assert.equal(typeof options.decoratePeriods, 'function');
         return { bundle: emptyWslBundle(), detected: [] };
       }
     });
     const session = summary.today.sessions['claude:s1'];
     assert.equal(summary.projectsEnabled, false);
+    assert.equal(session.projectId, '');
+    assert.equal(session.projectLabel, '');
+    // The timestamp backfill still runs (mtime fallback), only project attribution is skipped.
+    assert.ok(session.lastUsedAt);
+  } finally { fs.rmSync(home, { recursive: true, force: true }); }
+});
+
+test('session timestamps are backfilled even when project tracking is disabled', async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'token-monitor-ts-no-projects-'));
+  try {
+    const transcriptDir = path.join(home, '.claude', 'projects', 'repo');
+    fs.mkdirSync(transcriptDir, { recursive: true });
+    fs.writeFileSync(path.join(transcriptDir, 's1.jsonl'), `${JSON.stringify({ cwd: '/work/private-repo', timestamp: '2026-01-02T03:04:05Z' })}\n`);
+    const summary = await collectUsageOnce({
+      clients: 'claude', allTimeSince: '2025-01-01', deviceId: 'dev1', homeDir: home,
+      projectsEnabled: false, limitsEnabled: false, historyEnabled: false,
+      runTokscale: async () => ({ entries: [{ client: 'claude', sessionId: 's1', model: 'm', input: 1 }] }),
+      collectWslUsage: async () => ({ bundle: emptyWslBundle(), detected: [] })
+    });
+    const session = summary.today.sessions['claude:s1'];
+    // Timestamp backfilled so the session view can sort by recency (issue #182).
+    assert.equal(session.lastUsedAt, '2026-01-02T03:04:05.000Z');
+    // Project attribution still suppressed by the opt-out.
     assert.equal(session.projectId, '');
     assert.equal(session.projectLabel, '');
   } finally { fs.rmSync(home, { recursive: true, force: true }); }


### PR DESCRIPTION
## What

Session recency sort silently stopped working whenever project tracking was off, which is its default (`TOKEN_MONITOR_PROJECTS_ENABLED` / `projectsEnabled` defaults to false). Every session ended up with `sortTime=0`, so the session view fell back to pure token order (#182).

## Why

The timestamp backfill and the project-identity resolution share one decoration pass (`applySessionTimestamps` / `sessionTimestampMap`). That pass reads each session's transcript once to derive both the last-activity time and the workspace path. When the projects opt-out landed, every call to that pass got wrapped in `if (projectsEnabled)`, which was meant to skip the project metadata scan but swept the timestamps along with it. Result: with projects off, no session carried `startedAt`/`lastUsedAt`.

## Fix

Decouple the two concerns with a `resolveProjects` flag on the decoration deps (defaults to true):

- Timestamps (`startedAt`/`lastUsedAt`) always backfill.
- Only `projectId`/`projectLabel` resolution is gated: `applyFile` and the OpenCode branch do `resolveProjects ? projectIdentity(...) : {}`.
- `collectUsageOnce` now decorates unconditionally and passes `resolveProjects: projectsEnabled` at the progressive, main-block, and WSL `decoratePeriods` sites.

Cost stays at the pre-opt-out level: `jsonlTimestampCache` (keyed on size:mtimeMs) absorbs re-reads of unchanged transcripts, and projects-off skips `projectPathFromJsonl` entirely.

Scope note: this restores time sort for the tools with a designed timestamp reader (Claude, Codex, OpenCode). Tools whose sessions only expose an opaque id (GitHub Copilot, WorkBuddy, Kiro, Grok, etc.) have no timestamp source and still sort by token; adding those is separate per-client work.

## Verification

- `npm run verify` (lint + full suite): 1381/1381 pass.
- New regression test `session timestamps are backfilled even when project tracking is disabled`; updated the now-stale `decoratePeriods === undefined` assertion in `disabling project tracking skips local metadata attribution`.
- End-to-end against real sessions with `projectsEnabled: false`: all today sessions now carry timestamps, zero carry a `projectId` (opt-out preserved). With `projectsEnabled: true`, both are present, and the timestamps are identical across the two modes.

Refs #182. This restores the default time sort for the timestamp-bearing tools; the opaque-id tools in that thread (GitHub Copilot, WorkBuddy) have no timestamp source and are separate per-client work, so the issue stays open.
