### PR TITLE
style(ui): simplify glass surfaces

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -4607,7 +4607,6 @@ function applyAppearanceSettings(settings) {
   document.documentElement.style.setProperty('--line-alpha', (0.1 + depth * 0.09).toFixed(3));
   document.documentElement.style.setProperty('--line-strong-alpha', (0.18 + depth * 0.14).toFixed(3));
   document.documentElement.style.setProperty('--control-alpha', (0.03 + depth * 0.045).toFixed(3));
-  document.documentElement.style.setProperty('--highlight-alpha', (0.045 + depth * 0.06).toFixed(3));
   document.documentElement.classList.toggle('system-glass-disabled', systemGlassDisabled);
   els.windowsBackdropRow?.classList.toggle('hidden', !windowsGlass.showBackdropControl);
   if (els.windowsBackdropInput) {

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -4,6 +4,7 @@ const clientLabels = { claude: 'Claude Code', codex: 'Codex', hermes: 'Hermes', 
 const { clientColors, fallbackModelColors, modelVendorFor, modelColor } = window.TokenMonitorUsageCharts;
 const motionPreferenceApi = window.TokenMonitorMotionPreference;
 const windowsGlassApi = window.TokenMonitorWindowsGlass;
+const glassRenderingApi = window.TokenMonitorGlassRendering;
 const wslStatusPresentationApi = window.TokenMonitorWslStatusPresentation;
 const reducedMotionMedia = window.matchMedia?.('(prefers-reduced-motion: reduce)');
 const clientsWithIcon = new Set([
@@ -4598,7 +4599,10 @@ function applyControlLayout(swapSettingsAndRefresh) {
 }
 
 function applyAppearanceSettings(settings) {
-  const opacity = clamp(settings?.glassOpacity ?? 68, 0, 100) / 100;
+  const opacity = glassRenderingApi.renderedGlassOpacity(settings, {
+    platform: state.appInfo?.platform,
+    userAgent: navigator.userAgent
+  });
   const depth = clamp(settings?.glassBlur ?? 32, 0, 100) / 100;
   const systemGlassDisabled = settings?.systemGlass === false;
   const isWindows = navigator.userAgent.toLowerCase().includes('windows');

--- a/src/electron/renderer/glassRendering.js
+++ b/src/electron/renderer/glassRendering.js
@@ -6,7 +6,7 @@
   if (root) root.TokenMonitorGlassRendering = api;
 })(typeof globalThis !== 'undefined' ? globalThis : this, () => {
   function clampOpacity(value) {
-    const parsed = Number(value);
+    const parsed = value == null ? NaN : Number(value);
     const opacity = Number.isFinite(parsed) ? parsed : 68;
     return Math.max(0, Math.min(100, opacity)) / 100;
   }

--- a/src/electron/renderer/glassRendering.js
+++ b/src/electron/renderer/glassRendering.js
@@ -1,0 +1,27 @@
+'use strict';
+
+(function exposeGlassRendering(root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  if (root) root.TokenMonitorGlassRendering = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, () => {
+  function clampOpacity(value) {
+    const parsed = Number(value);
+    const opacity = Number.isFinite(parsed) ? parsed : 68;
+    return Math.max(0, Math.min(100, opacity)) / 100;
+  }
+
+  function isMacPlatform(platform, userAgent) {
+    if (String(platform || '').toLowerCase() === 'darwin') return true;
+    return String(userAgent || '').toLowerCase().includes('macintosh');
+  }
+
+  function renderedGlassOpacity(settings, context = {}) {
+    const requested = clampOpacity(settings?.glassOpacity);
+    const transparentMacFallback = settings?.systemGlass === false
+      && isMacPlatform(context.platform, context.userAgent);
+    return transparentMacFallback && requested < 0.05 ? 0.05 : requested;
+  }
+
+  return { renderedGlassOpacity };
+});

--- a/src/electron/renderer/index.html
+++ b/src/electron/renderer/index.html
@@ -1066,6 +1066,7 @@
     <script src="../motionPreference.js"></script>
     <script src="../windowsBackdropMode.js"></script>
     <script src="windowsGlass.js"></script>
+    <script src="glassRendering.js"></script>
     <script src="app.js"></script>
   </body>
 </html>

--- a/src/electron/renderer/styles.css
+++ b/src/electron/renderer/styles.css
@@ -14,12 +14,7 @@
   --line-alpha: 0.138;
   --line-strong-alpha: 0.238;
   --control-alpha: 0.049;
-  --highlight-alpha: 0.07;
   --glass: rgba(var(--glass-rgb), var(--glass-alpha));
-  --glass-surface:
-    linear-gradient(180deg, rgba(var(--overlay-rgb), var(--highlight-alpha)), rgba(var(--overlay-rgb), 0.022)),
-    linear-gradient(135deg, rgba(var(--overlay-rgb), 0.035), rgba(0, 0, 0, 0.09)),
-    var(--glass);
   --glass-filter: blur(32px) saturate(115%);
   --floating-bubble-radius: 17px;
   --glass-strong: rgba(31, 35, 41, 0.56);
@@ -78,11 +73,10 @@ input, textarea, [contenteditable="true"] {
   padding: 12px 14px 14px;
   overflow: hidden;
   isolation: isolate;
-  border: 1px solid var(--line-strong);
   border-radius: 14px;
   clip-path: inset(0 round 14px);
-  background: var(--glass-surface);
-  box-shadow: 0 22px 55px var(--shadow), inset 0 1px 0 rgba(var(--overlay-rgb), 0.13);
+  background: var(--glass);
+  box-shadow: 0 22px 55px var(--shadow);
   -webkit-backdrop-filter: var(--glass-filter);
   backdrop-filter: var(--glass-filter);
 }
@@ -105,14 +99,6 @@ html.is-mac-legacy .shell {
   border-radius: 10px;
   clip-path: inset(0 round 10px);
 }
-.shell::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  border-radius: inherit;
-  background: linear-gradient(180deg, rgba(var(--overlay-rgb), 0.08), transparent 36%);
-}
 .floating-bubble-tab {
   -webkit-app-region: no-drag;
   -webkit-appearance: none;
@@ -129,18 +115,14 @@ html.is-mac-legacy .shell {
   overflow: hidden;
   border: 0;
   border-radius: var(--floating-bubble-radius);
-  background: var(--glass-surface);
+  background: var(--glass);
   color: var(--number);
   cursor: grab;
-  box-shadow: inset 0 1px 0 rgba(var(--overlay-rgb), 0.13);
   outline: none;
   -webkit-backdrop-filter: var(--glass-filter);
   backdrop-filter: var(--glass-filter);
 }
 .system-glass-disabled .floating-bubble-tab {
-  box-shadow:
-    inset 0 0 0 1px var(--line-strong),
-    inset 0 1px 0 rgba(var(--overlay-rgb), 0.13);
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
 }

--- a/tests/electron/floatingBubble.test.js
+++ b/tests/electron/floatingBubble.test.js
@@ -360,7 +360,7 @@ test('dragFloatingBubbleBounds anchors the mini-window to the OS cursor point', 
   );
 });
 
-test('floating bubble collapsed styles fill the mini window with app glass styling', () => {
+test('glass surfaces keep the shared tint and blur without decorative chrome', () => {
   const css = fs.readFileSync(stylesPath, 'utf8');
   const app = fs.readFileSync(appPath, 'utf8');
   const html = fs.readFileSync(indexPath, 'utf8');
@@ -374,20 +374,29 @@ test('floating bubble collapsed styles fill the mini window with app glass styli
   assert.match(css, /html\.floating-bubble-collapsed-left,\s*body\.floating-bubble-collapsed-left/);
   assert.match(css, /html\.floating-bubble-collapsed-right,\s*body\.floating-bubble-collapsed-right/);
   const collapsedBlock = cssBlock(css, 'html\\.floating-bubble-collapsed-left,\\s*body\\.floating-bubble-collapsed-left,\\s*html\\.floating-bubble-collapsed-right,\\s*body\\.floating-bubble-collapsed-right');
+  const shellBlock = cssBlock(css, '\\.shell');
   const tabBlock = cssBlock(css, '\\.floating-bubble-tab');
+  const flatTabBlock = cssBlock(css, '\\.system-glass-disabled \\.floating-bubble-tab');
   assert.match(collapsedBlock, /background:\s*transparent;/);
+  assert.match(shellBlock, /background:\s*var\(--glass\);/);
+  assert.match(shellBlock, /box-shadow:\s*0 22px 55px var\(--shadow\);/);
+  assert.doesNotMatch(shellBlock, /(?:^|\n)\s*border\s*:/);
+  assert.doesNotMatch(shellBlock, /box-shadow:[^;]*\binset\b/);
   assert.match(tabBlock, /appearance:\s*none;/);
   assert.match(tabBlock, /border:\s*0;/);
   assert.match(tabBlock, /border-radius:\s*var\(--floating-bubble-radius\);/);
   assert.match(app, /const BUBBLE_CONTENT_MIN_W = 34;/);
-  assert.match(tabBlock, /background:\s*var\(--glass-surface\);/);
+  assert.match(tabBlock, /background:\s*var\(--glass\);/);
   assert.match(tabBlock, /color:\s*var\(--number\);/);
   assert.match(tabBlock, /backdrop-filter:\s*var\(--glass-filter\);/);
-  assert.match(css, /\.system-glass-disabled \.floating-bubble-tab\s*\{[\s\S]*backdrop-filter:\s*none;/);
+  assert.doesNotMatch(tabBlock, /box-shadow/);
+  assert.match(flatTabBlock, /backdrop-filter:\s*none;/);
+  assert.doesNotMatch(flatTabBlock, /box-shadow/);
   assert.match(app, /classList\.toggle\('system-glass-disabled', systemGlassDisabled\)/);
   assert.match(boot, /query\.get\('systemGlassDisabled'\) === '1'/);
-  assert.match(css, /--glass-surface:\s*[\s\S]*var\(--glass\);/);
   assert.match(css, /--glass-filter:\s*blur\(32px\) saturate\(115%\);/);
+  assert.doesNotMatch(css, /--glass-surface|--highlight-alpha|\.shell::after/);
+  assert.doesNotMatch(app, /--highlight-alpha/);
   assert.doesNotMatch(css, /--bubble-(?:alpha|blur)/);
   assert.doesNotMatch(app, /--bubble-(?:alpha|blur)/);
   assert.match(css, /html\.floating-bubble-collapsed-left body \.shell,\s*html\.floating-bubble-collapsed-right body \.shell/);

--- a/tests/electron/glassRendering.test.js
+++ b/tests/electron/glassRendering.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const { renderedGlassOpacity } = require('../../src/electron/renderer/glassRendering');
+
+test('transparent mode keeps a stable backing surface on macOS below five percent', () => {
+  assert.equal(renderedGlassOpacity(
+    { glassOpacity: 0, systemGlass: false },
+    { platform: 'darwin' }
+  ), 0.05);
+  assert.equal(renderedGlassOpacity(
+    { glassOpacity: 0, systemGlass: false },
+    { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X)' }
+  ), 0.05);
+  assert.equal(renderedGlassOpacity(
+    { glassOpacity: 1, systemGlass: false },
+    { platform: 'darwin' }
+  ), 0.05);
+  assert.equal(renderedGlassOpacity(
+    { glassOpacity: 2, systemGlass: false },
+    { platform: 'darwin' }
+  ), 0.05);
+  assert.equal(renderedGlassOpacity(
+    { glassOpacity: 3, systemGlass: false },
+    { platform: 'darwin' }
+  ), 0.05);
+  assert.equal(renderedGlassOpacity(
+    { glassOpacity: 4, systemGlass: false },
+    { platform: 'darwin' }
+  ), 0.05);
+  assert.equal(renderedGlassOpacity(
+    { glassOpacity: 5, systemGlass: false },
+    { platform: 'darwin' }
+  ), 0.05);
+  assert.equal(renderedGlassOpacity(
+    { glassOpacity: 6, systemGlass: false },
+    { platform: 'darwin' }
+  ), 0.06);
+});
+
+test('system glass and other platforms retain true zero opacity', () => {
+  assert.equal(renderedGlassOpacity(
+    { glassOpacity: 0, systemGlass: true },
+    { platform: 'darwin' }
+  ), 0);
+  assert.equal(renderedGlassOpacity(
+    { glassOpacity: 0, systemGlass: false },
+    { platform: 'win32', userAgent: 'Windows' }
+  ), 0);
+  assert.equal(renderedGlassOpacity(
+    { glassOpacity: 0, systemGlass: false },
+    { platform: 'linux' }
+  ), 0);
+});
+
+test('glass renderer normalizes invalid and out-of-range settings', () => {
+  assert.equal(renderedGlassOpacity({}, { platform: 'darwin' }), 0.68);
+  assert.equal(renderedGlassOpacity({ glassOpacity: -10, systemGlass: true }, { platform: 'darwin' }), 0);
+  assert.equal(renderedGlassOpacity({ glassOpacity: 120 }, { platform: 'win32' }), 1);
+});
+
+test('glass rendering helper loads before the renderer entry point', () => {
+  const html = fs.readFileSync(path.join(__dirname, '../../src/electron/renderer/index.html'), 'utf8');
+  assert.ok(html.indexOf('<script src="glassRendering.js"></script>') < html.indexOf('<script src="app.js"></script>'));
+});

--- a/tests/electron/glassRendering.test.js
+++ b/tests/electron/glassRendering.test.js
@@ -59,6 +59,7 @@ test('system glass and other platforms retain true zero opacity', () => {
 
 test('glass renderer normalizes invalid and out-of-range settings', () => {
   assert.equal(renderedGlassOpacity({}, { platform: 'darwin' }), 0.68);
+  assert.equal(renderedGlassOpacity({ glassOpacity: null, systemGlass: false }, { platform: 'darwin' }), 0.68);
   assert.equal(renderedGlassOpacity({ glassOpacity: -10, systemGlass: true }, { platform: 'darwin' }), 0);
   assert.equal(renderedGlassOpacity({ glassOpacity: 120 }, { platform: 'win32' }), 1);
 });


### PR DESCRIPTION
## Summary

- remove the top highlight and diagonal tint gradient so glass opacity and custom theme colours can reach their intended values without extra mixing
- remove the widget shell border and inset sheen, including the equivalent collapsed-bubble decoration
- delete the obsolete highlight variable/update path while preserving native Acrylic/Accent blur, tint, rounded corners, outer shadow, and functional UI borders

## Verification

- `npm run verify`
- manually compared all four decoration layers independently in-app on macOS and Windows; the temporary A/B controls were removed before this PR

## Visual verification

Each layer was toggled independently during review. The final result keeps all four decorative layers off so the native system material and selected custom colour are shown without additional surface mixing.

Follow-up to #229.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified glass surfaces by removing gradients and decorative chrome; shell and floating bubble now use `--glass` with only an outer shadow. Stabilized transparent mode on macOS and preserved the default glass opacity (68%) when settings are null or invalid.

- **Refactors**
  - Removed `--highlight-alpha`/`--glass-surface`; render `--glass` directly on shell and bubble.
  - Dropped shell border, inset sheen, and bubble inset shadows; kept blur, tint, rounded corners, and outer shadow.

- **Bug Fixes**
  - Added a glass rendering helper that normalizes opacity, defaults to 68%, and enforces a 5% floor for macOS transparent mode; true zero remains for system glass and non‑mac platforms.
  - Integrated the helper into `applyAppearanceSettings` and loaded it before the app entry; added tests for invalid/out‑of‑range normalization, macOS clamping, and load order.

<sup>Written for commit 83fe77b25966f6981a6371bbf9667cc229fcd111. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

