### PR TITLE
fix(release): sign installed Windows application

### DIFF
--- a/.github/signpath/application-artifact-configuration.xml
+++ b/.github/signpath/application-artifact-configuration.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
+  <parameters>
+    <parameter name="version" required="true" />
+  </parameters>
+  <zip-file>
+    <pe-file
+      path="application/Token Monitor.exe"
+      product-name="Token Monitor"
+      product-version="${version}">
+      <authenticode-sign />
+    </pe-file>
+  </zip-file>
+</artifact-configuration>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,10 @@ jobs:
           echo "${{ secrets.APPLE_API_KEY_BASE64 }}" | base64 --decode > "$RUNNER_TEMP/apple_api_key.p8"
           echo "APPLE_API_KEY=$RUNNER_TEMP/apple_api_key.p8" >> "$GITHUB_ENV"
       # APPIMAGE_EXTRACT_AND_RUN lets electron-builder's bundled appimagetool
-      # run without libfuse2 (absent on the runners); a no-op on mac/win.
-      - run: npm run dist:${{ matrix.target }}
+      # run without libfuse2 (absent on the runners).
+      - name: Build platform artifacts
+        if: matrix.target != 'win'
+        run: npm run dist:${{ matrix.target }}
         env:
           APPIMAGE_EXTRACT_AND_RUN: '1'
           CSC_LINK: ${{ matrix.target == 'mac' && secrets.MAC_CSC_LINK || '' }}
@@ -84,6 +86,78 @@ jobs:
             --wait
           xcrun stapler staple "$dmg_path"
           xcrun stapler validate "$dmg_path"
