### PR TITLE
perf(limits): bound probes and retry transient failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Three runtime entry points share a single `src/shared/` library:
 
 ### AI Tool Limits collector
 
-Usage and limits have independent lifecycles under `src/shared/deviceRuntime.js`: `UsageRuntime` owns the tokscale collector, while `LimitsRuntime` owns its refresh timer, per-provider latest-wins lanes, scoped account refreshes, finite probe deadlines, and `lastGood` / `lastAttempt` retention. Credential changes refresh or clear only the affected limits lane and never restart usage; Cursor additionally forces one targeted usage sync because its tokscale cache is self-synced.
+Usage and limits have independent lifecycles under `src/shared/deviceRuntime.js`: `UsageRuntime` owns the tokscale collector, while `LimitsRuntime` owns its refresh timer, bounded cross-provider concurrency, per-provider latest-wins serial lanes, scoped account refreshes, finite probe deadlines, retry/backoff, and `lastGood` / `lastAttempt` retention. Credential changes refresh or clear only the affected limits lane and never restart usage; Cursor additionally forces one targeted usage sync because its tokscale cache is self-synced.
 
 `DeviceState` composes both outputs into the unchanged device wire record, buffering limits until usage exists and cold-start previews until a complete usage baseline exists; limits-only updates preserve the usage `updatedAt`. Provider dispatch starts in `src/shared/limitCollector.js`, with provider-specific implementations split between that file and `src/shared/*Limits.js`; shared normalization remains in `src/shared/limits.js`. The hub and Worker receive the composed record and never need provider credentials.
 

--- a/src/shared/antigravityProbe.js
+++ b/src/shared/antigravityProbe.js
@@ -20,6 +20,10 @@ function probeTimeoutError() {
   return errorWithStatus('unavailable', 'Antigravity probe timed out');
 }
 
+function throwIfAborted(signal) {
+  if (signal?.aborted) throw abortError(signal);
+}
+
 function remainingMs(deadlineMs) {
   return Math.max(0, deadlineMs - Date.now());
 }
@@ -562,6 +566,7 @@ async function resolveWorkingEndpoint(candidates, call, deadlineMs, signal) {
       }, deadlineMs, attemptTimeoutMs);
       return { candidates: prioritizeCandidate(candidate, candidates), lastError: null };
     } catch (error) {
+      throwIfAborted(signal);
       lastError = error;
       // Any HTTP response proves that the port, scheme, and CSRF routing are
       // reachable even when this lightweight endpoint itself is unsupported.
@@ -606,11 +611,15 @@ async function groupedQuotaFromCandidates(candidates, call, {
             || preferredPlanInfoName(identity?.userStatus?.planStatus?.planInfo)
             || null;
           accountEmail = identity?.userStatus?.email?.trim?.() || null;
-        } catch (_) {}
+        } catch (_) {
+          throwIfAborted(signal);
+        }
+        throwIfAborted(signal);
         return { snapshot: { accountPlan, accountEmail, windows }, lastError };
       }
       lastError = errorWithStatus('unavailable', 'empty quota summary');
     } catch (err) {
+      throwIfAborted(signal);
       lastError = err;
       if (remainingMs(summaryDeadlineMs) <= 0) break;
     }
@@ -637,10 +646,14 @@ async function legacyQuotaFromCandidates(candidates, call, { probeDeadlineMs, si
           || null;
         const accountEmail = data.userStatus.email?.trim?.() || null;
         const models = modelsFromConfigs(configs);
-        if (models.length > 0) return { snapshot: { accountPlan, accountEmail, pools: collapsePools(models) }, lastError };
+        if (models.length > 0) {
+          throwIfAborted(signal);
+          return { snapshot: { accountPlan, accountEmail, pools: collapsePools(models) }, lastError };
+        }
       }
       lastError = errorWithStatus('unavailable', 'empty user status');
     } catch (err) {
+      throwIfAborted(signal);
       lastError = err;
       if (remainingMs(userStatusDeadlineMs) <= 0) break;
     }
@@ -655,10 +668,12 @@ async function legacyQuotaFromCandidates(candidates, call, { probeDeadlineMs, si
       }, probeDeadlineMs);
       const models = modelsFromConfigs(fallback?.clientModelConfigs);
       if (models.length > 0) {
+        throwIfAborted(signal);
         return { snapshot: { accountPlan: null, accountEmail: null, pools: collapsePools(models) }, lastError };
       }
       lastError = errorWithStatus('unavailable', 'empty model configs');
     } catch (err) {
+      throwIfAborted(signal);
       lastError = err;
       if (remainingMs(probeDeadlineMs) <= 0) break;
     }
@@ -683,9 +698,9 @@ async function detectedProcessInfos(deps) {
 async function probe(deps = {}) {
   const probeTimeoutMs = Math.max(1, Number(deps.probeTimeoutMs) || DEFAULT_PROBE_TIMEOUT_MS);
   const probeDeadlineMs = Date.now() + probeTimeoutMs;
+  throwIfAborted(deps.signal);
   const abortController = new AbortController();
-  const abortTimer = setTimeout(() => abortController.abort(), probeTimeoutMs);
-  if (deps.signal?.aborted) throw abortError(deps.signal);
+  const abortTimer = setTimeout(() => abortController.abort(probeTimeoutError()), probeTimeoutMs);
   const signal = deps.signal
     ? AbortSignal.any([abortController.signal, deps.signal])
     : abortController.signal;
@@ -727,6 +742,7 @@ async function probe(deps = {}) {
           return { info, candidates: [], error };
         }
       }));
+      throwIfAborted(signal);
       const candidatesByProcess = prepared.filter((entry) => entry.candidates.length > 0);
       for (const entry of prepared) {
         if (entry.error) lastError = entry.error;
@@ -741,6 +757,7 @@ async function probe(deps = {}) {
           signal
         })
       )));
+      throwIfAborted(signal);
       const grouped = groupedResults.find((result) => result.snapshot);
       if (grouped?.snapshot) return { ...grouped.snapshot, sourceDetail: kind };
       for (const result of groupedResults) lastError = result.lastError || lastError;
@@ -751,6 +768,7 @@ async function probe(deps = {}) {
           signal
         })
       )));
+      throwIfAborted(signal);
       const legacy = legacyResults.find((result) => result.snapshot);
       if (legacy?.snapshot) return { ...legacy.snapshot, sourceDetail: kind };
       for (const result of legacyResults) lastError = result.lastError || lastError;

--- a/src/shared/antigravityProbe.js
+++ b/src/shared/antigravityProbe.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { abortError } = require('./probeDeadline');
+
 const { spawn } = require('node:child_process');
 const https = require('node:https');
 const http = require('node:http');
@@ -28,17 +30,25 @@ function boundedTimeoutMs(deadlineMs, maximum = DEFAULT_RPC_TIMEOUT_MS) {
   return Math.max(1, Math.min(maximum, remaining));
 }
 
