### PR TITLE
fix(limits): stop disabled accounts appearing as checking

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -1686,6 +1686,10 @@ function enabledLimitProviderSet() {
   return new Set(configuredLimitProviderSelection());
 }
 
+function limitProviderEnabled(providerName) {
+  return enabledLimitProviderSet().has(providerName);
+}
+
 function limitProviderSelectionIncluding(providerName) {
   const selected = new Set(configuredLimitProviderSelection());
   selected.add(providerName);
@@ -6298,6 +6302,7 @@ async function onLimitProviderToggle() {
     setBreakdown('tool');
   }
   await saveSettings({ limitProviders: checked.join(','), limitsEnabled: checked.length > 0 });
+  clearDisabledLimitProviderPendingChecks(new Set(checked));
   await refreshStats({ force: true });
 }
 
@@ -7878,6 +7883,15 @@ const externalLimitAccountConfig = {
   }
 };
 
+function clearDisabledLimitProviderPendingChecks(enabledProviders) {
+  if (!enabledProviders.has('deepseek')) clearDeepseekPendingCheck();
+  if (!enabledProviders.has('minimax')) clearMinimaxPendingCheck();
+  if (!enabledProviders.has('copilot')) clearCopilotPendingCheck();
+  for (const providerName of Object.keys(externalLimitAccountConfig)) {
+    if (!enabledProviders.has(providerName)) clearExternalProviderCheckPending(providerName);
+  }
+}
+
 function externalProviderForAccount(providerName) {
   const provider = localProviderStatus(providerName);
   const config = externalLimitAccountConfig[providerName];
@@ -7932,8 +7946,8 @@ function isCurrentCopilotSignInFlow(flowId) {
   return current && incoming === current;
 }
 
-function copilotAccountStatusText(provider, configured, source) {
-  const accountStatus = limitProviderPresentationApi.apiKeyAccountStatus(provider, configured);
+function copilotAccountStatusText(provider, configured, source, enabled = true) {
+  const accountStatus = limitProviderPresentationApi.apiKeyAccountStatus(provider, configured, enabled);
   if (accountStatus === 'linked') {
     const accountName = String(provider?.accountName || '').trim();
     return accountName || t(source === 'env' ? 'settings.copilot.statusEnv' : 'settings.copilot.statusSet');
@@ -7942,6 +7956,7 @@ function copilotAccountStatusText(provider, configured, source) {
   if (accountStatus === 'notConfigured') return t('settings.copilot.statusNotSet');
   const statusKeys = {
     checking: 'settings.common.checking',
+    disabled: 'settings.limits.status.disabled',
     limited: 'settings.common.limited',
     unavailable: 'settings.common.unavailable',
     notChecked: 'settings.common.notChecked',
@@ -7950,8 +7965,8 @@ function copilotAccountStatusText(provider, configured, source) {
   return t(statusKeys[accountStatus] || 'settings.common.error');
 }
 
-function apiKeyAccountStatusText(providerName, provider, configured, source) {
-  const accountStatus = limitProviderPresentationApi.apiKeyAccountStatus(provider, configured);
+function apiKeyAccountStatusText(providerName, provider, configured, source, enabled = true) {
+  const accountStatus = limitProviderPresentationApi.apiKeyAccountStatus(provider, configured, enabled);
   if (accountStatus === 'linked') {
     return t(source === 'env' ? `settings.${providerName}.statusEnv` : `settings.${providerName}.statusSet`);
   }
@@ -7959,6 +7974,7 @@ function apiKeyAccountStatusText(providerName, provider, configured, source) {
   if (accountStatus === 'notConfigured') return t(`settings.${providerName}.statusNotSet`);
   const statusKeys = {
     checking: 'settings.common.checking',
+    disabled: 'settings.limits.status.disabled',
     limited: 'settings.common.limited',
     unavailable: 'settings.common.unavailable',
     notChecked: 'settings.common.notChecked',
@@ -8054,7 +8070,8 @@ function renderExternalProviderStatus(providerName) {
   const wasPending = Number(state[config.pendingKey] || 0) > 0;
   const provider = externalProviderForAccount(providerName);
   const configured = Boolean(state.settings?.[config.configuredKey]);
-  const pending = Number(state[config.pendingKey] || 0) > 0;
+  const enabled = limitProviderEnabled(providerName);
+  const pending = enabled && Number(state[config.pendingKey] || 0) > 0;
   const linked = externalProviderAccountLinked(providerName);
   if (providerName === 'ollama' && wasPending && !pending && linked) {
     setExternalAccountExpanded('ollama', false);
@@ -8070,7 +8087,7 @@ function renderExternalProviderStatus(providerName) {
   }
   setCursorStatusText(
     statusEl,
-    pending ? t('settings.common.checking') : apiKeyAccountStatusText(providerName, provider, configured, source)
+    pending ? t('settings.common.checking') : apiKeyAccountStatusText(providerName, provider, configured, source, enabled)
   );
   manualPanel.classList.toggle('hidden', linked);
   openBtn.classList.toggle('hidden', linked);
@@ -8103,8 +8120,9 @@ function renderMinimaxStatus() {
   const source = state.settings?.minimaxApiKeySource || '';
   const provider = minimaxProviderForAccount();
   const configured = Boolean(state.settings?.minimaxApiKeyConfigured);
+  const enabled = limitProviderEnabled('minimax');
   const linked = minimaxAccountLinked();
-  setCursorStatusText(statusEl, apiKeyAccountStatusText('minimax', provider, configured, source));
+  setCursorStatusText(statusEl, apiKeyAccountStatusText('minimax', provider, configured, source, enabled));
   manualPanel.classList.toggle('hidden', linked);
   openBtn.classList.toggle('hidden', linked);
   logoutBtn.classList.toggle('hidden', !linked || source !== 'settings');
@@ -8126,10 +8144,11 @@ function renderCopilotStatus() {
   const source = state.settings?.copilotApiTokenSource || '';
   const provider = copilotProviderForAccount();
   const configured = Boolean(state.settings?.copilotApiTokenConfigured);
+  const enabled = limitProviderEnabled('copilot');
   const linked = copilotAccountLinked();
   errorEl.textContent = state.copilotErrorMessage || '';
   errorEl.classList.toggle('hidden', !state.copilotErrorMessage);
-  setCursorStatusText(statusEl, copilotAccountStatusText(provider, configured, source));
+  setCursorStatusText(statusEl, copilotAccountStatusText(provider, configured, source, enabled));
   manualPanel.classList.toggle('hidden', linked);
   if (linked && state.copilotManualExpanded) setCopilotManualExpanded(false);
   signInBtn.classList.toggle('hidden', linked || state.copilotSignInBusy);
@@ -8156,8 +8175,9 @@ function renderDeepseekStatus() {
   const source = state.settings?.deepseekApiKeySource || '';
   const provider = deepseekProviderForAccount();
   const configured = Boolean(state.settings?.deepseekApiKeyConfigured);
+  const enabled = limitProviderEnabled('deepseek');
   const linked = deepseekAccountLinked();
-  setCursorStatusText(statusEl, apiKeyAccountStatusText('deepseek', provider, configured, source));
+  setCursorStatusText(statusEl, apiKeyAccountStatusText('deepseek', provider, configured, source, enabled));
   manualPanel.classList.toggle('hidden', linked);
   openBtn.classList.toggle('hidden', linked);
   logoutBtn.classList.toggle('hidden', !linked || source !== 'settings');

--- a/src/electron/renderer/limitProviderPresentation.js
+++ b/src/electron/renderer/limitProviderPresentation.js
@@ -177,8 +177,9 @@
     return status ? { label: 'Error', tone: 'warn' } : null;
   }
 
-  function apiKeyAccountStatus(provider, configured) {
+  function apiKeyAccountStatus(provider, configured, enabled = true) {
     if (!configured) return 'notConfigured';
+    if (!enabled) return 'disabled';
     const status = statusId(provider);
     if (!status) return 'checking';
     if (status === 'ok') return 'linked';

--- a/tests/electron/cursorSettingsLayout.test.js
+++ b/tests/electron/cursorSettingsLayout.test.js
@@ -687,7 +687,7 @@ test('DeepSeek account linked state requires a validated API key', () => {
 
   const renderBody = functionBody(app, 'renderDeepseekStatus', 'renderOpenCodeProfiles');
   assert.match(renderBody, /const configured = Boolean\(state\.settings\?\.deepseekApiKeyConfigured\);/);
-  assert.match(renderBody, /apiKeyAccountStatusText\('deepseek', provider, configured, source\)/);
+  assert.match(renderBody, /apiKeyAccountStatusText\('deepseek', provider, configured, source, enabled\)/);
 });
 
 test('DeepSeek key changes invalidate stale provider status before re-checking', () => {
@@ -709,6 +709,29 @@ test('DeepSeek key changes invalidate stale provider status before re-checking',
   const clearBody = functionBody(app, 'clearDeepseekProviderStatus', 'renderDeepseekStatus');
   assert.match(clearBody, /state\.stats\.limits\.providers = state\.stats\.limits\.providers\.filter/);
   assert.match(clearBody, /provider\.provider !== 'deepseek'/);
+});
+
+test('disabled credential providers settle account status instead of checking forever', () => {
+  const app = readRendererFile('app.js');
+  const toggleBody = functionBody(app, 'onLimitProviderToggle', 'onLimitProviderMove');
+  const clearBody = functionBody(app, 'clearDisabledLimitProviderPendingChecks', 'externalProviderForAccount');
+  const externalRenderBody = functionBody(app, 'renderExternalProviderStatus', 'setMinimaxAccountExpanded');
+  const deepseekRenderBody = functionBody(app, 'renderDeepseekStatus', 'renderOpenCodeProfiles');
+  const minimaxRenderBody = functionBody(app, 'renderMinimaxStatus', 'renderCopilotStatus');
+  const copilotRenderBody = functionBody(app, 'renderCopilotStatus', 'renderDeepseekStatus');
+
+  assert.match(toggleBody, /clearDisabledLimitProviderPendingChecks\(new Set\(checked\)\)/);
+  assert.match(clearBody, /clearDeepseekPendingCheck\(\)/);
+  assert.match(clearBody, /clearMinimaxPendingCheck\(\)/);
+  assert.match(clearBody, /clearCopilotPendingCheck\(\)/);
+  assert.match(clearBody, /Object\.keys\(externalLimitAccountConfig\)/);
+  assert.match(clearBody, /clearExternalProviderCheckPending\(providerName\)/);
+  assert.match(externalRenderBody, /const enabled = limitProviderEnabled\(providerName\);/);
+  assert.match(externalRenderBody, /const pending = enabled &&/);
+  assert.match(externalRenderBody, /apiKeyAccountStatusText\(providerName, provider, configured, source, enabled\)/);
+  assert.match(deepseekRenderBody, /apiKeyAccountStatusText\('deepseek', provider, configured, source, enabled\)/);
+  assert.match(minimaxRenderBody, /apiKeyAccountStatusText\('minimax', provider, configured, source, enabled\)/);
+  assert.match(copilotRenderBody, /copilotAccountStatusText\(provider, configured, source, enabled\)/);
 });
 
 test('MiniMax key changes invalidate stale provider status before re-checking', () => {

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -125,7 +125,9 @@ test('Grok CLI/Web capability tag is localized in settings', () => {
 
 test('API key account status distinguishes pending checks from completed failures', () => {
   assert.equal(apiKeyAccountStatus(null, false), 'notConfigured');
+  assert.equal(apiKeyAccountStatus(null, false, false), 'notConfigured');
   assert.equal(apiKeyAccountStatus(null, true), 'checking');
+  assert.equal(apiKeyAccountStatus(null, true, false), 'disabled');
   assert.equal(apiKeyAccountStatus({ status: 'ok' }, true), 'linked');
   assert.equal(apiKeyAccountStatus({ status: 'unauthorized' }, true), 'invalid');
   assert.equal(apiKeyAccountStatus({ status: 'rateLimited' }, true), 'limited');


### PR DESCRIPTION
## Summary

- show configured limit accounts as Disabled when their provider is turned off instead of leaving them at Checking
- clear pending credential checks when providers are disabled so stale loading state cannot survive a settings change
- apply the shared state handling to DeepSeek, MiniMax, GitHub Copilot, Z.ai, Z.ai Team, Volcengine, Qoder, Kimi, and Ollama

## Verification

- `node --test tests/electron/limitProviderPresentation.test.js tests/electron/cursorSettingsLayout.test.js`
- `npm run verify` (1479 passed, 1 skipped)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops disabled limit providers from showing as “Checking” and clears stale pending checks when providers are turned off. Applies to DeepSeek, MiniMax, GitHub Copilot, Z.ai, Z.ai Team, Volcengine, Qoder, Kimi, Ollama, and other external providers.

- **Bug Fixes**
  - Status logic now treats disabled providers as “Disabled” (enabled-aware `apiKeyAccountStatus`).
  - Clears pending credential checks on provider toggle to prevent stuck loading.
  - Propagates the enabled flag through status renderers (Copilot, DeepSeek, MiniMax, and all external providers) and updates tests.

<sup>Written for commit e63c1625d70920ea49f8fc77ff7606d10c1964f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