+      # Sign the branded application executable before it is embedded into the
+      # NSIS installer and portable wrapper. electron-builder's --prepackaged
+      # mode then packages these exact signed bytes without rebuilding the app.
+      - name: Build unpacked Windows application
+        if: matrix.target == 'win'
+        run: npm run dist:win:dir
+      # --prepackaged deliberately skips electron-builder's afterPack hooks, so
+      # preserve the same updater config that a normal NSIS build would embed.
+      - name: Write Windows updater configuration
+        if: matrix.target == 'win'
+        run: node scripts/signpath-windows-artifacts.js write-update-config dist/win-unpacked
+      - name: Prepare Windows application for signing
+        if: matrix.target == 'win'
+        id: prepare-unsigned-win-app
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/signpath-windows-artifacts.js prepare-application \
+            dist/win-unpacked "$RUNNER_TEMP/signpath-application-input" >> "$GITHUB_OUTPUT"
+      - name: Upload unsigned Windows application
+        if: matrix.target == 'win'
+        id: upload-unsigned-win-app
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: unsigned-windows-application
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+          # Upload the prepared root so the ZIP preserves application/ as the
+          # path required by the SignPath artifact configuration.
+          path: ${{ runner.temp }}/signpath-application-input
+      - name: Code-sign Windows application (SignPath)
+        if: matrix.target == 'win'
+        uses: SignPath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2.2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: 8bf2856b-5fb0-4c78-ba99-90931fcce837
+          project-slug: token-monitor
+          signing-policy-slug: release-signing
+          artifact-configuration-slug: application
+          github-artifact-id: ${{ steps.upload-unsigned-win-app.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: dist/signpath-application-output
+          parameters: |
+            version: ${{ toJSON(steps.prepare-unsigned-win-app.outputs.version) }}
+      - name: Apply signed Windows application
+        if: matrix.target == 'win'
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/signpath-windows-artifacts.js apply-application \
+            dist/win-unpacked dist/signpath-application-output
+      - name: Verify Windows application Authenticode signature
+        if: matrix.target == 'win'
+        shell: pwsh
+        run: |
+          $application = Get-Item -LiteralPath (Join-Path 'dist/win-unpacked' '${{ steps.prepare-unsigned-win-app.outputs.application }}') -ErrorAction Stop
+          $signature = Get-AuthenticodeSignature -FilePath $application.FullName
+          $subject = $signature.SignerCertificate.Subject
+          Write-Output "$($application.Name) — Status: $($signature.Status), Signer: $subject"
+          if ($signature.Status -ne 'Valid') {
+            throw "$($application.Name) Authenticode status is $($signature.Status), expected Valid"
+          }
+          if ($subject -notlike '*SignPath Foundation*') {
+            throw "$($application.Name) has unexpected signer: $subject"
+          }
+          if (-not $signature.TimeStamperCertificate) {
+            throw "$($application.Name) has no Authenticode timestamp"
+          }
+      - name: Package signed Windows application
+        if: matrix.target == 'win'
+        run: npm run dist:win:prepackaged
       # Keep the two public filenames in separate directories so SignPath can
       # require exactly one installer and one portable exe without overlapping
       # wildcard patterns.
@@ -93,8 +167,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          node scripts/signpath-windows-artifacts.js prepare \
-            dist "$RUNNER_TEMP/signpath-input" >> "$GITHUB_OUTPUT"
+          node scripts/signpath-windows-artifacts.js prepare-artifacts \
+            dist "$RUNNER_TEMP/signpath-artifact-input" >> "$GITHUB_OUTPUT"
       - name: Upload unsigned Windows artifacts
         if: matrix.target == 'win'
         id: upload-unsigned-win
@@ -104,11 +178,12 @@ jobs:
           if-no-files-found: error
           retention-days: 1
           compression-level: 0
-          # These two exact paths share signpath-input as their archive root,
+          # These two exact paths share signpath-artifact-input as their archive
+          # root,
           # preserving the installer/ and portable/ directories in the ZIP.
           path: |
-            ${{ runner.temp }}/signpath-input/installer/${{ steps.prepare-unsigned-win.outputs.installer }}
-            ${{ runner.temp }}/signpath-input/portable/${{ steps.prepare-unsigned-win.outputs.portable }}
+            ${{ runner.temp }}/signpath-artifact-input/installer/${{ steps.prepare-unsigned-win.outputs.installer }}
+            ${{ runner.temp }}/signpath-artifact-input/portable/${{ steps.prepare-unsigned-win.outputs.portable }}
       - name: Code-sign Windows artifacts (SignPath)
         if: matrix.target == 'win'
         uses: SignPath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2.2
@@ -120,7 +195,7 @@ jobs:
           artifact-configuration-slug: initial
           github-artifact-id: ${{ steps.upload-unsigned-win.outputs.artifact-id }}
           wait-for-completion: true
-          output-artifact-directory: dist/signpath-output
+          output-artifact-directory: dist/signpath-artifact-output
           parameters: |
             version: ${{ toJSON(steps.prepare-unsigned-win.outputs.version) }}
       # electron-builder hashes latest.yml and builds the .blockmap before this
@@ -132,11 +207,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          node scripts/signpath-windows-artifacts.js apply dist dist/signpath-output
+          node scripts/signpath-windows-artifacts.js apply-artifacts \
+            dist dist/signpath-artifact-output
       # SignPath's action succeeding only means it accepted and returned a file —
       # confirm the file it gave back is actually validly signed by the expected
       # certificate before it ships, mirroring the mac codesign/spctl checks above.
-      - name: Verify Windows Authenticode signature
+      - name: Verify Windows artifact Authenticode signatures
         if: matrix.target == 'win'
         shell: pwsh
         run: |

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -4,7 +4,7 @@ Free code signing provided by [SignPath.io](https://signpath.io/), certificate b
 
 ## Signed artifacts
 
-Token Monitor's production Windows installer (`Token-Monitor-Setup-*.exe`) and portable build (`Token-Monitor-*.exe`) are Authenticode-signed. The expected publisher is **SignPath Foundation**.
+The current release workflow Authenticode-signs Token Monitor's Windows application executable, installer (`Token-Monitor-Setup-*.exe`), and portable build (`Token-Monitor-*.exe`). The expected publisher is **SignPath Foundation**.
 
 ## Verify a download
 
@@ -18,12 +18,15 @@ Get-AuthenticodeSignature ".\Token-Monitor-Setup-<version>.exe", ".\Token-Monito
 
 A genuine Token Monitor release should show `Valid` status, SignPath Foundation as the signer, and timestamp information.
 
+After installation, the same check can be run against `Token Monitor.exe` in the application's installation directory.
+
 ## Signing controls
 
 - Signing requests originate from the repository's [release workflow](../.github/workflows/release.yml), which builds on GitHub-hosted runners.
 - Every production signing request requires manual approval in SignPath.
-- The version-controlled [artifact configuration](../.github/signpath/artifact-configuration.xml) restricts the signed files by exact path, product name, and product version.
-- Before publishing, the release workflow verifies both signatures, their signer, and their timestamps.
+- The version-controlled [application](../.github/signpath/application-artifact-configuration.xml) and [release artifact](../.github/signpath/artifact-configuration.xml) configurations restrict signed files by exact path, product name, and product version.
+- The application executable is signed before packaging; the resulting installer and portable wrapper are signed afterward.
+- Before publishing, the release workflow verifies all three signatures, their signer, and their timestamps.
 
 ## Team roles
 

--- a/package.json
+++ b/package.json
@@ -17,10 +17,14 @@
     "prepack": "npm run icons",
     "predist:mac": "npm run icons",
     "predist:win": "npm run icons",
+    "predist:win:dir": "npm run icons",
+    "predist:win:prepackaged": "npm run icons",
     "predist:linux": "npm run icons",
     "pack": "electron-builder --dir",
     "dist:mac": "electron-builder --mac --arm64 --publish never",
     "dist:win": "electron-builder --win --x64 --publish never",
+    "dist:win:dir": "electron-builder --win dir --x64 --publish never",
+    "dist:win:prepackaged": "electron-builder --prepackaged dist/win-unpacked --win nsis portable --x64 --publish never",
     "dist:linux": "electron-builder --linux --x64 --publish never",
     "verify:release-artifact-names": "node scripts/verify-updater-artifact-names.js dist",
     "lint": "eslint .",
@@ -83,7 +87,11 @@
           ]
         }
       ],
