### PR TITLE
fix(renderer): show account identity on home limits for multi-account providers

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -3563,7 +3563,15 @@ function homeLimitRows() {
     accountName: (provider, index, providerEntries) => {
       const id = String(provider?.provider || '').trim().toLowerCase();
       const option = providerOptions.find((entry) => entry.id === id);
-      return id === 'codex' && providerEntries.length > 1 ? codexAccountTitle(provider, index) : option?.label || id;
+      const baseLabel = option?.label || id;
+      if (providerEntries.length > 1) {
+        let suffix;
+        if (id === 'codex') suffix = codexAccountTitle(provider, index);
+        else if (id === 'mimo') suffix = mimoAccountTitle(provider, index);
+        else suffix = String(provider?.accountLabel || provider?.accountEmail || provider?.accountName || '').trim() || `Account ${index + 1}`;
+        return `${baseLabel} · ${suffix}`;
+      }
+      return baseLabel;
     }
   });
 }


### PR DESCRIPTION
## Summary
- 悬浮窗主页额度模块中，多账号 provider（OpenCode、MiMo 等）原来只显示 provider 名称，无法区分同一 provider 的不同账号
- 现在以 `Provider · 账号标识` 格式展示，如 `OpenCode · work`、`Codex · user@email.com`
- 单账号 provider 行为不变

## Changes
- `app.js`: 扩展 `homeLimitRows()` 中的 `accountName` 回调，对多账号 provider 追加账号标识作为后缀

## Test plan
- [ ] 多个 OpenCode profile 时，主页额度显示为 `OpenCode · 工作` / `OpenCode · 个人` 等，可区分
- [ ] 多个 Codex / MiMo 账号时，主页额度显示为 `Codex · user@email.com` 格式
- [ ] 单账号 provider 显示不变

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show account identity in the Home limits list for multi-account providers so users can tell accounts apart. Format: "Provider · account"; uses provider-specific titles for `codex`/`mimo`, otherwise falls back to account label/email/name or "Account N". Single-account providers are unchanged.

<sup>Written for commit cdbdaca98f6f56455cff9d035aaa366a979c3bfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

