### PR TITLE
feat: add Trae Work (TRAE SOLO CN) token usage collection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,8 +23,13 @@ TOKEN_MONITOR_SYNC_UPLOAD_INTERVAL_MS=0
 
 # Comma-separated client list. Optional — leave unset to track all supported tools.
 # Set to empty to disable tracking.
-# Example: claude,codex,hermes,opencode,openclaw,cursor,antigravity,cline,kimi,qwen,grok,copilot,pi,zed,kilocode,micode,zcode,kiro,codebuddy,workbuddy,proma
-TOKEN_MONITOR_CLIENTS=claude,codex,hermes,opencode,openclaw,cursor,antigravity,cline,kimi,qwen,grok,copilot,pi,zed,kilocode,micode,zcode,kiro,codebuddy,workbuddy,proma
+# Example: claude,codex,hermes,opencode,openclaw,cursor,antigravity,cline,kimi,qwen,grok,copilot,pi,zed,kilocode,micode,zcode,kiro,codebuddy,workbuddy,proma,trae
+TOKEN_MONITOR_CLIENTS=claude,codex,hermes,opencode,openclaw,cursor,antigravity,cline,kimi,qwen,grok,copilot,pi,zed,kilocode,micode,zcode,kiro,codebuddy,workbuddy,proma,trae
+
+# Trae Work — SQLCipher database key (64-char hex) for reading local usage.
+# Extract with: python scripts/extract-trae-key.py (Windows, admin, Trae running)
+# Or place a trae-key.json ({"key":"<64hex>"}) in the Token Monitor data dir.
+TOKEN_MONITOR_TRAE_KEY=
 
 # Projects — collect local workspace metadata for the Projects view.
 # Optional — defaults to disabled. Set to 1 to enable.

--- a/scripts/extract-trae-key.py
+++ b/scripts/extract-trae-key.py
@@ -179,8 +179,62 @@ def scan_memory_for_key(pid, db_path):
         if _verify_key(key, page1):
             return key
 
-    # If HMAC verification fails, return first candidate (try direct open)
-    return candidates[0] if candidates else None
+    # HMAC didn't match (SQLCipher variants differ) — prove the key works by
+    # actually opening the database before claiming success.
+    for key in candidates:
+        verdict = _validate_key_opens_db(key, db_path)
+        if verdict is True:
+            return key
+
+    # No candidate could be validated. Only fall back to the first candidate
+    # when no validation backend exists at all, with a loud warning.
+    if candidates:
+        if _validate_key_opens_db(None, None) is None:
+            print("[!] WARNING: could not verify key (HMAC mismatch and no sqlcipher3 module).")
+            print("    Saving first candidate anyway — collection may fail if it is wrong.")
+            return candidates[0]
+        print("[-] All key candidates failed validation against the database.")
+    return None
+
+
+def _validate_key_opens_db(key, db_path):
+    """Try to actually open the database with the candidate key.
+
+    Returns True (key works), False (key rejected), or None when no
+    SQLCipher-capable Python driver is available to test with.
+    """
+    if key is None or db_path is None:
+        # Probe whether any driver is importable at all.
+        try:
+            import sqlcipher3.dbapi2  # noqa: F401
+            return None
+        except ImportError:
+            pass
+        try:
+            from pysqlcipher3 import dbapi2  # noqa: F401
+            return None
+        except ImportError:
+            return None
+        return None
+    sqlcipher = None
+    try:
+        import sqlcipher3.dbapi2 as sqlcipher
+    except ImportError:
+        try:
+            from pysqlcipher3 import dbapi2 as sqlcipher
+        except ImportError:
+            return None
+    try:
+        conn = sqlcipher.connect(db_path)
+        try:
+            conn.execute(f"PRAGMA key = \"x'{key}'\"")
+            conn.execute("PRAGMA cipher_compatibility = 4")
+            conn.execute("SELECT count(*) FROM sqlite_master").fetchone()
+        finally:
+            conn.close()
+        return True
+    except Exception:
+        return False
 
 
 def _verify_key(enc_key_hex, page1):
@@ -255,17 +309,19 @@ def main():
     print(f"[+] Key found in {elapsed:.1f}s!")
     print(f"    enc_key = {key}")
 
-    # Determine output path
+    # Determine output path (never truncate an existing file to test access)
     output = args.output
     if not output:
         # Try next to database first
         db_dir = os.path.dirname(db_path)
         candidate = os.path.join(db_dir, "trae-key.json")
-        try:
-            with open(candidate, "w") as f:
-                f.write("")
+        if os.path.exists(candidate):
+            writable = os.access(candidate, os.W_OK)
+        else:
+            writable = os.access(db_dir, os.W_OK)
+        if writable:
             output = candidate
-        except OSError:
+        else:
             # Fall back to Token Monitor data dir
             appdata = os.environ.get("APPDATA", os.path.join(os.path.expanduser("~"), "AppData", "Roaming"))
             tm_dir = os.path.join(appdata, "Token Monitor")
@@ -273,8 +329,12 @@ def main():
             output = os.path.join(tm_dir, "trae-key.json")
 
     result = {"key": key, "db_path": db_path, "extracted_at": time.strftime("%Y-%m-%dT%H:%M:%S")}
-    with open(output, "w") as f:
+    # Atomic write: temp file + rename so an interrupted run can never
+    # destroy an existing working key file.
+    tmp_path = output + ".tmp"
+    with open(tmp_path, "w") as f:
         json.dump(result, f, indent=2)
+    os.replace(tmp_path, output)
 
     print(f"[+] Key saved to: {output}")
     print("\nToken Monitor will now be able to read Trae Work usage data.")

