### PR TITLE
fix(renderer): preserve usage animation continuity

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -1026,33 +1026,48 @@ function easeOutQuart(t) { return 1 - Math.pow(1 - t, 4); }
 // frame and overwrites a later static update (e.g. switching to a zero period
 // mid-animation).
 let numberAnimHandle = 0;
+let numberAnimTarget = null;
+let numberAnimValue = 0;
 function cancelNumberAnimation() {
-  if (numberAnimHandle) { cancelAnimationFrame(numberAnimHandle); numberAnimHandle = 0; }
+  if (numberAnimHandle) cancelAnimationFrame(numberAnimHandle);
+  numberAnimHandle = 0;
+  numberAnimTarget = null;
+}
+
+function headlineNumberIsAnimatingTo(value) {
+  return Boolean(numberAnimHandle) && numberAnimTarget === value;
 }
 
 function animateNumber(el, from, to, duration = 1000, onDone = null) {
   cancelNumberAnimation();
   if (prefersReducedMotion()) {
     el.textContent = formatNumber(to);
+    numberAnimValue = to;
     if (typeof onDone === 'function') onDone();
     return;
   }
   const start = performance.now();
   const delta = to - from;
+  numberAnimTarget = to;
+  numberAnimValue = from;
   function frame(now) {
     const progress = Math.min(1, (now - start) / duration);
-    el.textContent = formatNumber(from + delta * easeOutQuart(progress));
+    numberAnimValue = from + delta * easeOutQuart(progress);
+    el.textContent = formatNumber(numberAnimValue);
     if (progress < 1) {
       numberAnimHandle = requestAnimationFrame(frame);
     } else {
       numberAnimHandle = 0;
+      numberAnimTarget = null;
+      numberAnimValue = to;
       if (typeof onDone === 'function') onDone();
     }
   }
   numberAnimHandle = requestAnimationFrame(frame);
 }
 
