### PR TITLE
feat(devices): show operating system versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Two caveats on top of the table:
 
 ### Data flow contract
 
-The hub stores normalized device records (`normalizeDeviceRecord` in `usage.js`) and aggregates on read (`aggregateDevices`). The wire shape between agent/widget and hub is whatever `collectUsageOnce()` returns — that function is the source of truth, and `docs/API.md` documents the full contract. The core is `{deviceId, hostname, platform, updatedAt, agentVersion, today, month, allTime}` (each period has `{totalTokens, costUsd, clients, clientCosts, models, modelCosts}`), plus attribution fields (`trackedClients`, `clientStatus`, `wslStatus`, `periodWindows`, `projectsEnabled`) and optional `osVersion` / `agentRuntime` / `history` / `limits`. The Worker hub uses the exact same shapes.
+The hub stores normalized device records (`normalizeDeviceRecord` in `usage.js`) and aggregates on read (`aggregateDevices`). The wire shape between agent/widget and hub is whatever `collectUsageOnce()` returns — that function is the source of truth, and `docs/API.md` documents the full contract. The core is `{deviceId, hostname, platform, updatedAt, agentVersion, today, month, allTime}` (each period has `{totalTokens, costUsd, clients, clientCosts, models, modelCosts}`), plus attribution fields (`trackedClients`, `clientStatus`, `wslStatus`, `periodWindows`, `projectsEnabled`) and optional `osName` / `osVersion` / `agentRuntime` / `history` / `limits`. The Worker hub uses the exact same shapes.
 
 ### Stale devices
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Two caveats on top of the table:
 
 ### Data flow contract
 
-The hub stores normalized device records (`normalizeDeviceRecord` in `usage.js`) and aggregates on read (`aggregateDevices`). The wire shape between agent/widget and hub is whatever `collectUsageOnce()` returns — that function is the source of truth, and `docs/API.md` documents the full contract. The core is `{deviceId, hostname, platform, updatedAt, agentVersion, today, month, allTime}` (each period has `{totalTokens, costUsd, clients, clientCosts, models, modelCosts}`), plus attribution fields (`trackedClients`, `clientStatus`, `wslStatus`, `periodWindows`, `projectsEnabled`) and optional `agentRuntime` / `history` / `limits`. The Worker hub uses the exact same shapes.
+The hub stores normalized device records (`normalizeDeviceRecord` in `usage.js`) and aggregates on read (`aggregateDevices`). The wire shape between agent/widget and hub is whatever `collectUsageOnce()` returns — that function is the source of truth, and `docs/API.md` documents the full contract. The core is `{deviceId, hostname, platform, updatedAt, agentVersion, today, month, allTime}` (each period has `{totalTokens, costUsd, clients, clientCosts, models, modelCosts}`), plus attribution fields (`trackedClients`, `clientStatus`, `wslStatus`, `periodWindows`, `projectsEnabled`) and optional `osVersion` / `agentRuntime` / `history` / `limits`. The Worker hub uses the exact same shapes.
 
 ### Stale devices
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -46,6 +46,7 @@ Example payload:
   "deviceId": "macbook",
   "hostname": "macbook.local",
   "platform": "darwin-arm64",
+  "osVersion": "26.0",
   "updatedAt": "2026-05-18T00:00:00.000Z",
   "agentVersion": "0.3.0",
   "agentRuntime": "headless-agent",
@@ -187,6 +188,8 @@ Authenticated stats expose `projectsIncomplete: true` when a device omitted its 
 
 `trackedClients` is optional but recommended for agents and widgets. When it is present, the hub treats omitted clients as intentionally not collected in this payload and preserves their previous usage for that device. This keeps "tracking" as "collect future data" rather than "hide existing history".
 
+Current agents and widgets include `osVersion` so device details can show the operating-system release. macOS reports the product version from Electron or `sw_vers`; other platforms report the system release. The hub continues to accept older payloads without this field.
+
 `syncUploadIntervalMs` is optional. A remote-hub widget includes `0` for live uploads or the selected fixed interval in milliseconds (`600000`, `1200000`, or `1800000`). The hub uses a positive interval to keep the device and its limits fresh for at least twice the upload interval; omitted or `0` values retain the configured `staleAfterMs` behavior. Local collection and embedded-host ingest remain live.
 
 `periodWindows` is optional. Agents and widgets stamp each snapshot with the UTC instant its `today`/`month` windows end, computed in the device's own local time (`endsAt` = next local midnight / next local month start; `key` is the device-local day/month for reference). The hub uses it to expire a device's `today`/`month` from the aggregate once `now >= endsAt`, so a device that goes offline before re-posting does not keep contributing a stale day/month snapshot (`allTime` never expires). Payloads without `periodWindows` fall back to a UTC day/month comparison against `updatedAt`.
@@ -218,7 +221,7 @@ Response includes:
 - `projectsIncomplete` plus the corresponding `devices[].allTimeProjectsOmitted`, `devices[].allTimeProjectsIncomplete`, or `devices[].projectsEnabled` diagnostic
 - `historyPreview.daily[].activeTimeMs`, `historyPreview.monthly[].activeTimeMs`, and `historyPreview.summary.activeTimeMs` when tokscale graph exposes session active-time metrics
 - `limits.providers` aggregated by provider account
-- `devices`, including each device's normalized `periods`, `limits`, `receivedAt`, optional `syncUploadIntervalMs`, and optional `periodWindows`
+- `devices`, including each device's normalized `periods`, `limits`, `receivedAt`, `osVersion` when reported, optional `syncUploadIntervalMs`, and optional `periodWindows`
 - stale status for devices that have not reported recently
 
 If multiple devices report the same provider account, the hub keeps the freshest valid limits status for that account. Public Worker stats omit account identifiers.

--- a/docs/API.md
+++ b/docs/API.md
@@ -46,6 +46,7 @@ Example payload:
   "deviceId": "macbook",
   "hostname": "macbook.local",
   "platform": "darwin-arm64",
+  "osName": "macOS",
   "osVersion": "26.0",
   "updatedAt": "2026-05-18T00:00:00.000Z",
   "agentVersion": "0.3.0",
@@ -188,7 +189,7 @@ Authenticated stats expose `projectsIncomplete: true` when a device omitted its 
 
 `trackedClients` is optional but recommended for agents and widgets. When it is present, the hub treats omitted clients as intentionally not collected in this payload and preserves their previous usage for that device. This keeps "tracking" as "collect future data" rather than "hide existing history".
 
-Current agents and widgets include `osVersion` so device details can show the operating-system release. macOS reports the product version from Electron or `sw_vers`; other platforms report the system release. The hub continues to accept older payloads without this field.
+Current agents and widgets include `osName` and, when known, `osVersion` so device details can show a user-facing operating-system release. macOS uses the product version from Electron or `sw_vers`; Windows uses the product family and display version from the registry; Linux uses the distribution name and version from `os-release`. Detection failures fall back to an explicitly labelled Windows build or Linux kernel release. The hub continues to accept older payloads without these fields.
 
 `syncUploadIntervalMs` is optional. A remote-hub widget includes `0` for live uploads or the selected fixed interval in milliseconds (`600000`, `1200000`, or `1800000`). The hub uses a positive interval to keep the device and its limits fresh for at least twice the upload interval; omitted or `0` values retain the configured `staleAfterMs` behavior. Local collection and embedded-host ingest remain live.
 
