### PR TITLE
fix(history): preserve lifetime active days across aggregation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -197,6 +197,10 @@ Current agents and widgets include `osName` and, when known, `osVersion` so devi
 
 `limits` is optional. Agents and widgets include it when AI Tool Limits detection is enabled. Raw OAuth credentials, access tokens, refresh tokens, and provider response bodies must never be sent.
 
+`history` is optional and rides along on interval-gated history collection ticks. Its `daily` tier keeps the rolling 370-day window with per-client and per-model breakdowns, while `monthly` and `summary` retain lifetime rollups. Current clients also send `dailyTotals`, a compact all-time array of `{ date, tokens, cost, activeTimeMs }` rows without client/model identity. The hub unions these rows by date across devices so overlapping device activity counts as one active day and `/api/history` can support historical year heatmaps without expanding the detailed `daily` tier.
+
+`history.summary.activeDaysComplete` is `true` only when the active-day count was derived from complete `dailyTotals`. A mixed-version hub fails closed: if any stored device lacks complete daily totals, the aggregate omits `dailyTotals`, marks `activeDaysComplete: false`, and computes `activeDays` from the rolling `daily` window instead of presenting a partial lifetime count. If the compact calendar would exceed the ingest budget after existing payload reductions, the client omits it, sets `history.dailyTotalsOmitted` to the number of omitted rows, and also marks the count incomplete. Older hubs and clients safely ignore these optional fields.
+
 `limits.providers[].provider` is one of `claude`, `codex`, `cursor`, `antigravity`, `opencode`, `deepseek`, `minimax`, `mimo`, `grok`, `copilot`, `kiro`, `zai`, `zaiteam`, `volcengine`, `qoder`, `kimi`, or `ollama`.
 `limits.providers[].accountKey` is a stable hashed account identifier (`sha256:…`) used to dedupe the same account across devices. `accountEmail` is the account email when available, and `accountName` is a sanitized display/profile name. `accountLabel` is the legacy provider-defined short label retained for mixed-version compatibility: older OpenCode renderers use it as the profile name, while existing providers may use it for the plan. `planLabel` is the explicit plan label (for example `Plus`, `Go`, or `Zen`) when identity and plan must be carried separately; readers fall back to `accountLabel` for payloads produced before `planLabel` existed. These fields MAY be sent to the authenticated hub so devices can identify each account and its plan. The hub ingest is protected by the shared `secret`; the **public** stats endpoints (`publicLimits`) strip `accountKey`, `accountEmail`, `accountName`, `accountLabel`, and `planLabel` so neither account identity nor plan labels are exposed publicly.
 `limits.providers[].source` is one of `oauth`, `cli`, `web`, `rpc`, `local`, or `api`; `local` means the value was read from an on-disk store such as OpenCode Go usage from `opencode.db`, `web` means a browser/session cookie backed web endpoint (Cursor, OpenCode web accounts, Qoder, MiMo, Kimi membership, Ollama), and `api` means a provider HTTP API authenticated by an API key or AK/SK credentials (DeepSeek, Minimax, Copilot, GLM/Z.ai, Volcengine, Kimi Code).
@@ -221,11 +225,16 @@ Response includes:
 - `periodProjectsOmitted`, when a daily or monthly project rollup was itself too large to fit; the aggregate and affected devices expose omitted project counts and the widget marks that period's project breakdown incomplete
 - `projectsIncomplete` plus the corresponding `devices[].allTimeProjectsOmitted`, `devices[].allTimeProjectsIncomplete`, or `devices[].projectsEnabled` diagnostic
 - `historyPreview.daily[].activeTimeMs`, `historyPreview.monthly[].activeTimeMs`, and `historyPreview.summary.activeTimeMs` when tokscale graph exposes session active-time metrics
+- `historyPreview.summary.activeDaysComplete`, which callers must require before presenting `activeDays` as a lifetime count
 - `limits.providers` aggregated by provider account
 - `devices`, including each device's normalized `periods`, `limits`, `receivedAt`, `osName` / `osVersion` when reported, optional `syncUploadIntervalMs`, and optional `periodWindows`
 - stale status for devices that have not reported recently
 
 If multiple devices report the same provider account, the hub keeps the freshest valid limits status for that account. Public Worker stats omit account identifiers.
+
+## `GET /api/history`
+
+Returns the authenticated aggregate History. The detailed `daily` tier remains capped to the rolling 370-day window. When every stored device provides complete compact history, `dailyTotals` contains all observed dates merged across devices and `summary.activeDaysComplete` is `true`; otherwise `dailyTotals` is omitted and the flag is `false`.
 
 ## `GET /api/devices`
 

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -4209,13 +4209,13 @@ function renderHomeTrendsModule() {
     cell: activityLayout.cell,
     gap: activityLayout.gap
   });
-  const summaryActiveDays = state.stats?.historyPreview?.summary?.activeDays;
-  const activeDaysWindow = state.settings?.homeActiveDaysWindow || 'all';
-  const displayActiveDays = activeDaysWindow === 'year'
-    ? activity.cells.filter((cell) => cell.tokens > 0).length
-    : (Number.isFinite(summaryActiveDays)
-        ? summaryActiveDays
-        : activity.cells.filter((cell) => cell.tokens > 0).length);
+  const activeDaysPresentation = homeOverviewApi.homeActiveDaysPresentation({
+    requestedWindow: state.settings?.homeActiveDaysWindow || 'all',
+    summary: state.stats?.historyPreview?.summary,
+    cells: activity.cells
+  });
+  const activeDaysWindow = activeDaysPresentation.window;
+  const displayActiveDays = activeDaysPresentation.count;
   const activeDaysLabel = activeDaysWindow === 'year'
     ? t('home.activeDaysYear', { count: displayActiveDays })
     : t('home.activeDays', { count: displayActiveDays });