-const rowNumberAnimationHandles = new Map();
+const rowNumberAnimations = new Map();
+const rowBarAnimations = new Map();
 
 function prefersReducedMotion() {
   return motionPreferenceApi.shouldReduceMotion(state.settings?.reduceMotion, reducedMotionMedia?.matches);
@@ -1060,19 +1075,21 @@ function prefersReducedMotion() {
 
 function settleMotionAnimations() {
   cancelNumberAnimation();
+  numberAnimValue = state.currentTotal;
   els.totalTokens.textContent = formatNumber(state.currentTotal);
   updateTotalCompact(state.currentTotal);
-  for (const [el, handle] of rowNumberAnimationHandles) {
-    cancelAnimationFrame(handle);
-    const target = Number(el.dataset.motionTarget || el.dataset.motionValue || 0);
+  for (const [el, motion] of rowNumberAnimations) {
+    cancelAnimationFrame(motion.handle);
+    const target = Number(motion.target ?? el.dataset.motionTarget ?? el.dataset.motionValue ?? 0);
     el.textContent = formatNumber(target);
     el.dataset.motionValue = String(target);
     delete el.dataset.motionTarget;
   }
-  rowNumberAnimationHandles.clear();
+  rowNumberAnimations.clear();
   for (const animation of document.getAnimations?.() || []) {
     try { animation.finish(); } catch (_) { animation.cancel(); }
   }
+  rowBarAnimations.clear();
 }
 
 function applyReduceMotionPreference(value) {
@@ -1099,40 +1116,44 @@ function captureBreakdownMotion() {
 }
 
 function animateRowNumber(el, from, to, duration = 420) {
-  const previousHandle = rowNumberAnimationHandles.get(el);
-  if (previousHandle) cancelAnimationFrame(previousHandle);
-  if (!Number.isFinite(from) || !Number.isFinite(to) || from === to || prefersReducedMotion()) {
+  const previous = rowNumberAnimations.get(el);
+  if (previous?.target === to) return;
+  if (previous) cancelAnimationFrame(previous.handle);
+  const startValue = Number.isFinite(previous?.value) ? previous.value : from;
+  if (!Number.isFinite(startValue) || !Number.isFinite(to) || startValue === to || prefersReducedMotion()) {
     el.textContent = formatNumber(to);
     el.dataset.motionValue = String(Number(to) || 0);
     delete el.dataset.motionTarget;
-    rowNumberAnimationHandles.delete(el);
+    rowNumberAnimations.delete(el);
     return;
   }
   const startedAt = performance.now();
-  const delta = to - from;
-  el.textContent = formatNumber(from);
-  el.dataset.motionValue = String(from);
+  const delta = to - startValue;
+  const motion = { handle: 0, target: to, value: startValue };
+  el.textContent = formatNumber(startValue);
+  el.dataset.motionValue = String(startValue);
   el.dataset.motionTarget = String(to);
   function frame(now) {
     if (prefersReducedMotion()) {
       el.textContent = formatNumber(to);
       el.dataset.motionValue = String(Number(to) || 0);
       delete el.dataset.motionTarget;
-      rowNumberAnimationHandles.delete(el);
+      if (rowNumberAnimations.get(el) === motion) rowNumberAnimations.delete(el);
       return;
     }
     const progress = Math.min(1, (now - startedAt) / duration);
-    const current = from + delta * easeOutQuart(progress);
-    el.textContent = formatNumber(current);
-    el.dataset.motionValue = String(current);
+    motion.value = startValue + delta * easeOutQuart(progress);
+    el.textContent = formatNumber(motion.value);
+    el.dataset.motionValue = String(motion.value);
     if (progress < 1) {
-      rowNumberAnimationHandles.set(el, requestAnimationFrame(frame));
+      motion.handle = requestAnimationFrame(frame);
     } else {
       delete el.dataset.motionTarget;
-      rowNumberAnimationHandles.delete(el);
+      if (rowNumberAnimations.get(el) === motion) rowNumberAnimations.delete(el);
     }
   }
-  rowNumberAnimationHandles.set(el, requestAnimationFrame(frame));
+  motion.handle = requestAnimationFrame(frame);
+  rowNumberAnimations.set(el, motion);
 }
 
 function animateBreakdownFrom(snapshot, { duration = 420 } = {}) {
@@ -1172,9 +1193,14 @@ function animateBreakdownFrom(snapshot, { duration = 420 } = {}) {
 }
 
 function animateBarBetween(fill, fromScale, toScale, delay = 0, duration = 420) {
-  if (!fill?.animate || Math.abs(toScale - fromScale) < 0.001) return;
+  if (!fill?.animate) return;
+  const previous = rowBarAnimations.get(fill);
+  const previousIsActive = previous?.animation.pending || previous?.animation.playState === 'running';
+  if (previousIsActive && Math.abs(previous.target - toScale) < 0.001) return;
   for (const animation of fill.getAnimations()) animation.cancel();
-  fill.animate([
+  rowBarAnimations.delete(fill);
+  if (Math.abs(toScale - fromScale) < 0.001) return;
+  const animation = fill.animate([
     { transform: `scaleX(${fromScale})` },
     { transform: `scaleX(${toScale})` }
   ], {
@@ -1183,6 +1209,13 @@ function animateBarBetween(fill, fromScale, toScale, delay = 0, duration = 420) 
     easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
     fill: 'backwards'
   });
+  const motion = { animation, target: toScale };
+  const forget = () => {
+    if (rowBarAnimations.get(fill) === motion) rowBarAnimations.delete(fill);
+  };
+  animation.onfinish = forget;
+  animation.oncancel = forget;
+  rowBarAnimations.set(fill, motion);
 }
 
 function captureTrendBarMotion() {
@@ -1267,11 +1300,7 @@ function applyBarScale(fill, scale) {
   const safeScale = Math.max(0, Math.min(1, Number(scale) || 0));
   fill.style.setProperty('--bar-scale', String(safeScale));
   if (!state.animateBarsFromZero || prefersReducedMotion() || !fill.animate) return;
-  for (const animation of fill.getAnimations()) animation.cancel();
-  fill.animate([
-    { transform: 'scaleX(0)' },
-    { transform: `scaleX(${safeScale})` }
-  ], { duration: 420, easing: 'cubic-bezier(0.22, 1, 0.36, 1)' });
+  animateBarBetween(fill, 0, safeScale, 0, 420);
 }
 
 function rowWidth(value, max) {
@@ -3972,6 +4001,7 @@ function render() {
   const totalChanged = nextTotal !== state.currentTotal;
   if (state.suppressInitialNumberAnimation) {
     cancelNumberAnimation();
+    numberAnimValue = nextTotal;
     els.totalTokens.textContent = formatNumber(nextTotal);
     updateTotalCompact(nextTotal);
     state.suppressInitialNumberAnimation = false;
@@ -3980,13 +4010,15 @@ function render() {
     // widest endpoint first (a downward roll starts wider than it settles), so the
     // number never vanishes, clips, or resizes mid-roll. Re-fit on completion so a
     // window resize during the animation, or a downward settle, still ends correct.
-    const widest = formatNumber(nextTotal).length >= formatNumber(state.currentTotal).length ? nextTotal : state.currentTotal;
+    const animationFrom = numberAnimHandle ? numberAnimValue : state.currentTotal;
+    const widest = formatNumber(nextTotal).length >= formatNumber(animationFrom).length ? nextTotal : animationFrom;
     els.totalTokens.textContent = formatNumber(widest);
     updateTotalCompact(nextTotal);
-    animateNumber(els.totalTokens, state.currentTotal, nextTotal, state.periodMotionActive ? 800 : 1000, fitTotalNumber);
+    animateNumber(els.totalTokens, animationFrom, nextTotal, state.periodMotionActive ? 800 : 1000, fitTotalNumber);
     pulseLiveDot();
-  } else {
+  } else if (!headlineNumberIsAnimatingTo(nextTotal)) {
     cancelNumberAnimation();
+    numberAnimValue = nextTotal;
     els.totalTokens.textContent = formatNumber(nextTotal);
     updateTotalCompact(nextTotal);
   }

--- a/tests/electron/motionPreference.test.js
+++ b/tests/electron/motionPreference.test.js
@@ -43,8 +43,9 @@ test('appearance exposes and persists the three-state motion control', () => {
 
 test('enabling reduced motion settles active row counters immediately', () => {
   const app = read('app.js');
-  assert.match(app, /const rowNumberAnimationHandles = new Map\(\)/);
-  assert.match(app, /for \(const \[el, handle\] of rowNumberAnimationHandles\)[\s\S]*?cancelAnimationFrame\(handle\)[\s\S]*?rowNumberAnimationHandles\.clear\(\)/);
+  assert.match(app, /const rowNumberAnimations = new Map\(\)/);
+  assert.match(app, /for \(const \[el, motion\] of rowNumberAnimations\)[\s\S]*?cancelAnimationFrame\(motion\.handle\)[\s\S]*?rowNumberAnimations\.clear\(\)/);
+  assert.match(app, /rowBarAnimations\.clear\(\)/);
   assert.match(app, /el\.dataset\.motionTarget = String\(to\)/);
 });
 

--- a/tests/electron/rendererMotion.test.js
+++ b/tests/electron/rendererMotion.test.js
@@ -36,8 +36,8 @@ test('data bars animate on the compositor instead of changing layout width', () 
   assert.doesNotMatch(css, /(?:\.bar-fill|\.limit-meter-fill)\s*\{[^}]*transition:\s*width/s);
   assert.match(app, /applyBarScale\(fill, width \/ 100\)/);
   assert.match(app, /applyBarScale\(fill, safePercent \/ 100\)/);
-  assert.match(app, /state\.animateBarsFromZero[\s\S]*?transform: 'scaleX\(0\)'[\s\S]*?duration: 420/s);
-  assert.match(applyBarScale, /for \(const animation of fill\.getAnimations\(\)\) animation\.cancel\(\)/);
+  assert.match(app, /state\.animateBarsFromZero[\s\S]*?animateBarBetween\(fill, 0, safeScale, 0, 420\)/s);
+  assert.match(applyBarScale, /animateBarBetween\(fill, 0, safeScale, 0, 420\)/);
 });
 
 test('period changes preserve row identity, animate rank changes, and count from the previous total', () => {
@@ -64,8 +64,49 @@ test('live row updates count and resize bars together without slowing the headli
 
   assert.match(app, /const liveMotionSnapshot = !state\.periodMotionActive && !state\.animateBarsFromZero[\s\S]*?captureBreakdownMotion\(\)/);
   assert.match(app, /if \(liveMotionSnapshot\) animateBreakdownFrom\(liveMotionSnapshot, \{ duration: 600 \}\)/);
-  assert.match(app, /animateNumber\(els\.totalTokens, state\.currentTotal, nextTotal, state\.periodMotionActive \? 800 : 1000, fitTotalNumber\)/);
+  assert.match(app, /const animationFrom = numberAnimHandle \? numberAnimValue : state\.currentTotal/);
+  assert.match(app, /animateNumber\(els\.totalTokens, animationFrom, nextTotal, state\.periodMotionActive \? 800 : 1000, fitTotalNumber\)/);
   assert.match(app, /animateRowNumber\(row\.querySelector\('\.row-value'\), 0, value, duration\)/);
+});
+
+test('unrelated rerenders do not truncate an in-flight headline count', () => {
+  const app = read('app.js');
+  const renderTotal = app.slice(
+    app.indexOf('const totalChanged = nextTotal !== state.currentTotal'),
+    app.indexOf('state.currentTotal = nextTotal', app.indexOf('const totalChanged = nextTotal !== state.currentTotal'))
+  );
+
+  assert.match(app, /let numberAnimTarget = null;\s*let numberAnimValue = 0;/);
+  assert.match(app, /function headlineNumberIsAnimatingTo\(value\) \{\s*return Boolean\(numberAnimHandle\) && numberAnimTarget === value;\s*\}/);
+  assert.match(app, /numberAnimTarget = to;\s*numberAnimValue = from;/);
+  assert.match(app, /numberAnimValue = from \+ delta \* easeOutQuart\(progress\)/);
+  assert.match(renderTotal, /else if \(!headlineNumberIsAnimatingTo\(nextTotal\)\) \{\s*cancelNumberAnimation\(\)/);
+  assert.doesNotMatch(renderTotal, /else \{\s*cancelNumberAnimation\(\)/);
+});
+
+test('row motion preserves matching targets and continues changed targets from the visual state', () => {
+  const app = read('app.js');
+  const animateRowNumber = app.slice(
+    app.indexOf('function animateRowNumber('),
+    app.indexOf('function animateBreakdownFrom(', app.indexOf('function animateRowNumber('))
+  );
+  const animateBarBetween = app.slice(
+    app.indexOf('function animateBarBetween('),
+    app.indexOf('function captureTrendBarMotion(', app.indexOf('function animateBarBetween('))
+  );
+
+  assert.match(app, /const rowNumberAnimations = new Map\(\);\s*const rowBarAnimations = new Map\(\);/);
+  assert.match(animateRowNumber, /if \(previous\?\.target === to\) return;/);
+  assert.match(animateRowNumber, /const startValue = Number\.isFinite\(previous\?\.value\) \? previous\.value : from;/);
+  assert.match(animateRowNumber, /const motion = \{ handle: 0, target: to, value: startValue \}/);
+  assert.match(animateBarBetween, /const previousIsActive = previous\?\.animation\.pending \|\| previous\?\.animation\.playState === 'running';/);
+  assert.match(animateBarBetween, /if \(previousIsActive && Math\.abs\(previous\.target - toScale\) < 0\.001\) return;/);
+  assert.ok(
+    animateBarBetween.indexOf('for (const animation of fill.getAnimations()) animation.cancel()')
+      < animateBarBetween.indexOf('if (Math.abs(toScale - fromScale) < 0.001) return'),
+    'a stale bar tween must be cancelled even when the new target already matches the visual scale'
+  );
+  assert.match(animateBarBetween, /animation\.onfinish = forget;\s*animation\.oncancel = forget;\s*rowBarAnimations\.set\(fill, motion\);/);
 });
 
 test('view changes render immediately without a page crossfade', () => {
@@ -85,7 +126,7 @@ test('headline counting respects reduced-motion preferences', () => {
   const app = read('app.js');
   const animateNumber = app.slice(
     app.indexOf('function animateNumber('),
-    app.indexOf('const rowNumberAnimationHandles', app.indexOf('function animateNumber('))
+    app.indexOf('const rowNumberAnimations', app.indexOf('function animateNumber('))
   );
 
   assert.match(animateNumber, /if \(prefersReducedMotion\(\)\) \{[\s\S]*?el\.textContent = formatNumber\(to\);[\s\S]*?onDone\(\);[\s\S]*?return;/);

--- a/tests/electron/totalTokenCompact.test.js
+++ b/tests/electron/totalTokenCompact.test.js
@@ -54,8 +54,9 @@ test('compact total is an opt-in appearance preference', () => {
 test('compact total stays visible through the count-up, with the font pre-locked', () => {
   // The font is fitted to the widest endpoint before the roll starts, so the number
   // does not vanish, clip, or resize mid-animation in either direction.
-  assert.match(app, /const widest = formatNumber\(nextTotal\)\.length >= formatNumber\(state\.currentTotal\)\.length \? nextTotal : state\.currentTotal;/);
-  assert.match(app, /els\.totalTokens\.textContent = formatNumber\(widest\);\s*updateTotalCompact\(nextTotal\);\s*animateNumber\(els\.totalTokens, state\.currentTotal, nextTotal, state\.periodMotionActive \? 800 : 1000, fitTotalNumber\);/s);
+  assert.match(app, /const animationFrom = numberAnimHandle \? numberAnimValue : state\.currentTotal;/);
+  assert.match(app, /const widest = formatNumber\(nextTotal\)\.length >= formatNumber\(animationFrom\)\.length \? nextTotal : animationFrom;/);
+  assert.match(app, /els\.totalTokens\.textContent = formatNumber\(widest\);\s*updateTotalCompact\(nextTotal\);\s*animateNumber\(els\.totalTokens, animationFrom, nextTotal, state\.periodMotionActive \? 800 : 1000, fitTotalNumber\);/s);
   // animateNumber must not reset the font, or the pre-locked size would be lost.
   const animateBody = app.slice(app.indexOf('function animateNumber('), app.indexOf('function rowWidth('));
   assert.doesNotMatch(animateBody, /style\.fontSize/);


### PR DESCRIPTION
## Summary

- preserve in-flight headline, row-number, and usage-bar animations across unrelated renderer updates when their targets are unchanged
- continue changed totals and row values from their current visual state instead of jumping or restarting from stale endpoints
- retain the existing animation durations, easing, and reduced-motion behavior

## Root cause

The renderer updated the logical headline total as soon as a tween started. A later render with the same data then treated the value as settled, cancelled the active animation, and wrote the final value early. Row counters and bars had the inverse problem: unrelated renders restarted a full tween even when their targets had not changed.

The renderer now tracks each active animation's target and current visual state. Matching targets keep running; changed targets replace the old animation from the visible value; cancelled and completed animations are removed from tracking.

## Validation

- `npm run verify` (`1473` passed, `1` skipped)
- `node --test tests/electron/rendererMotion.test.js tests/electron/motionPreference.test.js tests/electron/totalTokenCompact.test.js` (`23/23` passed)
- `git diff --check`

Screenshots are not applicable because this is a timing-continuity fix with no visual styling change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves continuity of headline, row-number, and usage-bar animations across unrelated renders. In-flight tweens keep running when targets are unchanged; changed values continue from the current visual state instead of jumping.

- **Bug Fixes**
  - Headline count: track `numberAnimTarget` and `numberAnimValue` to avoid truncation; only cancel when the new target differs; width pre-lock uses the current anim value.
  - Row numbers: new `rowNumberAnimations` map stores handle/target/value; matching targets continue; changed targets start from the visible value; cleans up on finish/cancel.
  - Bars: new `rowBarAnimations` with `animateBarBetween()`; cancels stale tweens, skips no-ops, and keeps active tweens when the target is unchanged.
  - Reduced motion: `settleMotionAnimations()` now settles headline, row counters, and bars immediately; existing durations, easing, and preferences remain the same.

<sup>Written for commit 3c8a1b17d4fab08410c1645c5d04372bdfaa5802. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