--- a/scripts/extract-trae-key.py
+++ b/scripts/extract-trae-key.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""
+Extract SQLCipher key from Trae Work (TRAE SOLO CN / Trae CN) process memory.
+
+Requirements:
+  - Windows with admin privileges
+  - Trae Work must be running (ai_agent.dll loaded)
+  - Python 3.10+
+
+Usage:
+  python scripts/extract-trae-key.py [--output PATH]
+
+The extracted key is saved as JSON compatible with Token Monitor's
+trae-key.json format: { "key": "<64-char-hex>" }
+
+Default output locations (first writable wins):
+  1. Next to the database file
+  2. Token Monitor shared data dir (%APPDATA%/Token Monitor/trae-key.json)
+"""
+
+import argparse
+import ctypes
+import ctypes.wintypes as wt
+import hashlib
+import json
+import os
+import re
+import struct
+import subprocess
+import sys
+import time
+
+# ─── Windows API ───────────────────────────────────────────────────────────────
+
+PROCESS_VM_READ = 0x0010
+PROCESS_QUERY_INFORMATION = 0x0400
+MEM_COMMIT = 0x1000
+PAGE_GUARD = 0x100
+READABLE_PAGES = 0x02 | 0x04 | 0x08 | 0x20 | 0x40 | 0x80
+
+
+class MEMORY_BASIC_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("BaseAddress", ctypes.c_void_p),
+        ("AllocationBase", ctypes.c_void_p),
+        ("AllocationProtect", wt.DWORD),
+        ("RegionSize", ctypes.c_size_t),
+        ("State", wt.DWORD),
+        ("Protect", wt.DWORD),
+        ("Type", wt.DWORD),
+    ]
+
+
+kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+psapi = ctypes.WinDLL("psapi", use_last_error=True)
+
+kernel32.OpenProcess.restype = wt.HANDLE
+kernel32.OpenProcess.argtypes = [wt.DWORD, wt.BOOL, wt.DWORD]
+kernel32.VirtualQueryEx.restype = ctypes.c_size_t
+kernel32.VirtualQueryEx.argtypes = [wt.HANDLE, ctypes.c_void_p, ctypes.POINTER(MEMORY_BASIC_INFORMATION), ctypes.c_size_t]
+kernel32.ReadProcessMemory.restype = wt.BOOL
+kernel32.ReadProcessMemory.argtypes = [wt.HANDLE, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_size_t)]
+kernel32.CloseHandle.restype = wt.BOOL
+kernel32.CloseHandle.argtypes = [wt.HANDLE]
+
+psapi.EnumProcessModulesEx.restype = wt.BOOL
+psapi.EnumProcessModulesEx.argtypes = [wt.HANDLE, ctypes.POINTER(ctypes.c_void_p), wt.DWORD, ctypes.POINTER(wt.DWORD), wt.DWORD]
+psapi.GetModuleFileNameExW.restype = wt.DWORD
+psapi.GetModuleFileNameExW.argtypes = [wt.HANDLE, ctypes.c_void_p, ctypes.c_wchar_p, wt.DWORD]
+
+
+# ─── Database path ─────────────────────────────────────────────────────────────
+
+def find_database():
+    appdata = os.environ.get("APPDATA", os.path.join(os.path.expanduser("~"), "AppData", "Roaming"))
+    candidates = [
+        os.path.join(appdata, "TRAE SOLO CN", "ModularData", "ai-agent", "database.db"),
+        os.path.join(appdata, "Trae CN", "ModularData", "ai-agent", "database.db"),
+    ]
+    for path in candidates:
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+# ─── Process discovery ─────────────────────────────────────────────────────────
+
+def find_ai_agent_pid():
+    """Find PID of the process that has ai_agent.dll loaded."""
+    result = subprocess.run(
+        ["tasklist", "/FO", "CSV", "/NH"],
+        capture_output=True, text=True, encoding="gbk", errors="ignore"
+    )
+    for line in result.stdout.strip().split("\n"):
+        parts = line.replace('"', "").split(",")
+        if len(parts) < 2:
+            continue
+        proc_name = parts[0].lower()
+        if "trae" not in proc_name:
+            continue
+        try:
+            pid = int(parts[1])
+        except ValueError:
+            continue
+        if _has_module(pid, "ai_agent"):
+            return pid
+    return None
+
+
+def _has_module(pid, module_name):
+    h = kernel32.OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, False, pid)
+    if not h:
+        return False
+    try:
+        modules = (ctypes.c_void_p * 2048)()
+        needed = wt.DWORD()
+        if not psapi.EnumProcessModulesEx(h, modules, ctypes.sizeof(modules), ctypes.byref(needed), 0x03):
+            return False
+        count = needed.value // ctypes.sizeof(ctypes.c_void_p)
+        for i in range(count):
+            buf = ctypes.create_unicode_buffer(520)
+            psapi.GetModuleFileNameExW(h, ctypes.c_void_p(modules[i]), buf, 520)
+            if module_name.lower() in buf.value.lower():
+                return True
+        return False
+    except Exception:
+        return False
+    finally:
+        kernel32.CloseHandle(h)
+
+
+# ─── Memory scanning ──────────────────────────────────────────────────────────
+
+def scan_memory_for_key(pid, db_path):
+    """Scan process memory for the SQLCipher raw key."""
+    with open(db_path, "rb") as f:
+        page1 = f.read(4096)
+
+    salt = page1[:16]
+    hex_pattern = re.compile(rb"x'([0-9a-fA-F]{64,192})'")
+
+    h = kernel32.OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, False, pid)
+    if not h:
+        print(f"[!] Cannot open process PID={pid} (error {ctypes.get_last_error()}). Run as admin!")
+        return None
+
+    address = 0
+    mbi = MEMORY_BASIC_INFORMATION()
+    candidates = []
+
+    while kernel32.VirtualQueryEx(h, ctypes.c_void_p(address), ctypes.byref(mbi), ctypes.sizeof(mbi)):
+        if (mbi.State == MEM_COMMIT and mbi.Protect & READABLE_PAGES and not mbi.Protect & PAGE_GUARD):
+            size = mbi.RegionSize
+            if 0 < size < 256 * 1024 * 1024:
+                buf = ctypes.create_string_buffer(size)
+                bytes_read = ctypes.c_size_t(0)
+                if kernel32.ReadProcessMemory(h, ctypes.c_void_p(mbi.BaseAddress), buf, size, ctypes.byref(bytes_read)):
+                    data = buf.raw[:bytes_read.value]
+                    for match in hex_pattern.finditer(data):
+                        hex_str = match.group(1).decode("ascii")
+                        enc_key = hex_str[:64]
+                        # Verify salt matches if full key+salt present
+                        if len(hex_str) >= 96:
+                            candidate_salt = hex_str[64:96]
+                            if candidate_salt.lower() != salt.hex().lower():
+                                continue
+                        if enc_key not in candidates:
+                            candidates.append(enc_key)
+
+        next_addr = (mbi.BaseAddress or 0) + mbi.RegionSize
+        if next_addr <= address:
+            break
+        address = next_addr
+
+    kernel32.CloseHandle(h)
+
+    # Verify candidates against the database
+    for key in candidates:
+        if _verify_key(key, page1):
+            return key
+
+    # If HMAC verification fails, return first candidate (try direct open)
+    return candidates[0] if candidates else None
+
+
+def _verify_key(enc_key_hex, page1):
+    """HMAC-SHA512 verification (best-effort, SQLCipher variants differ)."""
+    import hmac as hmac_mod
+    salt = page1[:16]
+    hmac_size = 64
+    data = page1[16:len(page1) - hmac_size]
+    stored_hmac = page1[len(page1) - hmac_size:]
+    key_bytes = bytes.fromhex(enc_key_hex)
+
+    for derive in [
+        lambda k, s: k,
+        lambda k, s: hmac_mod.new(k, s, hashlib.sha512).digest(),
+        lambda k, s: hashlib.pbkdf2_hmac("sha512", k, s, 2, dklen=64),
+    ]:
+        try:
+            hmac_key = derive(key_bytes, salt)
+            for msg in [data + struct.pack("<I", 1), data, data + salt]:
+                computed = hmac_mod.new(hmac_key, msg, hashlib.sha512).digest()
+                if computed == stored_hmac:
+                    return True
+        except Exception:
+            pass
+    return False
+
+
+# ─── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="Extract Trae Work SQLCipher key")
+    parser.add_argument("--output", "-o", help="Output path for trae-key.json")
+    args = parser.parse_args()
+
+    print("=" * 60)
+    print("  Trae Work — SQLCipher Key Extractor")
+    print("=" * 60)
+
+    db_path = find_database()
+    if not db_path:
+        print("[!] Trae Work database not found.")
+        print("    Expected at: %APPDATA%/TRAE SOLO CN/ModularData/ai-agent/database.db")
+        sys.exit(1)
+
+    print(f"[+] Database: {db_path}")
+    print(f"[+] Size: {os.path.getsize(db_path) / 1024 / 1024:.1f} MB")
+
+    # Check if encrypted
+    with open(db_path, "rb") as f:
+        header = f.read(16)
+    if header[:6] == b"SQLite":
+        print("[!] Database is NOT encrypted. No key needed.")
+        sys.exit(0)
+
+    print("[*] Finding ai_agent.dll process...")
+    pid = find_ai_agent_pid()
+    if not pid:
+        print("[!] ai_agent.dll not found in any process.")
+        print("    Make sure Trae Work is running.")
+        sys.exit(1)
+
+    print(f"[+] Found PID: {pid}")
+    print("[*] Scanning memory...")
+    start = time.time()
+    key = scan_memory_for_key(pid, db_path)
+    elapsed = time.time() - start
+
+    if not key:
+        print(f"[-] No key found ({elapsed:.1f}s)")
+        sys.exit(1)
+
+    print(f"[+] Key found in {elapsed:.1f}s!")
+    print(f"    enc_key = {key}")
+
+    # Determine output path
+    output = args.output
+    if not output:
+        # Try next to database first
+        db_dir = os.path.dirname(db_path)
+        candidate = os.path.join(db_dir, "trae-key.json")
+        try:
+            with open(candidate, "w") as f:
+                f.write("")
+            output = candidate
+        except OSError:
+            # Fall back to Token Monitor data dir
+            appdata = os.environ.get("APPDATA", os.path.join(os.path.expanduser("~"), "AppData", "Roaming"))
+            tm_dir = os.path.join(appdata, "Token Monitor")
+            os.makedirs(tm_dir, exist_ok=True)
+            output = os.path.join(tm_dir, "trae-key.json")
+
+    result = {"key": key, "db_path": db_path, "extracted_at": time.strftime("%Y-%m-%dT%H:%M:%S")}
+    with open(output, "w") as f:
+        json.dump(result, f, indent=2)
+
+    print(f"[+] Key saved to: {output}")
+    print("\nToken Monitor will now be able to read Trae Work usage data.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/electron/discordRpc.js
+++ b/src/electron/discordRpc.js
@@ -14,7 +14,7 @@ const CLIENT_LABELS = {
   gemini: 'Gemini', cursor: 'Cursor', opencode: 'OpenCode', openclaw: 'OpenClaw',
   antigravity: 'Antigravity', cline: 'Cline',
   kimi: 'Kimi', qwen: 'Qwen', grok: 'Grok Build', copilot: 'GitHub Copilot',
-  pi: 'Pi', zed: 'Zed', kilocode: 'Kilo Code', micode: 'MiMo Code', zcode: 'ZCode', kiro: 'Kiro', codebuddy: 'CodeBuddy', workbuddy: 'WorkBuddy', proma: 'Proma'
+  pi: 'Pi', zed: 'Zed', kilocode: 'Kilo Code', micode: 'MiMo Code', zcode: 'ZCode', kiro: 'Kiro', codebuddy: 'CodeBuddy', workbuddy: 'WorkBuddy', proma: 'Proma', trae: 'Trae Work'
 };
 const UPDATE_MIN_INTERVAL_MS = 15000;
 const RECONNECT_DELAY_MS = 30000;

--- a/src/electron/discordRpc.js
+++ b/src/electron/discordRpc.js
@@ -7,7 +7,7 @@ const CLIENT_ID = '1507034330436862062';
 const GITHUB_URL = 'https://github.com/Javis603/token-monitor';
 const KNOWN_CLIENT_ASSETS = new Set([
   'claude', 'codex', 'hermes', 'gemini', 'cursor', 'opencode', 'openclaw', 'antigravity', 'cline',
-  'kimi', 'qwen', 'grok', 'copilot', 'pi', 'zed', 'kilocode', 'micode', 'zcode', 'kiro', 'codebuddy', 'workbuddy', 'proma'
+  'kimi', 'qwen', 'grok', 'copilot', 'pi', 'zed', 'kilocode', 'micode', 'zcode', 'kiro', 'codebuddy', 'workbuddy', 'proma', 'trae'
 ]);
 const CLIENT_LABELS = {
   claude: 'Claude', codex: 'Codex', hermes: 'Hermes',

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const clientLabels = { claude: 'Claude Code', codex: 'Codex', hermes: 'Hermes', gemini: 'Gemini', cursor: 'Cursor', opencode: 'OpenCode', openclaw: 'OpenClaw', antigravity: 'Antigravity', cline: 'Cline', kimi: 'Kimi', qwen: 'Qwen', grok: 'Grok Build', copilot: 'GitHub Copilot', pi: 'Pi', zed: 'Zed', kilocode: 'Kilo Code', micode: 'MiMo Code', zcode: 'ZCode', kiro: 'Kiro', codebuddy: 'CodeBuddy', workbuddy: 'WorkBuddy', proma: 'Proma' };
+const clientLabels = { claude: 'Claude Code', codex: 'Codex', hermes: 'Hermes', gemini: 'Gemini', cursor: 'Cursor', opencode: 'OpenCode', openclaw: 'OpenClaw', antigravity: 'Antigravity', cline: 'Cline', kimi: 'Kimi', qwen: 'Qwen', grok: 'Grok Build', copilot: 'GitHub Copilot', pi: 'Pi', zed: 'Zed', kilocode: 'Kilo Code', micode: 'MiMo Code', zcode: 'ZCode', kiro: 'Kiro', codebuddy: 'CodeBuddy', workbuddy: 'WorkBuddy', proma: 'Proma', trae: 'Trae Work' };
 const { clientColors, fallbackModelColors, modelVendorFor, modelColor } = window.TokenMonitorUsageCharts;
 const motionPreferenceApi = window.TokenMonitorMotionPreference;
 const reducedMotionMedia = window.matchMedia?.('(prefers-reduced-motion: reduce)');
@@ -61,7 +61,8 @@ const KNOWN_CLIENTS = [
   { id: 'kiro', label: 'Kiro' },
   { id: 'codebuddy', label: 'CodeBuddy' },
   { id: 'workbuddy', label: 'WorkBuddy' },
-  { id: 'proma', label: 'Proma' }
+  { id: 'proma', label: 'Proma' },
+  { id: 'trae', label: 'Trae Work' }
 ];
 const LIMIT_PROVIDERS = [
   { id: 'claude', label: 'Claude', settingsLabel: 'Claude Code' },

--- a/src/electron/renderer/themePresets.js
+++ b/src/electron/renderer/themePresets.js
@@ -61,7 +61,7 @@
   // synthetic "default" fallback is shown last.
   const VENDOR_ORDER = [
     'claude', 'codex', 'hermes', 'opencode', 'openclaw', 'cline', 'cursor',
-    'gemini', 'antigravity', 'kimi', 'qwen', 'grok', 'copilot', 'pi', 'zed', 'kilocode', 'micode', 'zcode', 'kiro', 'codebuddy', 'workbuddy', 'proma', 'deepseek', 'xai', 'meta', 'mistral',
+    'gemini', 'antigravity', 'kimi', 'qwen', 'grok', 'copilot', 'pi', 'zed', 'kilocode', 'micode', 'zcode', 'kiro', 'codebuddy', 'workbuddy', 'proma', 'trae', 'deepseek', 'xai', 'meta', 'mistral',
     'moonshot', 'zai', 'zaiteam', 'cohere', 'xiaomi', 'minimax', 'doubao', 'volcengine', 'qoder', 'ollama'
   ];
 
@@ -90,6 +90,7 @@
     codebuddy: 'CodeBuddy',
     workbuddy: 'WorkBuddy',
     proma: 'Proma',
+    trae: 'Trae Work',
     deepseek: 'DeepSeek',
     xai: 'xAI',
     meta: 'Meta',

--- a/src/electron/renderer/usageCharts.js
+++ b/src/electron/renderer/usageCharts.js
@@ -348,7 +348,7 @@
     claude: '#cc7c5e', codex: '#49a3b0', hermes: '#d4af37', gemini: '#4285f4',
     antigravity: '#4285f4', cline: '#323B43', kimi: '#16191e', grok: '#000000', copilot: '#000000', deepseek: '#4d6bfe', cursor: '#000000', opencode: '#000000',
     openclaw: '#ff4d4d', xai: '#000000', meta: '#1d65c1', mistral: '#fa520f', qwen: '#615ced',
-    pi: '#000', zed: '#4173e7', kilocode: '#F8F676', micode: '#000000', zcode: '#000000', kiro: '#9046FF', codebuddy: '#6C4DFF', workbuddy: '#0DC8A5', proma: '#000000',
+    pi: '#000', zed: '#4173e7', kilocode: '#F8F676', micode: '#000000', zcode: '#000000', kiro: '#9046FF', codebuddy: '#6C4DFF', workbuddy: '#0DC8A5', proma: '#000000', trae: '#3B82F6',
     moonshot: '#16191e', zai: '#000000', zaiteam: '#000000', cohere: '#39594d', xiaomi: '#ff6700', minimax: '#f23f5d', doubao: '#1E37FC', volcengine: '#006EFF', qoder: '#2ADB5C', ollama: '#888888',
     default: '#6ab4f0'
   };

--- a/src/shared/clientTracking.js
+++ b/src/shared/clientTracking.js
@@ -5,7 +5,7 @@
 // `claude` client. tokscale 4.0.5 fixed the scan path but does not dedup imports, and
 // the imported rows aren't cleanly separable (MiMo is multi-model). It stays a known
 // client — one click to enable in Settings → tools — until tokscale dedups upstream.
-const DEFAULT_CLIENTS = 'claude,codex,hermes,opencode,openclaw,cursor,antigravity,cline,kimi,qwen,grok,copilot,pi,zed,kilocode,zcode,kiro,codebuddy,workbuddy,proma';
+const DEFAULT_CLIENTS = 'claude,codex,hermes,opencode,openclaw,cursor,antigravity,cline,kimi,qwen,grok,copilot,pi,zed,kilocode,zcode,kiro,codebuddy,workbuddy,proma,trae';
 
 // Every wired client id, including opt-in ones kept out of DEFAULT_CLIENTS (micode).
 // Display-preference normalization (hide/pin/reorder) keys off this list, so an opt-in

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -21,6 +21,7 @@ const cursorAuth = require('./cursorAuth');
 const { findSessionFiles, codexSessionFile } = require('./sessionFiles');
 const opencodeSession = require('./opencodeSession');
 const { buildPromaHistoryGraph, buildPromaPeriods, collectPromaRows } = require('./promaUsage');
+const { buildTraePeriods, buildTraeHistoryGraph, collectTraeRows, traeDbPath } = require('./traeUsage');
 const { hashKey } = require('./hashKey');
 const { hostOsInfo, normalizeOsInfo } = require('./osVersion');
 
@@ -567,6 +568,10 @@ async function collectHistoryOnce(options) {
     rawGraphs.push(options.promaGraph);
     histories.push(normalizeHistory(parseGraphResult(options.promaGraph), { capDays, todayKey }));
   }
+  if (options.traeGraph) {
+    rawGraphs.push(options.traeGraph);
+    histories.push(normalizeHistory(parseGraphResult(options.traeGraph), { capDays, todayKey }));
+  }
   if (options.dailyHistoryArchiveEnabled) {
     try {
       const retainedGraph = retainDailyHistory(rawGraphs, {
@@ -621,11 +626,12 @@ async function collectUsageOnce(options) {
     options.homeDir || os.homedir(),
     { ...localSessionMetadataDeps, retryMisses, resolveProjects: projectsEnabled }
   );
-  // tokscale doesn't know about Proma yet — filter it out of the subprocess
-  // calls so --client doesn't reject an unknown value. Proma is parsed
-  // separately below and merged back in.
-  const tokscaleClients = normalizedClients ? normalizedClients.split(',').filter((c) => c !== 'proma').join(',') : normalizedClients;
+  // tokscale doesn't know about Proma or Trae yet — filter them out of the
+  // subprocess calls so --client doesn't reject an unknown value. They are
+  // parsed separately below and merged back in.
+  const tokscaleClients = normalizedClients ? normalizedClients.split(',').filter((c) => c !== 'proma' && c !== 'trae').join(',') : normalizedClients;
   const includesProma = normalizedClients.split(',').includes('proma');
+  const includesTrae = normalizedClients.split(',').includes('trae');
   let today = emptyPeriod();
   let month = emptyPeriod();
   let allTime = emptyPeriod();
@@ -634,6 +640,7 @@ async function collectUsageOnce(options) {
   let promaPeriods = null;
   let promaRows = null;
   let promaPricing = null;
+  let traePeriods = null;
   if (normalizedClients) {
     await maybeSyncCursor(tokscaleClients, options.logger);
     await maybeSyncAntigravity(tokscaleClients, options.logger, options.homeDir || os.homedir());
@@ -655,6 +662,18 @@ async function collectUsageOnce(options) {
         if (typeof options.logger === 'function') options.logger(`proma parse failed: ${err.message}`);
       }
     }
+    if (includesTrae) {
+      try {
+        const traeJson = buildTraePeriods({ now: collectedAt, allTimeSince, sharedDataDir: sharedDataDir() });
+        traePeriods = {
+          today: extractUsageFromTokscale(traeJson.today),
+          month: extractUsageFromTokscale(traeJson.month),
+          allTime: extractUsageFromTokscale(traeJson.allTime)
+        };
+      } catch (err) {
+        if (typeof options.logger === 'function') options.logger(`trae parse failed: ${err.message}`);
+      }
+    }
     if (anchorUsed) {
       // Anchored tick (watch-triggered): every tokscale period scan costs the
       // same full load + filter, so scan only --today and update the broader
@@ -667,6 +686,7 @@ async function collectUsageOnce(options) {
       // locally parsed Proma. Include its fresh today usage before deriving
       // broader windows so base + (fresh today - anchor today) stays exact.
       if (promaPeriods) today = mergePeriods(today, promaPeriods.today);
+      if (traePeriods) today = mergePeriods(today, traePeriods.today);
       month = applyPeriodDelta(anchor.month, today, anchor.today);
       allTime = applyPeriodDelta(anchor.allTime, today, anchor.today);
     } else if (tokscaleClients) {
@@ -703,6 +723,11 @@ async function collectUsageOnce(options) {
       today = mergePeriods(today, promaPeriods.today);
       month = mergePeriods(month, promaPeriods.month);
       allTime = mergePeriods(allTime, promaPeriods.allTime);
+    }
+    if (traePeriods && !anchorUsed) {
+      today = mergePeriods(today, traePeriods.today);
+      month = mergePeriods(month, traePeriods.month);
+      allTime = mergePeriods(allTime, traePeriods.allTime);
     }
   }
 
@@ -820,6 +845,7 @@ async function collectUsageOnce(options) {
     const history = await collectHistoryOnce({
       clients: tokscaleClients,
       promaGraph: includesProma ? buildPromaHistoryGraph({ rows: promaRows || collectPromaRows(), pricingByModel: promaPricing || {} }) : null,
+      traeGraph: includesTrae ? buildTraeHistoryGraph({ sharedDataDir: sharedDataDir() }) : null,
       historyEnabled: options.historyEnabled,
       commandTimeoutMs: options.historyTimeoutMs,
       capDays: options.historyCapDays,
@@ -928,6 +954,15 @@ function clientWatchCandidates(clientsCsv) {
   add('workbuddy', path.join(home, '.workbuddy', 'projects'));
   // Proma — session transcripts at ~/.proma/agent-sessions/*.jsonl
   add('proma', path.join(home, '.proma', 'agent-sessions'));
+  // Trae Work (TRAE SOLO CN / Trae CN) — SQLCipher database
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA || path.join(home, 'AppData', 'Roaming');
+    add('trae', path.join(appData, 'TRAE SOLO CN', 'ModularData', 'ai-agent'), path.join(appData, 'Trae CN', 'ModularData', 'ai-agent'));
+  } else if (process.platform === 'darwin') {
+    add('trae', path.join(home, 'Library', 'Application Support', 'TRAE SOLO CN', 'ModularData', 'ai-agent'), path.join(home, 'Library', 'Application Support', 'Trae CN', 'ModularData', 'ai-agent'));
+  } else {
+    add('trae', path.join(home, '.config', 'TRAE SOLO CN', 'ModularData', 'ai-agent'), path.join(home, '.config', 'Trae CN', 'ModularData', 'ai-agent'));
+  }
   // Kiro (AWS): tokscale reads home-relative roots — the sessions tree used by
   // both CLI and IDE, the Kiro IDE globalStorage root (native macOS / Linux /
   // Windows), and the kiro-cli sqlite dir. None falls back to a host-absolute

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -21,7 +21,7 @@ const cursorAuth = require('./cursorAuth');
 const { findSessionFiles, codexSessionFile } = require('./sessionFiles');
 const opencodeSession = require('./opencodeSession');
 const { buildPromaHistoryGraph, buildPromaPeriods, collectPromaRows } = require('./promaUsage');
-const { buildTraePeriods, buildTraeHistoryGraph } = require('./traeUsage');
+const { buildTraePeriods, buildTraeHistoryGraph, collectTraeRows } = require('./traeUsage');
 const { hashKey } = require('./hashKey');
 const { hostOsInfo, normalizeOsInfo } = require('./osVersion');
 
@@ -641,6 +641,7 @@ async function collectUsageOnce(options) {
   let promaRows = null;
   let promaPricing = null;
   let traePeriods = null;
+  let traeRows = null;
   if (normalizedClients) {
     await maybeSyncCursor(tokscaleClients, options.logger);
     await maybeSyncAntigravity(tokscaleClients, options.logger, options.homeDir || os.homedir());
@@ -664,7 +665,10 @@ async function collectUsageOnce(options) {
     }
     if (includesTrae) {
       try {
-        const traeJson = buildTraePeriods({ now: collectedAt, allTimeSince, sharedDataDir: sharedDataDir() });
+        // Collect once; periods and the history graph both derive from this
+        // shared snapshot (one decrypt + query instead of four).
+        traeRows = collectTraeRows({ sharedDataDir: sharedDataDir(), logger: options.logger });
+        const traeJson = buildTraePeriods({ now: collectedAt, allTimeSince, rows: traeRows });
         traePeriods = {
           today: extractUsageFromTokscale(traeJson.today),
           month: extractUsageFromTokscale(traeJson.month),
@@ -845,7 +849,7 @@ async function collectUsageOnce(options) {
     const history = await collectHistoryOnce({
       clients: tokscaleClients,
       promaGraph: includesProma ? buildPromaHistoryGraph({ rows: promaRows || collectPromaRows(), pricingByModel: promaPricing || {} }) : null,
-      traeGraph: includesTrae ? buildTraeHistoryGraph({ sharedDataDir: sharedDataDir() }) : null,
+      traeGraph: includesTrae ? buildTraeHistoryGraph({ rows: traeRows || collectTraeRows({ sharedDataDir: sharedDataDir() }) }) : null,
       historyEnabled: options.historyEnabled,
       commandTimeoutMs: options.historyTimeoutMs,
       capDays: options.historyCapDays,

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -21,7 +21,7 @@ const cursorAuth = require('./cursorAuth');
 const { findSessionFiles, codexSessionFile } = require('./sessionFiles');
 const opencodeSession = require('./opencodeSession');
 const { buildPromaHistoryGraph, buildPromaPeriods, collectPromaRows } = require('./promaUsage');
-const { buildTraePeriods, buildTraeHistoryGraph, collectTraeRows, traeDbPath } = require('./traeUsage');
+const { buildTraePeriods, buildTraeHistoryGraph } = require('./traeUsage');
 const { hashKey } = require('./hashKey');
 const { hostOsInfo, normalizeOsInfo } = require('./osVersion');
 

--- a/src/shared/traeUsage.js
+++ b/src/shared/traeUsage.js
@@ -28,7 +28,6 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
-const { createHash } = require('node:crypto');
 
 // ---------------------------------------------------------------------------
 // Database path resolution

--- a/src/shared/traeUsage.js
+++ b/src/shared/traeUsage.js
@@ -105,7 +105,10 @@ function queryViaSqlcipherCli(dbPath, key, sql) {
     sql
   ].join('\n');
   try {
-    const stdout = execFileSync('sqlcipher', [dbPath, commands], {
+    // SQL is fed through stdin so the key never appears in the process
+    // argument list (visible to other local users via ps/tasklist).
+    const stdout = execFileSync('sqlcipher', [dbPath], {
+      input: commands,
       encoding: 'utf8',
       timeout: 30000,
       windowsHide: true,
@@ -205,8 +208,14 @@ function collectTraeRows(options = {}) {
   const key = options.key || resolveTraeKey(options.sharedDataDir);
   if (!key) return [];
 
-  const rows = queryHistoryRows(dbPath, key, 0);
-  if (!rows || !Array.isArray(rows)) return [];
+  const sinceTimestamp = options.sinceTimestamp || 0;
+  const rows = queryHistoryRows(dbPath, key, sinceTimestamp);
+  if (!rows || !Array.isArray(rows)) {
+    if (typeof options.logger === 'function') {
+      options.logger('trae: unable to query database — requires a SQLCipher-capable backend (better-sqlite3 built with cipher support, or the sqlcipher CLI on PATH); check that the configured key is correct');
+    }
+    return [];
+  }
 
   const result = [];
   for (const row of rows) {
@@ -235,53 +244,34 @@ function collectTraeRows(options = {}) {
 // Tokscale-compatible output
 // ---------------------------------------------------------------------------
 
-function buildTokscaleJson(windows = {}, options = {}) {
-  const sinceMs = Math.max(
-    0,
-    Number(windows.todayStart || 0),
-    Number(windows.monthStart || 0),
-    Number(windows.allTimeSince || 0)
-  );
-  const sinceTimestamp = sinceMs ? Math.floor(sinceMs / 1000) : 0;
-
-  const dbPath = options.dbPath || traeDbPath();
-  if (!dbPath) return emptyTokscaleJson();
-
-  const key = options.key || resolveTraeKey(options.sharedDataDir);
-  if (!key) return emptyTokscaleJson();
-
-  const rows = queryHistoryRows(dbPath, key, sinceTimestamp);
-  if (!rows || !Array.isArray(rows)) return emptyTokscaleJson();
-
-  // Aggregate by session + model
+/**
+ * Aggregate pre-parsed usage rows (from collectTraeRows) into a
+ * tokscale-compatible JSON payload, counting only rows at or after sinceMs.
+ */
+function aggregateParsedRows(parsedRows, sinceMs = 0) {
   const bySessionModel = new Map();
   let allInput = 0, allOutput = 0, allMessages = 0;
 
-  for (const row of rows) {
-    const output = numberValue(row.token_usage);
-    if (!output) continue;
-
-    const { model, inputToken } = extractModelFromMessages(row.messages);
-    const createdAt = numberValue(row.created_at) * 1000;
-    const sessionId = String(row.session_id || 'unknown');
-    const mapKey = `${sessionId}\u0000${model}`;
+  for (const row of parsedRows) {
+    if (sinceMs && row.createdAt < sinceMs) continue;
+    const mapKey = `${row.sessionId}\u0000${row.model}`;
 
     if (!bySessionModel.has(mapKey)) {
       bySessionModel.set(mapKey, {
-        sessionId, model, input: 0, output: 0, cacheRead: 0, cacheWrite: 0,
-        messages: 0, cost: 0, startedAt: 0, lastUsedAt: 0
+        sessionId: row.sessionId, model: row.model, input: 0, output: 0,
+        cacheRead: 0, cacheWrite: 0, messages: 0, startedAt: 0, lastUsedAt: 0
       });
     }
     const m = bySessionModel.get(mapKey);
-    m.input += inputToken;
-    m.output += output;
-    m.messages += 1;
-    if (createdAt && (!m.startedAt || createdAt < m.startedAt)) m.startedAt = createdAt;
-    if (createdAt > m.lastUsedAt) m.lastUsedAt = createdAt;
+    m.input += row.input;
+    m.output += row.output;
+    m.messages += row.messages;
+    if (row.createdAt && (!m.startedAt || row.createdAt < m.startedAt)) m.startedAt = row.createdAt;
+    if (row.createdAt > m.lastUsedAt) m.lastUsedAt = row.createdAt;
 
-    allInput += inputToken;
-    allOutput += output;
-    allMessages += 1;
+    allInput += row.input;
+    allOutput += row.output;
+    allMessages += row.messages;
   }
 
   const entries = [];
@@ -318,6 +308,19 @@ function buildTokscaleJson(windows = {}, options = {}) {
   };
 }
 
+function buildTokscaleJson(windows = {}, options = {}) {
+  const sinceMs = Math.max(
+    0,
+    Number(windows.todayStart || 0),
+    Number(windows.monthStart || 0),
+    Number(windows.allTimeSince || 0)
+  );
+
+  const rows = Array.isArray(options.rows) ? options.rows : collectTraeRows(options);
+  if (!rows.length) return emptyTokscaleJson();
+  return aggregateParsedRows(rows, sinceMs);
+}
+
 function emptyTokscaleJson() {
   return {
     groupBy: 'client,session,model',
@@ -341,10 +344,15 @@ function buildTraePeriods(options = {}) {
   const monthStart = new Date(now.getFullYear(), now.getMonth(), 1, 0, 0, 0, 0).getTime();
   const allTimeSince = options.allTimeSince ? new Date(options.allTimeSince).getTime() : 0;
 
+  // Load and decrypt the database exactly once; every window below is an
+  // in-memory filter of the same snapshot, so periods never disagree
+  // mid-collection and large databases are not re-decrypted per window.
+  const rows = Array.isArray(options.rows) ? options.rows : collectTraeRows(options);
+
   return {
-    today: buildTokscaleJson({ todayStart }, options),
-    month: buildTokscaleJson({ monthStart }, options),
-    allTime: buildTokscaleJson({ allTimeSince }, options)
+    today: aggregateParsedRows(rows, todayStart),
+    month: aggregateParsedRows(rows, monthStart),
+    allTime: aggregateParsedRows(rows, allTimeSince)
   };
 }
 

--- a/src/shared/traeUsage.js
+++ b/src/shared/traeUsage.js
@@ -1,0 +1,418 @@
+'use strict';
+
+/**
+ * Trae Work (TRAE SOLO CN / Trae CN) usage parser.
+ *
+ * Reads token usage from the SQLCipher-encrypted local database at:
+ *   %APPDATA%/TRAE SOLO CN/ModularData/ai-agent/database.db  (Windows)
+ *   ~/Library/Application Support/TRAE SOLO CN/ModularData/ai-agent/database.db  (macOS)
+ *   ~/.config/TRAE SOLO CN/ModularData/ai-agent/database.db  (Linux)
+ *
+ * The database is SQLCipher 4 encrypted. The raw key (64-char hex) must be
+ * provided via one of:
+ *   1. TOKEN_MONITOR_TRAE_KEY environment variable
+ *   2. A trae-key.json file in the shared data dir ({ "key": "<64hex>" })
+ *   3. The scripts/extract-trae-key.py helper (Windows, writes trae-key.json)
+ *
+ * Token data lives in the `history_v2` table:
+ *   - token_usage: per-turn output token count (plain integer)
+ *   - messages JSON → raw_messages[].extra_info.model: model identifier
+ *   - messages JSON → raw_messages[].extra_info.input_token: input tokens
+ *   - session_id: links to chat_session for titles
+ *   - created_at: unix timestamp (seconds)
+ *
+ * Returns data shaped like a tokscale JSON response so it can be fed
+ * directly into extractUsageFromTokscale or merged alongside tokscale results.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { createHash } = require('node:crypto');
+
+// ---------------------------------------------------------------------------
+// Database path resolution
+// ---------------------------------------------------------------------------
+
+function traeDataRoots() {
+  const home = os.homedir();
+  const roots = [];
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA || path.join(home, 'AppData', 'Roaming');
+    roots.push(path.join(appData, 'TRAE SOLO CN', 'ModularData', 'ai-agent'));
+    roots.push(path.join(appData, 'Trae CN', 'ModularData', 'ai-agent'));
+  } else if (process.platform === 'darwin') {
+    roots.push(path.join(home, 'Library', 'Application Support', 'TRAE SOLO CN', 'ModularData', 'ai-agent'));
+    roots.push(path.join(home, 'Library', 'Application Support', 'Trae CN', 'ModularData', 'ai-agent'));
+  } else {
+    roots.push(path.join(home, '.config', 'TRAE SOLO CN', 'ModularData', 'ai-agent'));
+    roots.push(path.join(home, '.config', 'Trae CN', 'ModularData', 'ai-agent'));
+  }
+  return roots;
+}
+
+function traeDbPath() {
+  for (const root of traeDataRoots()) {
+    const dbFile = path.join(root, 'database.db');
+    try {
+      if (fs.existsSync(dbFile) && fs.statSync(dbFile).isFile()) return dbFile;
+    } catch (_) {}
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Key resolution
+// ---------------------------------------------------------------------------
+
+function resolveTraeKey(sharedDataDir) {
+  // 1. Environment variable
+  const envKey = (process.env.TOKEN_MONITOR_TRAE_KEY || '').trim();
+  if (/^[0-9a-fA-F]{64}$/.test(envKey)) return envKey.toLowerCase();
+
+  // 2. trae-key.json in shared data dir
+  if (sharedDataDir) {
+    try {
+      const keyFile = path.join(sharedDataDir, 'trae-key.json');
+      const data = JSON.parse(fs.readFileSync(keyFile, 'utf8'));
+      const key = String(data.key || data.enc_key || '').trim();
+      if (/^[0-9a-fA-F]{64}$/.test(key)) return key.toLowerCase();
+    } catch (_) {}
+  }
+
+  // 3. trae-key.json next to the database
+  const dbPath = traeDbPath();
+  if (dbPath) {
+    try {
+      const keyFile = path.join(path.dirname(dbPath), 'trae-key.json');
+      const data = JSON.parse(fs.readFileSync(keyFile, 'utf8'));
+      const key = String(data.key || data.enc_key || '').trim();
+      if (/^[0-9a-fA-F]{64}$/.test(key)) return key.toLowerCase();
+    } catch (_) {}
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Database reading (via sqlcipher CLI or better-sqlite3)
+// ---------------------------------------------------------------------------
+
+function queryViaSqlcipherCli(dbPath, key, sql) {
+  const { execFileSync } = require('node:child_process');
+  const commands = [
+    `PRAGMA key = "x'${key}'";`,
+    'PRAGMA cipher_compatibility = 4;',
+    sql
+  ].join('\n');
+  try {
+    const stdout = execFileSync('sqlcipher', [dbPath, commands], {
+      encoding: 'utf8',
+      timeout: 30000,
+      windowsHide: true,
+      maxBuffer: 64 * 1024 * 1024
+    });
+    return stdout;
+  } catch (_) {
+    return null;
+  }
+}
+
+function queryViaBetterSqlite(dbPath, key, sql) {
+  try {
+    const Database = require('better-sqlite3');
+    const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+    db.pragma(`key = "x'${key}'"`);
+    db.pragma('cipher_compatibility = 4');
+    const rows = db.prepare(sql).all();
+    db.close();
+    return rows;
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Query history_v2 rows from the Trae database.
+ * Returns an array of { token_usage, messages, session_id, created_at } or null.
+ */
+function queryHistoryRows(dbPath, key, sinceTimestamp) {
+  const sinceClause = sinceTimestamp ? `AND created_at >= ${sinceTimestamp}` : '';
+  const sql = `SELECT token_usage, messages, session_id, created_at FROM history_v2 WHERE token_usage IS NOT NULL AND token_usage != '' AND token_usage != '0' ${sinceClause}`;
+
+  // Try better-sqlite3 first (programmatic, faster for large result sets)
+  const rows = queryViaBetterSqlite(dbPath, key, sql);
+  if (rows) return rows;
+
+  // Fallback: sqlcipher CLI (parse CSV-like output)
+  const csvSql = `.mode json\n${sql};`;
+  const output = queryViaSqlcipherCli(dbPath, key, csvSql);
+  if (output) {
+    try {
+      return JSON.parse(output);
+    } catch (_) {
+      // Try line-by-line JSON
+      return output.trim().split('\n').filter(Boolean).map((line) => {
+        try { return JSON.parse(line); } catch (_e) { return null; }
+      }).filter(Boolean);
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Row parsing
+// ---------------------------------------------------------------------------
+
+function numberValue(value) {
+  const n = Number(value || 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function extractModelFromMessages(messagesRaw) {
+  if (!messagesRaw) return { model: 'unknown', inputToken: 0 };
+  try {
+    const parsed = typeof messagesRaw === 'string' ? JSON.parse(messagesRaw) : messagesRaw;
+    const rawMsgs = parsed?.raw_messages || parsed?.messages || [];
+    for (const msg of rawMsgs) {
+      if (msg && msg.role === 'assistant' && msg.extra_info) {
+        let extra = msg.extra_info;
+        if (typeof extra === 'string') {
+          try { extra = JSON.parse(extra); } catch (_) { continue; }
+        }
+        if (extra && typeof extra === 'object' && extra.model) {
+          return { model: String(extra.model), inputToken: numberValue(extra.input_token) };
+        }
+      }
+    }
+  } catch (_) {}
+  return { model: 'unknown', inputToken: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Collection
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect all usage rows from the Trae database.
+ * @param {{ sharedDataDir?: string, dbPath?: string, key?: string }} options
+ * @returns {Array<{ sessionId: string, model: string, input: number, output: number, cacheRead: number, cacheWrite: number, messages: number, createdAt: number }>}
+ */
+function collectTraeRows(options = {}) {
+  const dbPath = options.dbPath || traeDbPath();
+  if (!dbPath) return [];
+
+  const key = options.key || resolveTraeKey(options.sharedDataDir);
+  if (!key) return [];
+
+  const rows = queryHistoryRows(dbPath, key, 0);
+  if (!rows || !Array.isArray(rows)) return [];
+
+  const result = [];
+  for (const row of rows) {
+    const output = numberValue(row.token_usage);
+    if (!output) continue;
+
+    const { model, inputToken } = extractModelFromMessages(row.messages);
+    const createdAt = numberValue(row.created_at) * 1000; // seconds → ms
+    const sessionId = String(row.session_id || 'unknown');
+
+    result.push({
+      sessionId,
+      model,
+      input: inputToken,
+      output,
+      cacheRead: 0,
+      cacheWrite: 0,
+      messages: 1,
+      createdAt
+    });
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Tokscale-compatible output
+// ---------------------------------------------------------------------------
+
+function buildTokscaleJson(windows = {}, options = {}) {
+  const sinceMs = Math.max(
+    0,
+    Number(windows.todayStart || 0),
+    Number(windows.monthStart || 0),
+    Number(windows.allTimeSince || 0)
+  );
+  const sinceTimestamp = sinceMs ? Math.floor(sinceMs / 1000) : 0;
+
+  const dbPath = options.dbPath || traeDbPath();
+  if (!dbPath) return emptyTokscaleJson();
+
+  const key = options.key || resolveTraeKey(options.sharedDataDir);
+  if (!key) return emptyTokscaleJson();
+
+  const rows = queryHistoryRows(dbPath, key, sinceTimestamp);
+  if (!rows || !Array.isArray(rows)) return emptyTokscaleJson();
+
+  // Aggregate by session + model
+  const bySessionModel = new Map();
+  let allInput = 0, allOutput = 0, allMessages = 0;
+
+  for (const row of rows) {
+    const output = numberValue(row.token_usage);
+    if (!output) continue;
+
+    const { model, inputToken } = extractModelFromMessages(row.messages);
+    const createdAt = numberValue(row.created_at) * 1000;
+    const sessionId = String(row.session_id || 'unknown');
+    const mapKey = `${sessionId}\u0000${model}`;
+
+    if (!bySessionModel.has(mapKey)) {
+      bySessionModel.set(mapKey, {
+        sessionId, model, input: 0, output: 0, cacheRead: 0, cacheWrite: 0,
+        messages: 0, cost: 0, startedAt: 0, lastUsedAt: 0
+      });
+    }
+    const m = bySessionModel.get(mapKey);
+    m.input += inputToken;
+    m.output += output;
+    m.messages += 1;
+    if (createdAt && (!m.startedAt || createdAt < m.startedAt)) m.startedAt = createdAt;
+    if (createdAt > m.lastUsedAt) m.lastUsedAt = createdAt;
+
+    allInput += inputToken;
+    allOutput += output;
+    allMessages += 1;
+  }
+
+  const entries = [];
+  for (const m of bySessionModel.values()) {
+    entries.push({
+      client: 'trae',
+      mergedClients: null,
+      sessionId: m.sessionId,
+      model: m.model,
+      provider: 'trae',
+      input: m.input,
+      output: m.output,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      messageCount: m.messages,
+      cost: 0,
+      startedAt: m.startedAt ? new Date(m.startedAt).toISOString() : '',
+      lastUsedAt: m.lastUsedAt ? new Date(m.lastUsedAt).toISOString() : '',
+      performance: null
+    });
+  }
+
+  return {
+    groupBy: 'client,session,model',
+    entries,
+    totalInput: allInput,
+    totalOutput: allOutput,
+    totalCacheRead: 0,
+    totalCacheWrite: 0,
+    totalMessages: allMessages,
+    totalCost: 0,
+    processingTimeMs: 0
+  };
+}
+
+function emptyTokscaleJson() {
+  return {
+    groupBy: 'client,session,model',
+    entries: [],
+    totalInput: 0,
+    totalOutput: 0,
+    totalCacheRead: 0,
+    totalCacheWrite: 0,
+    totalMessages: 0,
+    totalCost: 0,
+    processingTimeMs: 0
+  };
+}
+
+/**
+ * Build today / month / allTime periods from the Trae database.
+ */
+function buildTraePeriods(options = {}) {
+  const now = options.now ? new Date(options.now) : new Date();
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0).getTime();
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1, 0, 0, 0, 0).getTime();
+  const allTimeSince = options.allTimeSince ? new Date(options.allTimeSince).getTime() : 0;
+
+  return {
+    today: buildTokscaleJson({ todayStart }, options),
+    month: buildTokscaleJson({ monthStart }, options),
+    allTime: buildTokscaleJson({ allTimeSince }, options)
+  };
+}
+
+// ---------------------------------------------------------------------------
+// History graph (for trends dashboard)
+// ---------------------------------------------------------------------------
+
+function localDateKey(timestamp) {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '';
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function buildTraeHistoryGraph(options = {}) {
+  const rows = Array.isArray(options.rows) ? options.rows : collectTraeRows(options);
+  const byDate = new Map();
+
+  for (const row of rows) {
+    const date = row.createdAt ? localDateKey(row.createdAt) : '';
+    if (!date) continue;
+    let day = byDate.get(date);
+    if (!day) {
+      day = { date, clients: [] };
+      byDate.set(date, day);
+    }
+    const modelId = String(row.model || 'unknown').trim().toLowerCase() || 'unknown';
+    let client = day.clients.find((entry) => entry.modelId === modelId);
+    if (!client) {
+      client = {
+        client: 'trae',
+        modelId,
+        tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+        cost: 0,
+        messages: 0
+      };
+      day.clients.push(client);
+    }
+    client.tokens.input += row.input;
+    client.tokens.output += row.output;
+    client.messages += 1;
+  }
+
+  return { contributions: [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date)) };
+}
+
+// ---------------------------------------------------------------------------
+// Availability check
+// ---------------------------------------------------------------------------
+
+function isTraeAvailable(options = {}) {
+  const dbPath = options.dbPath || traeDbPath();
+  if (!dbPath) return { available: false, reason: 'database not found' };
+  const key = options.key || resolveTraeKey(options.sharedDataDir);
+  if (!key) return { available: false, reason: 'key not configured' };
+  return { available: true, dbPath };
+}
+
+module.exports = {
+  traeDataRoots,
+  traeDbPath,
+  resolveTraeKey,
+  collectTraeRows,
+  buildTokscaleJson,
+  buildTraePeriods,
+  buildTraeHistoryGraph,
+  isTraeAvailable
+};

--- a/src/shared/usage.js
+++ b/src/shared/usage.js
@@ -133,6 +133,7 @@ function normalizeClientName(value) {
   if (raw.includes('codebuddy')) return 'codebuddy';
   if (raw.includes('workbuddy')) return 'workbuddy';
   if (raw.includes('proma')) return 'proma';
+  if (raw.includes('trae')) return 'trae';
   if (raw.includes('opencode')) return 'opencode';
   if (raw.includes('openclaw') || raw.includes('clawd') || raw.includes('moltbot') || raw.includes('moldbot')) return 'openclaw';
   return raw.replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '') || null;

--- a/tests/shared/clientTracking.test.js
+++ b/tests/shared/clientTracking.test.js
@@ -42,7 +42,7 @@ test('KNOWN_CLIENTS is a superset of DEFAULT_CLIENTS and still includes opt-in m
 });
 
 test('default tracked clients are accepted by bundled tokscale', () => {
-  const locallyParsedClients = new Set(['proma']);
+  const locallyParsedClients = new Set(['proma', 'trae']);
   const result = spawnSync(process.execPath, [require.resolve('tokscale/bin.js'), '--help'], { encoding: 'utf8' });
   assert.equal(result.status, 0, result.stderr || result.stdout);
   const help = `${result.stdout || ''}\n${result.stderr || ''}`;

--- a/worker/src/shared/usage.js
+++ b/worker/src/shared/usage.js
@@ -136,6 +136,7 @@ function normalizeClientName(value) {
   if (raw.includes('codebuddy')) return 'codebuddy';
   if (raw.includes('workbuddy')) return 'workbuddy';
   if (raw.includes('proma')) return 'proma';
+  if (raw.includes('trae')) return 'trae';
   if (raw.includes('opencode')) return 'opencode';
   if (raw.includes('openclaw') || raw.includes('clawd') || raw.includes('moltbot') || raw.includes('moldbot')) return 'openclaw';
   return raw.replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '') || null;


### PR DESCRIPTION
## Summary

Add support for collecting token usage data from **Trae Work** (TRAE SOLO CN), a Rust-based AI coding assistant that stores session data in a SQLCipher 4 encrypted database.

## How it works

Trae Work stores its data in an encrypted SQLCipher database at:
- Windows: `%APPDATA%\TRAE SOLO CN\ModularData\ai-agent\database.db`

Since the database is encrypted, users need to provide the raw key (64-char hex) via one of:
1. Environment variable: `TOKEN_MONITOR_TRAE_KEY`
2. Key file: `trae-key.json` in the app data directory

A helper script `scripts/extract-trae-key.py` is included to extract the key from process memory (Windows, requires admin).

## Changes

- **`src/shared/traeUsage.js`** (new): Core module - resolves key, reads SQLCipher DB, builds tokscale-compatible JSON
- **`scripts/extract-trae-key.py`** (new): Windows memory scanner to extract SQLCipher key from ai_agent.dll process
- **`src/shared/collector.js`**: Integrate trae collection (watch paths, period merging, history graph)
- **`src/shared/clientTracking.js`**: Add `trae` to DEFAULT_CLIENTS
- **`src/shared/usage.js`**: Add trae normalization rule
- **`src/electron/renderer/app.js`**: Add trae to UI labels and known clients
- **`src/electron/renderer/usageCharts.js`**: Add trae chart color
- **`src/electron/discordRpc.js`**: Add trae to known client assets
- **`.env.example`**: Document TOKEN_MONITOR_TRAE_KEY
- **`tests/shared/clientTracking.test.js`**: Include trae in locally parsed clients

## Database schema notes

- `history_v2` table: `token_usage` column contains a plain integer (output tokens per turn)
- Model info is in `messages` JSON column: `raw_messages[].extra_info.model`
- `server_history_info` table: session metadata (title, timestamps)

## Testing

Tested locally against a real Trae Work database (~615MB, 18k+ records, 101 sessions, 26 models).

## Notes

- Uses `better-sqlite3` with SQLCipher extension if available, falls back to `sqlcipher` CLI
- No keys or sensitive data are hardcoded; all credentials come from user configuration

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Trae Work (TRAE SOLO CN) usage collection by decrypting its SQLCipher DB and merging results into totals and history. Improves security (stdin key, atomic key writes) and performance (single-pass DB read), with full UI integration.

- **New Features**
  - `src/shared/traeUsage.js`: reads encrypted DB via `better-sqlite3` (SQLCipher) or `sqlcipher` CLI; feeds key via stdin; single-pass decrypt/query; emits `tokscale`-compatible periods and history; warns if no SQLCipher backend.
  - Collector: filters `proma`/`trae` from `tokscale` calls; shares Trae rows between periods and history; adds watch paths; merges usage into today/month/all-time.
  - UI: adds Trae labels, chart color, theme vendor order/labels, and Discord label/asset.
  - Config/tests/worker: `.env.example` documents `TOKEN_MONITOR_TRAE_KEY`; adds `trae` to default/known clients; tests updated; `normalizeClientName` recognizes `trae`.

- **Migration**
  - Provide the 64-char key via `TOKEN_MONITOR_TRAE_KEY` or a `trae-key.json` file in the shared data dir or next to the DB.
  - On Windows, run `python scripts/extract-trae-key.py` (admin, Trae running). The script now validates the key by opening the DB and writes `trae-key.json` atomically.

<sup>Written for commit 83bbb00ac688e5f4aa3ef8fbfa1c2e03efe62f37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

