### PR TITLE
fix(renderer): prevent large session list refresh jank

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -101,6 +101,12 @@ const { limitFillPercent, limitModeSuffix } = window.TokenMonitorLimitDisplayMod
 const i18n = window.TokenMonitorI18n;
 const currencyApi = window.TokenMonitorCurrency;
 const sessionRowsApi = window.TokenMonitorSessionRows;
+const breakdownRenderPolicyApi = window.TokenMonitorBreakdownRenderPolicy;
+const {
+  isLargeSessionBreakdown,
+  rowRenderFingerprint,
+  shouldAnimateBreakdownRows
+} = breakdownRenderPolicyApi;
 const deviceBreakdownApi = window.TokenMonitorDeviceBreakdown;
 const projectRowsApi = window.TokenMonitorProjectRows;
 const sessionDetailApi = window.TokenMonitorSessionDetail;
@@ -1080,6 +1086,7 @@ function animateNumber(el, from, to, duration = 1000, onDone = null) {
 
 const rowNumberAnimations = new Map();
 const rowBarAnimations = new Map();
+const rowRenderFingerprints = new WeakMap();
 
 function prefersReducedMotion() {
   return motionPreferenceApi.shouldReduceMotion(state.settings?.reduceMotion, reducedMotionMedia?.matches);
@@ -1112,8 +1119,10 @@ function applyReduceMotionPreference(value) {
 }
 
 function captureBreakdownMotion() {
+  const rows = Array.from(els.breakdown?.querySelectorAll('.row[data-key]') || []);
+  if (!shouldAnimateBreakdownRows(rows.length, { reducedMotion: prefersReducedMotion() })) return null;
   const snapshot = new Map();
-  for (const row of els.breakdown?.querySelectorAll('.row[data-key]') || []) {
+  for (const row of rows) {
     const rect = row.getBoundingClientRect();
     const fill = row.querySelector('.bar-fill');
     const trackWidth = fill?.parentElement?.getBoundingClientRect().width || 0;
@@ -1169,9 +1178,11 @@ function animateRowNumber(el, from, to, duration = 420) {
 }
 
 function animateBreakdownFrom(snapshot, { duration = 420 } = {}) {
-  if (prefersReducedMotion()) return;
+  if (!snapshot) return;
+  const rows = Array.from(els.breakdown?.querySelectorAll('.row[data-key]') || []);
+  if (!shouldAnimateBreakdownRows(rows.length, { reducedMotion: prefersReducedMotion() })) return;
   let enteringIndex = 0;
-  for (const row of els.breakdown?.querySelectorAll('.row[data-key]') || []) {
+  for (const row of rows) {
     const previous = snapshot.get(row.dataset.key);
     const value = Number(row.dataset.motionValue || 0);
     const fill = row.querySelector('.bar-fill');
@@ -1547,6 +1558,8 @@ function applyHomeListMark(mark, iconKind, color) {
 }
 
 function renderRows(rows, { incompleteHint = '' } = {}) {
+  const largeSessionList = isLargeSessionBreakdown(state.breakdown, rows.length);
+  els.breakdown.classList.toggle('large-session-list', largeSessionList);
   if (rows.length === 0 && !incompleteHint) {
     els.breakdown.replaceChildren();
     state.rowSignature = '';
@@ -1576,9 +1589,20 @@ function renderRows(rows, { incompleteHint = '' } = {}) {
   const current = new Map(Array.from(els.breakdown.children)
     .filter((child) => !child.classList.contains('breakdown-incomplete-hint'))
     .map((child) => [child.dataset.key, child]));
+  const renderContext = {
+    breakdown: state.breakdown,
+    currency: currentCurrency(),
+    currencyRatesEffective: state.settings?.currencyRatesEffective || null,
+    locale: currentLocale(),
+    showToolIcons: state.settings?.showToolIcons !== false
+  };
   for (const rowData of rows) {
     const row = current.get(rowData.key);
-    if (row) updateRow(row, { ...rowData, max });
+    if (!row) continue;
+    const fingerprint = rowRenderFingerprint(rowData, max, renderContext);
+    if (rowRenderFingerprints.get(row) === fingerprint) continue;
+    updateRow(row, { ...rowData, max });
+    rowRenderFingerprints.set(row, fingerprint);
   }
   if (liveMotionSnapshot) animateBreakdownFrom(liveMotionSnapshot, { duration: 600 });
 }

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -21,7 +21,7 @@ function osIconFor(platform) {
 }
 
 function iconKindFor(rowData, breakdown) {
-  if (!state.settings?.showToolIcons) return { kind: 'dot' };
+  if (!toolIconsEnabled(state.settings?.showToolIcons)) return { kind: 'dot' };
   if (breakdown === 'device') {
     const os = osIconFor(rowData.platform);
     return os ? { kind: 'icon', iconClass: `row-icon-os-${os}` } : { kind: 'dot' };
@@ -103,9 +103,11 @@ const currencyApi = window.TokenMonitorCurrency;
 const sessionRowsApi = window.TokenMonitorSessionRows;
 const breakdownRenderPolicyApi = window.TokenMonitorBreakdownRenderPolicy;
 const {
+  createAfterLayoutScheduler,
   isLargeSessionBreakdown,
   rowRenderFingerprint,
-  shouldAnimateBreakdownRows
+  shouldAnimateBreakdownRows,
+  toolIconsEnabled
 } = breakdownRenderPolicyApi;
 const deviceBreakdownApi = window.TokenMonitorDeviceBreakdown;
 const projectRowsApi = window.TokenMonitorProjectRows;
@@ -1087,6 +1089,32 @@ function animateNumber(el, from, to, duration = 1000, onDone = null) {
 const rowNumberAnimations = new Map();
 const rowBarAnimations = new Map();
 const rowRenderFingerprints = new WeakMap();
+const largeSessionContainmentScheduler = createAfterLayoutScheduler(
+  typeof requestAnimationFrame === 'function' ? requestAnimationFrame : null,
+  typeof cancelAnimationFrame === 'function' ? cancelAnimationFrame : null
+);
+
+function updateLargeSessionContainment(enabled, { remeasure = false } = {}) {
+  els.breakdown.classList.toggle('large-session-list', enabled);
+  if (!enabled) {
+    largeSessionContainmentScheduler.cancel();
+    els.breakdown.classList.remove('large-session-list-ready');
+    return;
+  }
+  if (remeasure) {
+    largeSessionContainmentScheduler.cancel();
+    els.breakdown.classList.remove('large-session-list-ready');
+  }
+  if (largeSessionContainmentScheduler.pending() || els.breakdown.classList.contains('large-session-list-ready')) return;
+  // Let Chromium lay out every new row without size containment first. The
+  // `auto` intrinsic size can then retain each row's real block size before
+  // off-screen rendering is enabled, avoiding scroll-geometry corrections.
+  largeSessionContainmentScheduler.schedule(() => {
+    if (els.breakdown.classList.contains('large-session-list')) {
+      els.breakdown.classList.add('large-session-list-ready');
+    }
+  });
+}
 
 function prefersReducedMotion() {
   return motionPreferenceApi.shouldReduceMotion(state.settings?.reduceMotion, reducedMotionMedia?.matches);
@@ -1347,7 +1375,7 @@ function rowTemplate(rowData) {
 
 function renderDeviceAccordion(accordionInner, deviceDetail) {
   const signature = JSON.stringify([
-    state.settings?.showToolIcons === true,
+    toolIconsEnabled(state.settings?.showToolIcons),
     deviceDetail.emptyText,
     deviceDetail.metaParts,
     deviceDetail.tools.map((tool) => [
@@ -1376,7 +1404,7 @@ function renderDeviceAccordion(accordionInner, deviceDetail) {
       const label = document.createElement('div');
       label.className = 'device-tool-label';
       const mark = document.createElement('span');
-      if (state.settings?.showToolIcons && clientsWithIcon.has(tool.client)) {
+      if (toolIconsEnabled(state.settings?.showToolIcons) && clientsWithIcon.has(tool.client)) {
         mark.className = `device-tool-mark row-icon row-icon-${tool.client}`;
       } else {
         mark.className = 'device-tool-mark dot';
@@ -1559,8 +1587,8 @@ function applyHomeListMark(mark, iconKind, color) {
 
 function renderRows(rows, { incompleteHint = '' } = {}) {
   const largeSessionList = isLargeSessionBreakdown(state.breakdown, rows.length);
-  els.breakdown.classList.toggle('large-session-list', largeSessionList);
   if (rows.length === 0 && !incompleteHint) {
+    updateLargeSessionContainment(false);
     els.breakdown.replaceChildren();
     state.rowSignature = '';
     return;
@@ -1574,7 +1602,8 @@ function renderRows(rows, { incompleteHint = '' } = {}) {
   const children = Array.from(els.breakdown.children);
   const existingHint = children.find((child) => child.classList.contains('breakdown-incomplete-hint'));
   const existing = new Map(children.filter((child) => child !== existingHint).map((child) => [child.dataset.key, child]));
-  if (signature !== state.rowSignature) {
+  const structureChanged = signature !== state.rowSignature;
+  if (structureChanged) {
     const nodes = rows.map((row) => existing.get(row.key) || rowTemplate(row));
     if (incompleteHint) {
       const hint = existingHint || document.createElement('p');
@@ -1586,6 +1615,7 @@ function renderRows(rows, { incompleteHint = '' } = {}) {
     els.breakdown.replaceChildren(...nodes);
     state.rowSignature = signature;
   }
+  updateLargeSessionContainment(largeSessionList, { remeasure: structureChanged });
   const current = new Map(Array.from(els.breakdown.children)
     .filter((child) => !child.classList.contains('breakdown-incomplete-hint'))
     .map((child) => [child.dataset.key, child]));
@@ -1594,7 +1624,7 @@ function renderRows(rows, { incompleteHint = '' } = {}) {
     currency: currentCurrency(),
     currencyRatesEffective: state.settings?.currencyRatesEffective || null,
     locale: currentLocale(),
-    showToolIcons: state.settings?.showToolIcons !== false
+    showToolIcons: toolIconsEnabled(state.settings?.showToolIcons)
   };
   for (const rowData of rows) {
     const row = current.get(rowData.key);

--- a/src/electron/renderer/breakdownRenderPolicy.js
+++ b/src/electron/renderer/breakdownRenderPolicy.js
@@ -1,0 +1,36 @@
+'use strict';
+
+(function exposeBreakdownRenderPolicy(root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  if (root) root.TokenMonitorBreakdownRenderPolicy = api;
+})(typeof window !== 'undefined' ? window : null, function createBreakdownRenderPolicy() {
+  // FLIP captures force synchronous layout and every animated row creates both Web
+  // Animations and a number-counting rAF. Keep that polish for the compact views it was
+  // designed for, but never fan it out across a Hub-sized session collection.
+  const MAX_ANIMATED_BREAKDOWN_ROWS = 40;
+
+  function rowCount(value) {
+    const count = Number(value);
+    return Number.isFinite(count) && count > 0 ? Math.floor(count) : 0;
+  }
+
+  function shouldAnimateBreakdownRows(count, options = {}) {
+    return options.reducedMotion !== true && rowCount(count) <= MAX_ANIMATED_BREAKDOWN_ROWS;
+  }
+
+  function isLargeSessionBreakdown(breakdown, count) {
+    return breakdown === 'session' && rowCount(count) > MAX_ANIMATED_BREAKDOWN_ROWS;
+  }
+
+  function rowRenderFingerprint(row, max, context = {}) {
+    return JSON.stringify([row || null, Number(max) || 0, context || null]);
+  }
+
+  return {
+    MAX_ANIMATED_BREAKDOWN_ROWS,
+    isLargeSessionBreakdown,
+    rowRenderFingerprint,
+    shouldAnimateBreakdownRows
+  };
+});

--- a/src/electron/renderer/breakdownRenderPolicy.js
+++ b/src/electron/renderer/breakdownRenderPolicy.js
@@ -23,14 +23,50 @@
     return breakdown === 'session' && rowCount(count) > MAX_ANIMATED_BREAKDOWN_ROWS;
   }
 
+  function toolIconsEnabled(value) {
+    return value === true;
+  }
+
+  function createAfterLayoutScheduler(requestFrame, cancelFrame) {
+    let handle = 0;
+
+    function cancel() {
+      if (!handle) return;
+      if (typeof cancelFrame === 'function') cancelFrame(handle);
+      handle = 0;
+    }
+
+    function schedule(callback) {
+      cancel();
+      if (typeof requestFrame !== 'function') {
+        callback();
+        return;
+      }
+      handle = requestFrame(() => {
+        handle = requestFrame(() => {
+          handle = 0;
+          callback();
+        });
+      });
+    }
+
+    return {
+      cancel,
+      pending: () => handle !== 0,
+      schedule
+    };
+  }
+
   function rowRenderFingerprint(row, max, context = {}) {
     return JSON.stringify([row || null, Number(max) || 0, context || null]);
   }
 
   return {
     MAX_ANIMATED_BREAKDOWN_ROWS,
+    createAfterLayoutScheduler,
     isLargeSessionBreakdown,
     rowRenderFingerprint,
-    shouldAnimateBreakdownRows
+    shouldAnimateBreakdownRows,
+    toolIconsEnabled
   };
 });

--- a/src/electron/renderer/index.html
+++ b/src/electron/renderer/index.html
@@ -1055,6 +1055,7 @@
     <script src="preferenceDragSort.js"></script>
     <script src="i18n.js"></script>
     <script src="sessionRows.js"></script>
+    <script src="breakdownRenderPolicy.js"></script>
     <script src="deviceBreakdown.js"></script>
     <script src="../../shared/projectKey.js"></script>
     <script src="projectRows.js"></script>

--- a/src/electron/renderer/styles.css
+++ b/src/electron/renderer/styles.css
@@ -2593,6 +2593,11 @@ html.is-windows .settings-panel select option {
 }
 
 .row { display: grid; gap: 6px; padding-bottom: 10px; border-bottom: 1px solid rgba(var(--line-rgb), 0.12); }
+.breakdown.large-session-list .session-row {
+  content-visibility: auto;
+  contain: layout paint style;
+  contain-intrinsic-block-size: auto 72px;
+}
 .row-head { display: flex; min-width: 0; align-items: center; justify-content: space-between; gap: 10px; font-size: 12px; }
 .row-name { display: flex; min-width: 0; flex: 1 1 auto; align-items: center; gap: 8px; color: var(--text); }
 .dot {

--- a/src/electron/renderer/styles.css
+++ b/src/electron/renderer/styles.css
@@ -2594,9 +2594,11 @@ html.is-windows .settings-panel select option {
 
 .row { display: grid; gap: 6px; padding-bottom: 10px; border-bottom: 1px solid rgba(var(--line-rgb), 0.12); }
 .breakdown.large-session-list .session-row {
+  contain-intrinsic-block-size: auto 72px;
+}
+.breakdown.large-session-list.large-session-list-ready .session-row {
   content-visibility: auto;
   contain: layout paint style;
-  contain-intrinsic-block-size: auto 72px;
 }
 .row-head { display: flex; min-width: 0; align-items: center; justify-content: space-between; gap: 10px; font-size: 12px; }
 .row-name { display: flex; min-width: 0; flex: 1 1 auto; align-items: center; gap: 8px; color: var(--text); }

--- a/tests/electron/breakdownRenderPolicy.test.js
+++ b/tests/electron/breakdownRenderPolicy.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  MAX_ANIMATED_BREAKDOWN_ROWS,
+  isLargeSessionBreakdown,
+  rowRenderFingerprint,
+  shouldAnimateBreakdownRows
+} = require('../../src/electron/renderer/breakdownRenderPolicy');
+
+const rendererDir = path.join(__dirname, '..', '..', 'src', 'electron', 'renderer');
+
+test('small breakdowns keep motion while large breakdowns skip it', () => {
+  assert.equal(shouldAnimateBreakdownRows(MAX_ANIMATED_BREAKDOWN_ROWS), true);
+  assert.equal(shouldAnimateBreakdownRows(MAX_ANIMATED_BREAKDOWN_ROWS + 1), false);
+});
+
+test('reduced motion skips layout capture even for small breakdowns', () => {
+  assert.equal(shouldAnimateBreakdownRows(1, { reducedMotion: true }), false);
+});
+
+test('only large session breakdowns opt into off-screen rendering containment', () => {
+  assert.equal(isLargeSessionBreakdown('session', MAX_ANIMATED_BREAKDOWN_ROWS + 1), true);
+  assert.equal(isLargeSessionBreakdown('session', MAX_ANIMATED_BREAKDOWN_ROWS), false);
+  assert.equal(isLargeSessionBreakdown('model', MAX_ANIMATED_BREAKDOWN_ROWS + 100), false);
+});
+
+test('row fingerprints stay stable until visible row output changes', () => {
+  const row = {
+    key: 'session:codex:s1',
+    kind: 'session',
+    name: 'Codex · gpt-5.6-sol',
+    subtitle: '21:53 · 465 msgs',
+    detail: 's1',
+    value: 1234,
+    cost: 0.42,
+    color: '#49a3b0',
+    client: 'codex'
+  };
+  const context = { breakdown: 'session', currency: 'USD', locale: 'en-US', showToolIcons: true };
+
+  const fingerprint = rowRenderFingerprint(row, 5000, context);
+  assert.equal(rowRenderFingerprint({ ...row }, 5000, { ...context }), fingerprint);
+  assert.notEqual(rowRenderFingerprint({ ...row, value: 1235 }, 5000, context), fingerprint);
+  assert.notEqual(rowRenderFingerprint(row, 6000, context), fingerprint);
+  assert.notEqual(rowRenderFingerprint(row, 5000, { ...context, currency: 'HKD' }), fingerprint);
+});
+
+test('renderer applies the policy before touching breakdown rows', () => {
+  const html = fs.readFileSync(path.join(rendererDir, 'index.html'), 'utf8');
+  const app = fs.readFileSync(path.join(rendererDir, 'app.js'), 'utf8');
+  const css = fs.readFileSync(path.join(rendererDir, 'styles.css'), 'utf8');
+
+  assert.ok(html.indexOf('<script src="breakdownRenderPolicy.js"></script>') < html.indexOf('<script src="app.js"></script>'));
+  assert.match(app, /shouldAnimateBreakdownRows\(rows\.length, \{ reducedMotion: prefersReducedMotion\(\) \}\)/);
+  assert.match(app, /if \(rowRenderFingerprints\.get\(row\) === fingerprint\) continue;/);
+  assert.match(app, /classList\.toggle\('large-session-list', largeSessionList\)/);
+  assert.match(css, /\.breakdown\.large-session-list \.session-row\s*\{[^}]*content-visibility:\s*auto;[^}]*contain:\s*layout paint style;/s);
+});

--- a/tests/electron/breakdownRenderPolicy.test.js
+++ b/tests/electron/breakdownRenderPolicy.test.js
@@ -7,9 +7,11 @@ const test = require('node:test');
 
 const {
   MAX_ANIMATED_BREAKDOWN_ROWS,
+  createAfterLayoutScheduler,
   isLargeSessionBreakdown,
   rowRenderFingerprint,
-  shouldAnimateBreakdownRows
+  shouldAnimateBreakdownRows,
+  toolIconsEnabled
 } = require('../../src/electron/renderer/breakdownRenderPolicy');
 
 const rendererDir = path.join(__dirname, '..', '..', 'src', 'electron', 'renderer');
@@ -21,6 +23,45 @@ test('small breakdowns keep motion while large breakdowns skip it', () => {
 
 test('reduced motion skips layout capture even for small breakdowns', () => {
   assert.equal(shouldAnimateBreakdownRows(1, { reducedMotion: true }), false);
+});
+
+test('tool icon state uses the same strict normalization as row rendering', () => {
+  assert.equal(toolIconsEnabled(undefined), false);
+  assert.equal(toolIconsEnabled(false), false);
+  assert.equal(toolIconsEnabled(true), true);
+});
+
+test('off-screen containment waits for two frames and can be cancelled', () => {
+  let nextHandle = 1;
+  const callbacks = new Map();
+  const requestFrame = (callback) => {
+    const handle = nextHandle++;
+    callbacks.set(handle, callback);
+    return handle;
+  };
+  const cancelFrame = (handle) => callbacks.delete(handle);
+  const runNextFrame = () => {
+    const [handle, callback] = callbacks.entries().next().value;
+    callbacks.delete(handle);
+    callback();
+  };
+  const scheduler = createAfterLayoutScheduler(requestFrame, cancelFrame);
+  let ready = false;
+
+  scheduler.schedule(() => { ready = true; });
+  assert.equal(scheduler.pending(), true);
+  runNextFrame();
+  assert.equal(ready, false);
+  assert.equal(scheduler.pending(), true);
+  runNextFrame();
+  assert.equal(ready, true);
+  assert.equal(scheduler.pending(), false);
+
+  scheduler.schedule(() => { ready = false; });
+  scheduler.cancel();
+  assert.equal(scheduler.pending(), false);
+  assert.equal(callbacks.size, 0);
+  assert.equal(ready, true);
 });
 
 test('only large session breakdowns opt into off-screen rendering containment', () => {
@@ -58,6 +99,9 @@ test('renderer applies the policy before touching breakdown rows', () => {
   assert.ok(html.indexOf('<script src="breakdownRenderPolicy.js"></script>') < html.indexOf('<script src="app.js"></script>'));
   assert.match(app, /shouldAnimateBreakdownRows\(rows\.length, \{ reducedMotion: prefersReducedMotion\(\) \}\)/);
   assert.match(app, /if \(rowRenderFingerprints\.get\(row\) === fingerprint\) continue;/);
-  assert.match(app, /classList\.toggle\('large-session-list', largeSessionList\)/);
-  assert.match(css, /\.breakdown\.large-session-list \.session-row\s*\{[^}]*content-visibility:\s*auto;[^}]*contain:\s*layout paint style;/s);
+  assert.match(app, /showToolIcons:\s*toolIconsEnabled\(state\.settings\?\.showToolIcons\)/);
+  assert.match(app, /updateLargeSessionContainment\(largeSessionList, \{ remeasure: structureChanged \}\)/);
+  assert.match(app, /largeSessionContainmentScheduler\.schedule\(\(\) => \{/);
+  assert.match(css, /\.breakdown\.large-session-list \.session-row\s*\{[^}]*contain-intrinsic-block-size:\s*auto 72px;/s);
+  assert.match(css, /\.breakdown\.large-session-list\.large-session-list-ready \.session-row\s*\{[^}]*content-visibility:\s*auto;[^}]*contain:\s*layout paint style;/s);
 });

--- a/tests/electron/deviceBreakdown.test.js
+++ b/tests/electron/deviceBreakdown.test.js
@@ -66,7 +66,7 @@ test('device breakdown browser helper loads before app.js and keeps reduced-moti
   assert.match(css, /\.device-model-list \{/);
   assert.match(css, /\.device-model-row \{[\s\S]*justify-content: space-between;/);
   assert.match(css, /@media \(prefers-reduced-motion: reduce\)[\s\S]*\.row-accordion/);
-  assert.match(app, /const signature = JSON\.stringify\(\[\s*state\.settings\?\.showToolIcons === true,/);
+  assert.match(app, /const signature = JSON\.stringify\(\[\s*toolIconsEnabled\(state\.settings\?\.showToolIcons\),/);
   assert.match(app, /deviceDetail: \{[\s\S]*emptyText: breakdown\.totalTokens > 0 \? t\('devices\.detailsUnavailable'\) : t\('home\.noTools'\)/);
   assert.doesNotMatch(app, /deviceDetail: breakdown\.totalTokens > 0 \?/);
 });


### PR DESCRIPTION
## Summary

- stop FLIP layout capture and per-row animations when a breakdown exceeds 40 rows
- skip DOM updates for rows whose rendered data and display context have not changed
- use native offscreen rendering containment for large Session lists while preserving the full dataset

## Root cause

Hub-backed Month and Total views can contain hundreds of merged sessions. Every stats push previously captured layout geometry for every row, updated every row, and created row, bar, and number animations across the full list. On Windows, that renderer/compositor workload caused periodic system-wide pointer jank even on high-end hardware.

Small breakdowns retain the existing animations. Large Session lists keep the same data, order, navigation, and Hub protocol; only their per-row transition effects are disabled.

## Validation

- `node --test tests/electron/breakdownRenderPolicy.test.js tests/electron/rendererMotion.test.js` (15 passed)
- `npm run verify` (1682 passed, 1 skipped)
- Windows 9950X3D smoke test in Hub mode: Month and Total no longer caused periodic pointer freezes
- 657-row microbenchmark: large-list motion disabled; render fingerprint pass averaged about 0.19 ms

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes UI jank during large Session breakdown refreshes by capping per-row animations, skipping unchanged updates, and deferring offscreen containment to avoid first-scroll shifts. Keeps data, order, and navigation the same; eliminates pointer freezes seen on Windows.

- **Bug Fixes**
  - Stop FLIP capture and row/bar/number animations when a breakdown exceeds 40 rows; honor reduced motion.
  - Skip DOM updates using a row render fingerprint; normalize tool icon state via `toolIconsEnabled(...)` so caching matches row updates.
  - Add `.large-session-list` containment with `content-visibility: auto`, enabling it after layout settles so rows keep real intrinsic height and avoid scroll-geometry corrections.
  - Introduce `breakdownRenderPolicy.js` and tests to enforce the policy end-to-end.

<sup>Written for commit aeddbf688f4a7d6584cc0297ad9874cdcbf14b5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