--- a/src/electron/renderer/homeOverview.js
+++ b/src/electron/renderer/homeOverview.js
@@ -255,6 +255,20 @@
     return { peak, dates };
   }
 
+  function homeActiveDaysPresentation({ requestedWindow = 'all', summary = {}, cells = [] } = {}) {
+    const rollingCount = (Array.isArray(cells) ? cells : [])
+      .reduce((count, cell) => count + (Math.max(0, finiteNumber(cell?.tokens) || 0) > 0 ? 1 : 0), 0);
+    const allTimeCount = finiteNumber(summary?.activeDays);
+    if (
+      requestedWindow === 'all'
+      && summary?.activeDaysComplete === true
+      && allTimeCount != null
+    ) {
+      return { window: 'all', count: Math.max(0, Math.round(allTimeCount)) };
+    }
+    return { window: 'year', count: rollingCount };
+  }
+
   function homeActivityHeatmapLayout() {
     return { cell: 9, gap: 3, radius: 2 };
   }
@@ -416,6 +430,7 @@
     homeActivityWheelRoute,
     homeActivityScrollTarget,
     homeActivityScrollRecord,
+    homeActiveDaysPresentation,
     remainingPercent,
     usedPercent
   };

--- a/src/shared/history.js
+++ b/src/shared/history.js
@@ -149,6 +149,23 @@ function activeTimeTotal(days) {
   return (Array.isArray(days) ? days : []).reduce((sum, day) => sum + num(day.activeTimeMs), 0);
 }
 