-function promiseBeforeDeadline(factory, deadlineMs, maximum = DEFAULT_RPC_TIMEOUT_MS) {
+function promiseBeforeDeadline(factory, deadlineMs, maximum = DEFAULT_RPC_TIMEOUT_MS, signal = null) {
   const timeoutMs = boundedTimeoutMs(deadlineMs, maximum);
+  if (signal?.aborted) return Promise.reject(abortError(signal));
   return new Promise((resolve, reject) => {
     let settled = false;
     const finish = (fn, value) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      signal?.removeEventListener?.('abort', onAbort);
       fn(value);
     };
+    const onAbort = () => finish(reject, abortError(signal));
     const timer = setTimeout(() => finish(reject, probeTimeoutError()), timeoutMs);
+    signal?.addEventListener?.('abort', onAbort, { once: true });
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
     Promise.resolve()
       .then(() => factory(timeoutMs))
       .then((value) => finish(resolve, value), (error) => finish(reject, error));
@@ -49,7 +59,8 @@ function callBeforeDeadline(call, args, deadlineMs, maximum = DEFAULT_RPC_TIMEOU
   return promiseBeforeDeadline(
     (timeoutMs) => call({ ...args, timeoutMs }),
     deadlineMs,
-    maximum
+    maximum,
+    args.signal
   );
 }
 
@@ -674,7 +685,11 @@ async function probe(deps = {}) {
   const probeDeadlineMs = Date.now() + probeTimeoutMs;
   const abortController = new AbortController();
   const abortTimer = setTimeout(() => abortController.abort(), probeTimeoutMs);
-  const runtimeDeps = { ...deps, signal: abortController.signal };
+  if (deps.signal?.aborted) throw abortError(deps.signal);
+  const signal = deps.signal
+    ? AbortSignal.any([abortController.signal, deps.signal])
+    : abortController.signal;
+  const runtimeDeps = { ...deps, signal };
   const listPorts = deps.listeningPorts || listeningPorts;
   const call = deps.callLs || callLs;
   let lastError = errorWithStatus('notConfigured', 'Antigravity language server not running');
@@ -682,7 +697,9 @@ async function probe(deps = {}) {
   try {
     const infos = await promiseBeforeDeadline(
       (timeoutMs) => detectedProcessInfos({ ...runtimeDeps, timeoutMs }),
-      probeDeadlineMs
+      probeDeadlineMs,
+      DEFAULT_RPC_TIMEOUT_MS,
+      signal
     );
 
     // Source priority is deliberate and independent of ps/PID order. Processes
@@ -694,14 +711,16 @@ async function probe(deps = {}) {
         try {
           const ports = await promiseBeforeDeadline(
             (timeoutMs) => listPorts(info.pid, { ...runtimeDeps, timeoutMs }),
-            probeDeadlineMs
+            probeDeadlineMs,
+            DEFAULT_RPC_TIMEOUT_MS,
+            signal
           );
           const initialCandidates = endpointCandidates(info, ports);
           const resolved = await resolveWorkingEndpoint(
             initialCandidates,
             call,
             probeDeadlineMs,
-            abortController.signal
+            signal
           );
           return { info, candidates: resolved.candidates, error: resolved.lastError };
         } catch (error) {
@@ -719,7 +738,7 @@ async function probe(deps = {}) {
         groupedQuotaFromCandidates(entry.candidates, call, {
           summaryDeadlineMs,
           probeDeadlineMs,
-          signal: abortController.signal
+          signal
         })
       )));
       const grouped = groupedResults.find((result) => result.snapshot);
@@ -729,7 +748,7 @@ async function probe(deps = {}) {
       const legacyResults = await Promise.all(candidatesByProcess.map((entry) => (
         legacyQuotaFromCandidates(entry.candidates, call, {
           probeDeadlineMs,
-          signal: abortController.signal
+          signal
         })
       )));
       const legacy = legacyResults.find((result) => result.snapshot);

--- a/src/shared/cursorProbe.js
+++ b/src/shared/cursorProbe.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const https = require('node:https');
+const { abortError } = require('./probeDeadline');
 
 const USAGE_SUMMARY_URL = 'https://cursor.com/api/usage-summary';
 const AUTH_ME_URL = 'https://cursor.com/api/auth/me';
@@ -144,16 +145,24 @@ function parseUserInfo(input) {
   };
 }
 
-function requestJson(url, sessionToken, { timeoutMs = 15000, httpsLib = https } = {}) {
+function requestJson(url, sessionToken, { timeoutMs = 15000, httpsLib = https, signal } = {}) {
+  if (signal?.aborted) return Promise.reject(abortError(signal));
   return new Promise((resolve) => {
     const parsed = new URL(url);
     let settled = false;
+    let req = null;
     const finish = (value) => {
       if (settled) return;
       settled = true;
+      signal?.removeEventListener?.('abort', onAbort);
       resolve(value);
     };
-    const req = httpsLib.request({
+    const onAbort = () => {
+      const error = abortError(signal);
+      try { req?.destroy?.(error); } catch (_) {}
+      finish({ ok: false, error: { kind: 'network', message: error.message } });
+    };
+    req = httpsLib.request({
       method: 'GET',
       hostname: parsed.hostname,
       path: `${parsed.pathname}${parsed.search}`,
@@ -186,6 +195,11 @@ function requestJson(url, sessionToken, { timeoutMs = 15000, httpsLib = https } 
       });
     }
     req.on('error', (err) => finish({ ok: false, error: { kind: 'network', message: err.message } }));
+    signal?.addEventListener?.('abort', onAbort, { once: true });
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
     req.end();
   });
 }

--- a/src/shared/grokLimits.js
+++ b/src/shared/grokLimits.js
@@ -706,8 +706,8 @@ async function fetchGrokLimits(options = {}, deps = {}) {
     });
   }
 
+  if (deps.signal?.aborted) throw abortError(deps.signal);
   try {
-    if (deps.signal?.aborted) throw abortError(deps.signal);
     return normalizeLimitProvider({
       provider: 'grok',
       accountKey: hashKey('grok', credential.token),

--- a/src/shared/grokLimits.js
+++ b/src/shared/grokLimits.js
@@ -663,6 +663,7 @@ async function fetchGrokLimits(options = {}, deps = {}) {
         windows
       });
     } catch (error) {
+      if (deps.signal?.aborted) throw abortError(deps.signal);
       const status = classifyGrokRpcError(error);
       if (!credential || status === 'unauthorized') {
         return status === 'unauthorized'
@@ -689,10 +690,12 @@ async function fetchGrokLimits(options = {}, deps = {}) {
       windows: []
     });
   }
+  if (deps.signal?.aborted) throw abortError(deps.signal);
   let windows;
   try {
     windows = await (deps.fetchWebGrpcBilling || fetchGrokWebGrpcBilling)(credential, deps);
   } catch (webError) {
+    if (deps.signal?.aborted) throw abortError(deps.signal);
     return normalizeLimitProvider({
       provider: 'grok',
       source: 'web',
@@ -704,6 +707,7 @@ async function fetchGrokLimits(options = {}, deps = {}) {
   }
 
   try {
+    if (deps.signal?.aborted) throw abortError(deps.signal);
     return normalizeLimitProvider({
       provider: 'grok',
       accountKey: hashKey('grok', credential.token),

--- a/src/shared/grokLimits.js
+++ b/src/shared/grokLimits.js
@@ -17,6 +17,7 @@ const { spawn } = require('node:child_process');
 const { normalizeLimitProvider } = require('./limits');
 const { hashKey } = require('./hashKey');
 const { createOutboundFetch } = require('./outboundFetch');
+const { abortError } = require('./probeDeadline');
 
 const GROK_WEB_BILLING_GRPC_URL = 'https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig';
 const GROK_KEY_NAMES = ['GROK_BEARER_TOKEN'];
@@ -437,6 +438,8 @@ async function fetchGrokRpcBilling(options = {}, deps = {}) {
   const command = grokRpcCommand(env, options);
   const args = grokRpcArgs(options);
   const timeoutMs = Number(deps.rpcTimeoutMs || deps.fetchTimeoutMs || 5000);
+  const signal = deps.signal;
+  if (signal?.aborted) throw abortError(signal);
 
   return new Promise((resolve, reject) => {
     let child;
@@ -448,6 +451,7 @@ async function fetchGrokRpcBilling(options = {}, deps = {}) {
     function cleanup() {
       if (timer) clearTimeout(timer);
       timer = null;
+      signal?.removeEventListener?.('abort', onAbort);
       if (child && typeof child.kill === 'function') {
         try { child.kill(); } catch (_) {}
       }
@@ -459,6 +463,10 @@ async function fetchGrokRpcBilling(options = {}, deps = {}) {
       cleanup();
       if (error) reject(error);
       else resolve(value);
+    }
+
+    function onAbort() {
+      finish(abortError(signal));
     }
 
     function writeJsonLine(value) {
@@ -504,6 +512,11 @@ async function fetchGrokRpcBilling(options = {}, deps = {}) {
     }
 
     timer = setTimeout(() => finish(grokRpcError('Grok RPC timed out')), timeoutMs);
+    signal?.addEventListener?.('abort', onAbort, { once: true });
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
     child.on?.('error', finish);
     child.on?.('exit', (code) => {
       if (!settled) finish(grokRpcError(`Grok RPC exited before billing response (${code ?? 'unknown'})`));
@@ -558,7 +571,7 @@ function unauthorizedGrokProvider(updatedAt, source = 'web', sourceDetail = '') 
 
 function resolveGrokFetch(deps = {}) {
   if (typeof deps.fetch === 'function') return deps.fetch;
-  return createOutboundFetch(deps.env || process.env);
+  return createOutboundFetch(deps.env || process.env, deps);
 }
 
 function isRetryableNetworkError(error) {
@@ -723,6 +736,7 @@ module.exports = {
   grokCredential,
   parseGrokBilling,
   parseGrokGrpcWebBilling,
+  resolveGrokFetch,
   fetchGrokRpcBilling,
   fetchGrokWebGrpcBilling,
   fetchGrokLimits,

--- a/src/shared/kiroLimits.js
+++ b/src/shared/kiroLimits.js
@@ -15,6 +15,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { spawn } = require('node:child_process');
 const { normalizeLimitProvider } = require('./limits');
+const { abortError } = require('./probeDeadline');
 const { hashKey } = require('./hashKey');
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -272,6 +273,8 @@ function runKiroUsageCli(deps = {}) {
   const env = { ...(deps.env || process.env), TERM: 'xterm-256color' };
   const command = deps.kiroCliPath || 'kiro-cli';
   const timeoutMs = Number(deps.kiroCliTimeoutMs || 20000);
+  const signal = deps.signal;
+  if (signal?.aborted) return Promise.reject(abortError(signal));
   return new Promise((resolve, reject) => {
     let child;
     try {
@@ -286,17 +289,33 @@ function runKiroUsageCli(deps = {}) {
     }
     let stdout = '';
     let stderr = '';
-    const timer = setTimeout(() => {
+    let settled = false;
+    const finish = (callback, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener?.('abort', onAbort);
+      callback(value);
+    };
+    const stopChild = () => {
       try { child.kill('SIGTERM'); } catch (_) {}
-      reject(errorWithStatus('unavailable', 'kiro-cli timed out'));
+    };
+    const onAbort = () => {
+      stopChild();
+      finish(reject, abortError(signal));
+    };
+    const timer = setTimeout(() => {
+      stopChild();
+      finish(reject, errorWithStatus('unavailable', 'kiro-cli timed out'));
     }, timeoutMs);
     child.stdout?.on('data', (chunk) => { stdout += chunk.toString(); });
     child.stderr?.on('data', (chunk) => { stderr += chunk.toString(); });
-    child.on('error', (error) => { clearTimeout(timer); reject(error); });
+    child.on('error', (error) => finish(reject, error));
     child.on('close', () => {
-      clearTimeout(timer);
-      resolve(stdout.trim() ? stdout : stderr);
+      finish(resolve, stdout.trim() ? stdout : stderr);
     });
+    signal?.addEventListener?.('abort', onAbort, { once: true });
+    if (signal?.aborted) onAbort();
   });
 }
 

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -1988,7 +1988,10 @@ async function readCodexRpcWithCommand(command, deps = {}) {
     });
     rpc.notify('initialized', {});
     let rateLimitResult = await rpc.send('account/rateLimits/read');
-    const accountResult = await rpc.send('account/read').catch(() => null);
+    const accountResult = await rpc.send('account/read').catch(() => {
+      if (signal?.aborted) throw abortError(signal);
+      return null;
+    });
     const account = accountResult?.account || null;
     let payload = codexRpcPayload(rateLimitResult, account, command, deps);
     if (deps.codexEmptyQuotaRetry !== false && shouldRetryCodexEmptyQuotaPayload(payload)) {
@@ -2002,11 +2005,14 @@ async function readCodexRpcWithCommand(command, deps = {}) {
             rateLimitResetCredits: retryPayload.rateLimitResetCredits || payload.rateLimitResetCredits
           };
         }
-      } catch (_) {}
+      } catch (_) {
+        if (signal?.aborted) throw abortError(signal);
+      }
     }
     if (!account && !hasCodexRateLimitWindows(codexRateLimitSnapshot(payload))) {
       throw errorWithStatus('notConfigured', 'Codex account not configured');
     }
+    if (signal?.aborted) throw abortError(signal);
     return payload;
   } finally {
     signal?.removeEventListener?.('abort', onAbort);

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -11,6 +11,8 @@ const {
   normalizeLimitProvider,
   normalizeLimitsSummary
 } = require('./limits');
+const { parseRetryAfterHeader } = require('./limitsRetryPolicy');
+const { abortError } = require('./probeDeadline');
 const cursorAuth = require('./cursorAuth');
 const cursorProbe = require('./cursorProbe');
 const antigravityProbe = require('./antigravityProbe');
@@ -478,28 +480,45 @@ function readWindowsCredentialSecret(_service, targets, deps = {}) {
 
 function readMacKeychainSecret(service, deps = {}) {
   const spawnFn = deps.spawn || spawn;
+  const signal = deps.signal;
+  if (signal?.aborted) return Promise.reject(abortError(signal));
   return new Promise((resolve, reject) => {
     const child = spawnFn('security', ['find-generic-password', '-s', service, '-w'], { windowsHide: true });
     let stdout = '';
     let stderr = '';
+    let settled = false;
+    const finish = (callback, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener?.('abort', onAbort);
+      callback(value);
+    };
+    const onAbort = () => {
+      try { child.kill('SIGTERM'); } catch (_) {}
+      finish(reject, abortError(signal));
+    };
     const timer = setTimeout(() => {
-      child.kill('SIGTERM');
-      reject(new Error('macOS keychain lookup timed out'));
+      try { child.kill('SIGTERM'); } catch (_) {}
+      finish(reject, new Error('macOS keychain lookup timed out'));
     }, 5000);
     child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
     child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
-    child.on('error', (error) => { clearTimeout(timer); reject(error); });
+    child.on('error', (error) => finish(reject, error));
     child.on('close', (code) => {
-      clearTimeout(timer);
-      if (code !== 0) reject(new Error(stderr.trim() || `security exited ${code}`));
-      else resolve(stdout.trim());
+      if (code !== 0) finish(reject, new Error(stderr.trim() || `security exited ${code}`));
+      else finish(resolve, stdout.trim());
     });
+    signal?.addEventListener?.('abort', onAbort, { once: true });
+    if (signal?.aborted) onAbort();
   });
 }
 
 function runProcessText(command, args = [], options = {}) {
   const spawnFn = options.spawn || spawn;
   const timeoutMs = Number(options.timeoutMs || 30000);
+  const signal = options.signal;
+  if (signal?.aborted) return Promise.reject(abortError(signal));
   return new Promise((resolve, reject) => {
     const child = spawnFn(command, args, {
       cwd: options.cwd,
@@ -509,21 +528,34 @@ function runProcessText(command, args = [], options = {}) {
     });
     let stdout = '';
     let stderr = '';
-    const timer = setTimeout(() => {
+    let settled = false;
+    const finish = (callback, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener?.('abort', onAbort);
+      callback(value);
+    };
+    const stopChild = () => {
       try { child.kill('SIGTERM'); } catch (_) {}
-      reject(errorWithStatus('unavailable', `${command} timed out`));
+    };
+    const onAbort = () => {
+      stopChild();
+      finish(reject, abortError(signal));
+    };
+    const timer = setTimeout(() => {
+      stopChild();
+      finish(reject, errorWithStatus('unavailable', `${command} timed out`));
     }, timeoutMs);
     child.stdout?.on('data', (chunk) => { stdout += chunk.toString(); });
     child.stderr?.on('data', (chunk) => { stderr += chunk.toString(); });
-    child.on('error', (error) => {
-      clearTimeout(timer);
-      reject(error);
-    });
+    child.on('error', (error) => finish(reject, error));
     child.on('close', (code) => {
-      clearTimeout(timer);
-      if (code === 0 && stdout.trim()) resolve(stdout);
-      else reject(errorWithStatus('unavailable', stderr.trim() || `${command} exited ${code}`));
+      if (code === 0 && stdout.trim()) finish(resolve, stdout);
+      else finish(reject, errorWithStatus('unavailable', stderr.trim() || `${command} exited ${code}`));
     });
+    signal?.addEventListener?.('abort', onAbort, { once: true });
+    if (signal?.aborted) onAbort();
   });
 }
 
@@ -1440,8 +1472,18 @@ function shouldRetryCodexEmptyQuotaPayload(payload = {}) {
 async function waitForCodexEmptyQuotaRetry(deps = {}) {
   const delayMs = Number(deps.codexEmptyQuotaRetryDelayMs ?? CODEX_EMPTY_QUOTA_RETRY_DELAY_MS);
   if (!Number.isFinite(delayMs) || delayMs <= 0) return;
-  await new Promise((resolve) => {
-    setTimeout(resolve, delayMs);
+  if (deps.signal?.aborted) throw abortError(deps.signal);
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(finish, delayMs);
+    const onAbort = () => finish(abortError(deps.signal));
+    function finish(error) {
+      clearTimeout(timer);
+      deps.signal?.removeEventListener?.('abort', onAbort);
+      if (error) reject(error);
+      else resolve();
+    }
+    deps.signal?.addEventListener?.('abort', onAbort, { once: true });
+    if (deps.signal?.aborted) onAbort();
   });
 }
 
@@ -1842,8 +1884,16 @@ function createJsonRpcClient(child, timeoutMs) {
   const pending = new Map();
 
   function rejectAll(error) {
-    for (const { reject } of pending.values()) reject(error);
+    for (const { reject, timer } of pending.values()) {
+      clearTimeout(timer);
+      reject(error);
+    }
     pending.clear();
+  }
+
+  function abort(error) {
+    closed = true;
+    rejectAll(error);
   }
 
   function handleMessage(message) {
@@ -1892,7 +1942,7 @@ function createJsonRpcClient(child, timeoutMs) {
     if (!closed) child.stdin.write(`${JSON.stringify(params === undefined ? { method } : { method, params })}\n`);
   }
 
-  return { send, notify, rejectAll };
+  return { abort, send, notify, rejectAll };
 }
 
 function shouldTryNextCodexCommand(error) {
@@ -1921,9 +1971,18 @@ function codexRpcPayload(rateLimitResult, account, command, deps = {}) {
 
 async function readCodexRpcWithCommand(command, deps = {}) {
   const timeoutMs = Number(deps.codexRpcTimeoutMs || CODEX_RPC_TIMEOUT_MS);
+  const platform = deps.platform || process.platform;
+  const signal = deps.signal;
+  if (signal?.aborted) throw abortError(signal);
   const child = spawnCodexAppServer({ ...deps, codexCommand: command });
   const rpc = createJsonRpcClient(child, timeoutMs);
+  const onAbort = () => {
+    rpc.abort(abortError(signal));
+    killCodexLoginProcess(child, platform, deps);
+  };
+  signal?.addEventListener?.('abort', onAbort, { once: true });
   try {
+    if (signal?.aborted) throw abortError(signal);
     await rpc.send('initialize', {
       clientInfo: { name: 'token-monitor', title: 'Token Monitor', version: appVersion() }
     });
@@ -1950,7 +2009,9 @@ async function readCodexRpcWithCommand(command, deps = {}) {
     }
     return payload;
   } finally {
-    try { child.kill('SIGTERM'); } catch (_) {}
+    signal?.removeEventListener?.('abort', onAbort);
+    rpc.abort(new Error('codex app-server closed'));
+    if (!signal?.aborted) killCodexLoginProcess(child, platform, deps);
   }
 }
 
@@ -2514,12 +2575,42 @@ function providerPhysicalBoundMs(provider, options = {}, deps = {}) {
   return base * jobs;
 }
 
+function createProbeFetch(fetchFn, context = {}, deps = {}) {
+  return async (url, init = {}) => {
+    const signals = [context.signal, init.signal].filter(Boolean);
+    const signal = signals.length > 1 ? AbortSignal.any(signals) : signals[0];
+    const response = await fetchFn(url, {
+      ...init,
+      ...(signal ? { signal } : {})
+    });
+    if (Number(response?.status) >= 400) {
+      const retryAfterMs = parseRetryAfterHeader(
+        response?.headers?.get?.('retry-after'),
+        (deps.now || Date.now)()
+      );
+      if (retryAfterMs !== null) context.onRetryAfter?.(retryAfterMs);
+    }
+    return response;
+  };
+}
+
+function resolveProviderFetch(provider, deps = {}) {
+  if (typeof deps.fetch === 'function') return deps.fetch;
+  if (provider === 'grok') return grokLimits.resolveGrokFetch(deps);
+  return fetch;
+}
+
 async function probeLimitProvider(provider, options = {}, context = {}, deps = {}) {
   const nowMs = (deps.now || Date.now)();
   const fetcher = providerFetchers(deps)[provider];
   if (!fetcher) return [statusProvider(provider, 'notConfigured', nowIso(nowMs))];
   try {
-    const result = await fetcher(options, { ...deps, signal: context.signal ?? deps.signal });
+    const signal = context.signal ?? deps.signal;
+    const result = await fetcher(options, {
+      ...deps,
+      fetch: createProbeFetch(resolveProviderFetch(provider, deps), { ...context, signal }, deps),
+      signal
+    });
     return (Array.isArray(result) ? result : [result]).filter(Boolean);
   } catch (error) {
     return [statusProvider(provider, providerStatusFromError(error), nowIso(nowMs))];
@@ -2548,7 +2639,7 @@ async function collectLimitsOnce(options = {}, deps = {}) {
 // full-snapshot TTL and has no in-flight coordination of its own.
 function createLimitsCollector(options = {}, deps = {}) {
   const { createLimitsRuntime } = require('./limitsRuntime');
-  const runtime = createLimitsRuntime(options, { ...deps, autoStart: false });
+  const runtime = createLimitsRuntime(options, { ...deps, autoStart: false, autoRetry: false });
   const refreshMs = normalizeLimitsRefreshMs(options.limitsRefreshMs ?? options.refreshMs);
   const now = deps.now || Date.now;
   let lastFullRefreshAt = null;
@@ -2630,7 +2721,7 @@ async function fetchCursorLimits(_options = {}, deps = {}) {
     };
   }
 
-  const result = await probe(account.sessionToken);
+  const result = await probe(account.sessionToken, deps);
   if (!result.ok) {
     const kind = result.error?.kind === 'unauthorized' ? 'unauthorized' : 'unavailable';
     return {
@@ -2750,6 +2841,8 @@ module.exports = {
   claudeCommandCandidates,
   codexCommandCandidates,
   codexCommandSourceDetail,
+  createProbeFetch,
+  resolveProviderFetch,
   createLimitsCollector,
   probeLimitProvider,
   providerPhysicalBoundMs,
@@ -2761,7 +2854,9 @@ module.exports = {
   fetchCursorLimits,
   fetchDeepSeekLimits,
   fetchMimoLimits,
+  readCodexRpcWithCommand,
   runCodexLogin,
+  runProcessText,
   deepseekToken,
   selectFundedRow,
   minimaxToken,

--- a/src/shared/limitsRetryPolicy.js
+++ b/src/shared/limitsRetryPolicy.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const DEFAULT_LIMITS_RETRY_BASE_MS = 5_000;
+const DEFAULT_LIMITS_RETRY_MAX_MS = 5 * 60_000;
+const MAX_RETRY_AFTER_MS = 60 * 60_000;
+const RETRY_AFTER_JITTER_MAX_MS = 5_000;
+
+const RETRYABLE_LIMIT_STATUSES = new Set([
+  'timeout',
+  'rateLimited',
+  'sourceRateLimited',
+  'unavailable',
+  'error'
+]);
+
+function positiveFinite(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function unitRandom(random = Math.random) {
+  const value = Number(random());
+  if (!Number.isFinite(value)) return 0.5;
+  return Math.max(0, Math.min(0.999999999, value));
+}
+
+function parseRetryAfterHeader(value, nowMs = Date.now()) {
+  const raw = String(value ?? '').trim();
+  if (!raw) return null;
+  if (/^\d+(?:\.\d+)?$/.test(raw)) {
+    return Math.min(MAX_RETRY_AFTER_MS, Math.max(0, Number(raw) * 1000));
+  }
+  const at = Date.parse(raw);
+  if (!Number.isFinite(at)) return null;
+  return Math.min(MAX_RETRY_AFTER_MS, Math.max(0, at - Number(nowMs || 0)));
+}
+
+function computeRetryDelayMs(attempt, options = {}) {
+  const random = options.random || Math.random;
+  const retryAfterMs = Number(options.retryAfterMs);
+  if (Number.isFinite(retryAfterMs) && retryAfterMs > 0) {
+    const bounded = Math.min(MAX_RETRY_AFTER_MS, retryAfterMs);
+    const jitterCap = Math.min(RETRY_AFTER_JITTER_MAX_MS, bounded * 0.1);
+    return Math.ceil(bounded + unitRandom(random) * jitterCap);
+  }
+
+  const baseMs = positiveFinite(options.baseMs, DEFAULT_LIMITS_RETRY_BASE_MS);
+  const maxMs = positiveFinite(options.maxMs, DEFAULT_LIMITS_RETRY_MAX_MS);
+  const exponent = Math.max(0, Math.min(30, Math.floor(Number(attempt) || 1) - 1));
+  const cap = Math.min(maxMs, baseMs * (2 ** exponent));
+  return Math.ceil((cap / 2) + unitRandom(random) * (cap / 2));
+}
+
+function isRetryableLimitStatus(status) {
+  return RETRYABLE_LIMIT_STATUSES.has(String(status || ''));
+}
+
+module.exports = {
+  DEFAULT_LIMITS_RETRY_BASE_MS,
+  DEFAULT_LIMITS_RETRY_MAX_MS,
+  MAX_RETRY_AFTER_MS,
+  RETRYABLE_LIMIT_STATUSES,
+  computeRetryDelayMs,
+  isRetryableLimitStatus,
+  parseRetryAfterHeader
+};

--- a/src/shared/limitsRuntime.js
+++ b/src/shared/limitsRuntime.js
@@ -15,6 +15,14 @@ const {
   pruneAttemptedResetBoundaries
 } = require('./limitResetBoundary');
 const { runWithProbeDeadline } = require('./probeDeadline');
+const {
+  DEFAULT_LIMITS_RETRY_BASE_MS,
+  DEFAULT_LIMITS_RETRY_MAX_MS,
+  computeRetryDelayMs,
+  isRetryableLimitStatus
+} = require('./limitsRetryPolicy');
+
+const DEFAULT_LIMITS_MAX_CONCURRENCY = 3;
 
 const TRANSIENT_STATUSES = new Set([
   'timeout',
@@ -22,6 +30,19 @@ const TRANSIENT_STATUSES = new Set([
   'sourceRateLimited',
   'unavailable',
   'error'
+]);
+
+const COOLDOWN_BYPASS_REASONS = new Set([
+  'credential-change',
+  'credential-edit',
+  'credential-save',
+  'enabled',
+  'identity-switch',
+  'login',
+  'profile-rename',
+  'profile-save',
+  'profile-state',
+  'provider-added'
 ]);
 
 function cloneValue(value) {
@@ -110,6 +131,10 @@ function publicAttemptStatus(status) {
   return status === 'timeout' ? 'error' : status || 'unavailable';
 }
 
+function bypassesProviderCooldown(reason) {
+  return COOLDOWN_BYPASS_REASONS.has(String(reason || ''));
+}
+
 function createLimitsRuntime(initialOptions = {}, deps = {}) {
   const now = deps.now || Date.now;
   const setTimer = deps.setTimeout || setTimeout;
@@ -121,6 +146,17 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
   const cleanupGraceMs = Number.isFinite(Number(deps.cleanupGraceMs))
     ? Math.max(0, Number(deps.cleanupGraceMs))
     : PROVIDER_CLEANUP_GRACE_MS;
+  const maxConcurrency = Number.isFinite(Number(deps.maxConcurrency))
+    ? Math.max(1, Math.floor(Number(deps.maxConcurrency)))
+    : DEFAULT_LIMITS_MAX_CONCURRENCY;
+  const retryBaseMs = Number.isFinite(Number(deps.retryBaseMs))
+    ? Math.max(1, Number(deps.retryBaseMs))
+    : DEFAULT_LIMITS_RETRY_BASE_MS;
+  const retryMaxMs = Number.isFinite(Number(deps.retryMaxMs))
+    ? Math.max(retryBaseMs, Number(deps.retryMaxMs))
+    : DEFAULT_LIMITS_RETRY_MAX_MS;
+  const autoRetry = deps.autoRetry !== false;
+  const random = deps.random || Math.random;
 
   let config = cloneValue(initialOptions);
   let enabled = parseBoolean(config.limitsEnabled ?? config.enabled, true);
@@ -130,7 +166,7 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
   let stopped = false;
   let started = false;
   let sequence = 0;
-  let executorActive = false;
+  let executorActive = 0;
   let pumpQueued = false;
   let intervalTimer = null;
   let resetTimer = null;
@@ -150,7 +186,11 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
         accountRevisions: new Map(),
         pending: new Map(),
         active: null,
-        identities: new Map()
+        identities: new Map(),
+        retryAttempt: 0,
+        retryNotBefore: 0,
+        retryScope: null,
+        retryTimer: null
       });
     }
     return lanes.get(provider);
@@ -160,6 +200,77 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
     if (!intent || intent.settled) return;
     intent.settled = true;
     intent.resolve(result);
+  }
+
+  function emitEvent(type, provider, detail = {}) {
+    try {
+      deps.onEvent?.({
+        type,
+        provider,
+        active: executorActive,
+        queued: providerQueue.length,
+        ...detail
+      });
+    } catch (_) {
+      // Diagnostics observers must never affect collection or retry state.
+    }
+  }
+
+  function clearRetryTimer(lane) {
+    if (lane.retryTimer !== null) clearTimer(lane.retryTimer);
+    lane.retryTimer = null;
+  }
+
+  function resetRetryPolicy(lane) {
+    clearRetryTimer(lane);
+    lane.retryAttempt = 0;
+    lane.retryNotBefore = 0;
+    lane.retryScope = null;
+  }
+
+  function scheduleRetryTimer(lane) {
+    clearRetryTimer(lane);
+    if (!autoRetry || stopped || !enabled || !configuredProviders.has(lane.provider) || !lane.retryScope) return;
+    const delayMs = Math.max(0, lane.retryNotBefore - now());
+    lane.retryTimer = setTimer(() => {
+      lane.retryTimer = null;
+      if (stopped || !enabled || !configuredProviders.has(lane.provider)) return;
+      lane.retryNotBefore = 0;
+      void queueScope(cloneValue(lane.retryScope), 'retry');
+    }, delayMs);
+  }
+
+  function retryStatus(rawRows, error) {
+    if (error) {
+      const status = error.status || (error.code === 'PROBE_TIMEOUT' ? 'timeout' : 'unavailable');
+      return isRetryableLimitStatus(status) ? status : '';
+    }
+    const rows = Array.isArray(rawRows) ? rawRows : rawRows?.providers || [];
+    return rows.map((row) => String(row?.status || '')).find(isRetryableLimitStatus) || '';
+  }
+
+  function applyRetryPolicy(lane, intent, rawRows, error, retryAfterMs) {
+    const status = retryStatus(rawRows, error);
+    if (!status) {
+      resetRetryPolicy(lane);
+      return;
+    }
+    lane.retryAttempt += 1;
+    const delayMs = computeRetryDelayMs(lane.retryAttempt, {
+      baseMs: retryBaseMs,
+      maxMs: retryMaxMs,
+      random,
+      retryAfterMs
+    });
+    lane.retryNotBefore = now() + delayMs;
+    lane.retryScope = cloneValue(intent.scope);
+    scheduleRetryTimer(lane);
+    emitEvent('retry-scheduled', lane.provider, {
+      attempt: lane.retryAttempt,
+      delayMs,
+      reason: status,
+      retryAfter: Number.isFinite(Number(retryAfterMs)) && Number(retryAfterMs) > 0
+    });
   }
 
   function cancelLane(lane, reason = 'superseded') {
@@ -382,6 +493,8 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
       expectedIdentityKeys: [...lane.identities.keys()]
     };
     lane.active = { intent, controller, dispatch };
+    emitEvent('probe-start', lane.provider, { reason: intent.reason });
+    let reportedRetryAfterMs = null;
     try {
       const resolved = deps.resolveConfigSnapshot
         ? await deps.resolveConfigSnapshot(cloneValue(intent.scope), cloneValue(config))
@@ -397,37 +510,43 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
           signal: AbortSignal.any([signal, controller.signal]),
           deadlineMs,
           scope: cloneValue(intent.scope),
-          reason: intent.reason
+          reason: intent.reason,
+          onRetryAfter(value) {
+            const parsed = Number(value);
+            if (!Number.isFinite(parsed) || parsed <= 0) return;
+            reportedRetryAfterMs = Math.max(reportedRetryAfterMs || 0, parsed);
+          }
         }, deps),
         { deadlineMs }
       );
       const committed = commitRows(lane, dispatch, rows);
+      if (committed) applyRetryPolicy(lane, intent, rows, null, reportedRetryAfterMs);
       finishIntent(intent, { superseded: !committed, snapshot: getSnapshot() });
     } catch (error) {
       const committed = commitRows(lane, dispatch, [], error);
+      if (committed) applyRetryPolicy(lane, intent, [], error, reportedRetryAfterMs || error?.retryAfterMs);
       finishIntent(intent, { superseded: !committed, error, snapshot: getSnapshot() });
     } finally {
       if (lane.active?.intent === intent) lane.active = null;
+      emitEvent('probe-finish', lane.provider, { reason: intent.reason });
     }
   }
 
-  async function pump() {
-    if (executorActive || stopped) return;
-    while (providerQueue.length > 0) {
+  function pump() {
+    if (stopped) return;
+    while (executorActive < maxConcurrency && providerQueue.length > 0) {
       const provider = providerQueue.shift();
       queuedProviders.delete(provider);
       const lane = lanes.get(provider);
       if (!lane || lane.active || lane.pending.size === 0 || !configuredProviders.has(provider)) continue;
       const intent = nextIntent(lane);
       if (!intent) continue;
-      executorActive = true;
-      try {
-        await dispatchIntent(lane, intent);
-      } finally {
-        executorActive = false;
+      executorActive += 1;
+      void dispatchIntent(lane, intent).finally(() => {
+        executorActive = Math.max(0, executorActive - 1);
         if (lane.pending.size > 0) enqueueProvider(provider);
-        for (const queuedProvider of [...providerQueue]) enqueueProvider(queuedProvider);
-      }
+        pump();
+      });
     }
   }
 
@@ -437,6 +556,16 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
       return Promise.resolve({ superseded: true, reason: 'disabled' });
     }
     const lane = laneFor(provider);
+    if (bypassesProviderCooldown(reason)) {
+      resetRetryPolicy(lane);
+    } else if (lane.retryNotBefore > now()) {
+      scheduleRetryTimer(lane);
+      return Promise.resolve({
+        deferred: true,
+        provider,
+        retryAt: new Date(lane.retryNotBefore).toISOString()
+      });
+    }
     const accountScoped = isAccountScope(scope);
     const identityKey = scopeIdentityKey(scope);
     const key = accountScoped ? identityKey : `${provider}:*`;
@@ -495,11 +624,13 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
       if (!lane) continue;
       if (!isAccountScope(normalized)) {
         cancelLane(lane, reason);
+        resetRetryPolicy(lane);
         lane.identities.clear();
         lane.accountRevisions.clear();
         continue;
       }
       const identityKeys = matchingIdentityKeys(lane, normalized);
+      resetRetryPolicy(lane);
       for (const identityKey of identityKeys) {
         lane.accountRevisions.set(identityKey, (lane.accountRevisions.get(identityKey) || 0) + 1);
         lane.identities.delete(identityKey);
@@ -529,6 +660,7 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
       const lane = lanes.get(provider);
       if (lane) {
         cancelLane(lane, 'provider removed');
+        resetRetryPolicy(lane);
         lane.identities.clear();
       }
       lanes.delete(provider);
@@ -540,6 +672,7 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
       resetTimer = null;
       for (const lane of lanes.values()) {
         cancelLane(lane, 'limits disabled');
+        resetRetryPolicy(lane);
         lane.identities.clear();
       }
       rebuildSnapshot();
@@ -571,6 +704,21 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
     return cloneValue(snapshot);
   }
 
+  function getDiagnostics() {
+    return {
+      active: executorActive,
+      maxConcurrency,
+      queued: providerQueue.length,
+      providers: [...lanes.values()].map((lane) => ({
+        provider: lane.provider,
+        active: Boolean(lane.active),
+        pending: lane.pending.size,
+        retryAttempt: lane.retryAttempt,
+        retryAt: lane.retryNotBefore > 0 ? new Date(lane.retryNotBefore).toISOString() : null
+      }))
+    };
+  }
+
   function subscribe(listener) {
     if (typeof listener !== 'function') throw new TypeError('listener must be a function');
     listeners.add(listener);
@@ -594,7 +742,10 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
     clearIntervalTimer();
     if (resetTimer !== null) clearTimer(resetTimer);
     resetTimer = null;
-    for (const lane of lanes.values()) cancelLane(lane, 'runtime stopped');
+    for (const lane of lanes.values()) {
+      cancelLane(lane, 'runtime stopped');
+      resetRetryPolicy(lane);
+    }
     providerQueue.length = 0;
     queuedProviders.clear();
     listeners.clear();
@@ -620,6 +771,7 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
 
   return {
     clear,
+    getDiagnostics,
     getSnapshot,
     reconfigure,
     refresh,
@@ -630,6 +782,7 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
 }
 
 module.exports = {
+  DEFAULT_LIMITS_MAX_CONCURRENCY,
   TRANSIENT_STATUSES,
   accountIdentityPart,
   createLimitsRuntime,

--- a/src/shared/limitsRuntime.js
+++ b/src/shared/limitsRuntime.js
@@ -33,6 +33,8 @@ const TRANSIENT_STATUSES = new Set([
 ]);
 
 const COOLDOWN_BYPASS_REASONS = new Set([
+  'account-added',
+  'account-state',
   'credential-change',
   'credential-edit',
   'credential-save',
@@ -42,7 +44,9 @@ const COOLDOWN_BYPASS_REASONS = new Set([
   'profile-rename',
   'profile-save',
   'profile-state',
-  'provider-added'
+  'provider-added',
+  'settings-change',
+  'system-account-switch'
 ]);
 
 function cloneValue(value) {

--- a/src/shared/probeDeadline.js
+++ b/src/shared/probeDeadline.js
@@ -66,5 +66,6 @@ async function runWithProbeDeadline(task, options = {}) {
 
 module.exports = {
   ProbeTimeoutError,
+  abortError,
   runWithProbeDeadline
 };

--- a/tests/shared/antigravityProbe.test.js
+++ b/tests/shared/antigravityProbe.test.js
@@ -6,6 +6,17 @@ const test = require('node:test');
 const probe = require('../../src/shared/antigravityProbe');
 const rootPackage = require('../../package.json');
 
+test('probe stops waiting for process discovery when the parent signal aborts', async () => {
+  const controller = new AbortController();
+  const pending = probe.probe({
+    signal: controller.signal,
+    probeTimeoutMs: 60_000,
+    detectProcessInfos: () => new Promise(() => {})
+  });
+  controller.abort(new Error('runtime stopped'));
+  await assert.rejects(pending, /runtime stopped/);
+});
+
 test('parseProcessLine extracts pid + csrf + extension port from a darwin ps line', () => {
   const line = '53602 /Applications/Antigravity.app/Contents/Resources/bin/language_server --standalone --override_ide_name antigravity --csrf_token ea1dbb2a-65a8-4766-a155-8e70f032f4ac --app_data_dir antigravity --extension_server_port 12345 --extension_server_csrf_token deadbeef';
   const info = probe._parseProcessLine(line);

--- a/tests/shared/antigravityProbe.test.js
+++ b/tests/shared/antigravityProbe.test.js
@@ -17,6 +17,22 @@ test('probe stops waiting for process discovery when the parent signal aborts', 
   await assert.rejects(pending, /runtime stopped/);
 });
 
+test('an already-aborted parent does not create the provider timeout timer', async (t) => {
+  let scheduled = 0;
+  t.mock.method(global, 'setTimeout', () => {
+    scheduled += 1;
+    return 1;
+  });
+  const controller = new AbortController();
+  controller.abort(new Error('already stopped'));
+
+  await assert.rejects(probe.probe({
+    signal: controller.signal,
+    probeTimeoutMs: 60_000
+  }), /already stopped/);
+  assert.equal(scheduled, 0);
+});
+
 test('parseProcessLine extracts pid + csrf + extension port from a darwin ps line', () => {
   const line = '53602 /Applications/Antigravity.app/Contents/Resources/bin/language_server --standalone --override_ide_name antigravity --csrf_token ea1dbb2a-65a8-4766-a155-8e70f032f4ac --app_data_dir antigravity --extension_server_port 12345 --extension_server_csrf_token deadbeef';
   const info = probe._parseProcessLine(line);
@@ -385,6 +401,32 @@ test('probe prefers quota summary and merges identity from GetUserStatus', async
   assert.equal(result.accountEmail, 'a@b.com');
   assert.equal(result.accountPlan, 'Google AI Pro');
   assert.deepEqual(result.windows.map((window) => window.name), ['Gemini 5-hour', 'Gemini weekly']);
+});
+
+test('parent cancellation during optional grouped identity lookup rejects the probe', async () => {
+  const controller = new AbortController();
+  const pending = probe.probe({
+    signal: controller.signal,
+    detectProcessInfo: async () => ({ pid: 1, csrfToken: 'csrf', extensionPort: null }),
+    listeningPorts: async () => [54733],
+    callLs: async ({ method }) => {
+      if (method === 'RetrieveUserQuotaSummary') {
+        return {
+          groups: [{
+            displayName: 'Gemini Models',
+            buckets: [{ bucketId: 'gemini-weekly', remainingFraction: 0.6 }]
+          }]
+        };
+      }
+      if (method === 'GetUserStatus') {
+        controller.abort(new Error('grouped lookup cancelled'));
+        return new Promise(() => {});
+      }
+      return { ok: true };
+    }
+  });
+
+  await assert.rejects(pending, /grouped lookup cancelled/);
 });
 
 test('probe checks every endpoint for grouped quota before accepting a legacy response', async () => {

--- a/tests/shared/cursorProbe.test.js
+++ b/tests/shared/cursorProbe.test.js
@@ -153,3 +153,27 @@ test('probe includes legacy request usage when auth returns a user id', async ()
   assert.equal(result.usage.requestsLimit, 8);
   assert.deepEqual(calls.sort(), ['/api/auth/me', '/api/usage-summary', '/api/usage?user=user_1'].sort());
 });
+
+test('probe destroys in-flight HTTPS requests when the parent signal aborts', async () => {
+  const controller = new AbortController();
+  const requests = [];
+  const fakeHttps = {
+    request() {
+      const req = new EventEmitter();
+      req.end = () => {};
+      req.setTimeout = () => {};
+      req.destroy = () => { req.destroyed = true; };
+      requests.push(req);
+      return req;
+    }
+  };
+
+  const pending = probe('tok', { httpsLib: fakeHttps, signal: controller.signal });
+  controller.abort(new Error('stop cursor probe'));
+
+  const result = await pending;
+  assert.equal(result.ok, false);
+  assert.equal(result.error.kind, 'network');
+  assert.equal(requests.length, 2);
+  assert.ok(requests.every((request) => request.destroyed));
+});

--- a/tests/shared/grokLimits.test.js
+++ b/tests/shared/grokLimits.test.js
@@ -372,6 +372,29 @@ test('fetchGrokRpcBilling kills the CLI when the parent signal aborts', async ()
   assert.equal(killed, true);
 });
 
+test('fetchGrokLimits does not start web fallback after the RPC parent signal aborts', async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-abort-'));
+  writeAuthJson(home, { 'https://auth.x.ai::client': { key: 'eyJsecret.signature' } });
+  const controller = new AbortController();
+  let webCalls = 0;
+  const pending = fetchGrokLimits({}, {
+    env: {},
+    grokHome: home,
+    signal: controller.signal,
+    fetchRpcBilling: async () => {
+      controller.abort(new Error('grok probe superseded'));
+      throw new Error('RPC aborted');
+    },
+    fetchWebGrpcBilling: async () => {
+      webCalls += 1;
+      return [];
+    }
+  });
+
+  await assert.rejects(pending, /grok probe superseded/);
+  assert.equal(webCalls, 0);
+});
+
 test('fetchGrokLimits prefers Grok CLI RPC billing before bearer web fallback', async () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-rpc-'));
   writeAuthJson(home, {

--- a/tests/shared/grokLimits.test.js
+++ b/tests/shared/grokLimits.test.js
@@ -395,6 +395,25 @@ test('fetchGrokLimits does not start web fallback after the RPC parent signal ab
   assert.equal(webCalls, 0);
 });
 
+test('fetchGrokLimits preserves cancellation after a successful web billing read', async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-web-abort-'));
+  writeAuthJson(home, { 'https://auth.x.ai::client': { key: 'eyJsecret.signature' } });
+  const controller = new AbortController();
+
+  await assert.rejects(fetchGrokLimits({}, {
+    env: {},
+    grokHome: home,
+    signal: controller.signal,
+    fetchRpcBilling: async () => {
+      throw new Error('RPC unavailable');
+    },
+    fetchWebGrpcBilling: async () => {
+      controller.abort(new Error('web result superseded'));
+      return [];
+    }
+  }), /web result superseded/);
+});
+
 test('fetchGrokLimits prefers Grok CLI RPC billing before bearer web fallback', async () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-rpc-'));
   writeAuthJson(home, {

--- a/tests/shared/grokLimits.test.js
+++ b/tests/shared/grokLimits.test.js
@@ -351,6 +351,27 @@ test('fetchGrokRpcBilling speaks Grok agent stdio x.ai/billing JSON-RPC', async 
   assert.equal(body.usage.totalUsed.val, 4200);
 });
 
+test('fetchGrokRpcBilling kills the CLI when the parent signal aborts', async () => {
+  const controller = new AbortController();
+  let killed = false;
+  const child = new EventEmitter();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.stdin = new Writable({ write(_chunk, _encoding, callback) { callback(); } });
+  child.kill = () => { killed = true; };
+
+  const pending = fetchGrokRpcBilling({}, {
+    env: {},
+    signal: controller.signal,
+    spawn: () => child,
+    rpcTimeoutMs: 60_000
+  });
+  controller.abort(new Error('stop grok probe'));
+
+  await assert.rejects(pending, /stop grok probe/);
+  assert.equal(killed, true);
+});
+
 test('fetchGrokLimits prefers Grok CLI RPC billing before bearer web fallback', async () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-rpc-'));
   writeAuthJson(home, {

--- a/tests/shared/kiroLimits.test.js
+++ b/tests/shared/kiroLimits.test.js
@@ -8,6 +8,7 @@ const {
   displayPlanName,
   parseResetDate,
   existingKiroCli,
+  runKiroUsageCli,
   fetchKiroLimits
 } = require('../../src/shared/kiroLimits');
 const { parseLimitProviders, fetchKiroLimits: fetchKiroLimitsViaCollector } = require('../../src/shared/limitCollector');
@@ -265,4 +266,24 @@ test('limitCollector re-exports fetchKiroLimits', async () => {
   });
   assert.equal(provider.provider, 'kiro');
   assert.equal(provider.status, 'ok');
+});
+
+test('runKiroUsageCli terminates immediately when the parent probe is aborted', async () => {
+  const { EventEmitter } = require('node:events');
+  const controller = new AbortController();
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  let kills = 0;
+  child.kill = () => { kills += 1; };
+
+  const pending = runKiroUsageCli({
+    signal: controller.signal,
+    spawn: () => child,
+    kiroCliTimeoutMs: 60_000
+  });
+  controller.abort(new Error('runtime stopped'));
+
+  await assert.rejects(pending, /runtime stopped/);
+  assert.equal(kills, 1);
 });

--- a/tests/shared/limitCollector.codex.test.js
+++ b/tests/shared/limitCollector.codex.test.js
@@ -542,6 +542,27 @@ test('LimitsRuntime compatibility retains Codex windows while exposing a transie
   assert.equal(second.providers[0].updatedAt, '2026-06-01T00:00:00.000Z');
 });
 
+test('LimitsRuntime compatibility keeps retries demand-driven instead of starting background timers', async () => {
+  let scheduledTimers = 0;
+  const collector = createLimitsCollector({
+    limitProviders: 'codex',
+    limitsRefreshMs: 60_000
+  }, {
+    setTimeout: () => {
+      scheduledTimers += 1;
+      return scheduledTimers;
+    },
+    clearTimeout: () => {},
+    providerFetchers: {
+      codex: async () => ({ provider: 'codex', status: 'unavailable', windows: [] })
+    }
+  });
+
+  await collector.snapshot(true);
+  assert.equal(scheduledTimers, 0);
+  collector.stop();
+});
+
 test('LimitsRuntime compatibility seeds last-good windows across a transient first refresh', async () => {
   // Switching the active Codex account reloads the collector (startMode), which
   // used to reset the in-memory transient-window cache. Seeding it from the last

--- a/tests/shared/limitCollectorRetryAfter.test.js
+++ b/tests/shared/limitCollectorRetryAfter.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { probeLimitProvider } = require('../../src/shared/limitCollector');
+
+test('probeLimitProvider reports Retry-After and links the parent signal into adapter fetches', async () => {
+  const parent = new AbortController();
+  const reported = [];
+  let fetchSignal = null;
+  const rows = await probeLimitProvider('kimi', {}, {
+    signal: parent.signal,
+    onRetryAfter: (delayMs) => reported.push(delayMs)
+  }, {
+    now: () => Date.parse('2026-07-22T04:00:00Z'),
+    fetch: async (_url, init) => {
+      fetchSignal = init.signal;
+      return {
+        ok: false,
+        status: 429,
+        headers: { get: (name) => name.toLowerCase() === 'retry-after' ? '12' : null }
+      };
+    },
+    providerFetchers: {
+      kimi: async (_options, deps) => {
+        const response = await deps.fetch('https://example.invalid/quota');
+        return { provider: 'kimi', status: response.status === 429 ? 'sourceRateLimited' : 'ok', windows: [] };
+      }
+    }
+  });
+
+  assert.equal(rows[0].status, 'sourceRateLimited');
+  assert.deepEqual(reported, [12_000]);
+  assert.equal(fetchSignal.aborted, false);
+  parent.abort(new Error('stop'));
+  assert.equal(fetchSignal.aborted, true);
+});
+
+test('probeLimitProvider reports an HTTP-date Retry-After without exposing it on the public row', async () => {
+  const reported = [];
+  const rows = await probeLimitProvider('kimi', {}, {
+    onRetryAfter: (delayMs) => reported.push(delayMs)
+  }, {
+    now: () => Date.parse('2026-07-22T04:00:00Z'),
+    fetch: async () => ({
+      ok: false,
+      status: 503,
+      headers: { get: () => 'Wed, 22 Jul 2026 04:00:20 GMT' }
+    }),
+    providerFetchers: {
+      kimi: async (_options, deps) => {
+        await deps.fetch('https://example.invalid/quota');
+        return { provider: 'kimi', status: 'unavailable', windows: [] };
+      }
+    }
+  });
+
+  assert.deepEqual(reported, [20_000]);
+  assert.equal(Object.hasOwn(rows[0], 'retryAfterMs'), false);
+});
+
+test('the probe wrapper preserves Grok proxy dispatch while adding the parent signal', async () => {
+  const controller = new AbortController();
+  let capturedInit = null;
+  class FakeProxyAgent {
+    constructor(options) {
+      this.options = options;
+    }
+  }
+
+  await probeLimitProvider('grok', {}, { signal: controller.signal }, {
+    env: { HTTPS_PROXY: 'http://proxy.test:7890', NO_PROXY: 'localhost' },
+    EnvHttpProxyAgent: FakeProxyAgent,
+    undiciFetch: async (_url, init) => {
+      capturedInit = init;
+      return { ok: true, status: 200, headers: { get: () => null } };
+    },
+    providerFetchers: {
+      grok: async (_options, deps) => {
+        await deps.fetch('https://grok.test/limits');
+        return { provider: 'grok', status: 'ok', windows: [] };
+      }
+    }
+  });
+
+  assert.equal(capturedInit.signal, controller.signal);
+  assert.ok(capturedInit.dispatcher instanceof FakeProxyAgent);
+  assert.equal(capturedInit.dispatcher.options.httpsProxy, 'http://proxy.test:7890');
+  assert.equal(capturedInit.dispatcher.options.noProxy, 'localhost');
+});

--- a/tests/shared/limitsRetryPolicy.test.js
+++ b/tests/shared/limitsRetryPolicy.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  MAX_RETRY_AFTER_MS,
+  computeRetryDelayMs,
+  isRetryableLimitStatus,
+  parseRetryAfterHeader
+} = require('../../src/shared/limitsRetryPolicy');
+
+test('parseRetryAfterHeader supports delay-seconds and HTTP dates', () => {
+  assert.equal(parseRetryAfterHeader('12', 1_000), 12_000);
+  assert.equal(
+    parseRetryAfterHeader('Wed, 22 Jul 2026 04:00:10 GMT', Date.parse('2026-07-22T04:00:00Z')),
+    10_000
+  );
+  assert.equal(parseRetryAfterHeader('invalid', 1_000), null);
+  assert.equal(parseRetryAfterHeader(String((MAX_RETRY_AFTER_MS / 1000) + 60), 1_000), MAX_RETRY_AFTER_MS);
+});
+
+test('computeRetryDelayMs applies exponential equal jitter with a maximum', () => {
+  assert.equal(computeRetryDelayMs(1, { baseMs: 1_000, maxMs: 4_000, random: () => 0 }), 500);
+  assert.equal(computeRetryDelayMs(2, { baseMs: 1_000, maxMs: 4_000, random: () => 0.5 }), 1_500);
+  assert.equal(computeRetryDelayMs(9, { baseMs: 1_000, maxMs: 4_000, random: () => 0.999 }), 3_998);
+});
+
+test('Retry-After takes precedence and receives only positive bounded jitter', () => {
+  assert.equal(computeRetryDelayMs(5, { retryAfterMs: 10_000, random: () => 0 }), 10_000);
+  assert.equal(computeRetryDelayMs(1, { retryAfterMs: 10_000, random: () => 0.5 }), 10_500);
+  assert.equal(computeRetryDelayMs(1, { retryAfterMs: MAX_RETRY_AFTER_MS * 2, random: () => 0 }), MAX_RETRY_AFTER_MS);
+});
+
+test('retryable statuses exclude terminal credential and configuration failures', () => {
+  for (const status of ['timeout', 'rateLimited', 'sourceRateLimited', 'unavailable', 'error']) {
+    assert.equal(isRetryableLimitStatus(status), true);
+  }
+  for (const status of ['ok', 'disabled', 'notConfigured', 'unauthorized']) {
+    assert.equal(isRetryableLimitStatus(status), false);
+  }
+});

--- a/tests/shared/limitsRuntime.test.js
+++ b/tests/shared/limitsRuntime.test.js
@@ -41,6 +41,7 @@ function runtimeDeps(overrides = {}) {
   return {
     autoStart: false,
     cleanupGraceMs: 0,
+    maxConcurrency: 1,
     providerPhysicalBoundMs: () => 100,
     ...overrides
   };
@@ -134,6 +135,41 @@ test('different account scopes stay independent inside one provider lane', async
   runtime.stop();
 });
 
+test('diagnostic events expose queue state without leaking scoped credentials', async () => {
+  const events = [];
+  const runtime = createLimitsRuntime({ limitProviders: ['kimi'] }, runtimeDeps({
+    onEvent: (event) => events.push(event),
+    probeProvider: async () => [providerRow('kimi', 'account', 'Kimi')]
+  }));
+
+  await runtime.refresh({ provider: 'kimi', credential: 'secret-cookie' }, 'credential-edit');
+
+  assert.deepEqual(events.map((event) => event.type), ['probe-start', 'probe-finish']);
+  assert.ok(events.every((event) => event.provider === 'kimi'));
+  assert.ok(events.every((event) => Number.isInteger(event.active) && Number.isInteger(event.queued)));
+  assert.ok(!JSON.stringify(events).includes('secret-cookie'));
+  await waitFor(() => runtime.getDiagnostics().active === 0, 'executor to become idle');
+  assert.deepEqual(runtime.getDiagnostics(), {
+    active: 0,
+    maxConcurrency: 1,
+    queued: 0,
+    providers: [{ provider: 'kimi', active: false, pending: 0, retryAttempt: 0, retryAt: null }]
+  });
+  runtime.stop();
+});
+
+test('a throwing diagnostic observer cannot break collection', async () => {
+  const runtime = createLimitsRuntime({ limitProviders: ['kimi'] }, runtimeDeps({
+    onEvent: () => { throw new Error('observer failed'); },
+    probeProvider: async () => [providerRow('kimi', 'account', 'Kimi')]
+  }));
+
+  const result = await runtime.refresh({ provider: 'kimi' }, 'manual');
+  assert.equal(result.superseded, false);
+  assert.equal(runtime.getSnapshot().providers[0].status, 'ok');
+  runtime.stop();
+});
+
 test('a later account edit trails an active provider-wide job without discarding other accounts', async () => {
   const jobs = [];
   const runtime = createLimitsRuntime({ limitProviders: ['mimo'] }, runtimeDeps({
@@ -187,11 +223,12 @@ test('provider-wide pending work supersedes older account-scoped pending work', 
   runtime.stop();
 });
 
-test('the shared limits executor never runs more than one provider job at once', async () => {
+test('the shared limits executor runs up to its configured bound', async () => {
   const jobs = [];
   let active = 0;
   let maximum = 0;
-  const runtime = createLimitsRuntime({ limitProviders: ['claude', 'kimi'] }, runtimeDeps({
+  const runtime = createLimitsRuntime({ limitProviders: ['claude', 'kimi', 'mimo'] }, runtimeDeps({
+    maxConcurrency: 2,
     probeProvider: (provider) => {
       active += 1;
       maximum = Math.max(maximum, active);
@@ -202,13 +239,158 @@ test('the shared limits executor never runs more than one provider job at once',
   }));
 
   const refresh = runtime.refresh({}, 'manual');
-  await waitFor(() => jobs.length === 1, 'first provider dispatch');
+  await waitFor(() => jobs.length === 2, 'first bounded provider batch');
+  assert.equal(active, 2);
   jobs[0].job.resolve([providerRow(jobs[0].provider, 'one', 'One')]);
-  await waitFor(() => jobs.length === 2, 'second provider dispatch');
+  await waitFor(() => jobs.length === 3, 'next provider dispatch');
   jobs[1].job.resolve([providerRow(jobs[1].provider, 'two', 'Two')]);
+  jobs[2].job.resolve([providerRow(jobs[2].provider, 'three', 'Three')]);
   await refresh;
 
-  assert.equal(maximum, 1);
+  assert.equal(maximum, 2);
+  runtime.stop();
+});
+
+test('a provider lane stays serial while other providers use executor capacity', async () => {
+  const jobs = [];
+  const activeByProvider = new Map();
+  let sameProviderOverlap = false;
+  const runtime = createLimitsRuntime({ limitProviders: ['claude', 'kimi'] }, runtimeDeps({
+    maxConcurrency: 2,
+    probeProvider: (provider, _config, context) => {
+      const active = (activeByProvider.get(provider) || 0) + 1;
+      activeByProvider.set(provider, active);
+      if (active > 1) sameProviderOverlap = true;
+      const job = deferred();
+      jobs.push({ provider, reason: context.reason, job });
+      return job.promise.finally(() => activeByProvider.set(provider, active - 1));
+    }
+  }));
+
+  const firstClaude = runtime.refresh({ provider: 'claude' }, 'manual');
+  const kimi = runtime.refresh({ provider: 'kimi' }, 'manual');
+  await waitFor(() => jobs.length === 2, 'cross-provider concurrency');
+  const secondClaude = runtime.refresh({ provider: 'claude' }, 'credential-save');
+  assert.equal((await firstClaude).superseded, true);
+  assert.equal(jobs.filter((job) => job.provider === 'claude').length, 1);
+
+  jobs.find((job) => job.provider === 'claude').job.resolve([providerRow('claude', 'old', 'Old')]);
+  await waitFor(() => jobs.filter((job) => job.provider === 'claude').length === 2, 'trailing Claude dispatch');
+  jobs.find((job) => job.provider === 'kimi').job.resolve([providerRow('kimi', 'kimi', 'Kimi')]);
+  jobs.filter((job) => job.provider === 'claude')[1].job.resolve([providerRow('claude', 'new', 'New')]);
+  await Promise.all([kimi, secondClaude]);
+
+  assert.equal(sameProviderOverlap, false);
+  runtime.stop();
+});
+
+test('a fast provider publishes before a slower provider finishes', async () => {
+  const jobs = new Map();
+  const updates = [];
+  const runtime = createLimitsRuntime({ limitProviders: ['claude', 'kimi'] }, runtimeDeps({
+    maxConcurrency: 2,
+    onUpdate: (summary) => updates.push(summary.providers.map((row) => row.provider)),
+    probeProvider: (provider) => {
+      const job = deferred();
+      jobs.set(provider, job);
+      return job.promise;
+    }
+  }));
+
+  const refresh = runtime.refresh({}, 'manual');
+  await waitFor(() => jobs.size === 2, 'parallel provider dispatches');
+  jobs.get('kimi').resolve([providerRow('kimi', 'kimi', 'Kimi')]);
+  await waitFor(() => updates.some((providers) => providers.includes('kimi')), 'incremental Kimi publication');
+  assert.equal(updates.at(-1).includes('claude'), false);
+  jobs.get('claude').resolve([providerRow('claude', 'claude', 'Claude')]);
+  await refresh;
+  assert.deepEqual(runtime.getSnapshot().providers.map((row) => row.provider).sort(), ['claude', 'kimi']);
+  runtime.stop();
+});
+
+test('Retry-After defers the provider retry and manual refresh does not bypass it', async () => {
+  const clock = fakeClock(10_000);
+  const calls = [];
+  const runtime = createLimitsRuntime({ limitProviders: ['kimi'] }, runtimeDeps({
+    now: clock.now,
+    setTimeout: clock.setTimeout,
+    clearTimeout: clock.clearTimeout,
+    random: () => 0,
+    probeProvider: async (_provider, _config, context) => {
+      calls.push(context.reason);
+      if (calls.length === 1) {
+        context.onRetryAfter(30_000);
+        return [{ provider: 'kimi', status: 'sourceRateLimited', windows: [] }];
+      }
+      return [providerRow('kimi', 'account', 'Kimi')];
+    }
+  }));
+
+  await runtime.refresh({ provider: 'kimi' }, 'interval');
+  assert.deepEqual(clock.delays(), [30_000]);
+  const manual = await runtime.refresh({ provider: 'kimi' }, 'manual');
+  assert.equal(manual.deferred, true);
+  assert.equal(calls.length, 1);
+  clock.advance(29_999);
+  assert.equal(calls.length, 1);
+  clock.advance(1);
+  await waitFor(() => calls.length === 2, 'Retry-After dispatch');
+  assert.deepEqual(calls, ['interval', 'retry']);
+  assert.deepEqual(clock.delays(), []);
+  runtime.stop();
+});
+
+test('transient failures use exponential jittered backoff and reset after success', async () => {
+  const clock = fakeClock(0);
+  let calls = 0;
+  const runtime = createLimitsRuntime({ limitProviders: ['kimi'] }, runtimeDeps({
+    now: clock.now,
+    setTimeout: clock.setTimeout,
+    clearTimeout: clock.clearTimeout,
+    retryBaseMs: 1_000,
+    retryMaxMs: 10_000,
+    random: () => 0,
+    probeProvider: async () => {
+      calls += 1;
+      if (calls < 3) return [{ provider: 'kimi', status: 'unavailable', windows: [] }];
+      return [providerRow('kimi', 'account', 'Kimi')];
+    }
+  }));
+
+  await runtime.refresh({ provider: 'kimi' }, 'interval');
+  assert.deepEqual(clock.delays(), [500]);
+  clock.advance(500);
+  await waitFor(() => calls === 2, 'first retry');
+  assert.deepEqual(clock.delays(), [1_000]);
+  clock.advance(1_000);
+  await waitFor(() => calls === 3, 'second retry');
+  assert.deepEqual(clock.delays(), []);
+  runtime.stop();
+});
+
+test('a credential change clears an old provider cooldown', async () => {
+  const clock = fakeClock(0);
+  const calls = [];
+  const runtime = createLimitsRuntime({ limitProviders: ['kimi'] }, runtimeDeps({
+    now: clock.now,
+    setTimeout: clock.setTimeout,
+    clearTimeout: clock.clearTimeout,
+    random: () => 0,
+    probeProvider: async (_provider, _config, context) => {
+      calls.push(context.reason);
+      if (calls.length === 1) {
+        context.onRetryAfter(60_000);
+        return [{ provider: 'kimi', status: 'sourceRateLimited', windows: [] }];
+      }
+      return [providerRow('kimi', 'new', 'New credential')];
+    }
+  }));
+
+  await runtime.refresh({ provider: 'kimi' }, 'interval');
+  assert.deepEqual(clock.delays(), [60_000]);
+  await runtime.refresh({ provider: 'kimi' }, 'credential-save');
+  assert.deepEqual(calls, ['interval', 'credential-save']);
+  assert.deepEqual(clock.delays(), []);
   runtime.stop();
 });
 

--- a/tests/shared/limitsRuntime.test.js
+++ b/tests/shared/limitsRuntime.test.js
@@ -368,30 +368,38 @@ test('transient failures use exponential jittered backoff and reset after succes
   runtime.stop();
 });
 
-test('a credential change clears an old provider cooldown', async () => {
-  const clock = fakeClock(0);
-  const calls = [];
-  const runtime = createLimitsRuntime({ limitProviders: ['kimi'] }, runtimeDeps({
-    now: clock.now,
-    setTimeout: clock.setTimeout,
-    clearTimeout: clock.clearTimeout,
-    random: () => 0,
-    probeProvider: async (_provider, _config, context) => {
-      calls.push(context.reason);
-      if (calls.length === 1) {
-        context.onRetryAfter(60_000);
-        return [{ provider: 'kimi', status: 'sourceRateLimited', windows: [] }];
+test('credential and account lifecycle changes clear an old provider cooldown', async () => {
+  for (const reason of [
+    'credential-save',
+    'account-added',
+    'account-state',
+    'system-account-switch',
+    'settings-change'
+  ]) {
+    const clock = fakeClock(0);
+    const calls = [];
+    const runtime = createLimitsRuntime({ limitProviders: ['kimi'] }, runtimeDeps({
+      now: clock.now,
+      setTimeout: clock.setTimeout,
+      clearTimeout: clock.clearTimeout,
+      random: () => 0,
+      probeProvider: async (_provider, _config, context) => {
+        calls.push(context.reason);
+        if (calls.length === 1) {
+          context.onRetryAfter(60_000);
+          return [{ provider: 'kimi', status: 'sourceRateLimited', windows: [] }];
+        }
+        return [providerRow('kimi', 'new', 'New credential')];
       }
-      return [providerRow('kimi', 'new', 'New credential')];
-    }
-  }));
+    }));
 
-  await runtime.refresh({ provider: 'kimi' }, 'interval');
-  assert.deepEqual(clock.delays(), [60_000]);
-  await runtime.refresh({ provider: 'kimi' }, 'credential-save');
-  assert.deepEqual(calls, ['interval', 'credential-save']);
-  assert.deepEqual(clock.delays(), []);
-  runtime.stop();
+    await runtime.refresh({ provider: 'kimi' }, 'interval');
+    assert.deepEqual(clock.delays(), [60_000], reason);
+    await runtime.refresh({ provider: 'kimi', accountKey: 'new' }, reason);
+    assert.deepEqual(calls, ['interval', reason], reason);
+    assert.deepEqual(clock.delays(), [], reason);
+    runtime.stop();
+  }
 });
 
 test('a transient failure retains matching lastGood windows with the latest status', async () => {

--- a/tests/shared/providerProcessCancellation.test.js
+++ b/tests/shared/providerProcessCancellation.test.js
@@ -19,6 +19,18 @@ function fakeChild() {
   return child;
 }
 
+function fakeRpcChild(onRequest) {
+  const child = fakeChild();
+  child.stdin.write = (line) => {
+    const request = JSON.parse(String(line));
+    const respond = (result) => {
+      queueMicrotask(() => child.stdout.emit('data', `${JSON.stringify({ id: request.id, result })}\n`));
+    };
+    onRequest(request, respond);
+  };
+  return child;
+}
+
 test('runProcessText terminates a CLI child when its parent signal aborts', async () => {
   const controller = new AbortController();
   const child = fakeChild();
@@ -47,4 +59,50 @@ test('Codex RPC terminates its app-server child when its parent signal aborts', 
   controller.abort(new Error('runtime stopped'));
   await assert.rejects(pending, /runtime stopped/);
   assert.equal(child.kills, 1);
+});
+
+test('Codex RPC preserves cancellation from the optional account read', async () => {
+  const controller = new AbortController();
+  const child = fakeRpcChild((request, respond) => {
+    if (request.method === 'initialize') respond({});
+    if (request.method === 'account/rateLimits/read') {
+      respond({
+        rateLimits: {
+          primary: { usedPercent: 10, resetsAt: '2026-07-22T12:00:00Z', windowDurationMins: 300 }
+        }
+      });
+    }
+    if (request.method === 'account/read') controller.abort(new Error('account read cancelled'));
+  });
+
+  await assert.rejects(readCodexRpcWithCommand('codex', {
+    signal: controller.signal,
+    spawn: () => child,
+    platform: 'linux',
+    codexRpcTimeoutMs: 1_000
+  }), /account read cancelled/);
+});
+
+test('Codex RPC preserves cancellation from the empty-quota retry read', async () => {
+  const controller = new AbortController();
+  let rateLimitReads = 0;
+  const child = fakeRpcChild((request, respond) => {
+    if (request.method === 'initialize') respond({});
+    if (request.method === 'account/read') {
+      respond({ account: { email: 'user@example.com', planType: 'plus' } });
+    }
+    if (request.method === 'account/rateLimits/read') {
+      rateLimitReads += 1;
+      if (rateLimitReads === 1) respond({ rateLimits: {} });
+      else controller.abort(new Error('quota retry cancelled'));
+    }
+  });
+
+  await assert.rejects(readCodexRpcWithCommand('codex', {
+    signal: controller.signal,
+    spawn: () => child,
+    platform: 'linux',
+    codexRpcTimeoutMs: 1_000,
+    codexEmptyQuotaRetryDelayMs: 0
+  }), /quota retry cancelled/);
 });

--- a/tests/shared/providerProcessCancellation.test.js
+++ b/tests/shared/providerProcessCancellation.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const test = require('node:test');
+
+const {
+  readCodexRpcWithCommand,
+  runProcessText
+} = require('../../src/shared/limitCollector');
+
+function fakeChild() {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = { write() {} };
+  child.kills = 0;
+  child.kill = () => { child.kills += 1; };
+  return child;
+}
+
+test('runProcessText terminates a CLI child when its parent signal aborts', async () => {
+  const controller = new AbortController();
+  const child = fakeChild();
+  const pending = runProcessText('fake-cli', [], {
+    signal: controller.signal,
+    spawn: () => child,
+    timeoutMs: 60_000
+  });
+
+  controller.abort(new Error('runtime stopped'));
+  await assert.rejects(pending, /runtime stopped/);
+  assert.equal(child.kills, 1);
+});
+
+test('Codex RPC terminates its app-server child when its parent signal aborts', async () => {
+  const controller = new AbortController();
+  const child = fakeChild();
+  const pending = readCodexRpcWithCommand('codex', {
+    signal: controller.signal,
+    spawn: () => child,
+    platform: 'linux',
+    codexRpcTimeoutMs: 60_000
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  controller.abort(new Error('runtime stopped'));
+  await assert.rejects(pending, /runtime stopped/);
+  assert.equal(child.kills, 1);
+});


### PR DESCRIPTION
## Summary

- run different limit providers through a bounded concurrency pool while keeping each provider on its own serial, latest-wins lane
- honor `Retry-After` and jittered exponential backoff for transient failures, with credential changes clearing stale cooldowns
- publish each provider completion incrementally through the existing full device record, without changing the hub/Worker wire shape
- propagate parent cancellation through fetch, CLI, RPC, Cursor HTTPS, and Antigravity probe paths while preserving Grok proxy behavior

This is the resilience layer deferred from #225 after usage collection and quota probing were split into independent runtimes.

## Validation

- `npm run verify` (1665 passed, 0 failed, 1 skipped)
- `npm run sync:worker` (no generated drift)
- focused concurrency, Retry-After/backoff, cancellation, proxy, and compatibility-facade regression tests

Fixes #220


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounded the limits probe executor and added Retry-After + jittered backoff for transient failures to improve resilience, supporting #220. Results publish incrementally and parent cancellation now propagates through fetch, CLI, RPC, and HTTPS.

- **New Features**
  - Bounded cross-provider pool with per-provider serial “latest-wins” lanes in `limitsRuntime` (configurable concurrency).
  - Retry policy (`limitsRetryPolicy`): parse `Retry-After`, exponential backoff with jitter; cleared on credential/profile changes; `createLimitsCollector` keeps retries demand-driven (no background timers).
  - Incremental publication: each provider completion updates the composed device record; hub/Worker wire shape unchanged.
  - Cancellation propagation: parent `AbortSignal` linked through `fetch`, HTTPS, CLI, and JSON-RPC (Cursor, Antigravity, Grok, Kiro, Codex), preserving Grok proxy behavior; helpers ensure child processes are terminated promptly.

<sup>Written for commit 2212eaedda189e45cd83c96c64f52da080bd1b8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