@@ -221,7 +222,7 @@ Response includes:
 - `projectsIncomplete` plus the corresponding `devices[].allTimeProjectsOmitted`, `devices[].allTimeProjectsIncomplete`, or `devices[].projectsEnabled` diagnostic
 - `historyPreview.daily[].activeTimeMs`, `historyPreview.monthly[].activeTimeMs`, and `historyPreview.summary.activeTimeMs` when tokscale graph exposes session active-time metrics
 - `limits.providers` aggregated by provider account
-- `devices`, including each device's normalized `periods`, `limits`, `receivedAt`, `osVersion` when reported, optional `syncUploadIntervalMs`, and optional `periodWindows`
+- `devices`, including each device's normalized `periods`, `limits`, `receivedAt`, `osName` / `osVersion` when reported, optional `syncUploadIntervalMs`, and optional `periodWindows`
 - stale status for devices that have not reported recently
 
 If multiple devices report the same provider account, the hub keeps the freshest valid limits status for that account. Public Worker stats omit account identifiers.

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -1622,7 +1622,7 @@ function deviceRowsForPeriod() {
     const period = device.periods?.[state.period] || {};
     const runtime = deviceRuntimeLabel(device.agentRuntime);
     const version = device.agentVersion ? `${runtime ? `${runtime} ` : ''}v${device.agentVersion}` : runtime;
-    const metaParts = [deviceBreakdownApi.devicePlatformLabel(device.platform, device.osVersion), version, deviceSyncedLabel(device.updatedAt)].filter(Boolean);
+    const metaParts = [deviceBreakdownApi.devicePlatformLabel(device.platform, device.osName, device.osVersion), version, deviceSyncedLabel(device.updatedAt)].filter(Boolean);
     return {
       key: device.deviceId,
       name: deviceLabel(device),

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -1580,14 +1580,6 @@ function deviceColor(stale) {
   return stale ? deviceStaleColor : deviceAccent;
 }
 
-function devicePlatformLabel(value) {
-  const platform = String(value || '').toLowerCase().split('-')[0];
-  if (platform === 'darwin') return 'macOS';
-  if (platform === 'win32') return 'Windows';
-  if (platform === 'linux') return 'Linux';
-  return String(value || '');
-}
-
 function deviceRuntimeLabel(value) {
   if (value === 'electron-widget') return t('devices.runtime.widget');
   if (value === 'headless-agent') return t('devices.runtime.agent');
@@ -1630,7 +1622,7 @@ function deviceRowsForPeriod() {
     const period = device.periods?.[state.period] || {};
     const runtime = deviceRuntimeLabel(device.agentRuntime);
     const version = device.agentVersion ? `${runtime ? `${runtime} ` : ''}v${device.agentVersion}` : runtime;
-    const metaParts = [devicePlatformLabel(device.platform), version, deviceSyncedLabel(device.updatedAt)].filter(Boolean);
+    const metaParts = [deviceBreakdownApi.devicePlatformLabel(device.platform, device.osVersion), version, deviceSyncedLabel(device.updatedAt)].filter(Boolean);
     return {
       key: device.deviceId,
       name: deviceLabel(device),

--- a/src/electron/renderer/deviceBreakdown.js
+++ b/src/electron/renderer/deviceBreakdown.js
@@ -40,14 +40,15 @@
     };
   }
 
-  function devicePlatformLabel(value, osVersion) {
+  function devicePlatformLabel(value, osName, osVersion) {
     const platform = String(value || '').toLowerCase().split('-')[0];
     let label = String(value || '');
     if (platform === 'darwin') label = 'macOS';
     else if (platform === 'win32') label = 'Windows';
     else if (platform === 'linux') label = 'Linux';
+    const name = String(osName || '').trim() || label;
     const version = String(osVersion || '').trim();
-    return [label, version].filter(Boolean).join(' ');
+    return [name, version].filter(Boolean).join(' ');
   }
 
   return { deviceBreakdownForPeriod, devicePlatformLabel };

--- a/src/electron/renderer/deviceBreakdown.js
+++ b/src/electron/renderer/deviceBreakdown.js
@@ -40,5 +40,15 @@
     };
   }
 
-  return { deviceBreakdownForPeriod };
+  function devicePlatformLabel(value, osVersion) {
+    const platform = String(value || '').toLowerCase().split('-')[0];
+    let label = String(value || '');
+    if (platform === 'darwin') label = 'macOS';
+    else if (platform === 'win32') label = 'Windows';
+    else if (platform === 'linux') label = 'Linux';
+    const version = String(osVersion || '').trim();
+    return [label, version].filter(Boolean).join(' ');
+  }
+
+  return { deviceBreakdownForPeriod, devicePlatformLabel };
 });

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -22,6 +22,7 @@ const { findSessionFiles, codexSessionFile } = require('./sessionFiles');
 const opencodeSession = require('./opencodeSession');
 const { buildPromaHistoryGraph, buildPromaPeriods, collectPromaRows } = require('./promaUsage');
 const { hashKey } = require('./hashKey');
