### PR TITLE
fix(home): clarify compact Antigravity limits

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -3603,7 +3603,10 @@ function homeLimitRows() {
   const providerOptions = limitProviderOrderApi.orderedLimitProviders(LIMIT_PROVIDERS, providerOrder);
   const hasConfiguredOrder = Boolean(state.settings?.homeLimitProviderOrder);
   return homeOverviewApi.homeLimitAccountsForProviders({
-    providers: state.stats?.limits?.providers || [],
+    providers: (state.stats?.limits?.providers || []).map((provider) => ({
+      ...provider,
+      windows: limitProviderPresentationApi.limitProviderCompactWindows(provider, provider.windows)
+    })),
     providerOptions,
     enabledProviderIds: Array.from(enabled),
     hiddenProviderIds: Array.from(hiddenHomeLimitProviderSet()),
@@ -3618,7 +3621,9 @@ function homeLimitRows() {
   });
 }
 
-function homeLimitWindowLabel(window) {
+function homeLimitWindowLabel(window, providerId = '', visibleWindows = []) {
+  const compactLabel = limitProviderPresentationApi.limitProviderCompactWindowLabel(providerId, window, visibleWindows);
+  if (compactLabel) return compactLabel;
   if (window?.kind === 'billing') {
     const label = String(window?.label || '').trim();
     if (label) return label;
@@ -3664,7 +3669,7 @@ function renderHomeLimitModule() {
       line.className = 'home-limit-window-line';
       const label = document.createElement('span');
       label.className = 'home-limit-window-label';
-      label.textContent = homeLimitWindowLabel(window);
+      label.textContent = homeLimitWindowLabel(window, row.providerId, row.windows);
       const value = document.createElement('span');
       value.className = 'home-list-value';
       const showUsed = Boolean(state.settings?.showLimitUsed);
@@ -3683,11 +3688,13 @@ function renderHomeLimitModule() {
       const resetAt = formatReset(window.resetsAt);
       const resetText = document.createElement('span');
       resetText.className = 'home-limit-reset';
-      resetText.textContent = window.resetsAt
+      const resetLabel = window.resetsAt
         ? resetAt || '\u00a0'
         : window.resetDescription
         ? t('home.reset', { value: window.resetDescription })
         : '\u00a0';
+      const periodLabel = limitProviderPresentationApi.limitProviderCompactWindowPeriodLabel(row.providerId, window, row.windows);
+      resetText.textContent = periodLabel && resetLabel !== '\u00a0' ? `${periodLabel} · ${resetLabel}` : resetLabel;
       metric.append(resetText);
       windows.append(metric);
     }

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -1841,12 +1841,8 @@ function antigravityQuotaGroups(provider) {
   const entries = (provider?.windows || [])
     .filter((window) => window.kind === 'session' || window.kind === 'weekly')
     .map((window) => {
-      const windowLabel = window.kind === 'session' ? '5-hour' : 'Weekly';
-      const label = String(window.label || '').trim();
-      const suffix = window.kind === 'session' ? /\s+5-hour$/i : /\s+weekly$/i;
-      if (!suffix.test(label)) return null;
-      const groupLabel = label.replace(suffix, '').trim();
-      return groupLabel ? { groupLabel, windowLabel, window } : null;
+      const presentation = limitProviderPresentationApi.antigravityQuotaWindow(window);
+      return presentation ? { ...presentation, window } : null;
     });
   // Legacy GetUserStatus pools have model names rather than group + period
   // labels. Keep their existing flat layout instead of guessing a hierarchy.

--- a/src/electron/renderer/homeOverview.js
+++ b/src/electron/renderer/homeOverview.js
@@ -96,6 +96,7 @@
   function homeLimitAccounts(accounts, limit = 3, { sort = 'remaining' } = {}) {
     return (accounts || [])
       .map((account, index) => {
+        const providerId = String(account?.providerId || '').trim().toLowerCase();
         const windows = accountWindows(account)
           .map((window, windowIndex) => ({
             kind: String(window.kind || '').trim().toLowerCase(),
@@ -111,6 +112,7 @@
           }))
           .filter((window) => window.remainingPercent != null || window.planStatus === 'expired' || window.value)
           .sort((a, b) => {
+            if (providerId === 'antigravity') return a.index - b.index;
             const aPriority = windowPriority.get(a.kind) ?? 10;
             const bPriority = windowPriority.get(b.kind) ?? 10;
             return aPriority - bPriority || a.index - b.index;

--- a/src/electron/renderer/limitProviderPresentation.js
+++ b/src/electron/renderer/limitProviderPresentation.js
@@ -70,6 +70,7 @@
   const CAPABILITY_STATUS_DUPLICATES = {
     'App/CLI must be open': 'Open app or CLI'
   };
+  const COMPACT_LIMIT_CRITICAL_PERCENT = 20;
 
   function normalizeId(value) {
     return String(value || '').trim().toLowerCase();
@@ -120,6 +121,86 @@
     const label = String(value || '').trim();
     if (!label || label.includes('@')) return label;
     return label.replace(/^[a-z]/, (letter) => letter.toUpperCase());
+  }
+
+  function antigravityGroupLabel(window) {
+    const kind = normalizeId(window?.kind);
+    const suffix = kind === 'session'
+      ? /\s+5-hour$/i
+      : kind === 'weekly'
+        ? /\s+weekly$/i
+        : null;
+    const label = String(window?.label || '').trim();
+    if (!suffix || !suffix.test(label)) return '';
+    return label.replace(suffix, '').trim();
+  }
+
+  function compactWindowRemaining(window) {
+    const rawRemaining = window?.remainingPercent;
+    const remaining = rawRemaining == null || String(rawRemaining).trim() === '' ? null : Number(rawRemaining);
+    if (remaining != null && Number.isFinite(remaining)) return Math.max(0, Math.min(100, remaining));
+    const rawUsed = window?.usedPercent;
+    const used = rawUsed == null || String(rawUsed).trim() === '' ? null : Number(rawUsed);
+    return used != null && Number.isFinite(used)
+      ? Math.max(0, Math.min(100, 100 - used))
+      : Number.POSITIVE_INFINITY;
+  }
+
+  function limitProviderCompactWindows(providerOrId, windows = []) {
+    if (providerId(providerOrId) !== 'antigravity') return windows;
+    const entries = (windows || []).map((window, index) => ({
+      window,
+      index,
+      groupLabel: antigravityGroupLabel(window)
+    }));
+    if (entries.length === 0 || entries.some((entry) => !entry.groupLabel)) return windows;
+    const groups = new Map();
+    for (const entry of entries) {
+      if (!groups.has(entry.groupLabel)) groups.set(entry.groupLabel, []);
+      groups.get(entry.groupLabel).push(entry);
+    }
+    const selected = [...groups.values()].map((groupEntries, groupIndex) => {
+      const tightest = (entries) => entries.slice().sort((a, b) => {
+        const aRemaining = compactWindowRemaining(a.window);
+        const bRemaining = compactWindowRemaining(b.window);
+        if (aRemaining !== bRemaining) return aRemaining - bRemaining;
+        return a.index - b.index;
+      })[0] || null;
+      const session = tightest(groupEntries.filter((entry) => normalizeId(entry.window?.kind) === 'session'));
+      const weekly = tightest(groupEntries.filter((entry) => normalizeId(entry.window?.kind) === 'weekly'));
+      const sessionRemaining = compactWindowRemaining(session?.window);
+      const weeklyRemaining = compactWindowRemaining(weekly?.window);
+      const weeklyIsCritical = weeklyRemaining < COMPACT_LIMIT_CRITICAL_PERCENT;
+      const entry = !session
+        ? weekly
+        : !weekly
+          ? session
+          : weeklyRemaining < sessionRemaining && (weeklyIsCritical || !Number.isFinite(sessionRemaining))
+            ? weekly
+            : session;
+      return { ...entry, groupIndex, remaining: compactWindowRemaining(entry.window) };
+    });
+    return selected
+      .sort((a, b) => a.remaining - b.remaining || a.groupIndex - b.groupIndex)
+      .slice(0, 2)
+      .sort((a, b) => a.groupIndex - b.groupIndex)
+      .map((entry) => entry.window);
+  }
+
+  function limitProviderCompactWindowLabel(providerOrId, window, visibleWindows = []) {
+    if (providerId(providerOrId) !== 'antigravity') return '';
+    const labels = (visibleWindows || []).map(antigravityGroupLabel);
+    const currentLabel = antigravityGroupLabel(window);
+    if (labels.length < 2 || !currentLabel || labels.some((label) => !label)) return '';
+    return new Set(labels).size === labels.length ? currentLabel : '';
+  }
+
+  function limitProviderCompactWindowPeriodLabel(providerOrId, window, visibleWindows = []) {
+    if (!limitProviderCompactWindowLabel(providerOrId, window, visibleWindows)) return '';
+    const kind = normalizeId(window?.kind);
+    if (kind === 'session') return '5-hour';
+    if (kind === 'weekly') return 'Weekly';
+    return '';
   }
 
   function limitResetRemainingMs(value, nowMs = Date.now(), resetNowGraceMs = 60 * 1000) {
@@ -308,6 +389,9 @@
     apiKeyAccountStatus,
     isCodexLiveAccount,
     limitProviderCapabilityTags,
+    limitProviderCompactWindowLabel,
+    limitProviderCompactWindowPeriodLabel,
+    limitProviderCompactWindows,
     limitProviderDisplayLabel,
     limitProviderMainDeviceLabel,
     limitProviderProvenance,

--- a/src/electron/renderer/limitProviderPresentation.js
+++ b/src/electron/renderer/limitProviderPresentation.js
@@ -123,7 +123,7 @@
     return label.replace(/^[a-z]/, (letter) => letter.toUpperCase());
   }
 
-  function antigravityGroupLabel(window) {
+  function antigravityQuotaWindow(window) {
     const kind = normalizeId(window?.kind);
     const suffix = kind === 'session'
       ? /\s+5-hour$/i
@@ -131,8 +131,10 @@
         ? /\s+weekly$/i
         : null;
     const label = String(window?.label || '').trim();
-    if (!suffix || !suffix.test(label)) return '';
-    return label.replace(suffix, '').trim();
+    if (!suffix || !suffix.test(label)) return null;
+    const groupLabel = label.replace(suffix, '').trim();
+    if (!groupLabel) return null;
+    return { groupLabel, windowLabel: kind === 'session' ? '5-hour' : 'Weekly' };
   }
 
   function compactWindowRemaining(window) {
@@ -151,7 +153,7 @@
     const entries = (windows || []).map((window, index) => ({
       window,
       index,
-      groupLabel: antigravityGroupLabel(window)
+      groupLabel: antigravityQuotaWindow(window)?.groupLabel || ''
     }));
     if (entries.length === 0 || entries.some((entry) => !entry.groupLabel)) return windows;
     const groups = new Map();
@@ -189,8 +191,8 @@
 
   function limitProviderCompactWindowLabel(providerOrId, window, visibleWindows = []) {
     if (providerId(providerOrId) !== 'antigravity') return '';
-    const labels = (visibleWindows || []).map(antigravityGroupLabel);
-    const currentLabel = antigravityGroupLabel(window);
+    const labels = (visibleWindows || []).map((candidate) => antigravityQuotaWindow(candidate)?.groupLabel || '');
+    const currentLabel = antigravityQuotaWindow(window)?.groupLabel || '';
     if (labels.length < 2 || !currentLabel || labels.some((label) => !label)) return '';
     return new Set(labels).size === labels.length ? currentLabel : '';
   }
@@ -386,6 +388,7 @@
   }
 
   return {
+    antigravityQuotaWindow,
     apiKeyAccountStatus,
     isCodexLiveAccount,
     limitProviderCapabilityTags,

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -8,6 +8,7 @@ const vm = require('node:vm');
 const accountIdentityApi = require('../../src/electron/renderer/accountIdentity');
 
 const {
+  antigravityQuotaWindow,
   apiKeyAccountStatus,
   isCodexLiveAccount,
   limitProviderDisplayLabel,
@@ -62,6 +63,18 @@ test('compact Antigravity labels distinguish duplicate periods by model group', 
   assert.equal(limitProviderCompactWindowLabel('antigravity', windows[0], windows), 'Gemini');
   assert.equal(limitProviderCompactWindowLabel('antigravity', windows[1], windows), 'Claude/GPT');
   assert.equal(limitProviderCompactWindowLabel('codex', windows[0], windows), '');
+});
+
+test('Antigravity quota presentation parses grouped period labels once', () => {
+  assert.deepEqual(antigravityQuotaWindow({ kind: 'session', label: 'Gemini 5-hour' }), {
+    groupLabel: 'Gemini',
+    windowLabel: '5-hour'
+  });
+  assert.deepEqual(antigravityQuotaWindow({ kind: 'weekly', label: 'Future Group weekly' }), {
+    groupLabel: 'Future Group',
+    windowLabel: 'Weekly'
+  });
+  assert.equal(antigravityQuotaWindow({ kind: 'weekly', label: 'Gemini Pro' }), null);
 });
 
 test('compact Antigravity windows surface critical weekly quotas per model group', () => {
@@ -531,11 +544,12 @@ test('Antigravity groups returned quota windows under dynamic model-family headi
   const renderProviderWindows = functionBody(app, 'renderProviderWindows', 'renderLimitProviderRow');
   const css = readRendererFile('styles.css');
 
+  const context = { limitProviderPresentationApi: { antigravityQuotaWindow } };
   const grouped = vm.runInNewContext(`${quotaGroups}\nantigravityQuotaGroups({ windows: [
     { kind: 'session', label: 'Gemini 5-hour' },
     { kind: 'weekly', label: 'Gemini weekly' },
     { kind: 'weekly', label: 'Future Group weekly' }
-  ] });`);
+  ] });`, context);
   assert.deepEqual(JSON.parse(JSON.stringify(grouped)), [
     {
       label: 'Gemini',
@@ -554,11 +568,10 @@ test('Antigravity groups returned quota windows under dynamic model-family headi
   const legacy = vm.runInNewContext(`${quotaGroups}\nantigravityQuotaGroups({ windows: [
     { kind: 'weekly', label: 'Gemini Pro' },
     { kind: 'weekly', label: 'Claude' }
-  ] });`);
+  ] });`, context);
   assert.deepEqual(JSON.parse(JSON.stringify(legacy)), []);
 
-  assert.match(quotaGroups, /window\.kind === 'session' \? '5-hour' : 'Weekly'/);
-  assert.match(quotaGroups, /const groupLabel = label\.replace\(suffix, ''\)\.trim\(\)/);
+  assert.match(quotaGroups, /limitProviderPresentationApi\.antigravityQuotaWindow\(window\)/);
   assert.match(quotaGroups, /groups\.set\(entry\.groupLabel, \[\]\)/);
   assert.match(quotaGroups, /entries\.some\(\(entry\) => entry === null\)/);
   assert.match(renderProviderWindows, /provider\.provider === 'antigravity'/);

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -12,6 +12,9 @@ const {
   isCodexLiveAccount,
   limitProviderDisplayLabel,
   limitProviderCapabilityTags,
+  limitProviderCompactWindowLabel,
+  limitProviderCompactWindowPeriodLabel,
+  limitProviderCompactWindows,
   limitProviderMainDeviceLabel,
   limitProviderProvenance,
   limitResetRemainingMs,
@@ -48,6 +51,75 @@ test('limitProviderDisplayLabel normalizes short account labels without rewritin
   assert.equal(limitProviderDisplayLabel('Team'), 'Team');
   assert.equal(limitProviderDisplayLabel('primary.user@example.com'), 'primary.user@example.com');
   assert.equal(limitProviderDisplayLabel(''), '');
+});
+
+test('compact Antigravity labels distinguish duplicate periods by model group', () => {
+  const windows = [
+    { kind: 'session', label: 'Gemini 5-hour' },
+    { kind: 'session', label: 'Claude/GPT 5-hour' }
+  ];
+
+  assert.equal(limitProviderCompactWindowLabel('antigravity', windows[0], windows), 'Gemini');
+  assert.equal(limitProviderCompactWindowLabel('antigravity', windows[1], windows), 'Claude/GPT');
+  assert.equal(limitProviderCompactWindowLabel('codex', windows[0], windows), '');
+});
+
+test('compact Antigravity windows surface critical weekly quotas per model group', () => {
+  const windows = [
+    { kind: 'session', label: 'Gemini 5-hour', remainingPercent: 100 },
+    { kind: 'weekly', label: 'Gemini weekly', remainingPercent: 0 },
+    { kind: 'session', label: 'Claude/GPT 5-hour', remainingPercent: 20 },
+    { kind: 'weekly', label: 'Claude/GPT weekly', remainingPercent: 80 }
+  ];
+
+  assert.deepEqual(limitProviderCompactWindows('antigravity', windows), [windows[1], windows[2]]);
+  const selected = limitProviderCompactWindows('antigravity', windows);
+  assert.equal(limitProviderCompactWindowPeriodLabel('antigravity', selected[0], selected), 'Weekly');
+  assert.equal(limitProviderCompactWindowPeriodLabel('antigravity', selected[1], selected), '5-hour');
+});
+
+test('compact Antigravity windows keep 5-hour primary until weekly is critical', () => {
+  const aboveCritical = [
+    { kind: 'session', label: 'Gemini 5-hour', remainingPercent: 60 },
+    { kind: 'weekly', label: 'Gemini weekly', remainingPercent: 30 }
+  ];
+  const critical = [
+    { kind: 'session', label: 'Gemini 5-hour', remainingPercent: 60 },
+    { kind: 'weekly', label: 'Gemini weekly', remainingPercent: 10 }
+  ];
+
+  assert.deepEqual(limitProviderCompactWindows('antigravity', aboveCritical), [aboveCritical[0]]);
+  assert.deepEqual(limitProviderCompactWindows('antigravity', critical), [critical[1]]);
+});
+
+test('compact Antigravity windows prefer 5-hour on ties and preserve legacy pools', () => {
+  const grouped = [
+    { kind: 'session', label: 'Gemini 5-hour', remainingPercent: 100 },
+    { kind: 'weekly', label: 'Gemini weekly', remainingPercent: 100 },
+    { kind: 'session', label: 'Claude/GPT 5-hour', remainingPercent: 100 },
+    { kind: 'weekly', label: 'Claude/GPT weekly', remainingPercent: 100 }
+  ];
+  const legacy = [
+    { kind: 'session', label: 'Gemini Pro', remainingPercent: 50 },
+    { kind: 'session', label: 'Gemini Flash', remainingPercent: 40 }
+  ];
+
+  assert.deepEqual(limitProviderCompactWindows('antigravity', grouped), [grouped[0], grouped[2]]);
+  assert.equal(limitProviderCompactWindows('antigravity', legacy), legacy);
+});
+
+test('compact Antigravity labels preserve period fallback when groups are not distinct', () => {
+  const differentPeriods = [
+    { kind: 'session', label: 'Gemini 5-hour' },
+    { kind: 'weekly', label: 'Gemini weekly' }
+  ];
+  const legacy = [
+    { kind: 'session', label: 'Gemini Pro' },
+    { kind: 'session', label: 'Gemini Flash' }
+  ];
+
+  assert.equal(limitProviderCompactWindowLabel('antigravity', differentPeriods[0], differentPeriods), '');
+  assert.equal(limitProviderCompactWindowLabel('antigravity', legacy[0], legacy), '');
 });
 
 test('limitResetRemainingMs keeps future resets, briefly marks reset time, and expires old timestamps', () => {
@@ -622,16 +694,21 @@ test('Home uses explicit billing labels so Copilot Premium and Chat stay distinc
   const app = readRendererFile('app.js');
   const i18n = readRendererFile('i18n.js');
   const homeLabel = functionBody(app, 'homeLimitWindowLabel', 'renderHomeLimitModule');
+  const homeRows = functionBody(app, 'homeLimitRows', 'homeLimitWindowLabel');
   const homeModule = functionBody(app, 'renderHomeLimitModule', 'renderHomeModelModule');
   const valueFormatter = functionBody(app, 'formatHomeLimitWindowValue', 'balanceRemainingWindow');
 
   assert.match(homeLabel, /if \(window\?\.kind === 'billing'\) \{/);
+  assert.match(homeLabel, /limitProviderCompactWindowLabel\(providerId, window, visibleWindows\)/);
+  assert.match(homeRows, /limitProviderCompactWindows\(provider, provider\.windows\)/);
   assert.match(homeLabel, /const label = String\(window\?\.label \|\| ''\)\.trim\(\);/);
   assert.match(homeLabel, /if \(label\) return label;/);
   assert.match(homeLabel, /billing: 'home\.limit\.billing'/);
   assert.match(homeLabel, /if \(window\?\.kind === 'balance'\) return 'Balance';/);
   assert.match(homeModule, /const showUsed = Boolean\(state\.settings\?\.showLimitUsed\);/);
   assert.match(homeModule, /value\.textContent = window\.value \|\| formatHomeLimitWindowValue\(window, showUsed\);/);
+  assert.match(homeModule, /limitProviderCompactWindowPeriodLabel\(row\.providerId, window, row\.windows\)/);
+  assert.match(homeModule, /`\$\{periodLabel\} · \$\{resetLabel\}`/);
   assert.match(valueFormatter, /`\$\{formatMoney\(window\.amount, window\.currency\)\} left`/);
   assert.match(valueFormatter, /`\$\{formatPercent\(percent\)\} \$\{limitModeSuffix\(showUsed\)\}`/);
   assert.doesNotMatch(i18n, /home\.limit\.(balance|leftPercent|leftAmount)/);


### PR DESCRIPTION
## Summary

- show Antigravity model groups as `Gemini` and `Claude/GPT` in the compact Home limits summary instead of duplicate `Session` labels
- keep each group's 5-hour window as the stable default, while surfacing a lower weekly window once it falls below the existing 20% critical threshold
- identify the selected period beside its reset time and preserve legacy pool labels plus the complete four-window Limits view

This is a Home presentation follow-up to #215 and #217. It does not change Antigravity quota collection or the limits wire shape.

## Testing

- `npm run verify` (1535 passed, 1 skipped)
- `node --test tests/electron/limitProviderPresentation.test.js tests/electron/homeOverview.test.js` (108 passed)
- `git diff --check`

## Visual verification

- confirmed the compact Home layout in the Electron widget with separate `Gemini` and `Claude/GPT` rows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the compact Home limits for Antigravity by showing model groups as “Gemini” and “Claude/GPT” instead of duplicate “Session” labels, and by surfacing the weekly window when it becomes critical. Shares parsing and selection logic so Home and Limits stay consistent without changing quota collection or the full Limits view.

- **Bug Fixes**
  - Selects 5-hour per group by default; switches to weekly when remaining <20%.
  - Shows period label (“5-hour” or “Weekly”) next to the reset timestamp.
  - Keeps Antigravity window order stable in Home and preserves legacy pool labels.
  - Adds tests for compact selection, labels, and Home rendering behavior.

- **Refactors**
  - Centralizes Antigravity quota parsing and compact-window selection in `limitProviderPresentation`, reused in Home and group headings.
  - Home now requests compact windows, labels, and period tags from the shared API for consistent display.

<sup>Written for commit 00e1c7ecb9fb54960ef600d41e11d7f50d2fbd12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

