### PR TITLE
fix(theme): separate accent and semantic colors

### DIFF
--- a/src/electron/renderer/styles.css
+++ b/src/electron/renderer/styles.css
@@ -28,11 +28,15 @@
   --line-strong: rgba(var(--line-rgb), var(--line-strong-alpha));
   --text: #eef5fb;
   --muted: #a3adbb;
-  --green: #b7ead4;
-  /* RGB triplet of the accent (--green), for the accent-tinted borders / glows /
+  --accent: #b7ead4;
+  /* RGB triplet of --accent, for accent-tinted borders / glows /
      active states. Driven from the chosen accent so they flip together — see
-     themeCssVarEntries(). Must match --green above. */
+     themeCssVarEntries(). Must match --accent above. */
   --accent-rgb: 183, 234, 212;
+  /* Semantic success is deliberately independent from the custom accent.
+     themeCssVarEntries() switches this to a darker green on light themes. */
+  --success: #b7ead4;
+  --success-rgb: 183, 234, 212;
   --number: #f3fbf7;
   /* Semantic blue, exposed as a triplet so the trend line and its area fill can
      share one hue (and match the blue heatmap ramp) instead of the fill borrowing
@@ -262,7 +266,7 @@ body.is-windows.floating-bubble-collapsed-right .floating-bubble-tab {
   transition: background 200ms ease, box-shadow 200ms ease;
 }
 .live-dot.live {
-  background: var(--green);
+  background: var(--accent);
   box-shadow: 0 0 4px rgba(var(--accent-rgb), 0.55);
 }
 /* One-shot flare on data update — flares, then settles back to the resting
@@ -414,7 +418,7 @@ body.is-windows.floating-bubble-collapsed-right .floating-bubble-tab {
   mask: url("icons/actions/settings.svg") center / contain no-repeat;
 }
 .icon-button:hover, .refresh-button:hover, .mode-button:hover, .settings-actions button:hover, .shortcut-recorder button:hover { border-color: var(--line-strong); background: rgba(var(--overlay-rgb), 0.072); }
-.icon-button.active { border-color: rgba(var(--accent-rgb), 0.58); color: var(--green); background: rgba(var(--accent-rgb), 0.08); }
+.icon-button.active { border-color: rgba(var(--accent-rgb), 0.58); color: var(--accent); background: rgba(var(--accent-rgb), 0.08); }
 /* The settings panel is a plain view on the widget glass (like the main
    breakdown), not a recessed slab: the section cards carry all the surface
    chrome themselves — a panel background would double-frame them. */