-      "icon": "build/icons/icon.ico"
+      "icon": "build/icons/icon.ico",
+      "verifyUpdateCodeSignature": true,
+      "signtoolOptions": {
+        "publisherName": "SignPath Foundation"
+      }
     },
     "linux": {
       "artifactName": "Token-Monitor-${version}.${ext}",

--- a/scripts/signpath-windows-artifacts.js
+++ b/scripts/signpath-windows-artifacts.js
@@ -29,18 +29,127 @@ function renderArtifactName(template, version) {
   return rendered;
 }
 
-function expectedWindowsArtifacts(packageJsonPath) {
+function signingPackageMetadata(packageJsonPath) {
   const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
   const version = pkg.version;
   if (typeof version !== 'string' || !/^[0-9A-Za-z][0-9A-Za-z.+-]*$/.test(version)) {
     throw new Error(`Unsupported package version for signing: ${String(version)}`);
   }
+  const productName = pkg.productName;
+  if (
+    typeof productName !== 'string' ||
+    !productName ||
+    path.posix.basename(productName) !== productName ||
+    path.win32.basename(productName) !== productName ||
+    /[\r\n]/.test(productName)
+  ) {
+    throw new Error(`Unsupported productName for signing: ${String(productName)}`);
+  }
+  return { pkg, version, productName };
+}
+
+function expectedWindowsApplication(packageJsonPath) {
+  const { version, productName } = signingPackageMetadata(packageJsonPath);
+  return {
+    version,
+    productName,
+    application: `${productName}.exe`
+  };
+}
+
+function expectedWindowsArtifacts(packageJsonPath) {
+  const { pkg, version } = signingPackageMetadata(packageJsonPath);
   const installer = renderArtifactName(pkg.build?.nsis?.artifactName || '', version);
   const portable = renderArtifactName(pkg.build?.portable?.artifactName || '', version);
   if (!installer || !portable || installer === portable) {
     throw new Error('package.json must define distinct NSIS and portable Windows artifact names');
   }
   return { version, installer, portable };
+}
+
+function windowsAppUpdateConfig(packageJsonPath) {
+  const { pkg, version } = signingPackageMetadata(packageJsonPath);
+  const build = pkg.build;
+  const win = build?.win;
+  if (Object.hasOwn(win || {}, 'publish')) {
+    throw new Error(
+      'Windows prepackaged builds do not support a build.win.publish override; ' +
+        'keep the updater provider in build.publish'
+    );
+  }
+
+  // electron-builder resolves and embeds the first publish provider during
+  // afterPack. --prepackaged skips that hook, so this writer intentionally
+  // supports only the exact release configuration below. Fail closed when the
+  // publish surface changes instead of silently emitting stale updater data.
+  if (!Array.isArray(build?.publish) || build.publish.length !== 1) {
+    throw new Error('Windows prepackaged builds require exactly one publish provider');
+  }
+  const publish = build.publish[0];
+  const publishKeys =
+    publish && typeof publish === 'object' && !Array.isArray(publish)
+      ? Object.keys(publish).sort()
+      : [];
+  const supportedPublishKeys = ['owner', 'provider', 'repo'];
+  if (JSON.stringify(publishKeys) !== JSON.stringify(supportedPublishKeys)) {
+    throw new Error(
+      'Windows prepackaged builds support exactly the GitHub publish fields ' +
+        `${supportedPublishKeys.join(', ')}; found ${publishKeys.join(', ') || 'none'}`
+    );
+  }
+  if (
+    publish.provider !== 'github' ||
+    typeof publish.owner !== 'string' ||
+    !publish.owner ||
+    typeof publish.repo !== 'string' ||
+    !publish.repo
+  ) {
+    throw new Error('Windows prepackaged builds require a GitHub publish owner and repo');
+  }
+  const versionWithoutBuildMetadata = version.split('+', 1)[0];
+  if (versionWithoutBuildMetadata.includes('-')) {
+    throw new Error(
+      'Windows prepackaged builds do not support prerelease update channels; ' +
+        'keep this writer aligned with electron-builder before publishing a prerelease'
+    );
+  }
+  const packageName = pkg.name;
+  if (typeof packageName !== 'string' || !/^[A-Za-z0-9._-]+$/.test(packageName)) {
+    throw new Error(`Unsupported package name for updater cache: ${String(packageName)}`);
+  }
+  const publisherName = win?.signtoolOptions?.publisherName;
+  if (win?.verifyUpdateCodeSignature !== true || typeof publisherName !== 'string' || !publisherName) {
+    throw new Error(
+      'Windows prepackaged builds must explicitly verify the expected code-signing publisher'
+    );
+  }
+
+  const yamlString = (value) => JSON.stringify(value);
+  return [
+    `owner: ${yamlString(publish.owner)}`,
+    `repo: ${yamlString(publish.repo)}`,
+    `provider: ${yamlString(publish.provider)}`,
+    `updaterCacheDirName: ${yamlString(`${packageName.toLowerCase()}-updater`)}`,
+    'publisherName:',
+    `  - ${yamlString(publisherName)}`,
+    ''
+  ].join('\n');
+}
+
+function writeWindowsAppUpdateConfig({ appDir, packageJsonPath }) {
+  const names = expectedWindowsApplication(packageJsonPath);
+  const applicationPath = path.join(appDir, names.application);
+  if (!fs.lstatSync(applicationPath, { throwIfNoEntry: false })?.isFile()) {
+    throw new Error(`Expected unpacked application executable is missing: ${applicationPath}`);
+  }
+  const updateConfigPath = path.join(appDir, 'resources', 'app-update.yml');
+  fs.mkdirSync(path.dirname(updateConfigPath), { recursive: true });
+  fs.writeFileSync(updateConfigPath, windowsAppUpdateConfig(packageJsonPath));
+  return { ...names, updateConfigPath };
+}
+
+function applicationSigningInputPath(names) {
+  return path.posix.join('application', names.application);
 }
 
 function signingInputPaths(names) {
@@ -64,6 +173,22 @@ function assertExactTopLevelWindowsArtifacts(distDir, names) {
         (actual.length ? actual.join(', ') : 'no executable files')
     );
   }
+}
+
+function prepareUnsignedWindowsApplication({ appDir, inputDir, packageJsonPath }) {
+  const names = expectedWindowsApplication(packageJsonPath);
+  const relativePath = applicationSigningInputPath(names);
+  const source = path.join(appDir, names.application);
+  if (!fs.lstatSync(source, { throwIfNoEntry: false })?.isFile()) {
+    throw new Error(`Expected unpacked application executable is missing: ${source}`);
+  }
+
+  fs.rmSync(inputDir, { recursive: true, force: true });
+  const destination = path.join(inputDir, ...relativePath.split('/'));
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.copyFileSync(source, destination);
+
+  return { ...names, relativePath };
 }
 
 function prepareUnsignedWindowsArtifacts({ distDir, inputDir, packageJsonPath }) {
@@ -170,6 +295,25 @@ function listExeFiles(rootDir, relativeDir = '') {
   });
 }
 
