### PR TITLE
fix(settings): restore custom pricing row layout

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -8785,8 +8785,9 @@ function renderCustomPricing() {
   }
   for (const ov of overrides) {
     const row = document.createElement('div');
-    row.className = 'managed-account-row';
-    const main = document.createElement('div');
+    row.className = 'managed-account-row custom-pricing-row';
+    const main = document.createElement('button');
+    main.type = 'button';
     main.className = 'managed-account-main custom-pricing-edit';
     main.title = t('settings.customPricing.edit');
     main.addEventListener('click', () => { if (openCustomPricingForm) openCustomPricingForm(ov); });
@@ -8799,7 +8800,7 @@ function renderCustomPricing() {
     main.append(name, meta);
     const remove = document.createElement('button');
     remove.type = 'button';
-    remove.className = 'managed-account-remove';
+    remove.className = 'managed-account-remove custom-pricing-remove';
     remove.textContent = t('settings.customPricing.remove');
     remove.addEventListener('click', async () => {
       const next = customPricingFormApi.removeOverride(state.settings?.customModelPricing || [], ov.modelId);

--- a/src/electron/renderer/styles.css
+++ b/src/electron/renderer/styles.css
@@ -4225,7 +4225,49 @@ html.is-windows .limit-live-badge {
   font-size: 0.85em;
 }
 
-.custom-pricing-edit { cursor: pointer; }
+.custom-pricing-row {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.custom-pricing-edit {
+  display: grid;
+  justify-self: stretch;
+  gap: 2px;
+  width: 100%;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.custom-pricing-edit:focus-visible {
+  outline: 1px solid rgba(115, 189, 245, 0.72);
+  outline-offset: 2px;
+}
+
+.custom-pricing-row .managed-account-meta {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 9px;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.custom-pricing-row .custom-pricing-remove {
+  width: auto;
+  height: 24px;
+  padding: 0 8px;
+  font-size: 10px;
+  line-height: 24px;
+  opacity: 0.72;
+}
 
 .opencode-profile-list {
   margin-bottom: 4px;

--- a/tests/electron/customPricingLayout.test.js
+++ b/tests/electron/customPricingLayout.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const rendererDir = path.join(__dirname, '..', '..', 'src', 'electron', 'renderer');
+const app = fs.readFileSync(path.join(rendererDir, 'app.js'), 'utf8');
+const styles = fs.readFileSync(path.join(rendererDir, 'styles.css'), 'utf8');
+
+function cssBlock(selector) {
+  const start = styles.indexOf(`${selector} {`);
+  assert.notEqual(start, -1, `${selector} should exist`);
+  const end = styles.indexOf('\n}', start);
+  assert.notEqual(end, -1, `${selector} should have a closing brace`);
+  return styles.slice(start, end + 2);
+}
+
+test('custom pricing rows keep their two-column layout contract', () => {
+  const renderStart = app.indexOf('function renderCustomPricing()');
+  const renderEnd = app.indexOf('function setupCustomPricingUI()', renderStart);
+  const render = app.slice(renderStart, renderEnd);
+
+  assert.match(render, /row\.className = 'managed-account-row custom-pricing-row'/);
+  assert.match(render, /const main = document\.createElement\('button'\);\s*main\.type = 'button'/);
+  assert.match(render, /remove\.className = 'managed-account-remove custom-pricing-remove'/);
+  assert.match(cssBlock('.custom-pricing-row'), /grid-template-columns: minmax\(0, 1fr\) auto/);
+});
+
+test('custom pricing metadata and localized remove action cannot collapse vertically', () => {
+  assert.match(cssBlock('.custom-pricing-row .managed-account-meta'), /white-space: nowrap/);
+  assert.match(cssBlock('.custom-pricing-row .managed-account-meta'), /text-overflow: ellipsis/);
+
+  const remove = cssBlock('.custom-pricing-row .custom-pricing-remove');
+  assert.match(remove, /width: auto/);
+  assert.match(remove, /padding: 0 8px/);
+});


### PR DESCRIPTION
## Summary

- restore a dedicated two-column layout for custom model pricing rows
- keep long model and price summaries on one truncated line
- preserve a full-width localized remove action
- make the row's edit action keyboard accessible
- add regression coverage for the layout contract

## Root cause

The shared managed-account row moved to a three-column grid, while custom pricing rows still render only an edit area and a remove button. Their content was therefore placed into the 20px account-control column and collapsed vertically.

## Scope

This is a UI-only fix. It does not change Tokscale, model pricing calculations, or provider-reported cost precedence.

Refs #224

## Validation

- `npm run verify`
- custom pricing layout detector: no findings
- manual visual verification pending


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the two-column layout for Settings → Custom Model Pricing rows so content no longer collapses. Also improves keyboard access and adds regression tests. Refs #224.

- Bug Fixes
  - Reintroduce a dedicated two-column grid via `.custom-pricing-row` (details + remove).
  - Turn the edit area into a `button` with `focus-visible` outline for keyboard users.
  - Keep model and price summary on one truncated line; prevent wrapping.
  - Keep the localized Remove button in its own column and stable size.
  - Add tests to lock the layout contract and non-wrapping behavior.
  - UI-only change; no pricing logic affected.

<sup>Written for commit 35ab313829e33068364eb0a27c10169d6965f752. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