@@ -548,7 +552,7 @@ body.is-windows.floating-bubble-collapsed-right .floating-bubble-tab {
 .export-auto-head .export-auto-toggle { flex: 1 1 auto; min-width: 0; }
 .export-status-pill { flex: 0 0 auto; }
 .export-status-pill.hidden { display: none; }
-.export-status-pill.is-active { color: var(--green); border-color: rgba(var(--accent-rgb), 0.5); background: rgba(var(--accent-rgb), 0.08); }
+.export-status-pill.is-active { color: var(--success); border-color: rgba(var(--success-rgb), 0.5); background: rgba(var(--success-rgb), 0.08); }
 .export-auto-details { display: grid; gap: 8px; }
 .export-auto-details.hidden { display: none; }
 .export-dir-row { display: flex; align-items: center; gap: 8px; min-width: 0; }
@@ -880,7 +884,7 @@ span.settings-note.settings-item-desc {
   mask: var(--settings-section-icon-url) center / contain no-repeat;
 }
 .settings-collapsible-group.expanded .settings-section-icon {
-  color: var(--green);
+  color: var(--accent);
   opacity: 1;
 }
 .settings-section-icon-general { --settings-section-icon-url: url("icons/settings/general.svg"); }
@@ -1174,7 +1178,7 @@ span.settings-note.settings-item-desc {
   width: auto;
   margin: 2px 0 0;
   flex: 0 0 auto;
-  accent-color: var(--green);
+  accent-color: var(--accent);
 }
 .settings-panel .hub-mode-option:has(input:checked) {
   border-color: rgba(var(--accent-rgb), 0.5);
@@ -1242,7 +1246,7 @@ span.settings-note.settings-item-desc {
   color: var(--muted);
   font-size: 10px;
 }
-.hub-status.ok { color: var(--green); border-color: rgba(var(--accent-rgb), 0.32); }
+.hub-status.ok { color: var(--success); border-color: rgba(var(--success-rgb), 0.32); }
 .hub-status.error { color: var(--red); border-color: rgba(244, 119, 136, 0.42); }
 .hub-status[hidden] { display: none; }
 .hub-address-list { display: grid; min-width: 0; gap: 5px; }
@@ -1312,7 +1316,7 @@ span.settings-note.settings-item-desc {
 }
 .tokscale-message:empty { display: none; } /* don't reserve a blank line while there's no status */
 .tokscale-message.error { color: var(--red); }
-.tokscale-message.success { color: var(--green); }
+.tokscale-message.success { color: var(--success); }
 .settings-panel .client-checkboxes {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -1336,7 +1340,7 @@ span.settings-note.settings-item-desc {
   flex: 0 0 auto;
   width: auto;
   margin: 0;
-  accent-color: var(--green);
+  accent-color: var(--accent);
 }
 .settings-panel .client-checkboxes label.client-checkbox > span {
   flex: 1 1 auto;
@@ -1484,8 +1488,8 @@ span.settings-note.settings-item-desc {
   white-space: nowrap;
 }
 .tool-status-tag-ok {
-  border-color: rgba(var(--accent-rgb), 0.28);
-  color: var(--green);
+  border-color: rgba(var(--success-rgb), 0.28);
+  color: var(--success);
 }
 .tool-status-tag-neutral {
   border-color: rgba(var(--line-rgb), 0.2);
@@ -1532,7 +1536,7 @@ span.settings-note.settings-item-desc {
 .tool-preference-toggle input[type="checkbox"] {
   width: auto;
   margin: 0;
-  accent-color: var(--green);
+  accent-color: var(--accent);
 }
 .tool-visibility-button,
 .tool-pin-button {
@@ -1545,7 +1549,7 @@ span.settings-note.settings-item-desc {
   border: 1px solid transparent;
   border-radius: 6px;
   background: transparent;
-  color: var(--green);
+  color: var(--accent);
   cursor: pointer;
 }
 .tool-visibility-button:hover {
@@ -1577,7 +1581,7 @@ span.settings-note.settings-item-desc {
 .tool-pin-button.is-pinned {
   border-color: rgba(var(--accent-rgb), 0.28);
   background: rgba(var(--accent-rgb), 0.06);
-  color: var(--green);
+  color: var(--accent);
 }
 .tool-visibility-button svg,
 .tool-pin-button svg {
@@ -1639,8 +1643,8 @@ span.settings-note.settings-item-desc {
   white-space: nowrap;
 }
 .limit-provider-tag-status {
-  border-color: rgba(var(--accent-rgb), 0.28);
-  color: var(--green);
+  border-color: rgba(var(--success-rgb), 0.28);
+  color: var(--success);
 }
 .limit-provider-tag-source {
   border-color: rgba(115, 189, 245, 0.24);
@@ -1650,12 +1654,12 @@ span.settings-note.settings-item-desc {
   border-color: rgba(var(--line-rgb), 0.18);
 }
 .limit-provider-tag-local {
-  border-color: rgba(var(--accent-rgb), 0.24);
-  color: var(--green);
+  border-color: rgba(var(--line-rgb), 0.18);
+  color: var(--muted);
 }
 .limit-provider-tag-remote {
-  border-color: rgba(241, 217, 115, 0.32);
-  color: var(--yellow);
+  border-color: rgba(115, 189, 245, 0.28);
+  color: var(--blue);
 }
 .limit-provider-tag-multi {
   border-color: rgba(115, 189, 245, 0.3);
@@ -1767,7 +1771,7 @@ span.settings-note.settings-item-desc {
   cursor: pointer;
 }
 .theme-preset-chip:hover { border-color: var(--line-strong); color: var(--text); }
-.theme-preset-chip.active { border-color: rgba(var(--accent-rgb), 0.58); color: var(--green); background: rgba(var(--accent-rgb), 0.08); }
+.theme-preset-chip.active { border-color: rgba(var(--accent-rgb), 0.58); color: var(--accent); background: rgba(var(--accent-rgb), 0.08); }
 .theme-preset-dot { width: 10px; height: 10px; border-radius: 50%; flex: 0 0 auto; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.25); }
 .theme-code-field { display: grid; gap: 6px; }
 .settings-panel input.theme-code-input {
@@ -1778,7 +1782,7 @@ span.settings-note.settings-item-desc {
 }
 .theme-code-status { min-height: 0; margin: 0; font-size: 10px; line-height: 1.35; }
 .theme-code-status:empty { display: none; }
-.theme-code-status.success { color: var(--green); }
+.theme-code-status.success { color: var(--success); }
 .theme-code-status.error { color: var(--red); }
 .theme-color-accordion { border-top: 1px solid var(--line); padding-top: 9px; }
 .color-picker-grid { display: grid; gap: 6px; }
@@ -1903,7 +1907,7 @@ html.is-windows .settings-panel select option {
 .refresh-button:active:not(:disabled) .refresh-button-icon { transform: scale(0.9); }
 .refresh-button:disabled { cursor: default; }
 .refresh-button.is-refreshing {
-  color: var(--green);
+  color: var(--accent);
   border-color: rgba(var(--accent-rgb), 0.58);
   background: rgba(var(--accent-rgb), 0.1);
   box-shadow: inset 0 1px 0 rgba(var(--overlay-rgb), 0.12), 0 0 0 1px rgba(var(--accent-rgb), 0.1);
@@ -1911,10 +1915,10 @@ html.is-windows .settings-panel select option {
 .refresh-button.is-refreshing .refresh-button-icon { display: none; }
 .refresh-button.is-refreshing .refresh-button-spinner { display: block; }
 .refresh-button.is-refreshed {
-  color: var(--green);
-  border-color: rgba(var(--accent-rgb), 0.64);
-  background: rgba(var(--accent-rgb), 0.12);
-  box-shadow: inset 0 1px 0 rgba(var(--overlay-rgb), 0.12), 0 0 12px rgba(var(--accent-rgb), 0.18);
+  color: var(--success);
+  border-color: rgba(var(--success-rgb), 0.64);
+  background: rgba(var(--success-rgb), 0.12);
+  box-shadow: inset 0 1px 0 rgba(var(--overlay-rgb), 0.12), 0 0 12px rgba(var(--success-rgb), 0.18);
 }
 .refresh-button.is-refresh-error {
   color: #ffd8d8;
@@ -1975,7 +1979,7 @@ html.is-windows .settings-panel select option {
 .tab:hover { color: var(--text); }
 .tab.active {
   border-color: transparent;
-  color: var(--green);
+  color: var(--accent);
   background: transparent;
   box-shadow: none;
 }
@@ -2545,7 +2549,7 @@ html.is-windows .settings-panel select option {
   padding: 0 8px;
   border-radius: 6px;
   border-color: rgba(var(--accent-rgb), 0.24);
-  color: var(--green);
+  color: var(--accent);
   font-size: 11px;
 }
 .home-empty {
@@ -2571,7 +2575,7 @@ html.is-windows .settings-panel select option {
   padding: 0 10px;
   border-radius: 7px;
   border-color: rgba(var(--accent-rgb), 0.24);
-  color: var(--green);
+  color: var(--accent);
   font-size: 11px;
 }
 
@@ -2901,8 +2905,8 @@ html.is-windows .settings-panel select option {
   line-height: 1.1;
 }
 .service-status-ok .service-status-pill {
-  border-color: rgba(var(--accent-rgb), 0.28);
-  color: var(--green);
+  border-color: rgba(var(--success-rgb), 0.28);
+  color: var(--success);
 }
 .service-status-degraded .service-status-pill {
   border-color: rgba(241, 217, 115, 0.32);
@@ -3008,7 +3012,7 @@ html.is-windows .settings-panel select option {
   margin-left: -6px;
   align-items: center;
   justify-content: center;
-  color: var(--green);
+  color: var(--accent);
   font-size: 10px;
   font-weight: 700;
   line-height: 1;
@@ -3124,7 +3128,7 @@ html.is-windows .limit-live-badge {
 .limit-account-switch-button:focus-visible {
   border-color: rgba(var(--accent-rgb), 0.32);
   background: rgba(var(--accent-rgb), 0.075);
-  color: var(--green);
+  color: var(--accent);
   box-shadow: 0 0 0 1px rgba(var(--accent-rgb), 0.16), inset 0 1px 0 rgba(var(--overlay-rgb), 0.1);
 }
 .limit-account-switch-button:disabled {
@@ -3523,7 +3527,7 @@ html.is-windows .limit-live-badge {
 }
 .view-switcher-menu-item.is-current {
   background: rgba(var(--accent-rgb), 0.08);
-  color: var(--green);
+  color: var(--accent);
 }
 .view-switcher-menu-label {
   min-width: 0;
@@ -3879,7 +3883,7 @@ html.is-windows .limit-live-badge {
 .view-subgroup-toggle:hover,
 .view-subgroup-toggle:focus-visible,
 .view-subgroup-toggle.is-expanded {
-  color: var(--green);
+  color: var(--accent);
 }
 .view-subgroup-toggle:focus-visible {
   outline: 2px solid rgba(var(--accent-rgb), 0.35);

--- a/src/electron/renderer/themePresets.js
+++ b/src/electron/renderer/themePresets.js
@@ -11,15 +11,14 @@
   // The customisable interface colours, in display order. Each maps to a CSS
   // custom property on :root (see styles.css). `bg` drives the glass tint
   // (--glass-rgb, an "r, g, b" triplet); `text` also drives --number (the big
-  // TOTAL figure) so it reads as plain text. The semantic status colours
-  // (--blue/--orange/--purple/--yellow/--red) are intentionally NOT exposed:
-  // they only surface in edge states (links, warnings, errors) and --purple is
-  // unused entirely, so a picker for them would be a no-op for everyday use.
+  // TOTAL figure) so it reads as plain text. Semantic status colours
+  // (--success/--blue/--orange/--purple/--yellow/--red) are intentionally NOT
+  // exposed: their meaning must remain stable when the accent changes.
   const INTERFACE_COLOR_KEYS = ['accent', 'bg', 'text', 'muted'];
   const THEME_CODE_VERSION = 'TM1';
 
   const THEME_VAR_MAP = {
-    accent: '--green',
+    accent: '--accent',
     bg: '--glass-rgb',
     text: '--text',
     muted: '--muted'
@@ -55,6 +54,8 @@
   const LIGHT_LINE_RGB = '24, 28, 36';
   const LIGHT_PANEL_RGB = '255, 255, 255';
   const LIGHT_SUNKEN_RGB = '188, 196, 206';
+  const LIGHT_SUCCESS = '#18794e';
+  const LIGHT_SUCCESS_RGB = '24, 121, 78';
 
   // Vendors shown in the vendor-colour list, tracked clients first. Vendors not
   // listed here but present in clientColors are appended after these, then the
@@ -204,6 +205,11 @@
     entries.push({ name: '--line-rgb', value: light ? LIGHT_LINE_RGB : null });
     entries.push({ name: '--panel-rgb', value: light ? LIGHT_PANEL_RGB : null });
     entries.push({ name: '--sunken-rgb', value: light ? LIGHT_SUNKEN_RGB : null });
+    // Semantic success stays green regardless of the custom accent. Use a
+    // darker green on pale themes so status text and borders keep their
+    // contrast instead of inheriting the user's interaction colour.
+    entries.push({ name: '--success', value: light ? LIGHT_SUCCESS : null });
+    entries.push({ name: '--success-rgb', value: light ? LIGHT_SUCCESS_RGB : null });
     entries.push({ name: 'color-scheme', value: light ? 'light' : null });
     return entries;
   }

--- a/tests/electron/controlLayoutSwap.test.js
+++ b/tests/electron/controlLayoutSwap.test.js
@@ -231,7 +231,7 @@ test('refresh button exposes busy, success, and error feedback states', () => {
   assert.match(css, /\.refresh-button\.is-refreshing \.refresh-button-spinner\s*\{\s*display:\s*block;\s*\}/, 'loading state reveals the masked spinner');
   assert.match(cssRule(css, '.refresh-button-spinner::before'), /mask:\s*url\("icons\/actions\/spinner\.svg"\)/, 'spinner is a reusable asset file, not markup inlined in the page');
   assert.equal(declaration(cssRule(css, '.refresh-button-spinner::before'), 'background'), 'currentColor', 'spinner mask is tinted by the button state color');
-  assert.match(cssRule(css, '.refresh-button.is-refreshed'), /border-color:\s*rgba\(var\(--accent-rgb\)/);
+  assert.match(cssRule(css, '.refresh-button.is-refreshed'), /border-color:\s*rgba\(var\(--success-rgb\)/);
   assert.match(cssRule(css, '.refresh-button.is-refresh-error'), /border-color:\s*rgba\(255,\s*99,\s*99/);
 
   const spinnerSvg = readRendererFile('icons/actions/spinner.svg');

--- a/tests/electron/serviceStatusDom.test.js
+++ b/tests/electron/serviceStatusDom.test.js
@@ -284,7 +284,7 @@ test('view switcher preserves click-to-cycle and direct selection without crowdi
   assert.match(cssRule(css, '.view-switcher'), /flex:\s*0 1 auto/);
   assert.match(cssRule(css, '.view-switcher-current'), /min-width:\s*0/);
   assert.match(cssRule(css, '.view-switcher-current'), /color:\s*var\(--muted\)/);
-  assert.doesNotMatch(cssRule(css, '.view-switcher-current'), /color:\s*var\(--green\)/);
+  assert.doesNotMatch(cssRule(css, '.view-switcher-current'), /color:\s*var\(--accent\)/);
   assert.match(cssRule(css, '.view-switcher-disclosure'), /flex:\s*0 0 24px/);
   assert.match(cssRule(css, '.view-switcher-menu'), /position:\s*absolute/);
   assert.match(cssRule(css, '.view-switcher-menu'), /width:\s*100%/);

--- a/tests/electron/themePresets.test.js
+++ b/tests/electron/themePresets.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const test = require('node:test');
 
 const {
@@ -29,9 +31,8 @@ const { clientColors } = require('../../src/electron/renderer/usageCharts');
 
 test('interface palette is the four always-visible colours, each mapped to a CSS variable', () => {
   assert.deepEqual(INTERFACE_COLOR_KEYS, ['accent', 'bg', 'text', 'muted']);
-  // Semantic status colours (blue/orange/purple/yellow/red) are intentionally
-  // not customisable — they only surface in edge states and purple is unused.
-  for (const dead of ['blue', 'orange', 'purple', 'yellow', 'red']) {
+  // Semantic status colours are intentionally not customisable.
+  for (const dead of ['success', 'blue', 'orange', 'purple', 'yellow', 'red']) {
     assert.ok(!INTERFACE_COLOR_KEYS.includes(dead), `${dead} should not be customisable`);
   }
   for (const key of INTERFACE_COLOR_KEYS) {
@@ -40,6 +41,54 @@ test('interface palette is the four always-visible colours, each mapped to a CSS
   }
   // bg default must equal the --glass-rgb default (48, 52, 56).
   assert.equal(hexToRgbTriplet(DEFAULT_THEME.bg), '48, 52, 56');
+});
+
+test('semantic success states stay independent from the custom accent', () => {
+  const css = fs.readFileSync(path.join(__dirname, '../../src/electron/renderer/styles.css'), 'utf8');
+  const semanticSelectors = [
+    '.export-status-pill.is-active',
+    '.hub-status.ok',
+    '.tokscale-message.success',
+    '.tool-status-tag-ok',
+    '.theme-code-status.success',
+    '.refresh-button.is-refreshed',
+    '.service-status-ok .service-status-pill'
+  ];
+
+  for (const selector of semanticSelectors) {
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const rule = css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`))?.[1] || '';
+    assert.match(rule, /var\(--success(?:-rgb)?\)/, `${selector} should use semantic success`);
+    assert.doesNotMatch(rule, /var\(--accent(?:-rgb)?\)/, `${selector} should not inherit the custom accent`);
+  }
+});
+
+test('presence and current-account indicators follow the custom accent', () => {
+  const css = fs.readFileSync(path.join(__dirname, '../../src/electron/renderer/styles.css'), 'utf8');
+  for (const selector of ['.live-dot.live', '.limit-live-badge']) {
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const rule = css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`))?.[1] || '';
+    assert.match(rule, /var\(--accent(?:-rgb)?\)/, `${selector} should follow the custom accent`);
+    assert.doesNotMatch(rule, /var\(--success(?:-rgb)?\)/, `${selector} should not imply success`);
+  }
+});
+
+test('device provenance tags use informational colours instead of state colours', () => {
+  const css = fs.readFileSync(path.join(__dirname, '../../src/electron/renderer/styles.css'), 'utf8');
+  const ruleFor = (selector) => {
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`))?.[1] || '';
+  };
+
+  const local = ruleFor('.limit-provider-tag-local');
+  assert.match(local, /color:\s*var\(--muted\)/);
+  assert.doesNotMatch(local, /var\(--(?:accent|success|yellow)(?:-rgb)?\)/);
+
+  for (const selector of ['.limit-provider-tag-remote', '.limit-provider-tag-multi']) {
+    const rule = ruleFor(selector);
+    assert.match(rule, /color:\s*var\(--blue\)/, `${selector} should be informational`);
+    assert.doesNotMatch(rule, /var\(--(?:accent|success|yellow)(?:-rgb)?\)/, `${selector} should not imply selection, success, or warning`);
+  }
 });
 
 test('hexToRgbTriplet converts hex to a CSS rgb triplet', () => {
@@ -61,9 +110,10 @@ test('themeCssVarEntries maps bg to --glass-rgb and mirrors text onto --number',
   assert.equal(set['--glass-rgb'], '16, 16, 16'); // bg becomes a triplet
   assert.equal(set['--text'], '#abcdef');
   assert.equal(set['--number'], '#abcdef'); // big TOTAL figure follows text
-  assert.equal(set['--green'], '#112233'); // accent maps to --green
+  assert.equal(set['--accent'], '#112233'); // accent maps to the interaction token
   assert.equal(set['--accent-rgb'], '17, 34, 51'); // accent also flips the tints
   assert.equal(cleared['--accent-rgb'], null); // absent accent -> :root default
+  assert.equal(set['--success'], null); // dark-theme success never inherits accent
 });
 
 test('isLightHex detects pale backgrounds', () => {
@@ -79,7 +129,7 @@ test('themeCssVarEntries flips the overlay/border system for light backgrounds',
 
   // Dark bg -> surface vars cleared to the dark :root defaults.
   const dark = byName(themeCssVarEntries({ bg: '#0b0c0e' }));
-  for (const name of ['--overlay-rgb', '--line-rgb', '--panel-rgb', '--sunken-rgb', 'color-scheme']) {
+  for (const name of ['--overlay-rgb', '--line-rgb', '--panel-rgb', '--sunken-rgb', '--success', '--success-rgb', 'color-scheme']) {
     assert.equal(dark[name], null, `${name} should be cleared on a dark bg`);
   }
 
@@ -90,6 +140,8 @@ test('themeCssVarEntries flips the overlay/border system for light backgrounds',
   assert.equal(light['--line-rgb'], '24, 28, 36');
   assert.equal(light['--panel-rgb'], '255, 255, 255');
   assert.equal(light['--sunken-rgb'], '188, 196, 206');
+  assert.equal(light['--success'], '#18794e');
+  assert.equal(light['--success-rgb'], '24, 121, 78');
   assert.equal(light['color-scheme'], 'light');
 
   // No bg override resolves to the dark default, so no flip.


### PR DESCRIPTION
## Summary

- Separate the customizable accent token from semantic success colors.
- Keep selections, controls, the live presence dot, and the current-account marker tied to the accent.
- Keep healthy, tracking, connected, and completed states green regardless of the chosen accent.
- Render device provenance as neutral or informational metadata instead of success or warning states.
- Use a darker semantic green on light themes to preserve readable contrast.

## Why

The appearance accent previously mapped to `--green`, so changing it also recolored labels such as `正常` and `追蹤中`. That mixed interaction styling with system-health meaning and could turn positive states purple, blue, or another user-selected color.

## Visual behavior

With a custom purple accent, tabs, checkboxes, the live presence dot, and the current-account marker remain purple. Healthy service and tracking labels remain semantic green; degraded and error states keep their existing yellow and red colors.

## Validation

- `npm run verify` (1513 passed, 1 skipped, 0 failed)
- `git diff --check`
- Confirmed no remaining `--green` references under `src` or `tests`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separates the UI accent from semantic success colors so changing the accent no longer recolors health/tracking states; controls keep using the accent, success stays green with better light-theme contrast.

- Bug Fixes
  - Healthy, tracking, connected, and completed states now use semantic green, independent of the accent.
  - Device provenance tags use neutral/blue (informational), not success/warning.
  - Light themes use a darker green for success to keep contrast readable.

- Refactors
  - Replaced --green with --accent for interactive UI; added --success and --success-rgb.
  - themePresets maps accent to --accent and sets success tokens on light themes.
  - Tests updated to validate accent vs success separation.

<sup>Written for commit 9a51608d2db177e889a70e4ae707a90a890432b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