+function applySignedWindowsApplication({ appDir, signedDir, packageJsonPath }) {
+  const names = expectedWindowsApplication(packageJsonPath);
+  const relativePath = applicationSigningInputPath(names);
+  const actualExePaths = listExeFiles(signedDir).sort();
+  if (JSON.stringify(actualExePaths) !== JSON.stringify([relativePath])) {
+    throw new Error(
+      `Signed application artifact must contain exactly ${relativePath}; found ` +
+        (actualExePaths.length ? actualExePaths.join(', ') : 'no executable files')
+    );
+  }
+
+  const destination = path.join(appDir, names.application);
+  if (!fs.lstatSync(destination, { throwIfNoEntry: false })?.isFile()) {
+    throw new Error(`Expected unpacked application executable is missing: ${destination}`);
+  }
+  fs.copyFileSync(path.join(signedDir, ...relativePath.split('/')), destination);
+  return { ...names, relativePath };
+}
+
 async function applySignedWindowsArtifacts({ distDir, signedDir, packageJsonPath }) {
   const names = expectedWindowsArtifacts(packageJsonPath);
   const relativePaths = signingInputPaths(names);
@@ -223,30 +367,73 @@ async function applySignedWindowsArtifacts({ distDir, signedDir, packageJsonPath
 }
 
 if (require.main === module) {
-  const [, , command, distDirArg, signingDirArg, packageJsonPathArg = 'package.json'] = process.argv;
-  if (!['prepare', 'apply'].includes(command) || !distDirArg || !signingDirArg) {
+  const [, , command, sourceDirArg, signingDirArg, packageJsonPathArg = 'package.json'] = process.argv;
+  const commands = [
+    'write-update-config',
+    'prepare-application',
+    'apply-application',
+    'prepare-artifacts',
+    'apply-artifacts'
+  ];
+  const signingDirRequired = command !== 'write-update-config';
+  if (
+    !commands.includes(command) ||
+    !sourceDirArg ||
+    (signingDirRequired && !signingDirArg)
+  ) {
     console.error(
-      'Usage: node signpath-windows-artifacts.js <prepare|apply> <distDir> <signingDir> [packageJson]'
+      'Usage: node signpath-windows-artifacts.js ' +
+        '<write-update-config|prepare-application|apply-application|' +
+        'prepare-artifacts|apply-artifacts> <appOrDistDir> [signingDir] [packageJson]'
     );
     process.exitCode = 1;
   } else {
-    const options = {
-      distDir: path.resolve(distDirArg),
-      packageJsonPath: path.resolve(packageJsonPathArg)
+    const packageJsonPath = path.resolve(packageJsonPathArg);
+    const sourceDir = path.resolve(sourceDirArg);
+    const signingDir = signingDirArg ? path.resolve(signingDirArg) : null;
+    const operations = {
+      'write-update-config': () =>
+        writeWindowsAppUpdateConfig({ appDir: sourceDir, packageJsonPath }),
+      'prepare-application': () =>
+        prepareUnsignedWindowsApplication({
+          appDir: sourceDir,
+          inputDir: signingDir,
+          packageJsonPath
+        }),
+      'apply-application': () =>
+        applySignedWindowsApplication({
+          appDir: sourceDir,
+          signedDir: signingDir,
+          packageJsonPath
+        }),
+      'prepare-artifacts': () =>
+        prepareUnsignedWindowsArtifacts({
+          distDir: sourceDir,
+          inputDir: signingDir,
+          packageJsonPath
+        }),
+      'apply-artifacts': () =>
+        applySignedWindowsArtifacts({
+          distDir: sourceDir,
+          signedDir: signingDir,
+          packageJsonPath
+        })
     };
-    const operation =
-      command === 'prepare'
-        ? Promise.resolve(
-            prepareUnsignedWindowsArtifacts({ ...options, inputDir: path.resolve(signingDirArg) })
-          )
-        : applySignedWindowsArtifacts({ ...options, signedDir: path.resolve(signingDirArg) });
+    const operation = Promise.resolve().then(operations[command]);
 
     operation
       .then((result) => {
-        if (command === 'prepare') {
+        if (command === 'write-update-config') {
+          console.log(`Wrote ${result.updateConfigPath}`);
+        } else if (command === 'prepare-application') {
+          console.log(`version=${result.version}`);
+          console.log(`application=${result.application}`);
+        } else if (command === 'prepare-artifacts') {
           console.log(`version=${result.version}`);
           console.log(`installer=${result.installer}`);
           console.log(`portable=${result.portable}`);
+        } else if (command === 'apply-application') {
+          console.log(`Applied signed ${result.application} to the unpacked application`);
         } else {
           console.log(
             `Applied signed ${result.installer} and ${result.portable}; updated ${result.patchedYmlFiles.join(', ')}`
@@ -261,11 +448,17 @@ if (require.main === module) {
 }
 
 module.exports = {
+  expectedWindowsApplication,
   expectedWindowsArtifacts,
+  windowsAppUpdateConfig,
+  writeWindowsAppUpdateConfig,
+  applicationSigningInputPath,
   signingInputPaths,
   assertExactTopLevelWindowsArtifacts,
+  prepareUnsignedWindowsApplication,
   prepareUnsignedWindowsArtifacts,
   patchLatestYamlForSignedFile,
   listExeFiles,
+  applySignedWindowsApplication,
   applySignedWindowsArtifacts
 };

--- a/tests/shared/signpathWindowsArtifacts.test.js
+++ b/tests/shared/signpathWindowsArtifacts.test.js
@@ -8,13 +8,19 @@ const test = require('node:test');
 const zlib = require('node:zlib');
 
 const {
+  expectedWindowsApplication,
   expectedWindowsArtifacts,
+  windowsAppUpdateConfig,
+  writeWindowsAppUpdateConfig,
+  prepareUnsignedWindowsApplication,
   prepareUnsignedWindowsArtifacts,
   patchLatestYamlForSignedFile,
+  applySignedWindowsApplication,
   applySignedWindowsArtifacts
 } = require('../../scripts/signpath-windows-artifacts');
 
 const VERSION = '0.30.0';
+const APPLICATION = 'Token Monitor.exe';
 const INSTALLER = `Token-Monitor-Setup-${VERSION}.exe`;
 const PORTABLE = `Token-Monitor-${VERSION}.exe`;
 const PROJECT_ROOT = path.resolve(__dirname, '..', '..');
@@ -44,17 +50,21 @@ function openingTagAttributes(xml, tagName) {
   return tags;
 }
 
-test('SignPath configuration restricts every signed PE to the release product metadata', () => {
+test('SignPath configurations restrict every signed PE to the release product metadata', () => {
   const pkg = JSON.parse(fs.readFileSync(path.join(PROJECT_ROOT, 'package.json'), 'utf8'));
-  const xml = fs.readFileSync(
+  const artifactXml = fs.readFileSync(
     path.join(PROJECT_ROOT, '.github', 'signpath', 'artifact-configuration.xml'),
     'utf8'
   );
+  const applicationXml = fs.readFileSync(
+    path.join(PROJECT_ROOT, '.github', 'signpath', 'application-artifact-configuration.xml'),
+    'utf8'
+  );
 
-  assert.deepEqual(openingTagAttributes(xml, 'parameter'), [
+  assert.deepEqual(openingTagAttributes(artifactXml, 'parameter'), [
     { name: 'version', required: 'true' }
   ]);
-  assert.deepEqual(openingTagAttributes(xml, 'pe-file'), [
+  assert.deepEqual(openingTagAttributes(artifactXml, 'pe-file'), [
     {
       path: 'installer/Token-Monitor-Setup-${version}.exe',
       'product-name': pkg.productName,
@@ -66,6 +76,37 @@ test('SignPath configuration restricts every signed PE to the release product me
       'product-version': '${version}'
     }
   ]);
+  assert.deepEqual(openingTagAttributes(applicationXml, 'parameter'), [
+    { name: 'version', required: 'true' }
+  ]);
+  assert.deepEqual(openingTagAttributes(applicationXml, 'pe-file'), [
+    {
+      path: `application/${pkg.productName}.exe`,
+      'product-name': pkg.productName,
+      'product-version': '${version}'
+    }
+  ]);
+  assert.equal(pkg.build.win.verifyUpdateCodeSignature, true);
+  assert.equal(pkg.build.win.signtoolOptions.publisherName, 'SignPath Foundation');
+});
+
+test('release workflow signs the application before packaging and signs public artifacts last', () => {
+  const workflow = fs.readFileSync(
+    path.join(PROJECT_ROOT, '.github', 'workflows', 'release.yml'),
+    'utf8'
+  );
+  const unpacked = workflow.indexOf('npm run dist:win:dir');
+  const signApplication = workflow.indexOf('artifact-configuration-slug: application');
+  const prepackaged = workflow.indexOf('npm run dist:win:prepackaged');
+  const signArtifacts = workflow.indexOf('artifact-configuration-slug: initial');
+  const rebuildBlockmap = workflow.indexOf('node scripts/signpath-windows-artifacts.js apply-artifacts');
+
+  assert.ok(unpacked >= 0);
+  assert.match(workflow, /path: \$\{\{ runner\.temp \}\}\/signpath-application-input\s/);
+  assert.ok(unpacked < signApplication);
+  assert.ok(signApplication < prepackaged);
+  assert.ok(prepackaged < signArtifacts);
+  assert.ok(signArtifacts < rebuildBlockmap);
 });
 
 function makeFixture(t) {
@@ -73,20 +114,40 @@ function makeFixture(t) {
   const distDir = path.join(root, 'dist');
   const inputDir = path.join(root, 'input');
   const signedDir = path.join(root, 'signed');
+  const appDir = path.join(distDir, 'win-unpacked');
   const packageJsonPath = path.join(root, 'package.json');
-  fs.mkdirSync(distDir);
+  fs.mkdirSync(appDir, { recursive: true });
   fs.writeFileSync(
     packageJsonPath,
     JSON.stringify({
+      name: 'token-monitor',
       version: VERSION,
+      productName: 'Token Monitor',
       build: {
+        win: {
+          verifyUpdateCodeSignature: true,
+          signtoolOptions: { publisherName: 'SignPath Foundation' }
+        },
         nsis: { artifactName: 'Token-Monitor-Setup-${version}.${ext}' },
-        portable: { artifactName: 'Token-Monitor-${version}.${ext}' }
+        portable: { artifactName: 'Token-Monitor-${version}.${ext}' },
+        publish: [{ provider: 'github', owner: 'Javis603', repo: 'token-monitor' }]
       }
     })
   );
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-  return { root, distDir, inputDir, signedDir, packageJsonPath };
+  return { root, distDir, inputDir, signedDir, appDir, packageJsonPath };
+}
+
+function writeUnsignedApplication(fixture) {
+  fs.writeFileSync(path.join(fixture.appDir, APPLICATION), 'unsigned-application');
+}
+
+function writeSignedApplication(fixture) {
+  fs.mkdirSync(path.join(fixture.signedDir, 'application'), { recursive: true });
+  fs.writeFileSync(
+    path.join(fixture.signedDir, 'application', APPLICATION),
+    'signed-application-bytes'
+  );
 }
 
 function writeUnsignedArtifacts(fixture) {
@@ -112,6 +173,93 @@ test('expectedWindowsArtifacts resolves the public installer and portable names 
   });
 });
 
+test('expectedWindowsApplication resolves the branded executable from package.json', (t) => {
+  const fixture = makeFixture(t);
+  assert.deepEqual(expectedWindowsApplication(fixture.packageJsonPath), {
+    version: VERSION,
+    productName: 'Token Monitor',
+    application: APPLICATION
+  });
+});
+
+test('writes the updater config skipped by electron-builder prepackaged mode', (t) => {
+  const fixture = makeFixture(t);
+  writeUnsignedApplication(fixture);
+  const expected = [
+    'owner: "Javis603"',
+    'repo: "token-monitor"',
+    'provider: "github"',
+    'updaterCacheDirName: "token-monitor-updater"',
+    'publisherName:',
+    '  - "SignPath Foundation"',
+    ''
+  ].join('\n');
+
+  assert.equal(windowsAppUpdateConfig(fixture.packageJsonPath), expected);
+  const result = writeWindowsAppUpdateConfig(fixture);
+  assert.equal(fs.readFileSync(result.updateConfigPath, 'utf8'), expected);
+});
+
+test('refuses to write an updater config without publisher verification', (t) => {
+  const fixture = makeFixture(t);
+  const pkg = JSON.parse(fs.readFileSync(fixture.packageJsonPath, 'utf8'));
+  pkg.build.win.verifyUpdateCodeSignature = false;
+  fs.writeFileSync(fixture.packageJsonPath, JSON.stringify(pkg));
+
+  assert.throws(
+    () => windowsAppUpdateConfig(fixture.packageJsonPath),
+    /must explicitly verify the expected code-signing publisher/
+  );
+});
+
+test('refuses updater publish configurations with multiple providers', (t) => {
+  const fixture = makeFixture(t);
+  const pkg = JSON.parse(fs.readFileSync(fixture.packageJsonPath, 'utf8'));
+  pkg.build.publish.push({ provider: 'generic', url: 'https://example.test/updates' });
+  fs.writeFileSync(fixture.packageJsonPath, JSON.stringify(pkg));
+
+  assert.throws(
+    () => windowsAppUpdateConfig(fixture.packageJsonPath),
+    /require exactly one publish provider/
+  );
+});
+
+test('refuses updater publish fields the prepackaged writer does not preserve', (t) => {
+  const fixture = makeFixture(t);
+  const pkg = JSON.parse(fs.readFileSync(fixture.packageJsonPath, 'utf8'));
+  pkg.build.publish[0].channel = 'beta';
+  fs.writeFileSync(fixture.packageJsonPath, JSON.stringify(pkg));
+
+  assert.throws(
+    () => windowsAppUpdateConfig(fixture.packageJsonPath),
+    /support exactly the GitHub publish fields owner, provider, repo/
+  );
+});
+
+test('refuses a platform publish override the prepackaged writer would ignore', (t) => {
+  const fixture = makeFixture(t);
+  const pkg = JSON.parse(fs.readFileSync(fixture.packageJsonPath, 'utf8'));
+  pkg.build.win.publish = [{ provider: 'generic', url: 'https://example.test/updates' }];
+  fs.writeFileSync(fixture.packageJsonPath, JSON.stringify(pkg));
+
+  assert.throws(
+    () => windowsAppUpdateConfig(fixture.packageJsonPath),
+    /do not support a build\.win\.publish override/
+  );
+});
+
+test('refuses prerelease versions whose update channel electron-builder would derive', (t) => {
+  const fixture = makeFixture(t);
+  const pkg = JSON.parse(fs.readFileSync(fixture.packageJsonPath, 'utf8'));
+  pkg.version = '0.31.0-beta.1';
+  fs.writeFileSync(fixture.packageJsonPath, JSON.stringify(pkg));
+
+  assert.throws(
+    () => windowsAppUpdateConfig(fixture.packageJsonPath),
+    /do not support prerelease update channels/
+  );
+});
+
 test('expectedWindowsArtifacts rejects unsafe output names and output-parameter versions', (t) => {
   const fixture = makeFixture(t);
   const pkg = JSON.parse(fs.readFileSync(fixture.packageJsonPath, 'utf8'));
@@ -123,6 +271,64 @@ test('expectedWindowsArtifacts rejects unsafe output names and output-parameter 
   pkg.build.portable.artifactName = '..\\Token-Monitor-${version}.${ext}';
   fs.writeFileSync(fixture.packageJsonPath, JSON.stringify(pkg));
   assert.throws(() => expectedWindowsArtifacts(fixture.packageJsonPath), /Unsupported Windows artifactName/);
+});
+
+test('expectedWindowsApplication rejects an unsafe product name', (t) => {
+  const fixture = makeFixture(t);
+  const pkg = JSON.parse(fs.readFileSync(fixture.packageJsonPath, 'utf8'));
+  pkg.productName = '..\\Token Monitor';
+  fs.writeFileSync(fixture.packageJsonPath, JSON.stringify(pkg));
+  assert.throws(() => expectedWindowsApplication(fixture.packageJsonPath), /Unsupported productName/);
+});
+
+test('prepareUnsignedWindowsApplication creates an exact application signing input', (t) => {
+  const fixture = makeFixture(t);
+  writeUnsignedApplication(fixture);
+  fs.mkdirSync(fixture.inputDir);
+  fs.writeFileSync(path.join(fixture.inputDir, 'stale.exe'), 'stale');
+
+  const result = prepareUnsignedWindowsApplication(fixture);
+
+  assert.equal(result.relativePath, `application/${APPLICATION}`);
+  assert.deepEqual(fs.readdirSync(fixture.inputDir), ['application']);
+  assert.equal(
+    fs.readFileSync(path.join(fixture.inputDir, 'application', APPLICATION), 'utf8'),
+    'unsigned-application'
+  );
+});
+
+test('prepareUnsignedWindowsApplication fails when the branded executable is absent', (t) => {
+  const fixture = makeFixture(t);
+  assert.throws(
+    () => prepareUnsignedWindowsApplication(fixture),
+    /Expected unpacked application executable is missing/
+  );
+});
+
+test('applySignedWindowsApplication replaces only the branded executable', (t) => {
+  const fixture = makeFixture(t);
+  writeUnsignedApplication(fixture);
+  writeSignedApplication(fixture);
+
+  applySignedWindowsApplication(fixture);
+
+  assert.equal(
+    fs.readFileSync(path.join(fixture.appDir, APPLICATION), 'utf8'),
+    'signed-application-bytes'
+  );
+});
+
+test('applySignedWindowsApplication rejects missing or extra signed executables', (t) => {
+  const fixture = makeFixture(t);
+  writeUnsignedApplication(fixture);
+  writeSignedApplication(fixture);
+  fs.writeFileSync(path.join(fixture.signedDir, 'unexpected.exe'), 'unexpected');
+
+  assert.throws(() => applySignedWindowsApplication(fixture), /must contain exactly/);
+  assert.equal(
+    fs.readFileSync(path.join(fixture.appDir, APPLICATION), 'utf8'),
+    'unsigned-application'
+  );
 });
 
 test('prepareUnsignedWindowsArtifacts creates a strict two-directory signing input', (t) => {


### PR DESCRIPTION
## Summary

- build the unpacked Windows application and sign the branded `Token Monitor.exe` with the production SignPath policy before packaging
- package the signed application into NSIS and portable artifacts, then sign and verify the public wrappers as the final release bytes
- preserve the updater configuration skipped by electron-builder's `--prepackaged` mode and fail closed if the supported publish configuration drifts
- regenerate the signed installer's blockmap, SHA-512, and size before publishing updater metadata

## Why

The existing outer signatures already protect downloads and electron-updater verification. This change adds an independently verifiable Authenticode identity to the installed and portable application executable, improving signing coverage and compatibility with Windows trust controls such as Smart App Control.

This is release hardening; electron-updater does not require the inner application signature.

## SignPath setup

Before the first release from this workflow, create the SignPath artifact configuration with slug `application` from `.github/signpath/application-artifact-configuration.xml`. The existing `initial` configuration continues to sign the public installer and portable artifacts.

## Verification

- `npm run verify` — 1445 tests passed
- `node --test tests/shared/signpathWindowsArtifacts.test.js` — 27 tests passed
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sign the installed Windows app (`Token Monitor.exe`) with SignPath before packaging, then sign the NSIS installer and portable wrapper, and verify all signatures. This hardens releases and improves Windows trust compatibility (e.g., Smart App Control).

- **New Features**
  - Build unpacked Windows app, write updater config for `--prepackaged`, and sign via SignPath `application` policy before packaging.
  - Package the signed app into NSIS and portable artifacts, then sign and verify the public wrappers.
  - Enforce publisher verification (`SignPath Foundation`) and Authenticode timestamp checks in CI.
  - Regenerate blockmap, SHA-512, and sizes from the final signed bytes; update docs and tests.

- **Migration**
  - Create the SignPath artifact configuration with slug `application` from `.github/signpath/application-artifact-configuration.xml` before the first release from this workflow.

<sup>Written for commit 0af0dd464733b1ae61eeff190f97037eb6800124. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