+// Full-history daily totals stay intentionally compact: they carry exactly what
+// an all-time active-day count and a future year heatmap need, without repeating
+// the per-client/per-model maps retained in the rolling `daily` tier.
+function compactDailyTotals(days) {
+  const byDate = new Map();
+  for (const day of (Array.isArray(days) ? days : [])) {
+    const date = String(day?.date || '').slice(0, 10);
+    if (!date) continue;
+    const current = byDate.get(date) || { date, tokens: 0, cost: 0, activeTimeMs: 0 };
+    current.tokens += num(day.tokens);
+    current.cost += num(day.cost);
+    current.activeTimeMs += num(day.activeTimeMs);
+    byDate.set(date, current);
+  }
+  return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
+}
+
 function monthlyRollup(days) {
   const byMonth = new Map();
   for (const d of (Array.isArray(days) ? days : [])) {
@@ -199,6 +216,7 @@ function normalizeHistory(graphData, options = {}) {
   const full = (graphData && Array.isArray(graphData.contributions) ? graphData.contributions : [])
     .slice()
     .sort((a, b) => a.date.localeCompare(b.date));
+  const dailyTotals = compactDailyTotals(full);
 
   const daily = rollingDailyWindow(full, todayKey, capDays).map((d) => ({ ...d }));
   computeIntensities(daily);
@@ -207,17 +225,18 @@ function normalizeHistory(graphData, options = {}) {
   const totalTokens = full.reduce((s, d) => s + num(d.tokens), 0);
   const totalCost = full.reduce((s, d) => s + num(d.cost), 0);
   const messages = full.reduce((s, d) => s + num(d.messages), 0);
-  const activeDays = full.reduce((s, d) => s + (num(d.tokens) > 0 ? 1 : 0), 0);
-  const peakDayTokens = full.reduce((m, d) => Math.max(m, num(d.tokens)), 0);
-  const { currentStreak, longestStreak } = computeStreaks(full, todayKey);
+  const activeDays = dailyTotals.reduce((s, d) => s + (num(d.tokens) > 0 ? 1 : 0), 0);
+  const peakDayTokens = dailyTotals.reduce((m, d) => Math.max(m, num(d.tokens)), 0);
+  const { currentStreak, longestStreak } = computeStreaks(dailyTotals, todayKey);
   const timeMetrics = normalizeTimeMetrics(graphData?.timeMetrics);
-  const activeTimeMs = timeMetrics ? timeMetrics.totalActiveTimeMs : activeTimeTotal(full);
+  const activeTimeMs = timeMetrics ? timeMetrics.totalActiveTimeMs : activeTimeTotal(dailyTotals);
 
   return {
     daily,
+    dailyTotals,
     monthly,
     summary: {
-      totalTokens, totalCost, activeDays, currentStreak, longestStreak,
+      totalTokens, totalCost, activeDays, activeDaysComplete: true, currentStreak, longestStreak,
       peakDayTokens, favoriteModel: favoriteModelOf(full), messages,
       activeTimeMs,
       ...(timeMetrics ? { timeMetrics } : {})
@@ -254,9 +273,18 @@ function mergeMonthlyMaps(histories) {
   return [...byMonth.values()].sort((a, b) => a.month.localeCompare(b.month));
 }
 
+function mergeDailyTotalMaps(histories) {
+  const days = [];
+  for (const history of histories) {
+    days.push(...history.dailyTotals);
+  }
+  return compactDailyTotals(days);
+}
+
 // Combine per-device histories. daily unions by date (sum + recompute intensity); monthly
-// unions by month. Lifetime totals come from the uncapped monthly tier; daily-granularity
-// stats (active days / peak / streaks) come from the merged daily window.
+// unions by month. New devices also provide compact all-time dailyTotals, which lets the
+// hub deduplicate dates exactly across devices. Mixed-version aggregates fail closed to
+// the rolling daily window instead of treating partial lifetime dates as complete.
 function mergeHistories(histories, options = {}) {
   const list = Array.isArray(histories) ? histories : [];
   const todayKey = String(options.todayKey || new Date().toISOString().slice(0, 10)).slice(0, 10);
@@ -268,6 +296,12 @@ function mergeHistories(histories, options = {}) {
   const daily = rollingDailyWindow(mergeDailyMaps(list), todayKey, capDays);
   computeIntensities(daily);
   const monthly = mergeMonthlyMaps(list);
+  const activeDaysComplete = list.length > 0 && list.every((history) => (
+    Array.isArray(history?.dailyTotals)
+    && history?.summary?.activeDaysComplete === true
+  ));
+  const dailyTotals = activeDaysComplete ? mergeDailyTotalMaps(list) : null;
+  const dailyDerived = dailyTotals || daily;
 
   const totalTokens = monthly.reduce((s, m) => s + num(m.tokens), 0);
   const totalCost = monthly.reduce((s, m) => s + num(m.cost), 0);
@@ -275,17 +309,18 @@ function mergeHistories(histories, options = {}) {
     for (const v of Object.values(m.perClient || {})) s += num(v.messages);
     return s;
   }, 0);
-  const activeDays = daily.reduce((s, d) => s + (num(d.tokens) > 0 ? 1 : 0), 0);
-  const peakDayTokens = daily.reduce((mx, d) => Math.max(mx, num(d.tokens)), 0);
-  const { currentStreak, longestStreak } = computeStreaks(daily, todayKey);
+  const activeDays = dailyDerived.reduce((s, d) => s + (num(d.tokens) > 0 ? 1 : 0), 0);
+  const peakDayTokens = dailyDerived.reduce((mx, d) => Math.max(mx, num(d.tokens)), 0);
+  const { currentStreak, longestStreak } = computeStreaks(dailyDerived, todayKey);
   const favoriteModel = favoriteModelOf(daily);
   const activeTimeMs = activeTimeTotal(monthly.length ? monthly : daily);
 
   return {
     daily,
+    ...(dailyTotals ? { dailyTotals } : {}),
     monthly,
     summary: {
-      totalTokens, totalCost, activeDays, currentStreak, longestStreak,
+      totalTokens, totalCost, activeDays, activeDaysComplete, currentStreak, longestStreak,
       peakDayTokens, favoriteModel, messages, activeTimeMs
     }
   };
@@ -294,11 +329,14 @@ function mergeHistories(histories, options = {}) {
 // Defensively normalize arbitrary wire JSON to the { daily, monthly, summary } shape.
 function coerceHistory(raw) {
   const src = raw && typeof raw === 'object' ? raw : {};
-  return {
+  const history = {
     daily: Array.isArray(src.daily) ? src.daily : [],
     monthly: Array.isArray(src.monthly) ? src.monthly : [],
     summary: src.summary && typeof src.summary === 'object' ? src.summary : {}
   };
+  if (Array.isArray(src.dailyTotals)) history.dailyTotals = src.dailyTotals;
+  if (Number.isFinite(src.dailyTotalsOmitted)) history.dailyTotalsOmitted = src.dailyTotalsOmitted;
+  return history;
 }
 
 // Trim a full History to a compact, per-client-free payload for /api/stats.

--- a/src/shared/syncPayload.js
+++ b/src/shared/syncPayload.js
@@ -111,6 +111,13 @@ function buildSyncPayload(summary, { omitAllTimeProjects = false } = {}) {
   delete payload.allTimeProjectsIncomplete;
   delete payload.sessionDetailsOmitted;
   delete payload.periodProjectsOmitted;
+  if (summary.history && typeof summary.history === 'object') {
+    payload.history = { ...summary.history };
+    if (summary.history.summary && typeof summary.history.summary === 'object') {
+      payload.history.summary = { ...summary.history.summary };
+    }
+    if (Array.isArray(payload.history.dailyTotals)) delete payload.history.dailyTotalsOmitted;
+  }
 
   for (const periodName of ['today', 'month']) {
     const period = summary[periodName];
@@ -132,6 +139,18 @@ function buildSyncPayload(summary, { omitAllTimeProjects = false } = {}) {
     }
   }
   return payload;
+}
+
+function omitHistoryDailyTotals(payload) {
+  if (!Array.isArray(payload?.history?.dailyTotals)) return false;
+  const omitted = payload.history.dailyTotals.length;
+  payload.history = {
+    ...payload.history,
+    summary: { ...(payload.history.summary || {}), activeDaysComplete: false },
+    dailyTotalsOmitted: omitted
+  };
+  delete payload.history.dailyTotals;
+  return true;
 }
 
 function serializeSyncPayload(summary, options = {}) {
@@ -159,6 +178,9 @@ function serializeSyncPayload(summary, options = {}) {
       if (Buffer.byteLength(body, 'utf8') <= maxBytes) break;
     }
   }
+  if (Buffer.byteLength(body, 'utf8') > maxBytes && omitHistoryDailyTotals(payload)) {
+    body = JSON.stringify(payload);
+  }
   return { payload, body, bytes: Buffer.byteLength(body, 'utf8') };
 }
 
@@ -182,6 +204,9 @@ async function postSyncPayload(fetchFn, url, { headers = {}, summary, logger } =
       .map(([period, count]) => `${period}: ${count}`)
       .join(', ');
     logger(`project detail omitted for sync (${omitted}); payload reduced to ${serialized.bytes} bytes (budget ${SYNC_PAYLOAD_BUDGET_BYTES})`);
+  }
+  if (serialized.payload?.history?.dailyTotalsOmitted > 0 && typeof logger === 'function') {
+    logger(`all-time daily history omitted from sync (${serialized.payload.history.dailyTotalsOmitted} days); payload reduced to ${serialized.bytes} bytes (budget ${SYNC_PAYLOAD_BUDGET_BYTES})`);
   }
   let response = await fetchFn(url, { method: 'POST', headers, body: serialized.body });
   const canRetryWithoutProjects = response.status === 413

--- a/src/shared/usage.js
+++ b/src/shared/usage.js
@@ -858,7 +858,15 @@ function aggregateHistory(devices) {
   const histories = [];
   for (const record of devices) {
     const normalized = normalizeDeviceRecord(record);
-    if (!hasOwn(normalized, 'history')) continue;
+    if (!hasOwn(normalized, 'history')) {
+      // A legacy/history-disabled device with all-time usage may own active
+      // dates absent from the histories we can merge. Include an incomplete
+      // sentinel so mixed-version hubs never advertise an exact lifetime count.
+      if (normalized.periods.allTime.totalTokens > 0) {
+        histories.push({ daily: [], monthly: [], summary: { activeDaysComplete: false } });
+      }
+      continue;
+    }
     histories.push(normalized.history);
   }
   return mergeHistories(histories);

--- a/tests/electron/homeOverview.test.js
+++ b/tests/electron/homeOverview.test.js
@@ -15,6 +15,7 @@ const {
   homeActivityWheelRoute,
   homeActivityScrollTarget,
   homeActivityScrollRecord,
+  homeActiveDaysPresentation,
   homeTrendSummary,
   pickHomeHistory,
   patchDailyToday,
@@ -55,6 +56,33 @@ test('Home activity heatmap is a scaled copy of the dashboard heatmap', () => {
   assert.match(rule(css, '.home-activity-canvas .heat-bright-layer'), /pointer-events:\s*none/);
   assert.match(rule(css, '.home-activity-tooltip'), /position:\s*fixed/);
   assert.match(rule(css, '.home-activity-canvas .heat-month'), /fill:\s*rgba\(var\(--line-rgb\), 0\.5\)/);
+});
+
+test('Home uses exact all-time active days only when aggregation is complete', () => {
+  const cells = [{ tokens: 10 }, { tokens: 0 }, { tokens: 20 }];
+  assert.deepEqual(homeActiveDaysPresentation({
+    requestedWindow: 'all',
+    summary: { activeDays: 450, activeDaysComplete: true },
+    cells
+  }), { window: 'all', count: 450 });
+  assert.deepEqual(homeActiveDaysPresentation({
+    requestedWindow: 'all',
+    summary: { activeDays: 450, activeDaysComplete: false },
+    cells
+  }), { window: 'year', count: 2 });
+  assert.deepEqual(homeActiveDaysPresentation({
+    requestedWindow: 'all',
+    summary: { activeDays: 450 },
+    cells
+  }), { window: 'year', count: 2 });
+});
+
+test('Home keeps an explicit 12-month active-days selection', () => {
+  assert.deepEqual(homeActiveDaysPresentation({
+    requestedWindow: 'year',
+    summary: { activeDays: 450, activeDaysComplete: true },
+    cells: [{ tokens: 10 }, { tokens: 0 }]
+  }), { window: 'year', count: 1 });
 });
 
 test('Home module selection is independent from main view preferences', () => {

--- a/tests/shared/deviceWireCompatibility.test.js
+++ b/tests/shared/deviceWireCompatibility.test.js
@@ -34,7 +34,11 @@ test('composed full records remain compatible with hub normalization and merging
     today: period(10),
     month: period(20),
     allTime: period(30),
-    history: { daily: [{ date: '2026-07-21', totalTokens: 10, costUsd: 0 }] }
+    history: {
+      daily: [{ date: '2026-07-21', totalTokens: 10, costUsd: 0 }],
+      dailyTotals: [{ date: '2025-01-01', tokens: 10, cost: 0, activeTimeMs: 1000 }],
+      summary: { activeDays: 1, activeDaysComplete: true }
+    }
   });
   state.updateLimits({
     updatedAt: '2026-07-21T01:01:00.000Z',
@@ -54,6 +58,8 @@ test('composed full records remain compatible with hub normalization and merging
   const normalized = normalizeDeviceRecord(records[1].record);
   assert.equal(normalized.periods.today.totalTokens, 10);
   assert.equal(normalized.history.daily[0].totalTokens, 10);
+  assert.equal(normalized.history.dailyTotals[0].date, '2025-01-01');
+  assert.equal(normalized.history.summary.activeDaysComplete, true);
   assert.equal(normalized.limits.providers[0].status, 'unavailable');
   assert.equal(normalized.limits.providers[0].windows[0].usedPercent, 40);
 
@@ -63,6 +69,7 @@ test('composed full records remain compatible with hub normalization and merging
   });
   assert.equal(merged.periods.today.totalTokens, 10);
   assert.equal(merged.history.daily[0].totalTokens, 10);
+  assert.equal(merged.history.dailyTotals[0].tokens, 10);
   assert.equal(merged.updatedAt, '2026-07-21T01:00:00.000Z');
   assert.equal(merged.receivedAt, '2026-07-21T01:01:01.000Z');
 });

--- a/tests/shared/history.test.js
+++ b/tests/shared/history.test.js
@@ -181,6 +181,11 @@ test('normalizeHistory caps daily but keeps monthly/summary full', () => {
   assert.deepEqual(h.daily.map((d) => d.date), ['2026-06-06', '2026-06-07']);
   assert.equal(h.daily[1].intensity, 4); // highest cost day
   assert.equal(h.daily[1].activeTimeMs, 180000);
+  assert.deepEqual(h.dailyTotals, [
+    { date: '2024-01-01', tokens: 100, cost: 5, activeTimeMs: 60000 },
+    { date: '2026-06-06', tokens: 10, cost: 1, activeTimeMs: 120000 },
+    { date: '2026-06-07', tokens: 30, cost: 3, activeTimeMs: 180000 }
+  ]);
 
   // monthly: uncapped -> includes 2024-01
   assert.deepEqual(h.monthly.map((m) => m.month), ['2024-01', '2026-06']);
@@ -190,6 +195,7 @@ test('normalizeHistory caps daily but keeps monthly/summary full', () => {
   assert.equal(h.summary.totalTokens, 140);
   assert.equal(h.summary.totalCost, 9);
   assert.equal(h.summary.activeDays, 3);
+  assert.equal(h.summary.activeDaysComplete, true);
   assert.equal(h.summary.peakDayTokens, 100);
   assert.equal(h.summary.messages, 5);
   assert.equal(h.summary.favoriteModel, 'opus'); // 100 + 30 tokens
@@ -230,7 +236,10 @@ test('mergeHistories sums daily across devices and recomputes derived fields', (
   assert.deepEqual(d7.perClient.claude, { tokens: 20, cost: 2, messages: 1 });
   assert.deepEqual(d7.perClient.codex, { tokens: 5, cost: 0.5, messages: 1 });
   assert.equal(d7.intensity, 4);                       // highest-cost merged day
+  assert.deepEqual(m.dailyTotals.map((d) => d.date), ['2026-06-06', '2026-06-07']);
   assert.equal(m.summary.totalTokens, 35);
+  assert.equal(m.summary.activeDays, 2);
+  assert.equal(m.summary.activeDaysComplete, true);
   assert.equal(m.summary.currentStreak, 2);
   assert.equal(m.summary.peakDayTokens, 25);
   assert.equal(m.summary.activeTimeMs, 210000);
@@ -241,9 +250,33 @@ test('mergeHistories handles empty list', () => {
   assert.deepEqual(m.daily, []);
   assert.deepEqual(m.monthly, []);
   assert.equal(m.summary.totalTokens, 0);
+  assert.equal(m.summary.activeDaysComplete, false);
 });
 
 const { coerceHistory, historyPreview, historyRevision } = require('../../src/shared/history');
+
+test('mergeHistories deduplicates all-time active dates outside the rolling window', () => {
+  const dev1 = normalizeHistory(parseGraphResult(graphFromDays([
+    { date: '2024-01-01', tokens: 100, cost: 5, activeTimeMs: 60000 },
+    { date: '2026-06-07', tokens: 10, cost: 1, activeTimeMs: 120000 }
+  ])), { todayKey: '2026-06-07', capDays: 30 });
+  const dev2 = normalizeHistory(parseGraphResult(graphFromDays([
+    { date: '2024-01-01', tokens: 50, cost: 2, activeTimeMs: 30000 },
+    { date: '2025-01-02', tokens: 25, cost: 1, activeTimeMs: 45000 }
+  ])), { todayKey: '2026-06-07', capDays: 30 });
+
+  const merged = mergeHistories([dev1, dev2], { todayKey: '2026-06-07', capDays: 30 });
+
+  assert.deepEqual(merged.daily.map((day) => day.date), ['2026-06-07']);
+  assert.deepEqual(merged.dailyTotals, [
+    { date: '2024-01-01', tokens: 150, cost: 7, activeTimeMs: 90000 },
+    { date: '2025-01-02', tokens: 25, cost: 1, activeTimeMs: 45000 },
+    { date: '2026-06-07', tokens: 10, cost: 1, activeTimeMs: 120000 }
+  ]);
+  assert.equal(merged.summary.activeDays, 3);
+  assert.equal(merged.summary.activeDaysComplete, true);
+  assert.equal(merged.summary.peakDayTokens, 150);
+});
 
 test('mergeHistories re-caps stale device daily rows without losing lifetime totals', () => {
   const history = {
@@ -259,9 +292,29 @@ test('mergeHistories re-caps stale device daily rows without losing lifetime tot
   };
   const merged = mergeHistories([history], { todayKey: '2026-06-07', capDays: 370 });
   assert.deepEqual(merged.daily.map((day) => day.date), ['2026-06-07']);
+  assert.equal(Object.hasOwn(merged, 'dailyTotals'), false);
   assert.equal(merged.summary.activeDays, 1);
+  assert.equal(merged.summary.activeDaysComplete, false);
   assert.equal(merged.summary.peakDayTokens, 10);
   assert.equal(merged.summary.totalTokens, 110);
+});
+
+test('mergeHistories fails closed when any device lacks complete daily totals', () => {
+  const current = normalizeHistory(parseGraphResult(graphFromDays([
+    { date: '2024-01-01', tokens: 100, cost: 5 },
+    { date: '2026-06-07', tokens: 10, cost: 1 }
+  ])), { todayKey: '2026-06-07', capDays: 30 });
+  const legacy = {
+    daily: [{ date: '2026-06-06', tokens: 5, cost: 0.5, perClient: {}, perModel: {} }],
+    monthly: [{ month: '2026-06', tokens: 5, cost: 0.5, perClient: {}, perModel: {} }],
+    summary: { activeDays: 200 }
+  };
+
+  const merged = mergeHistories([current, legacy], { todayKey: '2026-06-07', capDays: 30 });
+
+  assert.equal(Object.hasOwn(merged, 'dailyTotals'), false);
+  assert.equal(merged.summary.activeDays, 2);
+  assert.equal(merged.summary.activeDaysComplete, false);
 });
 
 test('historyRevision is key-order stable and tracks breakdown changes', () => {
@@ -275,7 +328,12 @@ test('historyRevision is key-order stable and tracks breakdown changes', () => {
 test('coerceHistory normalizes shape and drops garbage', () => {
   assert.deepEqual(coerceHistory(null), { daily: [], monthly: [], summary: {} });
   assert.deepEqual(coerceHistory({ daily: 'x' }), { daily: [], monthly: [], summary: {} });
-  const ok = { daily: [{ date: '2026-06-07', tokens: 1 }], monthly: [{ month: '2026-06', tokens: 1 }], summary: { totalTokens: 1 } };
+  const ok = {
+    daily: [{ date: '2026-06-07', tokens: 1 }],
+    dailyTotals: [{ date: '2024-01-01', tokens: 1, cost: 0, activeTimeMs: 0 }],
+    monthly: [{ month: '2026-06', tokens: 1 }],
+    summary: { totalTokens: 1, activeDaysComplete: true }
+  };
   assert.deepEqual(coerceHistory(ok), ok);
 });
 
@@ -285,13 +343,18 @@ test('historyPreview keeps recent totals only (no per-client)', () => {
     const date = `2026-06-${String(i).padStart(2, '0')}`;
     daily.push({ date, tokens: i, cost: i / 10, activeTimeMs: i * 1000, intensity: 1, perClient: { claude: { tokens: i } }, perModel: {} });
   }
-  const history = { daily, monthly: [{ month: '2026-05', tokens: 9, cost: 1, perClient: { claude: { tokens: 9 } } }],
-    summary: { totalTokens: 100 } };
+  const history = {
+    daily,
+    dailyTotals: [{ date: '2024-01-01', tokens: 1, cost: 0.1, activeTimeMs: 1000 }],
+    monthly: [{ month: '2026-05', tokens: 9, cost: 1, perClient: { claude: { tokens: 9 } } }],
+    summary: { totalTokens: 100, activeDaysComplete: true }
+  };
   const p = historyPreview(history, { dailyDays: 30, monthlyMonths: 12 });
   assert.equal(p.daily.length, 30);                 // last 30 of 40
   assert.equal(p.daily[0].date, '2026-06-11');      // 40 - 30 + 1 = 11th
   assert.deepEqual(p.daily[29], { date: '2026-06-40', tokens: 40, cost: 4, activeTimeMs: 40000 });
   assert.equal(p.daily[0].perClient, undefined);    // stripped
+  assert.equal(Object.hasOwn(p, 'dailyTotals'), false);
   assert.deepEqual(p.monthly[0], { month: '2026-05', tokens: 9, cost: 1, activeTimeMs: 0 });
-  assert.deepEqual(p.summary, { totalTokens: 100 });
+  assert.deepEqual(p.summary, { totalTokens: 100, activeDaysComplete: true });
 });

--- a/tests/shared/syncPayload.test.js
+++ b/tests/shared/syncPayload.test.js
@@ -43,7 +43,11 @@ test('syncPayload bounds uploads by omitting all-time sessions', () => {
       models: { opus: 30 },
       sessions: { old: { totalTokens: 30 } }
     },
-    history: { daily: [{ date: '2026-07-11', totalTokens: 10 }] },
+    history: {
+      daily: [{ date: '2026-07-11', totalTokens: 10 }],
+      dailyTotals: [{ date: '2025-01-01', tokens: 10, cost: 1, activeTimeMs: 1000 }],
+      summary: { activeDays: 1, activeDaysComplete: true }
+    },
     limits: { providers: [] }
   };
 
@@ -56,6 +60,35 @@ test('syncPayload bounds uploads by omitting all-time sessions', () => {
   assert.deepEqual(payload.allTime.models, summary.allTime.models);
   assert.deepEqual(payload.history, summary.history);
   assert.equal(summary.allTime.sessions.old.totalTokens, 30);
+});
+
+test('serializeSyncPayload omits oversized all-time daily totals and marks history incomplete', () => {
+  const dailyTotals = Array.from({ length: 40 }, (_, index) => ({
+    date: new Date(Date.UTC(2026, 0, index + 1)).toISOString().slice(0, 10),
+    tokens: 1000 + index,
+    cost: index / 10,
+    activeTimeMs: index * 1000
+  }));
+  const summary = {
+    deviceId: 'large-calendar',
+    today: { totalTokens: 10 },
+    month: { totalTokens: 20 },
+    allTime: { totalTokens: 30 },
+    history: {
+      daily: dailyTotals.slice(-2),
+      dailyTotals,
+      summary: { activeDays: 40, activeDaysComplete: true }
+    }
+  };
+
+  const { payload, bytes } = serializeSyncPayload(summary, { maxBytes: 500 });
+
+  assert.ok(bytes <= 500, `expected ${bytes} bytes to fit the test budget`);
+  assert.equal(Object.hasOwn(payload.history, 'dailyTotals'), false);
+  assert.equal(payload.history.dailyTotalsOmitted, 40);
+  assert.equal(payload.history.summary.activeDaysComplete, false);
+  assert.equal(summary.history.dailyTotals.length, 40);
+  assert.equal(summary.history.summary.activeDaysComplete, true);
 });
 
 test('syncPayload strips recomputable projects and keeps bounded all-time projects', () => {

--- a/tests/shared/usage.test.js
+++ b/tests/shared/usage.test.js
@@ -984,6 +984,28 @@ test('aggregateHistory tolerates devices without history', () => {
   assert.deepEqual(merged.daily, []);
 });
 
+test('aggregateHistory fails closed when a usage-contributing device has no history', () => {
+  const merged = aggregateHistory([
+    {
+      deviceId: 'new-agent',
+      allTime: { totalTokens: 10 },
+      history: {
+        daily: [{ date: '2026-06-07', tokens: 10, cost: 1, perClient: {}, perModel: {} }],
+        dailyTotals: [{ date: '2026-06-07', tokens: 10, cost: 1, activeTimeMs: 0 }],
+        monthly: [],
+        summary: { activeDaysComplete: true }
+      }
+    },
+    {
+      deviceId: 'old-agent',
+      allTime: { totalTokens: 20 }
+    }
+  ]);
+
+  assert.equal(merged.summary.activeDaysComplete, false);
+  assert.equal('dailyTotals' in merged, false);
+});
+
 test('carryDeviceHistory carries prior history forward when the incoming snapshot omits it', () => {
   const previous = {
     deviceId: 'm1', receivedAt: '2026-06-08T00:00:00.000Z',

--- a/worker/src/shared/history.js
+++ b/worker/src/shared/history.js
@@ -152,6 +152,23 @@ function activeTimeTotal(days) {
   return (Array.isArray(days) ? days : []).reduce((sum, day) => sum + num(day.activeTimeMs), 0);
 }
 
+// Full-history daily totals stay intentionally compact: they carry exactly what
+// an all-time active-day count and a future year heatmap need, without repeating
+// the per-client/per-model maps retained in the rolling `daily` tier.
+function compactDailyTotals(days) {
+  const byDate = new Map();
+  for (const day of (Array.isArray(days) ? days : [])) {
+    const date = String(day?.date || '').slice(0, 10);
+    if (!date) continue;
+    const current = byDate.get(date) || { date, tokens: 0, cost: 0, activeTimeMs: 0 };
+    current.tokens += num(day.tokens);
+    current.cost += num(day.cost);
+    current.activeTimeMs += num(day.activeTimeMs);
+    byDate.set(date, current);
+  }
+  return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
+}
+
 function monthlyRollup(days) {
   const byMonth = new Map();
   for (const d of (Array.isArray(days) ? days : [])) {
@@ -202,6 +219,7 @@ function normalizeHistory(graphData, options = {}) {
   const full = (graphData && Array.isArray(graphData.contributions) ? graphData.contributions : [])
     .slice()
     .sort((a, b) => a.date.localeCompare(b.date));
+  const dailyTotals = compactDailyTotals(full);
 
   const daily = rollingDailyWindow(full, todayKey, capDays).map((d) => ({ ...d }));
   computeIntensities(daily);
@@ -210,17 +228,18 @@ function normalizeHistory(graphData, options = {}) {
   const totalTokens = full.reduce((s, d) => s + num(d.tokens), 0);
   const totalCost = full.reduce((s, d) => s + num(d.cost), 0);
   const messages = full.reduce((s, d) => s + num(d.messages), 0);
-  const activeDays = full.reduce((s, d) => s + (num(d.tokens) > 0 ? 1 : 0), 0);
-  const peakDayTokens = full.reduce((m, d) => Math.max(m, num(d.tokens)), 0);
-  const { currentStreak, longestStreak } = computeStreaks(full, todayKey);
+  const activeDays = dailyTotals.reduce((s, d) => s + (num(d.tokens) > 0 ? 1 : 0), 0);
+  const peakDayTokens = dailyTotals.reduce((m, d) => Math.max(m, num(d.tokens)), 0);
+  const { currentStreak, longestStreak } = computeStreaks(dailyTotals, todayKey);
   const timeMetrics = normalizeTimeMetrics(graphData?.timeMetrics);
-  const activeTimeMs = timeMetrics ? timeMetrics.totalActiveTimeMs : activeTimeTotal(full);
+  const activeTimeMs = timeMetrics ? timeMetrics.totalActiveTimeMs : activeTimeTotal(dailyTotals);
 
   return {
     daily,
+    dailyTotals,
     monthly,
     summary: {
-      totalTokens, totalCost, activeDays, currentStreak, longestStreak,
+      totalTokens, totalCost, activeDays, activeDaysComplete: true, currentStreak, longestStreak,
       peakDayTokens, favoriteModel: favoriteModelOf(full), messages,
       activeTimeMs,
       ...(timeMetrics ? { timeMetrics } : {})
@@ -257,9 +276,18 @@ function mergeMonthlyMaps(histories) {
   return [...byMonth.values()].sort((a, b) => a.month.localeCompare(b.month));
 }
 
+function mergeDailyTotalMaps(histories) {
+  const days = [];
+  for (const history of histories) {
+    days.push(...history.dailyTotals);
+  }
+  return compactDailyTotals(days);
+}
+
 // Combine per-device histories. daily unions by date (sum + recompute intensity); monthly
-// unions by month. Lifetime totals come from the uncapped monthly tier; daily-granularity
-// stats (active days / peak / streaks) come from the merged daily window.
+// unions by month. New devices also provide compact all-time dailyTotals, which lets the
+// hub deduplicate dates exactly across devices. Mixed-version aggregates fail closed to
+// the rolling daily window instead of treating partial lifetime dates as complete.
 function mergeHistories(histories, options = {}) {
   const list = Array.isArray(histories) ? histories : [];
   const todayKey = String(options.todayKey || new Date().toISOString().slice(0, 10)).slice(0, 10);
@@ -271,6 +299,12 @@ function mergeHistories(histories, options = {}) {
   const daily = rollingDailyWindow(mergeDailyMaps(list), todayKey, capDays);
   computeIntensities(daily);
   const monthly = mergeMonthlyMaps(list);
+  const activeDaysComplete = list.length > 0 && list.every((history) => (
+    Array.isArray(history?.dailyTotals)
+    && history?.summary?.activeDaysComplete === true
+  ));
+  const dailyTotals = activeDaysComplete ? mergeDailyTotalMaps(list) : null;
+  const dailyDerived = dailyTotals || daily;
 
   const totalTokens = monthly.reduce((s, m) => s + num(m.tokens), 0);
   const totalCost = monthly.reduce((s, m) => s + num(m.cost), 0);
@@ -278,17 +312,18 @@ function mergeHistories(histories, options = {}) {
     for (const v of Object.values(m.perClient || {})) s += num(v.messages);
     return s;
   }, 0);
-  const activeDays = daily.reduce((s, d) => s + (num(d.tokens) > 0 ? 1 : 0), 0);
-  const peakDayTokens = daily.reduce((mx, d) => Math.max(mx, num(d.tokens)), 0);
-  const { currentStreak, longestStreak } = computeStreaks(daily, todayKey);
+  const activeDays = dailyDerived.reduce((s, d) => s + (num(d.tokens) > 0 ? 1 : 0), 0);
+  const peakDayTokens = dailyDerived.reduce((mx, d) => Math.max(mx, num(d.tokens)), 0);
+  const { currentStreak, longestStreak } = computeStreaks(dailyDerived, todayKey);
   const favoriteModel = favoriteModelOf(daily);
   const activeTimeMs = activeTimeTotal(monthly.length ? monthly : daily);
 
   return {
     daily,
+    ...(dailyTotals ? { dailyTotals } : {}),
     monthly,
     summary: {
-      totalTokens, totalCost, activeDays, currentStreak, longestStreak,
+      totalTokens, totalCost, activeDays, activeDaysComplete, currentStreak, longestStreak,
       peakDayTokens, favoriteModel, messages, activeTimeMs
     }
   };
@@ -297,11 +332,14 @@ function mergeHistories(histories, options = {}) {
 // Defensively normalize arbitrary wire JSON to the { daily, monthly, summary } shape.
 function coerceHistory(raw) {
   const src = raw && typeof raw === 'object' ? raw : {};
-  return {
+  const history = {
     daily: Array.isArray(src.daily) ? src.daily : [],
     monthly: Array.isArray(src.monthly) ? src.monthly : [],
     summary: src.summary && typeof src.summary === 'object' ? src.summary : {}
   };
+  if (Array.isArray(src.dailyTotals)) history.dailyTotals = src.dailyTotals;
+  if (Number.isFinite(src.dailyTotalsOmitted)) history.dailyTotalsOmitted = src.dailyTotalsOmitted;
+  return history;
 }
 
 // Trim a full History to a compact, per-client-free payload for /api/stats.

--- a/worker/src/shared/usage.js
+++ b/worker/src/shared/usage.js
@@ -861,7 +861,15 @@ function aggregateHistory(devices) {
   const histories = [];
   for (const record of devices) {
     const normalized = normalizeDeviceRecord(record);
-    if (!hasOwn(normalized, 'history')) continue;
+    if (!hasOwn(normalized, 'history')) {
+      // A legacy/history-disabled device with all-time usage may own active
+      // dates absent from the histories we can merge. Include an incomplete
+      // sentinel so mixed-version hubs never advertise an exact lifetime count.
+      if (normalized.periods.allTime.totalTokens > 0) {
+        histories.push({ daily: [], monthly: [], summary: { activeDaysComplete: false } });
+      }
+      continue;
+    }
     histories.push(normalized.history);
   }
   return mergeHistories(histories);


### PR DESCRIPTION
## Summary

- add a compact all-time `dailyTotals` tier to the existing History contract while keeping the detailed `daily` tier capped at 370 days
- union compact rows by date across Hub and Worker devices so overlapping activity is counted once
- expose `activeDaysComplete` and fail closed to the existing “近 12 個月活躍” presentation for mixed-version or payload-trimmed data
- document the wire contract and payload-budget behavior

## Why

The daily history archive already retains observations older than 370 days, but the wire History previously discarded their day-level granularity. Monthly totals preserve lifetime usage but cannot deduplicate the same active date across multiple devices, so Hub aggregation could not safely present an all-time active-day count.

This keeps the existing archive and rolling detailed heatmap unchanged, adds only identity-free per-day totals, and treats completeness as an explicit contract instead of guessing from partial data.

## Compatibility

- local mode gets an exact lifetime active-day count from the existing archive
- Hub mode becomes exact when every usage-contributing device reports the new compact tier
- older/history-disabled devices and oversized payloads mark the aggregate incomplete, so the Home view falls back to the rolling 12-month count
- no new dependency or setting is introduced; older clients and hubs can ignore the optional fields

## Validation

- `npm run sync:worker`
- `npm run verify` — 1693 passed, 0 failed, 1 skipped

Refs #210


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a compact all‑time `history.dailyTotals` tier and uses it to dedupe active days across devices. The Home view now shows an exact all‑time active‑day count only when `history.summary.activeDaysComplete` is true; otherwise it falls back to the last 12 months.

- **Bug Fixes**
  - Aggregate lifetime metrics from `dailyTotals` (merge by date) and compute `activeDays`, peak, and streaks from it when complete.
  - Fail closed for mixed versions: if any device lacks complete totals or they’re omitted, set `history.summary.activeDaysComplete: false`, drop `dailyTotals` from the aggregate, and use the 12‑month window in UI.
  - Sync payloads may omit oversized `history.dailyTotals`; record `history.dailyTotalsOmitted` and set `activeDaysComplete: false`.
  - API/docs: clarify `/api/history`, `history.dailyTotals`, and `history.summary.activeDaysComplete`.
  - Compatibility: local mode remains exact; hubs become exact once all usage‑contributing devices report totals. Older clients/hubs can ignore the new optional fields.

<sup>Written for commit 67ca751f8ffcc723d359d23efa65e05bc0027ff3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