+const { hostOsVersion, normalizeOsVersion } = require('./osVersion');
 
 function toUnpackedPath(p) {
   // electron-builder asarUnpack stores real files at .../app.asar.unpacked/...
@@ -604,6 +605,9 @@ async function collectUsageOnce(options) {
   // build path on a non-Windows CI box (the real process.platform stays for
   // tokscale binary resolution, which is genuinely platform-bound).
   const platformValue = options.platform || process.platform;
+  const osVersion = options.osVersion === undefined
+    ? hostOsVersion()
+    : normalizeOsVersion(options.osVersion);
   const normalizedClients = normalizeClientsCsv(clients);
   const projectsEnabled = options.projectsEnabled !== false;
   const localSessionMetadataDeps = {
@@ -796,6 +800,7 @@ async function collectUsageOnce(options) {
     deviceId,
     hostname: os.hostname(),
     platform: `${process.platform}-${process.arch}`,
+    ...(osVersion ? { osVersion } : {}),
     updatedAt: collectedAt.toISOString(),
     agentVersion,
     ...(agentRuntime ? { agentRuntime } : {}),
@@ -1109,6 +1114,9 @@ function startCollector(options) {
     intervalMs, historyIntervalMs = 15 * 60 * 1000, historyEnabled = true, watchEnabled, watchDebounceMs, limitsEnabled,
     onUpdate, onPreview, onError, logger
   } = options;
+  const deviceOsVersion = options.osVersion === undefined
+    ? hostOsVersion()
+    : normalizeOsVersion(options.osVersion);
   const log = logger || (() => {});
   const limitsCollector = limitsEnabled !== false ? createLimitsCollector(options) : null;
   let tickInFlight = false;
@@ -1182,6 +1190,7 @@ function startCollector(options) {
         deviceId,
         agentVersion,
         agentRuntime,
+        osVersion: deviceOsVersion,
         limitsCollector,
         includeHistory,
         forceLimits: Boolean(tickOptions.forceLimits),
@@ -1200,6 +1209,7 @@ function startCollector(options) {
               const preview = {
                 deviceId, hostname: os.hostname(),
                 platform: `${process.platform}-${process.arch}`,
+                ...(deviceOsVersion ? { osVersion: deviceOsVersion } : {}),
                 updatedAt: partial.updatedAt,
                 agentVersion, agentRuntime,
                 trackedClients: (clients || '').split(',').filter(Boolean),

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -22,7 +22,7 @@ const { findSessionFiles, codexSessionFile } = require('./sessionFiles');
 const opencodeSession = require('./opencodeSession');
 const { buildPromaHistoryGraph, buildPromaPeriods, collectPromaRows } = require('./promaUsage');
 const { hashKey } = require('./hashKey');
-const { hostOsVersion, normalizeOsVersion } = require('./osVersion');
+const { hostOsInfo, normalizeOsInfo } = require('./osVersion');
 
 function toUnpackedPath(p) {
   // electron-builder asarUnpack stores real files at .../app.asar.unpacked/...
@@ -605,9 +605,9 @@ async function collectUsageOnce(options) {
   // build path on a non-Windows CI box (the real process.platform stays for
   // tokscale binary resolution, which is genuinely platform-bound).
   const platformValue = options.platform || process.platform;
-  const osVersion = options.osVersion === undefined
-    ? hostOsVersion()
-    : normalizeOsVersion(options.osVersion);
+  const osInfo = options.osInfo === undefined
+    ? hostOsInfo()
+    : normalizeOsInfo(options.osInfo);
   const normalizedClients = normalizeClientsCsv(clients);
   const projectsEnabled = options.projectsEnabled !== false;
   const localSessionMetadataDeps = {
@@ -800,7 +800,8 @@ async function collectUsageOnce(options) {
     deviceId,
     hostname: os.hostname(),
     platform: `${process.platform}-${process.arch}`,
-    ...(osVersion ? { osVersion } : {}),
+    ...(osInfo.name ? { osName: osInfo.name } : {}),
+    ...(osInfo.version ? { osVersion: osInfo.version } : {}),
     updatedAt: collectedAt.toISOString(),
     agentVersion,
     ...(agentRuntime ? { agentRuntime } : {}),
@@ -1114,9 +1115,9 @@ function startCollector(options) {
     intervalMs, historyIntervalMs = 15 * 60 * 1000, historyEnabled = true, watchEnabled, watchDebounceMs, limitsEnabled,
     onUpdate, onPreview, onError, logger
   } = options;
-  const deviceOsVersion = options.osVersion === undefined
-    ? hostOsVersion()
-    : normalizeOsVersion(options.osVersion);
+  const deviceOsInfo = options.osInfo === undefined
+    ? hostOsInfo()
+    : normalizeOsInfo(options.osInfo);
   const log = logger || (() => {});
   const limitsCollector = limitsEnabled !== false ? createLimitsCollector(options) : null;
   let tickInFlight = false;
@@ -1190,7 +1191,7 @@ function startCollector(options) {
         deviceId,
         agentVersion,
         agentRuntime,
-        osVersion: deviceOsVersion,
+        osInfo: deviceOsInfo,
         limitsCollector,
         includeHistory,
         forceLimits: Boolean(tickOptions.forceLimits),
@@ -1209,7 +1210,8 @@ function startCollector(options) {
               const preview = {
                 deviceId, hostname: os.hostname(),
                 platform: `${process.platform}-${process.arch}`,
-                ...(deviceOsVersion ? { osVersion: deviceOsVersion } : {}),
+                ...(deviceOsInfo.name ? { osName: deviceOsInfo.name } : {}),
+                ...(deviceOsInfo.version ? { osVersion: deviceOsInfo.version } : {}),
                 updatedAt: partial.updatedAt,
                 agentVersion, agentRuntime,
                 trackedClients: (clients || '').split(',').filter(Boolean),

--- a/src/shared/osVersion.js
+++ b/src/shared/osVersion.js
@@ -1,15 +1,126 @@
 'use strict';
 
 const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
 const os = require('node:os');
 
+const MAX_OS_NAME_LENGTH = 64;
 const MAX_OS_VERSION_LENGTH = 128;
+const WINDOWS_CURRENT_VERSION_KEY = 'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion';
+
+function normalizeOsName(value) {
+  return String(value || '').trim().slice(0, MAX_OS_NAME_LENGTH);
+}
 
 function normalizeOsVersion(value) {
   return String(value || '').trim().slice(0, MAX_OS_VERSION_LENGTH);
 }
 
-function detectOsVersion(options = {}) {
+function normalizeOsInfo(value) {
+  return {
+    name: normalizeOsName(value?.name),
+    version: normalizeOsVersion(value?.version)
+  };
+}
+
+function commandOptions() {
+  return {
+    encoding: 'utf8',
+    timeout: 1000,
+    stdio: ['ignore', 'pipe', 'ignore']
+  };
+}
+
+function registryValues(output) {
+  const values = Object.create(null);
+  for (const line of String(output || '').split(/\r?\n/)) {
+    const match = line.match(/^\s*([^\s]+)\s+REG_[A-Z0-9_]+\s+(.*?)\s*$/i);
+    if (match) values[match[1].toLowerCase()] = match[2];
+  }
+  return values;
+}
+
+function windowsProductName(productName, build) {
+  const raw = normalizeOsName(productName).replace(/^Microsoft\s+/i, '');
+  const server = raw.match(/Windows Server\s+\d{4}/i);
+  if (server) return server[0].replace(/^windows server/i, 'Windows Server');
+  const desktop = raw.match(/Windows\s+\d+(?:\.\d+)?/i);
+  if (desktop) {
+    if (/^Windows 10$/i.test(desktop[0]) && build >= 22000) return 'Windows 11';
+    return desktop[0].replace(/^windows/i, 'Windows');
+  }
+  if (build >= 22000) return 'Windows 11';
+  if (build >= 10240) return 'Windows 10';
+  return 'Windows';
+}
+
+function detectWindowsInfo(options) {
+  const run = options.execFileSync || execFileSync;
+  let values = Object.create(null);
+  try {
+    values = registryValues(run('reg.exe', ['query', WINDOWS_CURRENT_VERSION_KEY], commandOptions()));
+  } catch (_) {}
+
+  let release = '';
+  try {
+    release = normalizeOsVersion((options.release || os.release)());
+  } catch (_) {}
+  const releaseBuild = release.split('.')[2];
+  const build = Number.parseInt(values.currentbuildnumber || values.currentbuild || releaseBuild, 10);
+  const name = windowsProductName(values.productname, Number.isFinite(build) ? build : 0);
+  const displayVersion = normalizeOsVersion(values.displayversion || values.releaseid);
+  const version = displayVersion || (Number.isFinite(build) && build > 0 ? `build ${build}` : release);
+  return normalizeOsInfo({ name, version });
+}
+
+function unquoteOsReleaseValue(value) {
+  const raw = String(value || '').trim();
+  if (raw.length >= 2 && raw[0] === "'" && raw.at(-1) === "'") return raw.slice(1, -1);
+  if (raw.length >= 2 && raw[0] === '"' && raw.at(-1) === '"') {
+    return raw.slice(1, -1).replace(/\\(["\\$`])/g, '$1');
+  }
+  return raw;
+}
+
+function parseOsRelease(output) {
+  const values = Object.create(null);
+  for (const line of String(output || '').split(/\r?\n/)) {
+    const match = line.match(/^([A-Z][A-Z0-9_]*)=(.*)$/);
+    if (match) values[match[1]] = unquoteOsReleaseValue(match[2]);
+  }
+  return values;
+}
+
+function detectLinuxInfo(options) {
+  const readFile = options.readFileSync || fs.readFileSync;
+  let values = Object.create(null);
+  for (const filePath of ['/etc/os-release', '/usr/lib/os-release']) {
+    try {
+      values = parseOsRelease(readFile(filePath, 'utf8'));
+      break;
+    } catch (_) {}
+  }
+
+  const name = normalizeOsName(values.NAME);
+  const prettyName = normalizeOsVersion(values.PRETTY_NAME);
+  if (name) {
+    const prettyVersion = prettyName.toLowerCase().startsWith(name.toLowerCase())
+      ? prettyName.slice(name.length).trim()
+      : '';
+    return normalizeOsInfo({
+      name,
+      version: prettyVersion || values.VERSION_ID || values.VERSION
+    });
+  }
+
+  let release = '';
+  try {
+    release = normalizeOsVersion((options.release || os.release)());
+  } catch (_) {}
+  return normalizeOsInfo({ name: 'Linux', version: release ? `kernel ${release}` : '' });
+}
+
+function detectOsInfo(options = {}) {
   const platform = options.platform || process.platform;
   if (platform === 'darwin') {
     const getSystemVersion = options.getSystemVersion || (() => {
@@ -17,34 +128,31 @@ function detectOsVersion(options = {}) {
     });
     try {
       const version = normalizeOsVersion(getSystemVersion());
-      if (version) return version;
+      if (version) return { name: 'macOS', version };
     } catch (_) {}
 
     const run = options.execFileSync || execFileSync;
     try {
-      return normalizeOsVersion(run('/usr/bin/sw_vers', ['-productVersion'], {
-        encoding: 'utf8',
-        timeout: 1000,
-        stdio: ['ignore', 'pipe', 'ignore']
-      }));
+      return normalizeOsInfo({
+        name: 'macOS',
+        version: run('/usr/bin/sw_vers', ['-productVersion'], commandOptions())
+      });
     } catch (_) {
-      return '';
+      return { name: 'macOS', version: '' };
     }
   }
-
-  const release = options.release || os.release;
-  try {
-    return normalizeOsVersion(release());
-  } catch (_) {
-    return '';
-  }
+  if (platform === 'win32') return detectWindowsInfo(options);
+  if (platform === 'linux') return detectLinuxInfo(options);
+  let version = '';
+  try { version = (options.release || os.release)(); } catch (_) {}
+  return normalizeOsInfo({ name: platform, version });
 }
 
-let cachedHostOsVersion;
+let cachedHostOsInfo;
 
-function hostOsVersion() {
-  if (cachedHostOsVersion === undefined) cachedHostOsVersion = detectOsVersion();
-  return cachedHostOsVersion;
+function hostOsInfo() {
+  if (cachedHostOsInfo === undefined) cachedHostOsInfo = detectOsInfo();
+  return cachedHostOsInfo;
 }
 
-module.exports = { detectOsVersion, hostOsVersion, normalizeOsVersion };
+module.exports = { detectOsInfo, hostOsInfo, normalizeOsInfo, normalizeOsName, normalizeOsVersion };

--- a/src/shared/osVersion.js
+++ b/src/shared/osVersion.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const os = require('node:os');
+
+const MAX_OS_VERSION_LENGTH = 128;
+
+function normalizeOsVersion(value) {
+  return String(value || '').trim().slice(0, MAX_OS_VERSION_LENGTH);
+}
+
+function detectOsVersion(options = {}) {
+  const platform = options.platform || process.platform;
+  if (platform === 'darwin') {
+    const getSystemVersion = options.getSystemVersion || (() => {
+      return typeof process.getSystemVersion === 'function' ? process.getSystemVersion() : '';
+    });
+    try {
+      const version = normalizeOsVersion(getSystemVersion());
+      if (version) return version;
+    } catch (_) {}
+
+    const run = options.execFileSync || execFileSync;
+    try {
+      return normalizeOsVersion(run('/usr/bin/sw_vers', ['-productVersion'], {
+        encoding: 'utf8',
+        timeout: 1000,
+        stdio: ['ignore', 'pipe', 'ignore']
+      }));
+    } catch (_) {
+      return '';
+    }
+  }
+
+  const release = options.release || os.release;
+  try {
+    return normalizeOsVersion(release());
+  } catch (_) {
+    return '';
+  }
+}
+
+let cachedHostOsVersion;
+
+function hostOsVersion() {
+  if (cachedHostOsVersion === undefined) cachedHostOsVersion = detectOsVersion();
+  return cachedHostOsVersion;
+}
+
+module.exports = { detectOsVersion, hostOsVersion, normalizeOsVersion };

--- a/src/shared/osVersion.js
+++ b/src/shared/osVersion.js
@@ -89,6 +89,14 @@ function parseOsRelease(output) {
   return values;
 }
 
+function systemRelease(options) {
+  try {
+    return normalizeOsVersion((options.release || os.release)());
+  } catch (_) {
+    return '';
+  }
+}
+
 function detectLinuxInfo(options) {
   const readFile = options.readFileSync || fs.readFileSync;
   let values = Object.create(null);
@@ -105,16 +113,15 @@ function detectLinuxInfo(options) {
     const prettyVersion = prettyName.toLowerCase().startsWith(name.toLowerCase())
       ? prettyName.slice(name.length).trim()
       : '';
+    const distroVersion = normalizeOsVersion(prettyVersion || values.VERSION_ID || values.VERSION);
+    const release = distroVersion ? '' : systemRelease(options);
     return normalizeOsInfo({
       name,
-      version: prettyVersion || values.VERSION_ID || values.VERSION
+      version: distroVersion || (release ? `kernel ${release}` : '')
     });
   }
 
-  let release = '';
-  try {
-    release = normalizeOsVersion((options.release || os.release)());
-  } catch (_) {}
+  const release = systemRelease(options);
   return normalizeOsInfo({ name: 'Linux', version: release ? `kernel ${release}` : '' });
 }
 

--- a/src/shared/osVersion.js
+++ b/src/shared/osVersion.js
@@ -49,8 +49,6 @@ function windowsProductName(productName, build) {
     if (/^Windows 10$/i.test(desktop[0]) && build >= 22000) return 'Windows 11';
     return desktop[0].replace(/^windows/i, 'Windows');
   }
-  if (build >= 22000) return 'Windows 11';
-  if (build >= 10240) return 'Windows 10';
   return 'Windows';
 }
 

--- a/src/shared/usage.js
+++ b/src/shared/usage.js
@@ -626,6 +626,10 @@ function normalizeDeviceOsVersion(value) {
   return String(value || '').trim().slice(0, 128);
 }
 
+function normalizeDeviceOsName(value) {
+  return String(value || '').trim().slice(0, 64);
+}
+
 function normalizeDeviceRecord(record) {
   const nowIso = new Date().toISOString();
   const normalized = {
@@ -639,6 +643,7 @@ function normalizeDeviceRecord(record) {
     periods: {},
     limits: normalizeLimitsSummary(record.limits)
   };
+  if (hasOwn(record, 'osName')) normalized.osName = normalizeDeviceOsName(record.osName);
   if (hasOwn(record, 'osVersion')) normalized.osVersion = normalizeDeviceOsVersion(record.osVersion);
   if (hasOwn(record, 'trackedClients')) normalized.trackedClients = normalizeTrackedClients(record.trackedClients);
   if (hasOwn(record, 'clientStatus')) normalized.clientStatus = normalizeClientStatus(record.clientStatus);
@@ -818,6 +823,9 @@ function mergeDeviceRecord(existing, incoming) {
     if (!hasOwn(normalizedIncoming, 'osVersion') && hasOwn(normalizedExisting, 'osVersion')) {
       normalizedIncoming.osVersion = normalizedExisting.osVersion;
     }
+    if (!hasOwn(normalizedIncoming, 'osName') && hasOwn(normalizedExisting, 'osName')) {
+      normalizedIncoming.osName = normalizedExisting.osName;
+    }
   }
   if (!hasIncomingLimits) normalizedIncoming.limits = normalizedExisting.limits;
   else normalizedIncoming.limits = mergeDeviceLimits(normalizedExisting, normalizedIncoming);
@@ -941,6 +949,7 @@ function aggregateDevices(devices, staleAfterMs, nowMs = Date.now()) {
       deviceId: normalized.deviceId,
       hostname: normalized.hostname,
       platform: normalized.platform,
+      ...(hasOwn(normalized, 'osName') ? { osName: normalized.osName } : {}),
       ...(hasOwn(normalized, 'osVersion') ? { osVersion: normalized.osVersion } : {}),
       agentVersion: normalized.agentVersion,
       agentRuntime: normalized.agentRuntime,

--- a/src/shared/usage.js
+++ b/src/shared/usage.js
@@ -622,6 +622,10 @@ function normalizePeriodOmissionCounts(value) {
   return Object.keys(normalized).length > 0 ? normalized : null;
 }
 
+function normalizeDeviceOsVersion(value) {
+  return String(value || '').trim().slice(0, 128);
+}
+
 function normalizeDeviceRecord(record) {
   const nowIso = new Date().toISOString();
   const normalized = {
@@ -635,6 +639,7 @@ function normalizeDeviceRecord(record) {
     periods: {},
     limits: normalizeLimitsSummary(record.limits)
   };
+  if (hasOwn(record, 'osVersion')) normalized.osVersion = normalizeDeviceOsVersion(record.osVersion);
   if (hasOwn(record, 'trackedClients')) normalized.trackedClients = normalizeTrackedClients(record.trackedClients);
   if (hasOwn(record, 'clientStatus')) normalized.clientStatus = normalizeClientStatus(record.clientStatus);
   if (hasOwn(record, 'wslStatus')) normalized.wslStatus = normalizeWslStatus(record.wslStatus);
@@ -810,6 +815,9 @@ function mergeDeviceRecord(existing, incoming) {
     if (!hasOwn(normalizedIncoming, 'syncUploadIntervalMs') && hasOwn(normalizedExisting, 'syncUploadIntervalMs')) {
       normalizedIncoming.syncUploadIntervalMs = normalizedExisting.syncUploadIntervalMs;
     }
+    if (!hasOwn(normalizedIncoming, 'osVersion') && hasOwn(normalizedExisting, 'osVersion')) {
+      normalizedIncoming.osVersion = normalizedExisting.osVersion;
+    }
   }
   if (!hasIncomingLimits) normalizedIncoming.limits = normalizedExisting.limits;
   else normalizedIncoming.limits = mergeDeviceLimits(normalizedExisting, normalizedIncoming);
@@ -933,6 +941,7 @@ function aggregateDevices(devices, staleAfterMs, nowMs = Date.now()) {
       deviceId: normalized.deviceId,
       hostname: normalized.hostname,
       platform: normalized.platform,
+      ...(hasOwn(normalized, 'osVersion') ? { osVersion: normalized.osVersion } : {}),
       agentVersion: normalized.agentVersion,
       agentRuntime: normalized.agentRuntime,
       updatedAt: normalized.updatedAt,

--- a/tests/electron/deviceBreakdown.test.js
+++ b/tests/electron/deviceBreakdown.test.js
@@ -51,9 +51,10 @@ test('deviceBreakdownForPeriod tolerates shared models and legacy device records
 });
 
 test('devicePlatformLabel appends OS versions without exposing architecture', () => {
-  assert.equal(devicePlatformLabel('darwin-arm64', '26.0'), 'macOS 26.0');
-  assert.equal(devicePlatformLabel('win32-x64', '10.0.26100'), 'Windows 10.0.26100');
-  assert.equal(devicePlatformLabel('linux-x64', ''), 'Linux');
+  assert.equal(devicePlatformLabel('darwin-arm64', 'macOS', '26.0'), 'macOS 26.0');
+  assert.equal(devicePlatformLabel('win32-x64', 'Windows 11', '24H2'), 'Windows 11 24H2');
+  assert.equal(devicePlatformLabel('linux-x64', 'Ubuntu', '24.04.2 LTS'), 'Ubuntu 24.04.2 LTS');
+  assert.equal(devicePlatformLabel('linux-x64', '', ''), 'Linux');
 });
 
 test('device breakdown browser helper loads before app.js and keeps reduced-motion coverage', () => {

--- a/tests/electron/deviceBreakdown.test.js
+++ b/tests/electron/deviceBreakdown.test.js
@@ -4,7 +4,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
-const { deviceBreakdownForPeriod } = require('../../src/electron/renderer/deviceBreakdown');
+const { deviceBreakdownForPeriod, devicePlatformLabel } = require('../../src/electron/renderer/deviceBreakdown');
 
 test('deviceBreakdownForPeriod nests sorted models under each tool', () => {
   const result = deviceBreakdownForPeriod({ periods: { month: {
@@ -48,6 +48,12 @@ test('deviceBreakdownForPeriod tolerates shared models and legacy device records
     totalTokens: 20,
     tools: []
   });
+});
+
+test('devicePlatformLabel appends OS versions without exposing architecture', () => {
+  assert.equal(devicePlatformLabel('darwin-arm64', '26.0'), 'macOS 26.0');
+  assert.equal(devicePlatformLabel('win32-x64', '10.0.26100'), 'Windows 10.0.26100');
+  assert.equal(devicePlatformLabel('linux-x64', ''), 'Linux');
 });
 
 test('device breakdown browser helper loads before app.js and keeps reduced-motion coverage', () => {

--- a/tests/shared/collectorPeriodWindows.test.js
+++ b/tests/shared/collectorPeriodWindows.test.js
@@ -54,10 +54,12 @@ test('collectUsageOnce stamps updatedAt and periodWindows from one injected cloc
   const summary = await collectUsageOnce({
     clients: '',
     deviceId: 'device-a',
+    osVersion: '26.0',
     now,
     historyEnabled: false,
     limitsEnabled: false
   });
   assert.equal(summary.updatedAt, now.toISOString());
+  assert.equal(summary.osVersion, '26.0');
   assert.deepEqual(summary.periodWindows, computePeriodWindows(now));
 });

--- a/tests/shared/collectorPeriodWindows.test.js
+++ b/tests/shared/collectorPeriodWindows.test.js
@@ -54,12 +54,13 @@ test('collectUsageOnce stamps updatedAt and periodWindows from one injected cloc
   const summary = await collectUsageOnce({
     clients: '',
     deviceId: 'device-a',
-    osVersion: '26.0',
+    osInfo: { name: 'macOS', version: '26.0' },
     now,
     historyEnabled: false,
     limitsEnabled: false
   });
   assert.equal(summary.updatedAt, now.toISOString());
+  assert.equal(summary.osName, 'macOS');
   assert.equal(summary.osVersion, '26.0');
   assert.deepEqual(summary.periodWindows, computePeriodWindows(now));
 });

--- a/tests/shared/collectorPreviewWslCarry.test.js
+++ b/tests/shared/collectorPreviewWslCarry.test.js
@@ -84,6 +84,7 @@ test('warm progressive preview keeps the frozen WSL contribution in today and mo
     commandTimeoutMs: 1000,
     deviceId: 'dev1',
     agentVersion: 'test',
+    osVersion: '26.5.2',
     intervalMs: 60 * 60 * 1000,
     watchEnabled: false,
     historyEnabled: false,
@@ -100,6 +101,7 @@ test('warm progressive preview keeps the frozen WSL contribution in today and mo
     await waitForUpdates(updates, 1);
     const cold = previews.slice();
     assert.ok(cold.length >= 1, 'cold tick should emit at least one preview');
+    assert.equal(cold[0].osVersion, '26.5.2', 'preview carries static OS metadata immediately');
     assert.equal(cold[0].today.totalTokens, 100, 'cold preview today is host-only (no WSL anchor yet)');
 
     // Second (warm) tick: previews must merge the frozen WSL snapshot captured on

--- a/tests/shared/collectorPreviewWslCarry.test.js
+++ b/tests/shared/collectorPreviewWslCarry.test.js
@@ -84,7 +84,7 @@ test('warm progressive preview keeps the frozen WSL contribution in today and mo
     commandTimeoutMs: 1000,
     deviceId: 'dev1',
     agentVersion: 'test',
-    osVersion: '26.5.2',
+    osInfo: { name: 'macOS', version: '26.5.2' },
     intervalMs: 60 * 60 * 1000,
     watchEnabled: false,
     historyEnabled: false,
@@ -101,6 +101,7 @@ test('warm progressive preview keeps the frozen WSL contribution in today and mo
     await waitForUpdates(updates, 1);
     const cold = previews.slice();
     assert.ok(cold.length >= 1, 'cold tick should emit at least one preview');
+    assert.equal(cold[0].osName, 'macOS', 'preview carries the friendly OS name immediately');
     assert.equal(cold[0].osVersion, '26.5.2', 'preview carries static OS metadata immediately');
     assert.equal(cold[0].today.totalTokens, 100, 'cold preview today is host-only (no WSL anchor yet)');
 

--- a/tests/shared/osVersion.test.js
+++ b/tests/shared/osVersion.test.js
@@ -3,23 +3,23 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 
-const { detectOsVersion, normalizeOsVersion } = require('../../src/shared/osVersion');
+const { detectOsInfo, normalizeOsInfo } = require('../../src/shared/osVersion');
 
-test('detectOsVersion prefers Electron system version on macOS', () => {
+test('detectOsInfo prefers the macOS product version from Electron', () => {
   let spawned = false;
-  const version = detectOsVersion({
+  const info = detectOsInfo({
     platform: 'darwin',
     getSystemVersion: () => ' 26.0.1 ',
     execFileSync: () => { spawned = true; }
   });
 
-  assert.equal(version, '26.0.1');
+  assert.deepEqual(info, { name: 'macOS', version: '26.0.1' });
   assert.equal(spawned, false);
 });
 
-test('detectOsVersion uses sw_vers for a headless macOS agent', () => {
+test('detectOsInfo uses sw_vers for a headless macOS agent', () => {
   let invocation;
-  const version = detectOsVersion({
+  const info = detectOsInfo({
     platform: 'darwin',
     getSystemVersion: () => '',
     execFileSync: (...args) => {
@@ -28,24 +28,89 @@ test('detectOsVersion uses sw_vers for a headless macOS agent', () => {
     }
   });
 
-  assert.equal(version, '15.6');
+  assert.deepEqual(info, { name: 'macOS', version: '15.6' });
   assert.equal(invocation[0], '/usr/bin/sw_vers');
   assert.deepEqual(invocation[1], ['-productVersion']);
 });
 
-test('detectOsVersion uses the system release outside macOS', () => {
-  assert.equal(detectOsVersion({ platform: 'win32', release: () => '10.0.26100' }), '10.0.26100');
-  assert.equal(detectOsVersion({ platform: 'linux', release: () => '6.8.0-60-generic' }), '6.8.0-60-generic');
+test('detectOsInfo reports the Windows product family and display version', () => {
+  const info = detectOsInfo({
+    platform: 'win32',
+    release: () => '10.0.26100',
+    execFileSync: () => [
+      'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion',
+      '    ProductName    REG_SZ    Windows 10 Pro',
+      '    DisplayVersion    REG_SZ    24H2',
+      '    CurrentBuildNumber    REG_SZ    26100'
+    ].join('\r\n')
+  });
+
+  assert.deepEqual(info, { name: 'Windows 11', version: '24H2' });
 });
 
-test('detectOsVersion omits a macOS version when product detection fails', () => {
-  assert.equal(detectOsVersion({
+test('detectOsInfo falls back to an honest Windows build label', () => {
+  const info = detectOsInfo({
+    platform: 'win32',
+    release: () => '10.0.26100',
+    execFileSync: () => { throw new Error('registry unavailable'); }
+  });
+
+  assert.deepEqual(info, { name: 'Windows 11', version: 'build 26100' });
+});
+
+test('detectOsInfo uses the Linux distribution name and product version', () => {
+  const info = detectOsInfo({
+    platform: 'linux',
+    readFileSync: (filePath) => {
+      assert.equal(filePath, '/etc/os-release');
+      return [
+        'NAME="Ubuntu"',
+        'VERSION_ID="24.04"',
+        'PRETTY_NAME="Ubuntu 24.04.2 LTS"'
+      ].join('\n');
+    }
+  });
+
+  assert.deepEqual(info, { name: 'Ubuntu', version: '24.04.2 LTS' });
+});
+
+test('detectOsInfo falls back to the vendor os-release file', () => {
+  const visited = [];
+  const info = detectOsInfo({
+    platform: 'linux',
+    readFileSync: (filePath) => {
+      visited.push(filePath);
+      if (filePath === '/etc/os-release') throw new Error('missing');
+      return 'NAME="Fedora Linux"\nPRETTY_NAME="Fedora Linux 42 (Workstation Edition)"\n';
+    }
+  });
+
+  assert.deepEqual(visited, ['/etc/os-release', '/usr/lib/os-release']);
+  assert.deepEqual(info, { name: 'Fedora Linux', version: '42 (Workstation Edition)' });
+});
+
+test('detectOsInfo labels a Linux kernel fallback honestly', () => {
+  assert.deepEqual(detectOsInfo({
+    platform: 'linux',
+    readFileSync: () => { throw new Error('unavailable'); },
+    release: () => '6.8.0-60-generic'
+  }), { name: 'Linux', version: 'kernel 6.8.0-60-generic' });
+});
+
+test('detectOsInfo keeps a macOS label when product detection fails', () => {
+  assert.deepEqual(detectOsInfo({
     platform: 'darwin',
     getSystemVersion: () => { throw new Error('unavailable'); },
     execFileSync: () => { throw new Error('unavailable'); }
-  }), '');
+  }), { name: 'macOS', version: '' });
 });
 
-test('normalizeOsVersion trims and bounds external values', () => {
-  assert.equal(normalizeOsVersion(`  ${'1'.repeat(200)}  `).length, 128);
+test('normalizeOsInfo trims and bounds external values', () => {
+  assert.deepEqual(normalizeOsInfo({
+    name: `  ${'n'.repeat(100)}  `,
+    version: `  ${'1'.repeat(200)}  `
+  }), {
+    name: 'n'.repeat(64),
+    version: '1'.repeat(128)
+  });
 });

--- a/tests/shared/osVersion.test.js
+++ b/tests/shared/osVersion.test.js
@@ -103,6 +103,16 @@ test('detectOsInfo falls back to the vendor os-release file', () => {
   assert.deepEqual(info, { name: 'Fedora Linux', version: '42 (Workstation Edition)' });
 });
 
+test('detectOsInfo keeps a rolling distro name and labels its kernel fallback', () => {
+  const info = detectOsInfo({
+    platform: 'linux',
+    readFileSync: () => 'NAME="Arch Linux"\nPRETTY_NAME="Arch Linux"\n',
+    release: () => '6.15.7-arch1-1'
+  });
+
+  assert.deepEqual(info, { name: 'Arch Linux', version: 'kernel 6.15.7-arch1-1' });
+});
+
 test('detectOsInfo labels a Linux kernel fallback honestly', () => {
   assert.deepEqual(detectOsInfo({
     platform: 'linux',

--- a/tests/shared/osVersion.test.js
+++ b/tests/shared/osVersion.test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { detectOsVersion, normalizeOsVersion } = require('../../src/shared/osVersion');
+
+test('detectOsVersion prefers Electron system version on macOS', () => {
+  let spawned = false;
+  const version = detectOsVersion({
+    platform: 'darwin',
+    getSystemVersion: () => ' 26.0.1 ',
+    execFileSync: () => { spawned = true; }
+  });
+
+  assert.equal(version, '26.0.1');
+  assert.equal(spawned, false);
+});
+
+test('detectOsVersion uses sw_vers for a headless macOS agent', () => {
+  let invocation;
+  const version = detectOsVersion({
+    platform: 'darwin',
+    getSystemVersion: () => '',
+    execFileSync: (...args) => {
+      invocation = args;
+      return '15.6\n';
+    }
+  });
+
+  assert.equal(version, '15.6');
+  assert.equal(invocation[0], '/usr/bin/sw_vers');
+  assert.deepEqual(invocation[1], ['-productVersion']);
+});
+
+test('detectOsVersion uses the system release outside macOS', () => {
+  assert.equal(detectOsVersion({ platform: 'win32', release: () => '10.0.26100' }), '10.0.26100');
+  assert.equal(detectOsVersion({ platform: 'linux', release: () => '6.8.0-60-generic' }), '6.8.0-60-generic');
+});
+
+test('detectOsVersion omits a macOS version when product detection fails', () => {
+  assert.equal(detectOsVersion({
+    platform: 'darwin',
+    getSystemVersion: () => { throw new Error('unavailable'); },
+    execFileSync: () => { throw new Error('unavailable'); }
+  }), '');
+});
+
+test('normalizeOsVersion trims and bounds external values', () => {
+  assert.equal(normalizeOsVersion(`  ${'1'.repeat(200)}  `).length, 128);
+});

--- a/tests/shared/osVersion.test.js
+++ b/tests/shared/osVersion.test.js
@@ -48,14 +48,28 @@ test('detectOsInfo reports the Windows product family and display version', () =
   assert.deepEqual(info, { name: 'Windows 11', version: '24H2' });
 });
 
-test('detectOsInfo falls back to an honest Windows build label', () => {
+test('detectOsInfo keeps the Windows build fallback product-neutral', () => {
   const info = detectOsInfo({
     platform: 'win32',
     release: () => '10.0.26100',
     execFileSync: () => { throw new Error('registry unavailable'); }
   });
 
-  assert.deepEqual(info, { name: 'Windows 11', version: 'build 26100' });
+  assert.deepEqual(info, { name: 'Windows', version: 'build 26100' });
+});
+
+test('detectOsInfo does not confuse Windows Server with Windows 11', () => {
+  const info = detectOsInfo({
+    platform: 'win32',
+    release: () => '10.0.26100',
+    execFileSync: () => [
+      '    ProductName    REG_SZ    Windows Server 2025 Datacenter',
+      '    DisplayVersion    REG_SZ    24H2',
+      '    CurrentBuildNumber    REG_SZ    26100'
+    ].join('\r\n')
+  });
+
+  assert.deepEqual(info, { name: 'Windows Server 2025', version: '24H2' });
 });
 
 test('detectOsInfo uses the Linux distribution name and product version', () => {

--- a/tests/shared/syncPayload.test.js
+++ b/tests/shared/syncPayload.test.js
@@ -23,10 +23,12 @@ test('syncPayload preserves the upload interval used by hub staleness checks', (
 test('syncPayload carries OS version metadata to the hub', () => {
   const payload = syncPayload({
     deviceId: 'dev-a',
+    osName: 'macOS',
     osVersion: '26.0',
     limits: { providers: [] }
   });
 
+  assert.equal(payload.osName, 'macOS');
   assert.equal(payload.osVersion, '26.0');
 });
 

--- a/tests/shared/syncPayload.test.js
+++ b/tests/shared/syncPayload.test.js
@@ -20,6 +20,16 @@ test('syncPayload preserves the upload interval used by hub staleness checks', (
   assert.equal(payload.syncUploadIntervalMs, 20 * 60 * 1000);
 });
 
+test('syncPayload carries OS version metadata to the hub', () => {
+  const payload = syncPayload({
+    deviceId: 'dev-a',
+    osVersion: '26.0',
+    limits: { providers: [] }
+  });
+
+  assert.equal(payload.osVersion, '26.0');
+});
+
 test('syncPayload bounds uploads by omitting all-time sessions', () => {
   const summary = {
     deviceId: 'dev-a',

--- a/tests/shared/usage.test.js
+++ b/tests/shared/usage.test.js
@@ -65,6 +65,25 @@ test('mergeDeviceRecord allows explicit empty limits to clear stale provider sta
   assert.deepEqual(merged.limits.providers, []);
 });
 
+test('device records carry, expose, and preserve OS versions', () => {
+  const existing = recordWithLimits({ osVersion: '15.6' });
+  const updated = mergeDeviceRecord(existing, {
+    deviceId: 'macbook',
+    osVersion: '26.0',
+    updatedAt: '2026-05-27T00:01:00.000Z'
+  });
+  assert.equal(updated.osVersion, '26.0');
+  assert.equal(aggregateDevices([updated], 0).devices[0].osVersion, '26.0');
+
+  const limitsOnly = mergeDeviceRecord(updated, {
+    deviceId: 'macbook',
+    limitsOnly: true,
+    limits: { providers: [] },
+    updatedAt: '2026-05-27T00:02:00.000Z'
+  });
+  assert.equal(limitsOnly.osVersion, '26.0');
+});
+
 test('aggregateDevices does not let an orphaned stale device id override the current limits state', () => {
   const oldDevice = recordWithLimits({
     deviceId: 'old-device-id',

--- a/tests/shared/usage.test.js
+++ b/tests/shared/usage.test.js
@@ -65,14 +65,17 @@ test('mergeDeviceRecord allows explicit empty limits to clear stale provider sta
   assert.deepEqual(merged.limits.providers, []);
 });
 
-test('device records carry, expose, and preserve OS versions', () => {
-  const existing = recordWithLimits({ osVersion: '15.6' });
+test('device records carry, expose, and preserve friendly OS metadata', () => {
+  const existing = recordWithLimits({ osName: 'macOS', osVersion: '15.6' });
   const updated = mergeDeviceRecord(existing, {
     deviceId: 'macbook',
+    osName: 'macOS',
     osVersion: '26.0',
     updatedAt: '2026-05-27T00:01:00.000Z'
   });
+  assert.equal(updated.osName, 'macOS');
   assert.equal(updated.osVersion, '26.0');
+  assert.equal(aggregateDevices([updated], 0).devices[0].osName, 'macOS');
   assert.equal(aggregateDevices([updated], 0).devices[0].osVersion, '26.0');
 
   const limitsOnly = mergeDeviceRecord(updated, {
@@ -81,6 +84,7 @@ test('device records carry, expose, and preserve OS versions', () => {
     limits: { providers: [] },
     updatedAt: '2026-05-27T00:02:00.000Z'
   });
+  assert.equal(limitsOnly.osName, 'macOS');
   assert.equal(limitsOnly.osVersion, '26.0');
 });
 

--- a/worker/src/shared/usage.js
+++ b/worker/src/shared/usage.js
@@ -629,6 +629,10 @@ function normalizeDeviceOsVersion(value) {
   return String(value || '').trim().slice(0, 128);
 }
 
+function normalizeDeviceOsName(value) {
+  return String(value || '').trim().slice(0, 64);
+}
+
 function normalizeDeviceRecord(record) {
   const nowIso = new Date().toISOString();
   const normalized = {
@@ -642,6 +646,7 @@ function normalizeDeviceRecord(record) {
     periods: {},
     limits: normalizeLimitsSummary(record.limits)
   };
+  if (hasOwn(record, 'osName')) normalized.osName = normalizeDeviceOsName(record.osName);
   if (hasOwn(record, 'osVersion')) normalized.osVersion = normalizeDeviceOsVersion(record.osVersion);
   if (hasOwn(record, 'trackedClients')) normalized.trackedClients = normalizeTrackedClients(record.trackedClients);
   if (hasOwn(record, 'clientStatus')) normalized.clientStatus = normalizeClientStatus(record.clientStatus);
@@ -821,6 +826,9 @@ function mergeDeviceRecord(existing, incoming) {
     if (!hasOwn(normalizedIncoming, 'osVersion') && hasOwn(normalizedExisting, 'osVersion')) {
       normalizedIncoming.osVersion = normalizedExisting.osVersion;
     }
+    if (!hasOwn(normalizedIncoming, 'osName') && hasOwn(normalizedExisting, 'osName')) {
+      normalizedIncoming.osName = normalizedExisting.osName;
+    }
   }
   if (!hasIncomingLimits) normalizedIncoming.limits = normalizedExisting.limits;
   else normalizedIncoming.limits = mergeDeviceLimits(normalizedExisting, normalizedIncoming);
@@ -944,6 +952,7 @@ function aggregateDevices(devices, staleAfterMs, nowMs = Date.now()) {
       deviceId: normalized.deviceId,
       hostname: normalized.hostname,
       platform: normalized.platform,
+      ...(hasOwn(normalized, 'osName') ? { osName: normalized.osName } : {}),
       ...(hasOwn(normalized, 'osVersion') ? { osVersion: normalized.osVersion } : {}),
       agentVersion: normalized.agentVersion,
       agentRuntime: normalized.agentRuntime,

--- a/worker/src/shared/usage.js
+++ b/worker/src/shared/usage.js
@@ -625,6 +625,10 @@ function normalizePeriodOmissionCounts(value) {
   return Object.keys(normalized).length > 0 ? normalized : null;
 }
 
+function normalizeDeviceOsVersion(value) {
+  return String(value || '').trim().slice(0, 128);
+}
+
 function normalizeDeviceRecord(record) {
   const nowIso = new Date().toISOString();
   const normalized = {
@@ -638,6 +642,7 @@ function normalizeDeviceRecord(record) {
     periods: {},
     limits: normalizeLimitsSummary(record.limits)
   };
+  if (hasOwn(record, 'osVersion')) normalized.osVersion = normalizeDeviceOsVersion(record.osVersion);
   if (hasOwn(record, 'trackedClients')) normalized.trackedClients = normalizeTrackedClients(record.trackedClients);
   if (hasOwn(record, 'clientStatus')) normalized.clientStatus = normalizeClientStatus(record.clientStatus);
   if (hasOwn(record, 'wslStatus')) normalized.wslStatus = normalizeWslStatus(record.wslStatus);
@@ -813,6 +818,9 @@ function mergeDeviceRecord(existing, incoming) {
     if (!hasOwn(normalizedIncoming, 'syncUploadIntervalMs') && hasOwn(normalizedExisting, 'syncUploadIntervalMs')) {
       normalizedIncoming.syncUploadIntervalMs = normalizedExisting.syncUploadIntervalMs;
     }
+    if (!hasOwn(normalizedIncoming, 'osVersion') && hasOwn(normalizedExisting, 'osVersion')) {
+      normalizedIncoming.osVersion = normalizedExisting.osVersion;
+    }
   }
   if (!hasIncomingLimits) normalizedIncoming.limits = normalizedExisting.limits;
   else normalizedIncoming.limits = mergeDeviceLimits(normalizedExisting, normalizedIncoming);
@@ -936,6 +944,7 @@ function aggregateDevices(devices, staleAfterMs, nowMs = Date.now()) {
       deviceId: normalized.deviceId,
       hostname: normalized.hostname,
       platform: normalized.platform,
+      ...(hasOwn(normalized, 'osVersion') ? { osVersion: normalized.osVersion } : {}),
       agentVersion: normalized.agentVersion,
       agentRuntime: normalized.agentRuntime,
       updatedAt: normalized.updatedAt,


### PR DESCRIPTION
## Summary

- Collect structured operating-system name and version metadata automatically, including progressive local previews and sync payloads.
- Use user-facing product releases: macOS product versions from Electron or `sw_vers`, Windows product families and display versions from the registry, and Linux distribution releases from `os-release`.
- Preserve and expose the metadata through hub normalization, limits-only updates, device aggregation, and the generated Worker shared module.
- Show the result in the existing single-line device footer while keeping architecture hidden and falling back cleanly for older devices.

## Display examples

- `macOS 26.5.2`
- `Windows 11 24H2`
- `Windows Server 2025 24H2`
- `Ubuntu 24.04.2 LTS`
- Rolling distributions without a product version retain their name and use an explicit kernel fallback, for example `Arch Linux kernel 6.15.7-arch1-1`.
- If product metadata is unavailable, use a neutral fallback such as `Windows build 26100` or `Linux kernel 6.8.0-60-generic` rather than guessing a product from a kernel or build number.

## Compatibility

- `osName` and `osVersion` are additive fields, and hubs continue to accept older payloads that do not contain them.
- No setting or migration is required; detection is cached once per Widget or Agent process.

## Testing

- `npm run verify` — 1496 passed, 1 skipped.
- Focused OS detection, collector, sync, aggregation, and renderer tests — 82 passed.
- `npm run sync:worker` — generated Worker shared modules are in sync.
- Confirmed this Mac reports `macOS 26.5.2` and that both fields survive `aggregateDevices()` into the renderer-facing `stats.devices[]` payload.
