### PR TITLE
fix(limits): refresh expired reset windows

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -662,10 +662,9 @@ function syncCurrencyRateControls() {
 function formatTime(value) { const date = value ? new Date(value) : new Date(); return Number.isNaN(date.getTime()) ? '--:--:--' : date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' }); }
 function formatPercent(value) { return Number.isFinite(Number(value)) ? `${Math.round(Number(value))}%` : '--'; }
 function formatReset(value) {
-  const date = value ? new Date(value) : null;
-  if (!date || Number.isNaN(date.getTime())) return '';
-  const diffMs = date.getTime() - Date.now();
-  if (diffMs <= 0) return 'Reset now';
+  const diffMs = limitProviderPresentationApi.limitResetRemainingMs(value);
+  if (diffMs === null) return '';
+  if (diffMs === 0) return 'Reset now';
   return `Reset ${formatDuration(diffMs)}`;
 }
 function formatDuration(ms) {
@@ -2110,7 +2109,9 @@ function limitWindowNode(label, window, color, tone = 1, valueOverride = null, d
   const meter = limitMeterNode(color, fillPercent, tone);
   const reset = document.createElement('div');
   reset.className = 'limit-reset';
-  const resetText = formatReset(window?.resetsAt) || window?.resetDescription || '';
+  const resetText = window?.resetsAt
+    ? formatReset(window.resetsAt)
+    : window?.resetDescription || '';
   if (detailText) {
     // Keep the reset text left-aligned (consistent with every other provider)
     // and add the absolute count on the right, under the top-line percentage.
@@ -3633,9 +3634,11 @@ function renderHomeLimitModule() {
       const resetAt = formatReset(window.resetsAt);
       const resetText = document.createElement('span');
       resetText.className = 'home-limit-reset';
-      resetText.textContent = resetAt || (window.resetDescription
+      resetText.textContent = window.resetsAt
+        ? resetAt || '\u00a0'
+        : window.resetDescription
         ? t('home.reset', { value: window.resetDescription })
-        : '\u00a0');
+        : '\u00a0';
       metric.append(resetText);
       windows.append(metric);
     }

--- a/src/electron/renderer/limitProviderPresentation.js
+++ b/src/electron/renderer/limitProviderPresentation.js
@@ -122,6 +122,16 @@
     return label.replace(/^[a-z]/, (letter) => letter.toUpperCase());
   }
 
+  function limitResetRemainingMs(value, nowMs = Date.now(), resetNowGraceMs = 60 * 1000) {
+    if (!value) return null;
+    const resetMs = new Date(value).getTime();
+    const currentMs = Number(nowMs);
+    if (!Number.isFinite(resetMs) || !Number.isFinite(currentMs)) return null;
+    const remainingMs = resetMs - currentMs;
+    if (remainingMs > 0) return remainingMs;
+    return remainingMs >= -Math.max(0, Number(resetNowGraceMs) || 0) ? 0 : null;
+  }
+
   // The "live" Codex account is the one THIS device's Codex app/CLI is currently
   // signed into (sourceDetail app/cli/unknown). Managed accounts added inside
   // Token Monitor report sourceDetail 'managed' and are NOT live. A remote
@@ -301,6 +311,7 @@
     limitProviderDisplayLabel,
     limitProviderMainDeviceLabel,
     limitProviderProvenance,
+    limitResetRemainingMs,
     limitProviderSourceLabel,
     limitProviderStatusLabel,
     limitProviderSettingsTags

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1108,6 +1108,66 @@ function configFingerprint(clientsCsv, allTimeSince, projectsEnabled = true) {
 // valid, so a long-running session periodically rescans month/allTime
 // and picks up any changes that the delta-derivation might miss.
 const FULL_SCAN_INTERVAL_MS = 60 * 60 * 1000;
+const LIMITS_RESET_BOUNDARY_DELAY_MS = 30 * 1000;
+const LIMITS_RESET_BOUNDARY_MIN_TIMER_MS = 5 * 1000;
+const LIMITS_RESET_BOUNDARY_MAX_TIMER_MS = 2_147_483_647;
+
+function limitResetBoundaryEntries(limits) {
+  const entries = [];
+  for (const provider of limits?.providers || []) {
+    const providerKey = [
+      provider?.provider,
+      provider?.accountKey,
+      provider?.accountEmail,
+      provider?.accountLabel
+    ].map((value) => String(value || '').trim()).join(':');
+    const scope = {
+      provider: String(provider?.provider || '').trim(),
+      accountKey: String(provider?.accountKey || '').trim(),
+      accountEmail: String(provider?.accountEmail || '').trim().toLowerCase(),
+      accountLabel: String(provider?.accountLabel || '').trim(),
+      sourceDetail: String(provider?.sourceDetail || '').trim()
+    };
+    for (const window of provider?.windows || []) {
+      const resetAt = Date.parse(window?.resetsAt || '');
+      if (!Number.isFinite(resetAt)) continue;
+      entries.push({
+        resetAt,
+        key: `${providerKey}:${String(window?.kind || '').trim()}:${new Date(resetAt).toISOString()}`,
+        scope
+      });
+    }
+  }
+  return entries;
+}
+
+function nextLimitsResetBoundary(limits, nowMs = Date.now(), attempted = new Set()) {
+  let refreshAt = Infinity;
+  let keys = [];
+  let scopes = new Map();
+  for (const entry of limitResetBoundaryEntries(limits)) {
+    if (attempted.has(entry.key)) continue;
+    const candidate = entry.resetAt + LIMITS_RESET_BOUNDARY_DELAY_MS;
+    if (candidate < refreshAt) {
+      refreshAt = candidate;
+      keys = [entry.key];
+      scopes = new Map([[JSON.stringify(entry.scope), entry.scope]]);
+    } else if (candidate === refreshAt) {
+      keys.push(entry.key);
+      scopes.set(JSON.stringify(entry.scope), entry.scope);
+    }
+  }
+  if (!Number.isFinite(refreshAt)) return null;
+  return {
+    refreshAt,
+    delayMs: Math.min(
+      LIMITS_RESET_BOUNDARY_MAX_TIMER_MS,
+      Math.max(LIMITS_RESET_BOUNDARY_MIN_TIMER_MS, refreshAt - nowMs)
+    ),
+    keys,
+    scopes: [...scopes.values()]
+  };
+}
 
 function startCollector(options) {
   const {
@@ -1120,6 +1180,13 @@ function startCollector(options) {
     : normalizeOsInfo(options.osInfo);
   const log = logger || (() => {});
   const limitsCollector = limitsEnabled !== false ? createLimitsCollector(options) : null;
+  const resetBoundaryNow = typeof options.resetBoundaryNow === 'function' ? options.resetBoundaryNow : Date.now;
+  const setResetBoundaryTimer = typeof options.resetBoundarySetTimeout === 'function'
+    ? options.resetBoundarySetTimeout
+    : setTimeout;
+  const clearResetBoundaryTimer = typeof options.resetBoundaryClearTimeout === 'function'
+    ? options.resetBoundaryClearTimeout
+    : clearTimeout;
   let tickInFlight = false;
   let tickPending = false;
   let pendingForceLimits = false;
@@ -1136,7 +1203,10 @@ function startCollector(options) {
   let pendingWaiters = [];
   let debounceTimer = null;
   let intervalTimer = null;
+  let resetBoundaryTimer = null;
+  let lastSummary = null;
   let stopped = false;
+  const attemptedResetBoundaries = new Set();
   const watchers = [];
 
   // On-disk anchor: persist full-scan snapshots so the collector can reuse
@@ -1173,6 +1243,52 @@ function startCollector(options) {
     const waiters = pendingWaiters;
     pendingWaiters = [];
     for (const resolve of waiters) resolve();
+  }
+
+  function clearScheduledResetBoundary() {
+    if (!resetBoundaryTimer) return;
+    clearResetBoundaryTimer(resetBoundaryTimer);
+    resetBoundaryTimer = null;
+  }
+
+  function scheduleLimitsResetBoundary(limits) {
+    clearScheduledResetBoundary();
+    if (stopped || !limitsCollector) return;
+    const next = nextLimitsResetBoundary(limits, resetBoundaryNow(), attemptedResetBoundaries);
+    if (!next) return;
+    resetBoundaryTimer = setResetBoundaryTimer(() => {
+      resetBoundaryTimer = null;
+      if (resetBoundaryNow() < next.refreshAt) {
+        scheduleLimitsResetBoundary(lastSummary?.limits);
+        return;
+      }
+      for (const key of next.keys) attemptedResetBoundaries.add(key);
+      refreshLimitsAtResetBoundary(next.scopes);
+    }, next.delayMs);
+  }
+
+  async function refreshLimitsAtResetBoundary(scopes) {
+    if (stopped || !limitsCollector || !lastSummary) return;
+    try {
+      let limits = lastSummary.limits;
+      for (const scope of scopes || []) {
+        limits = await limitsCollector.refreshScope(scope);
+      }
+      if (stopped) return;
+      const summary = {
+        ...lastSummary,
+        updatedAt: new Date(resetBoundaryNow()).toISOString(),
+        limits,
+        limitsOnly: true
+      };
+      lastSummary = summary;
+      scheduleLimitsResetBoundary(limits);
+      await onUpdate?.(summary, 'limits-reset-boundary');
+    } catch (error) {
+      if (stopped) return;
+      if (onError) onError(error, 'limits-reset-boundary');
+      else log(`collector tick failed (limits-reset-boundary): ${error.message}`);
+    }
   }
 
   async function performTick(reason, tickOptions = {}) {
@@ -1271,6 +1387,8 @@ function startCollector(options) {
         wslAnchor = captured.wslBundle;
         wslStatusAnchor = captured.wslStatus || null;
       }
+      lastSummary = summary;
+      scheduleLimitsResetBoundary(summary.limits);
       await onUpdate?.(summary, reason);
     } catch (error) {
       if (stopped) return;
@@ -1360,6 +1478,7 @@ function startCollector(options) {
     stopped = true;
     if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
     if (intervalTimer) { clearTimeout(intervalTimer); intervalTimer = null; }
+    clearScheduledResetBoundary();
     for (const watcher of watchers) {
       try { watcher.close(); } catch (_) {}
     }
@@ -1387,7 +1506,9 @@ module.exports = {
   decideResolver,
   DEFAULT_HISTORY_INTERVAL_MS,
   HISTORY_INTERVAL_VALUES,
+  LIMITS_RESET_BOUNDARY_MAX_TIMER_MS,
   localTodayKey,
+  nextLimitsResetBoundary,
   normalizeHistoryIntervalMs,
   sessionTimestampMap,
   locateBundledBinary,

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1169,6 +1169,13 @@ function nextLimitsResetBoundary(limits, nowMs = Date.now(), attempted = new Set
   };
 }
 
+function pruneAttemptedResetBoundaries(limits, attempted) {
+  const currentKeys = new Set(limitResetBoundaryEntries(limits).map((entry) => entry.key));
+  for (const key of attempted) {
+    if (!currentKeys.has(key)) attempted.delete(key);
+  }
+}
+
 function startCollector(options) {
   const {
     clients, allTimeSince, commandTimeoutMs, deviceId, agentVersion, agentRuntime,
@@ -1254,6 +1261,10 @@ function startCollector(options) {
   function scheduleLimitsResetBoundary(limits) {
     clearScheduledResetBoundary();
     if (stopped || !limitsCollector) return;
+    // Keep stale keys that are still present so a failed/source-stale refresh
+    // cannot loop, but discard historical windows once a fresh snapshot no
+    // longer contains them. This bounds the set to the current limits shape.
+    pruneAttemptedResetBoundaries(limits, attemptedResetBoundaries);
     const next = nextLimitsResetBoundary(limits, resetBoundaryNow(), attemptedResetBoundaries);
     if (!next) return;
     resetBoundaryTimer = setResetBoundaryTimer(() => {
@@ -1514,6 +1525,7 @@ module.exports = {
   locateBundledBinary,
   lookupModelPricing,
   normalizePromaPricing,
+  pruneAttemptedResetBoundaries,
   readDownloadedPointer,
   resolvePlatformBinary,
   resolvePromaPricing,

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -2537,6 +2537,15 @@ function createLimitsCollector(options = {}, deps = {}) {
   async function refreshScope(scope) {
     const current = (deps.now || Date.now)();
     if (!scope?.provider) throw new TypeError('limit refresh scope requires a provider');
+    if (scope.provider === 'mimo') {
+      // Validate before collectLimitsOnce converts provider errors into a
+      // status row. An ambiguous multi-account scope must leave the cache
+      // untouched instead of replacing every MiMo account or probing them all.
+      mimoLimits.scopedMimoManagedAccounts(
+        options.mimoManagedAccounts || deps.mimoManagedAccounts,
+        scope
+      );
+    }
     if (inFlight) return inFlight;
     const scopeKey = JSON.stringify(scope);
     if (scopedInFlight.has(scopeKey)) return scopedInFlight.get(scopeKey);

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -2065,9 +2065,28 @@ async function fetchLiveCodexAccount(deps = {}, nowMs = Date.now()) {
 
 async function fetchCodexLimits(options = {}, deps = {}) {
   const nowMs = (deps.now || Date.now)();
+  const scope = options.limitRefreshScope?.provider === 'codex'
+    ? options.limitRefreshScope
+    : null;
   const managedAccounts = normalizeCodexManagedAccounts(options.codexManagedAccounts || deps.codexManagedAccounts)
-    .filter((account) => account.enabled !== false);
-  const includeLiveAccount = options.includeLiveCodexAccount !== false;
+    .filter((account) => account.enabled !== false)
+    .filter((account) => {
+      if (!scope) return true;
+      if (scope.sourceDetail && scope.sourceDetail !== 'managed') return false;
+      const accountKey = codexAccountKeyFromSeed(account.accountKey || account.email || account.id || account.homePath);
+      if (scope.accountKey) return accountKey === scope.accountKey;
+      if (scope.accountEmail) return account.email === scope.accountEmail;
+      if (scope.accountLabel) return account.accountLabel === scope.accountLabel;
+      return false;
+    });
+  let includeLiveAccount = options.includeLiveCodexAccount !== false;
+  if (scope) {
+    if (scope.sourceDetail) {
+      includeLiveAccount = includeLiveAccount && scope.sourceDetail !== 'managed';
+    } else if (scope.accountKey) {
+      includeLiveAccount = includeLiveAccount && readLiveCodexIdentity(deps).accountKey === scope.accountKey;
+    }
+  }
   // Single live account: keep the original single-provider shape (and error
   // propagation) so a signed-out/not-configured state surfaces as before.
   if (managedAccounts.length === 0) {
@@ -2168,10 +2187,19 @@ async function fetchOpenCodeLimits(options = {}, deps = {}) {
     cookies.push({ name: 'default (env)', cookie: envCookie });
   }
 
-  const goLocal = collectGo({ env: deps.env || process.env, now: () => nowMs });
+  const multiAccountMode = cookies.length > 1;
+  const scope = options.limitRefreshScope?.provider === 'opencode'
+    ? options.limitRefreshScope
+    : null;
+  if (scope && multiAccountMode) {
+    cookies = scope.accountLabel
+      ? cookies.filter(({ name }) => name === scope.accountLabel)
+      : [];
+  }
 
-  // ── Single account (<1 cookie): OLD merged behavior ──────────────────────
-  if (cookies.length <= 1) {
+  // ── Single account (0 or 1 cookie): existing merged behavior ─────────────
+  if (!multiAccountMode) {
+    const goLocal = collectGo({ env: deps.env || process.env, now: () => nowMs });
     const cookie = cookies[0]?.cookie;
     const [goWeb, zen] = cookie
       ? await Promise.all([
@@ -2437,7 +2465,10 @@ async function collectLimitsOnce(options = {}, deps = {}) {
     ...(deps.providerFetchers || {})
   };
   const providers = [];
-  for (const provider of parseLimitProviders(options.limitProviders ?? options.providers)) {
+  const scope = options.limitRefreshScope;
+  const selectedProviders = parseLimitProviders(options.limitProviders ?? options.providers)
+    .filter((provider) => !scope?.provider || provider === scope.provider);
+  for (const provider of selectedProviders) {
     try {
       const result = await fetchers[provider](options);
       if (Array.isArray(result)) providers.push(...result);
@@ -2447,6 +2478,45 @@ async function collectLimitsOnce(options = {}, deps = {}) {
     }
   }
   return normalizeLimitsSummary({ updatedAt: nowIso(nowMs), refreshMs, providers });
+}
+
+function limitProviderMatchesScope(provider, scope) {
+  if (!provider || provider.provider !== scope?.provider) return false;
+  if (scope.accountKey) return provider.accountKey === scope.accountKey;
+  if (scope.accountEmail) return provider.accountEmail === scope.accountEmail;
+  if (scope.accountLabel) return provider.accountLabel === scope.accountLabel;
+  if (scope.sourceDetail) return provider.sourceDetail === scope.sourceDetail;
+  return true;
+}
+
+function mergeScopedLimits(cachedInput, partialInput, scope, nowMs) {
+  const partial = normalizeLimitsSummary(partialInput);
+  if (!cachedInput) return partial;
+  const cached = normalizeLimitsSummary(cachedInput);
+  const existingTarget = cached.providers.filter((provider) => limitProviderMatchesScope(provider, scope));
+  const refreshedTarget = mergeCodexTransientWindows({
+    updatedAt: cached.updatedAt,
+    refreshMs: cached.refreshMs,
+    providers: existingTarget
+  }, partial, nowMs).providers;
+  const providers = [];
+  let inserted = false;
+  for (const provider of cached.providers) {
+    if (!limitProviderMatchesScope(provider, scope)) {
+      providers.push(provider);
+      continue;
+    }
+    if (!inserted) {
+      providers.push(...refreshedTarget);
+      inserted = true;
+    }
+  }
+  if (!inserted) providers.push(...refreshedTarget);
+  return normalizeLimitsSummary({
+    updatedAt: partial.updatedAt,
+    refreshMs: cached.refreshMs,
+    providers
+  });
 }
 
 function createLimitsCollector(options = {}, deps = {}) {
@@ -2462,6 +2532,25 @@ function createLimitsCollector(options = {}, deps = {}) {
   let cached = options.previousLimits ? normalizeLimitsSummary(options.previousLimits) : null;
   let cachedAt = 0;
   let inFlight = null;
+  const scopedInFlight = new Map();
+
+  async function refreshScope(scope) {
+    const current = (deps.now || Date.now)();
+    if (!scope?.provider) throw new TypeError('limit refresh scope requires a provider');
+    if (inFlight) return inFlight;
+    const scopeKey = JSON.stringify(scope);
+    if (scopedInFlight.has(scopeKey)) return scopedInFlight.get(scopeKey);
+    const task = collectLimitsOnce({
+      ...options,
+      limitsRefreshMs: refreshMs,
+      limitRefreshScope: scope
+    }, deps).then((summary) => {
+      cached = mergeScopedLimits(cached, summary, scope, current);
+      return cached;
+    }).finally(() => { scopedInFlight.delete(scopeKey); });
+    scopedInFlight.set(scopeKey, task);
+    return task;
+  }
 
   async function snapshot(force = false) {
     const current = (deps.now || Date.now)();
@@ -2477,7 +2566,7 @@ function createLimitsCollector(options = {}, deps = {}) {
     return inFlight;
   }
 
-  return { snapshot };
+  return { refreshScope, snapshot };
 }
 
 function hashCursorAccountKey(account) {

--- a/src/shared/mimoLimits.js
+++ b/src/shared/mimoLimits.js
@@ -335,7 +335,17 @@ function normalizeMimoManagedAccounts(value) {
 }
 
 async function fetchMimoLimits(options = {}, deps = {}) {
-  const accounts = normalizeMimoManagedAccounts(options.mimoManagedAccounts || deps.mimoManagedAccounts);
+  const scope = options.limitRefreshScope?.provider === 'mimo'
+    ? options.limitRefreshScope
+    : null;
+  const accounts = normalizeMimoManagedAccounts(options.mimoManagedAccounts || deps.mimoManagedAccounts)
+    .filter((account, _index, all) => {
+      if (!scope) return true;
+      if (scope.accountKey) return account.accountKey === scope.accountKey;
+      if (scope.accountEmail) return account.accountEmail === scope.accountEmail;
+      if (scope.accountLabel) return account.accountLabel === scope.accountLabel;
+      return all.length === 1;
+    });
   if (!accounts.length) {
     return statusProvider('notConfigured', new Date((deps.now || Date.now)()).toISOString());
   }

--- a/src/shared/mimoLimits.js
+++ b/src/shared/mimoLimits.js
@@ -334,18 +334,31 @@ function normalizeMimoManagedAccounts(value) {
   return accounts;
 }
 
+function scopedMimoManagedAccounts(value, scope) {
+  const accounts = normalizeMimoManagedAccounts(value);
+  if (!scope) return accounts;
+  const hasAccountIdentifier = Boolean(
+    scope.accountKey || scope.accountEmail || scope.accountLabel
+  );
+  if (!hasAccountIdentifier && accounts.length > 1) {
+    throw new TypeError('MiMo limit refresh scope requires an account identifier when multiple accounts are configured');
+  }
+  return accounts.filter((account) => {
+    if (scope.accountKey) return account.accountKey === scope.accountKey;
+    if (scope.accountEmail) return account.accountEmail === scope.accountEmail;
+    if (scope.accountLabel) return account.accountLabel === scope.accountLabel;
+    return true;
+  });
+}
+
 async function fetchMimoLimits(options = {}, deps = {}) {
   const scope = options.limitRefreshScope?.provider === 'mimo'
     ? options.limitRefreshScope
     : null;
-  const accounts = normalizeMimoManagedAccounts(options.mimoManagedAccounts || deps.mimoManagedAccounts)
-    .filter((account, _index, all) => {
-      if (!scope) return true;
-      if (scope.accountKey) return account.accountKey === scope.accountKey;
-      if (scope.accountEmail) return account.accountEmail === scope.accountEmail;
-      if (scope.accountLabel) return account.accountLabel === scope.accountLabel;
-      return all.length === 1;
-    });
+  const accounts = scopedMimoManagedAccounts(
+    options.mimoManagedAccounts || deps.mimoManagedAccounts,
+    scope
+  );
   if (!accounts.length) {
     return statusProvider('notConfigured', new Date((deps.now || Date.now)()).toISOString());
   }
@@ -389,5 +402,6 @@ module.exports = {
   parseMimoBalance,
   parseMimoProfile,
   parseMimoPlanDetail,
-  parseMimoPlanUsage
+  parseMimoPlanUsage,
+  scopedMimoManagedAccounts
 };

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -14,6 +14,7 @@ const {
   limitProviderCapabilityTags,
   limitProviderMainDeviceLabel,
   limitProviderProvenance,
+  limitResetRemainingMs,
   limitProviderSettingsTags
 } = require('../../src/electron/renderer/limitProviderPresentation');
 
@@ -49,6 +50,16 @@ test('limitProviderDisplayLabel normalizes short account labels without rewritin
   assert.equal(limitProviderDisplayLabel(''), '');
 });
 
+test('limitResetRemainingMs keeps future resets, briefly marks reset time, and expires old timestamps', () => {
+  const now = Date.parse('2026-07-10T03:00:00.000Z');
+
+  assert.equal(limitResetRemainingMs('2026-07-10T04:30:00.000Z', now), 90 * 60 * 1000);
+  assert.equal(limitResetRemainingMs('2026-07-10T02:59:30.000Z', now), 0);
+  assert.equal(limitResetRemainingMs('2026-07-10T02:58:59.000Z', now), null);
+  assert.equal(limitResetRemainingMs('not-a-date', now), null);
+  assert.equal(limitResetRemainingMs(null, now), null);
+});
+
 const rendererDir = path.join(__dirname, '..', '..', 'src', 'electron', 'renderer');
 
 function readRendererFile(name) {
@@ -79,6 +90,21 @@ function runLocalLiveCodexProvider(source, state) {
     { accountIdentityApi, state }
   );
 }
+
+test('Limits and Home share reset expiry while preserving the existing reset copy', () => {
+  const app = readRendererFile('app.js');
+  const formatReset = functionBody(app, 'formatReset', 'formatDuration');
+  const limitWindow = functionBody(app, 'limitWindowNode', 'providersByLimitProviderId');
+  const homeLimits = functionBody(app, 'renderHomeLimitModule', 'renderHomeModelModule');
+
+  assert.match(formatReset, /limitResetRemainingMs\(value\)/);
+  assert.match(formatReset, /diffMs === 0\) return 'Reset now'/);
+  assert.match(formatReset, /return `Reset \$\{formatDuration\(diffMs\)\}`/);
+  assert.match(limitWindow, /window\?\.resetsAt\s*\? formatReset\(window\.resetsAt\)/);
+  assert.doesNotMatch(limitWindow, /formatReset\(window\?\.resetsAt\) \|\| window\?\.resetDescription/);
+  assert.match(homeLimits, /window\.resetsAt\s*\? resetAt \|\|/);
+  assert.doesNotMatch(app, /noActiveLimitWindow|formatResetDuration/);
+});
 
 test('capability tags explain how each provider is collected in settings', () => {
   assert.deepEqual(limitProviderCapabilityTags('claude'), ['Auto', 'OAuth/CLI']);

--- a/tests/shared/collectorForceLimits.test.js
+++ b/tests/shared/collectorForceLimits.test.js
@@ -88,6 +88,192 @@ test('manual collector tick can force the limits snapshot', async () => {
   }
 });
 
+test('reset boundary refreshes limits only and does not loop on a stale timestamp', { timeout: 5000 }, async () => {
+  const childProcess = require('node:child_process');
+  const originalSpawn = childProcess.spawn;
+  let spawnCalls = 0;
+  const spawn = fakeTokscaleSpawn();
+  childProcess.spawn = (...args) => {
+    spawnCalls += 1;
+    return spawn(...args);
+  };
+
+  const limitCollectorPath = require.resolve('../../src/shared/limitCollector');
+  const collectorPath = require.resolve('../../src/shared/collector');
+  const limitCollector = require(limitCollectorPath);
+  const originalCreateLimitsCollector = limitCollector.createLimitsCollector;
+  let now = Date.parse('2026-07-20T00:00:00.000Z');
+  const resetAt = new Date(now + 60 * 1000).toISOString();
+  const limits = {
+    updatedAt: new Date(now).toISOString(),
+    refreshMs: 300000,
+    providers: [{
+      provider: 'codex',
+      accountKey: 'codex-test',
+      status: 'ok',
+      windows: [{ kind: 'session', usedPercent: 50, resetsAt: resetAt }]
+    }]
+  };
+  const snapshotCalls = [];
+  limitCollector.createLimitsCollector = () => ({
+    snapshot: async (force = false) => {
+      snapshotCalls.push({ force: Boolean(force), scope: null });
+      return limits;
+    },
+    refreshScope: async (scope) => {
+      snapshotCalls.push({ force: true, scope });
+      return limits;
+    }
+  });
+  delete require.cache[collectorPath];
+
+  const timers = [];
+  const setBoundaryTimer = (fn, delayMs) => {
+    const timer = { fn, delayMs, cleared: false };
+    timers.push(timer);
+    return timer;
+  };
+  const clearBoundaryTimer = (timer) => { timer.cleared = true; };
+
+  try {
+    const { startCollector } = require(collectorPath);
+    const updates = [];
+    const errors = [];
+    const handle = startCollector({
+      clients: 'claude',
+      allTimeSince: '2024-01-01',
+      commandTimeoutMs: 1000,
+      deviceId: 'test-device',
+      agentVersion: 'test',
+      intervalMs: 60000,
+      watchEnabled: false,
+      watchDebounceMs: 10,
+      limitsEnabled: true,
+      resetBoundaryNow: () => now,
+      resetBoundarySetTimeout: setBoundaryTimer,
+      resetBoundaryClearTimeout: clearBoundaryTimer,
+      onUpdate: (summary, reason) => updates.push({ summary, reason }),
+      onError: (error, reason) => errors.push({ error, reason })
+    });
+
+    await waitForUpdates(updates, 1);
+    const initialSpawnCalls = spawnCalls;
+    const timer = timers.find((candidate) => !candidate.cleared);
+    assert.ok(timer);
+    assert.equal(timer.delayMs, 90 * 1000);
+
+    now = Date.parse(resetAt) + 30 * 1000;
+    timer.cleared = true;
+    timer.fn();
+    await waitForUpdates(updates, 2);
+    handle.stop();
+
+    assert.deepEqual(snapshotCalls, [
+      { force: false, scope: null },
+      {
+        force: true,
+        scope: {
+          provider: 'codex',
+          accountKey: 'codex-test',
+          accountEmail: '',
+          accountLabel: '',
+          sourceDetail: ''
+        }
+      }
+    ]);
+    assert.equal(spawnCalls, initialSpawnCalls);
+    assert.equal(updates[1].reason, 'limits-reset-boundary');
+    assert.equal(updates[1].summary.limitsOnly, true);
+    assert.equal(updates[1].summary.today, updates[0].summary.today);
+    assert.equal(timers.filter((candidate) => !candidate.cleared).length, 0);
+    assert.deepEqual(errors, []);
+  } finally {
+    childProcess.spawn = originalSpawn;
+    limitCollector.createLimitsCollector = originalCreateLimitsCollector;
+    delete require.cache[collectorPath];
+  }
+});
+
+test('stopping the collector cancels a pending reset-boundary refresh', { timeout: 5000 }, async () => {
+  const childProcess = require('node:child_process');
+  const originalSpawn = childProcess.spawn;
+  childProcess.spawn = fakeTokscaleSpawn();
+
+  const limitCollectorPath = require.resolve('../../src/shared/limitCollector');
+  const collectorPath = require.resolve('../../src/shared/collector');
+  const limitCollector = require(limitCollectorPath);
+  const originalCreateLimitsCollector = limitCollector.createLimitsCollector;
+  const now = Date.parse('2026-07-20T00:00:00.000Z');
+  limitCollector.createLimitsCollector = () => ({
+    snapshot: async () => ({
+      updatedAt: new Date(now).toISOString(),
+      refreshMs: 300000,
+      providers: [{
+        provider: 'claude',
+        accountKey: 'claude-test',
+        status: 'ok',
+        windows: [{ kind: 'weekly', usedPercent: 10, resetsAt: new Date(now + 60 * 60 * 1000).toISOString() }]
+      }]
+    })
+  });
+  delete require.cache[collectorPath];
+
+  let timer = null;
+  try {
+    const { startCollector } = require(collectorPath);
+    const updates = [];
+    const handle = startCollector({
+      clients: 'claude',
+      allTimeSince: '2024-01-01',
+      commandTimeoutMs: 1000,
+      deviceId: 'test-device',
+      agentVersion: 'test',
+      intervalMs: 60000,
+      watchEnabled: false,
+      watchDebounceMs: 10,
+      limitsEnabled: true,
+      resetBoundaryNow: () => now,
+      resetBoundarySetTimeout: (fn, delayMs) => {
+        timer = { fn, delayMs, cleared: false };
+        return timer;
+      },
+      resetBoundaryClearTimeout: (activeTimer) => { activeTimer.cleared = true; },
+      onUpdate: (summary, reason) => updates.push({ summary, reason })
+    });
+
+    await waitForUpdates(updates, 1);
+    assert.ok(timer);
+    assert.equal(timer.cleared, false);
+    handle.stop();
+    assert.equal(timer.cleared, true);
+  } finally {
+    childProcess.spawn = originalSpawn;
+    limitCollector.createLimitsCollector = originalCreateLimitsCollector;
+    delete require.cache[collectorPath];
+  }
+});
+
+test('reset boundary scheduling caps timers that exceed the Node timeout range', () => {
+  const collectorPath = require.resolve('../../src/shared/collector');
+  delete require.cache[collectorPath];
+  const {
+    LIMITS_RESET_BOUNDARY_MAX_TIMER_MS,
+    nextLimitsResetBoundary
+  } = require(collectorPath);
+  const now = Date.parse('2026-07-01T00:00:00.000Z');
+  const next = nextLimitsResetBoundary({
+    providers: [{
+      provider: 'copilot',
+      accountKey: 'copilot-test',
+      windows: [{ kind: 'monthly', resetsAt: '2026-08-01T00:00:00.000Z' }]
+    }]
+  }, now);
+
+  assert.equal(next.delayMs, LIMITS_RESET_BOUNDARY_MAX_TIMER_MS);
+  assert.equal(next.refreshAt, Date.parse('2026-08-01T00:00:30.000Z'));
+  delete require.cache[collectorPath];
+});
+
 test('collectUsageOnce returns empty usage without spawning tokscale when clients is empty', async () => {
   const childProcess = require('node:child_process');
   const originalSpawn = childProcess.spawn;

--- a/tests/shared/collectorForceLimits.test.js
+++ b/tests/shared/collectorForceLimits.test.js
@@ -274,6 +274,29 @@ test('reset boundary scheduling caps timers that exceed the Node timeout range',
   delete require.cache[collectorPath];
 });
 
+test('reset boundary scheduling prunes historical attempted keys but retains current stale keys', () => {
+  const collectorPath = require.resolve('../../src/shared/collector');
+  delete require.cache[collectorPath];
+  const {
+    nextLimitsResetBoundary,
+    pruneAttemptedResetBoundaries
+  } = require(collectorPath);
+  const limits = {
+    providers: [{
+      provider: 'codex',
+      accountKey: 'codex-test',
+      windows: [{ kind: 'session', resetsAt: '2026-07-20T00:01:00.000Z' }]
+    }]
+  };
+  const currentKey = nextLimitsResetBoundary(limits).keys[0];
+  const attempted = new Set(['historical-reset-key', currentKey]);
+
+  pruneAttemptedResetBoundaries(limits, attempted);
+
+  assert.deepEqual([...attempted], [currentKey]);
+  delete require.cache[collectorPath];
+});
+
 test('collectUsageOnce returns empty usage without spawning tokscale when clients is empty', async () => {
   const childProcess = require('node:child_process');
   const originalSpawn = childProcess.spawn;

--- a/tests/shared/limitCollector.claude.test.js
+++ b/tests/shared/limitCollector.claude.test.js
@@ -212,6 +212,28 @@ test('Claude OAuth usage mapping preserves fractional percentage utilization val
   assert.equal(cliCalls, 0);
 });
 
+test('Claude OAuth usage preserves a real idle five-hour window without a reset timestamp', () => {
+  const provider = mapClaudeUsageToProvider({
+    five_hour: { utilization: 0, resets_at: null },
+    seven_day: { utilization: 12, resets_at: '2026-06-18T10:00:00Z' }
+  });
+  const session = provider.windows.find((window) => window.kind === 'session');
+
+  assert.equal(session.usedPercent, 0);
+  assert.equal(session.remainingPercent, 100);
+  assert.equal(session.resetsAt, null);
+});
+
+test('Claude OAuth usage omits the five-hour window only when the API returns null', () => {
+  const provider = mapClaudeUsageToProvider({
+    five_hour: null,
+    seven_day: { utilization: 12, resets_at: '2026-06-18T10:00:00Z' }
+  });
+
+  assert.equal(provider.windows.some((window) => window.kind === 'session'), false);
+  assert.equal(provider.windows.some((window) => window.kind === 'weekly'), true);
+});
+
 test('Claude limits keep successful OAuth quota on macOS instead of replacing it with CLI', async () => {
   let cliCalls = 0;
   const provider = await fetchClaudeLimits({}, {

--- a/tests/shared/limitCollector.codex.test.js
+++ b/tests/shared/limitCollector.codex.test.js
@@ -383,9 +383,16 @@ test('fetchCodexLimits returns one provider per managed Codex account', async ()
 test('fetchCodexLimits can refresh only the requested managed Codex account', async () => {
   const seenHomes = [];
   const providers = await fetchCodexLimits({
-    includeLiveCodexAccount: false,
+    limitRefreshScope: {
+      provider: 'codex',
+      accountKey: 'sha256:target',
+      accountEmail: 'target@example.com',
+      accountLabel: '',
+      sourceDetail: 'managed'
+    },
     codexManagedAccounts: [
-      { id: 'target', email: 'target@example.com', homePath: '/tmp/token-monitor-codex/target' }
+      { id: 'other', accountKey: 'sha256:other', email: 'other@example.com', homePath: '/tmp/token-monitor-codex/other' },
+      { id: 'target', accountKey: 'sha256:target', email: 'target@example.com', homePath: '/tmp/token-monitor-codex/target' }
     ]
   }, {
     now: () => Date.parse('2026-06-01T00:00:00Z'),
@@ -401,6 +408,7 @@ test('fetchCodexLimits can refresh only the requested managed Codex account', as
 
   assert.deepEqual(seenHomes, ['/tmp/token-monitor-codex/target']);
   assert.equal(providers.length, 1);
+  assert.equal(providers[0].accountKey, 'sha256:target');
   assert.equal(providers[0].accountEmail, 'target@example.com');
   assert.equal(providers[0].sourceDetail, 'managed');
 });
@@ -423,6 +431,56 @@ test('fetchCodexLimits does not fall back to live account when scoped accounts n
 
   assert.deepEqual(seenHomes, []);
   assert.deepEqual(providers, []);
+});
+
+test('createLimitsCollector scoped snapshot preserves unrelated providers and accounts', async () => {
+  const oldAt = '2026-06-01T00:00:00.000Z';
+  const newAt = '2026-06-01T00:01:00.000Z';
+  const calls = [];
+  const collector = createLimitsCollector({
+    limitsEnabled: true,
+    limitProviders: 'claude,codex',
+    previousLimits: {
+      updatedAt: oldAt,
+      refreshMs: 300000,
+      providers: [
+        { provider: 'claude', accountKey: 'claude-a', status: 'ok', updatedAt: oldAt, windows: [] },
+        { provider: 'codex', accountKey: 'codex-a', status: 'ok', updatedAt: oldAt, windows: [{ kind: 'session', usedPercent: 10 }] },
+        { provider: 'codex', accountKey: 'codex-b', status: 'ok', updatedAt: oldAt, windows: [{ kind: 'session', usedPercent: 20 }] }
+      ]
+    }
+  }, {
+    now: () => Date.parse(newAt),
+    providerFetchers: {
+      claude: async () => {
+        calls.push('claude');
+        throw new Error('unrelated provider must not refresh');
+      },
+      codex: async (options) => {
+        calls.push(`codex:${options.limitRefreshScope.accountKey}`);
+        return {
+          provider: 'codex',
+          accountKey: 'codex-b',
+          status: 'ok',
+          updatedAt: newAt,
+          windows: [{ kind: 'session', usedPercent: 30 }]
+        };
+      }
+    }
+  });
+
+  const summary = await collector.refreshScope({
+    provider: 'codex',
+    accountKey: 'codex-b',
+    accountEmail: '',
+    accountLabel: '',
+    sourceDetail: ''
+  });
+
+  assert.deepEqual(calls, ['codex:codex-b']);
+  assert.equal(summary.providers.find((provider) => provider.accountKey === 'claude-a').updatedAt, oldAt);
+  assert.equal(summary.providers.find((provider) => provider.accountKey === 'codex-a').windows[0].usedPercent, 10);
+  assert.equal(summary.providers.find((provider) => provider.accountKey === 'codex-b').windows[0].usedPercent, 30);
 });
 
 test('createLimitsCollector retains recent Codex quota windows across one empty refresh', async () => {

--- a/tests/shared/limitCollector.opencode.test.js
+++ b/tests/shared/limitCollector.opencode.test.js
@@ -164,3 +164,40 @@ test('fetchOpenCodeLimits: surfaces unauthorized when no source has data', async
   assert.strictEqual(p.status, 'unauthorized');
   assert.strictEqual(p.source, 'web');
 });
+
+test('fetchOpenCodeLimits refresh scope probes only the requested profile', async () => {
+  const now = Date.UTC(2026, 5, 4, 12, 0, 0);
+  const cookies = [];
+  const summary = await collectLimitsOnce({
+    limitProviders: 'claude,opencode',
+    limitsEnabled: true,
+    limitRefreshScope: {
+      provider: 'opencode',
+      accountKey: 'sha256:work',
+      accountLabel: 'work'
+    },
+    opencodeProfiles: {
+      personal: { enabled: true, cookie: 'personal-cookie' },
+      work: { enabled: true, cookie: 'work-cookie' }
+    }
+  }, {
+    now: () => now,
+    opencodeCollectGo: () => ({ status: 'notConfigured', windows: [] }),
+    opencodeFetchGoWeb: async (cookie) => {
+      cookies.push(cookie);
+      return { status: 'ok', workspaceId: 'work', windows: [{ kind: 'session', usedPercent: 20 }] };
+    },
+    opencodeFetchZen: async (cookie) => {
+      cookies.push(cookie);
+      return { status: 'ok', workspaceId: 'work', windows: [], balanceUsd: 5 };
+    },
+    providerFetchers: {
+      claude: async () => { throw new Error('unrelated provider must not refresh'); }
+    }
+  });
+
+  assert.deepStrictEqual(cookies, ['work-cookie', 'work-cookie']);
+  assert.equal(summary.providers.length, 1);
+  assert.equal(summary.providers[0].provider, 'opencode');
+  assert.equal(summary.providers[0].accountLabel, 'work');
+});

--- a/tests/shared/mimoLimits.test.js
+++ b/tests/shared/mimoLimits.test.js
@@ -361,6 +361,32 @@ test('fetchMimoLimits returns one row per enabled account and skips disabled acc
   assert.equal(result[0].accountKey, 'sha256:mimo-1');
 });
 
+test('fetchMimoLimits refresh scope probes only the requested account', async () => {
+  const accounts = [
+    managed(COOKIE),
+    managed('userId=456; api-platform_serviceToken=second', {
+      id: 'mimo-2', accountKey: 'sha256:mimo-2'
+    })
+  ];
+  const cookies = [];
+  const result = await fetchMimoLimits({
+    mimoManagedAccounts: accounts,
+    limitRefreshScope: { provider: 'mimo', accountKey: 'sha256:mimo-2' }
+  }, {
+    fetch: async (url, init) => {
+      cookies.push(init.headers.Cookie);
+      return url.endsWith('/balance')
+        ? response({ code: 0, data: { balance: '1', currency: 'USD' } })
+        : response({ code: 0, data: {} });
+    }
+  });
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].accountKey, 'sha256:mimo-2');
+  assert.ok(cookies.length > 0);
+  assert.ok(cookies.every((cookie) => cookie.includes('userId=456')));
+});
+
 test('fetchMimoLimits starts managed accounts in parallel', async () => {
   const accounts = [
     managed(COOKIE),

--- a/tests/shared/mimoLimits.test.js
+++ b/tests/shared/mimoLimits.test.js
@@ -11,6 +11,7 @@ const {
   parseMimoPlanUsage,
   parseMimoProfile
 } = require('../../src/shared/mimoLimits');
+const { createLimitsCollector } = require('../../src/shared/limitCollector');
 
 const COOKIE = 'unrelated=drop; userId=123; api-platform_serviceToken=secret; api-platform_ph=optional';
 
@@ -383,6 +384,82 @@ test('fetchMimoLimits refresh scope probes only the requested account', async ()
 
   assert.equal(result.length, 1);
   assert.equal(result[0].accountKey, 'sha256:mimo-2');
+  assert.ok(cookies.length > 0);
+  assert.ok(cookies.every((cookie) => cookie.includes('userId=456')));
+});
+
+test('fetchMimoLimits fails closed for a provider-only scope with multiple accounts', async () => {
+  const accounts = [
+    managed(COOKIE),
+    managed('userId=456; api-platform_serviceToken=second', {
+      id: 'mimo-2', accountKey: 'sha256:mimo-2'
+    })
+  ];
+  let fetchCalls = 0;
+
+  await assert.rejects(fetchMimoLimits({
+    mimoManagedAccounts: accounts,
+    limitRefreshScope: { provider: 'mimo' }
+  }, {
+    fetch: async () => {
+      fetchCalls += 1;
+      return response({ code: 0, data: {} });
+    }
+  }), /requires an account identifier/);
+
+  assert.equal(fetchCalls, 0);
+});
+
+test('createLimitsCollector leaves cached MiMo accounts untouched for an ambiguous scope', async () => {
+  const accounts = [
+    managed(COOKIE),
+    managed('userId=456; api-platform_serviceToken=second', {
+      id: 'mimo-2', accountKey: 'sha256:mimo-2'
+    })
+  ];
+  let fetchCalls = 0;
+  const cookies = [];
+  const oldAt = '2026-07-20T00:00:00.000Z';
+  const collector = createLimitsCollector({
+    limitsEnabled: true,
+    limitProviders: 'mimo',
+    mimoManagedAccounts: accounts,
+    previousLimits: {
+      updatedAt: oldAt,
+      refreshMs: 300000,
+      providers: accounts.map((account) => ({
+        provider: 'mimo',
+        accountKey: account.accountKey,
+        status: 'ok',
+        updatedAt: oldAt,
+        windows: []
+      }))
+    }
+  }, {
+    fetch: async (url, init) => {
+      fetchCalls += 1;
+      cookies.push(init.headers.Cookie);
+      return url.endsWith('/balance')
+        ? response({ code: 0, data: { balance: '1', currency: 'USD' } })
+        : response({ code: 0, data: {} });
+    }
+  });
+
+  await assert.rejects(
+    collector.refreshScope({ provider: 'mimo' }),
+    /requires an account identifier/
+  );
+  assert.equal(fetchCalls, 0);
+
+  const summary = await collector.refreshScope({
+    provider: 'mimo',
+    accountKey: 'sha256:mimo-2'
+  });
+  assert.deepEqual(
+    summary.providers.map((provider) => provider.accountKey),
+    ['sha256:mimo-1', 'sha256:mimo-2']
+  );
+  assert.equal(summary.providers[0].updatedAt, oldAt);
   assert.ok(cookies.length > 0);
   assert.ok(cookies.every((cookie) => cookie.includes('userId=456')));
 });


### PR DESCRIPTION
## Summary

- keep `Reset now` visible for a 60-second grace period, then hide stale reset timestamps
- refresh limits from the source device 30 seconds after a reset boundary without rerunning usage collection
- scope boundary refreshes to only the provider/account whose window expired
- preserve the existing English reset copy, duration formatting, and real zero-utilization Claude five-hour windows

## Why

A stale reset timestamp could remain visible indefinitely. Expiring it in the renderer fixes the display, but without a source-owned boundary refresh a healthy device could briefly show no reset value after the grace period. The collector now refreshes the due account at the boundary and publishes a `limitsOnly` update while leaving unrelated providers, accounts, and usage periods untouched.

This supersedes #112 and builds on @joyehuang's original stale reset-window fix.

## Validation

- `npm run verify` (`1507 passed`, `1 skipped`)
- `npm run sync:worker` (no generated drift)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expire stale reset timestamps and auto-refresh limits at reset boundaries so the UI stays accurate without re-running usage collection. Hardened scheduling and scoping to avoid loops and ensure only the targeted provider/account/profile refreshes.

- Bug Fixes
  - Keep "Reset now" visible for 60s after `resetsAt`, then hide; share reset logic across Limits and Home while preserving copy and real zero-utilization Claude five-hour windows.
  - Schedule a limits-only refresh 30s after a reset boundary, scoped to the exact provider/account (Codex managed vs. live, OpenCode profile, or specific MiMo account).
  - Prevent loops by pruning attempted reset keys to the current limits snapshot.
  - For MiMo, reject ambiguous provider-only scopes when multiple accounts exist and leave the cache untouched.
  - Merge scoped refreshes into the cache without changing unrelated providers/accounts; retain Codex transient session windows.
  - Cap timers to Node’s max, floor at 5s, and cancel pending timers on collector stop.
  - Leave unrelated providers, accounts, and usage periods untouched; no usage re-collection.

<sup>Written for commit 93bc31209ae9c4033478aaa5be4b05b9f629e188. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

