### PR TITLE
fix(pricing): enforce custom model overrides

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -390,6 +390,7 @@ function electronUsageConfig(errorPrefix) {
     historyIntervalMs: normalizeHistoryIntervalMs(settings.historyIntervalMs),
     watchEnabled: collectorWatchEnabled(),
     watchDebounceMs: 1500,
+    getCustomModelPricing: () => settings.customModelPricing || [],
     dailyHistoryArchiveWriteEnabled: () => !isExternalAgentActive(),
     onError: (error, reason) => console.log(`[${errorPrefix}] ${reason}: ${error.message}`),
     logger: (message) => console.log(`[${errorPrefix}] ${message}`)

--- a/src/electron/runtimeConfig.js
+++ b/src/electron/runtimeConfig.js
@@ -71,6 +71,7 @@ function usageConfigFromSettings(settings = {}, context = {}) {
     watchEnabled: context.watchEnabled,
     watchDebounceMs: Number(context.watchDebounceMs || 1500),
     wslScanEnabled: settings.wslScanEnabled !== false,
+    customModelPricing: context.getCustomModelPricing || settings.customModelPricing || [],
     onError: context.onError,
     logger: context.logger
   };

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -11,6 +11,7 @@ const { appVersion } = require('./appVersion');
 const { normalizeClientsCsv } = require('./clientTracking');
 const { tokscalePackageNameForPlatform, tokscalePlatformKey } = require('./tokscalePlatform');
 const { customPricingPath } = require('./tokscaleConfig');
+const { createCustomPricingCostResolver, normalizeCustomPricingSetting } = require('./tokscaleCustomPricing');
 const { applyPeriodDelta, emptyPeriod, extractUsageFromTokscale, mergePeriods } = require('./usage');
 const { collectWslUsage: collectWslUsageImpl, emptyWslBundle, probeWslState: probeWslStateImpl } = require('./wslUsage');
 const { hermesProfileWatchDirs, resolveHermesHome } = require('./hermesProfiles');
@@ -618,6 +619,8 @@ async function collectUsageOnce(options) {
     : normalizeOsInfo(options.osInfo);
   const normalizedClients = normalizeClientsCsv(clients);
   const projectsEnabled = options.projectsEnabled !== false;
+  const costResolver = createCustomPricingCostResolver(options.customModelPricing);
+  const extractUsage = (json) => extractUsageFromTokscale(json, { costResolver });
   const localSessionMetadataDeps = {
     ...(options.sessionMetadataDeps || {}),
     metadataCache: new Map(),
@@ -655,9 +658,9 @@ async function collectUsageOnce(options) {
         });
         const promaJson = buildPromaPeriods({ now: collectedAt, allTimeSince, rows: promaRows, pricingByModel: promaPricing });
         promaPeriods = {
-          today: extractUsageFromTokscale(promaJson.today),
-          month: extractUsageFromTokscale(promaJson.month),
-          allTime: extractUsageFromTokscale(promaJson.allTime)
+          today: extractUsage(promaJson.today),
+          month: extractUsage(promaJson.month),
+          allTime: extractUsage(promaJson.allTime)
         };
       } catch (err) {
         if (typeof options.logger === 'function') options.logger(`proma parse failed: ${err.message}`);
@@ -669,7 +672,7 @@ async function collectUsageOnce(options) {
       // windows exactly via applyPeriodDelta — one spawn instead of three.
       if (tokscaleClients) {
         const todayJson = await runTokscaleFn({ clients: tokscaleClients, flags: ['--today'], commandTimeoutMs });
-        today = extractUsageFromTokscale(todayJson);
+        today = extractUsage(todayJson);
       }
       // The persisted anchor contains every Windows-side client, including
       // locally parsed Proma. Include its fresh today usage before deriving
@@ -681,15 +684,15 @@ async function collectUsageOnce(options) {
       // Serial on purpose: concurrent scans triple the peak CPU/IO load, which
       // is what let the issue #15 self-trigger loop spike tokscale past 500% CPU.
       const todayJson = await runTokscaleFn({ clients: tokscaleClients, flags: ['--today'], commandTimeoutMs });
-      today = extractUsageFromTokscale(todayJson);
+      today = extractUsage(todayJson);
       if (typeof options.onProgress === 'function') decorateLocalPeriods({ today });
       try { if (typeof options.onProgress === 'function') options.onProgress({ today, updatedAt: new Date().toISOString() }); } catch (_) {}
       const monthJson = await runTokscaleFn({ clients: tokscaleClients, flags: ['--month'], commandTimeoutMs });
-      month = extractUsageFromTokscale(monthJson);
+      month = extractUsage(monthJson);
       if (typeof options.onProgress === 'function') decorateLocalPeriods({ today, month });
       try { if (typeof options.onProgress === 'function') options.onProgress({ today, month, updatedAt: new Date().toISOString() }); } catch (_) {}
       const allTimeJson = await runTokscaleFn({ clients: tokscaleClients, flags: ['--since', allTimeSince], commandTimeoutMs });
-      allTime = extractUsageFromTokscale(allTimeJson);
+      allTime = extractUsage(allTimeJson);
     }
     // Always decorate: session timestamps drive the recency sort regardless of the
     // Projects opt-out (issue #182). decorateLocalPeriods gates only project identity
@@ -742,6 +745,7 @@ async function collectUsageOnce(options) {
           commandTimeoutMs: options.pricingTimeoutMs ?? Math.min(commandTimeoutMs || PROMA_PRICING_LOOKUP_TIMEOUT_MS, PROMA_PRICING_LOOKUP_TIMEOUT_MS),
           pricingRevision: options.pricingRevision
         }),
+        costResolver,
         logger: options.logger,
         decoratePeriods: (periods, home) => applySessionTimestamps(periods, home, { scopedHome: true, resolveProjects: projectsEnabled })
       });
@@ -762,6 +766,7 @@ async function collectUsageOnce(options) {
           commandTimeoutMs: options.pricingTimeoutMs ?? Math.min(commandTimeoutMs || PROMA_PRICING_LOOKUP_TIMEOUT_MS, PROMA_PRICING_LOOKUP_TIMEOUT_MS),
           pricingRevision: options.pricingRevision
         }),
+        costResolver,
         logger: options.logger,
         decoratePeriods: (periods, home) => applySessionTimestamps(periods, home, { scopedHome: true, resolveProjects: projectsEnabled })
       });
@@ -1101,10 +1106,35 @@ function wslPeriodsForPreview(wslAnchor, anchorDateKey, todayKey) {
   };
 }
 
-function configFingerprint(clientsCsv, allTimeSince, projectsEnabled = true) {
+function resolveCustomModelPricing(value, logger) {
+  try {
+    return typeof value === 'function' ? value() : value;
+  } catch (error) {
+    if (typeof logger === 'function') logger(`custom pricing read failed: ${error.message}`);
+    return [];
+  }
+}
+
+function customPricingFingerprint(value) {
+  const byModel = new Map();
+  for (const entry of normalizeCustomPricingSetting(value)) {
+    const modelId = entry.modelId.toLowerCase();
+    byModel.set(modelId, {
+      modelId,
+      inputPerM: entry.inputPerM,
+      outputPerM: entry.outputPerM,
+      cacheReadPerM: entry.cacheReadPerM
+    });
+  }
+  return [...byModel.values()].sort((left, right) => left.modelId.localeCompare(right.modelId));
+}
+
+function configFingerprint(clientsCsv, allTimeSince, projectsEnabled = true, customModelPricing = []) {
   // Deterministic string that captures the config inputs anchor correctness
   // depends on. When this changes, the persisted anchor is invalidated.
-  return `${normalizeClientsCsv(clientsCsv)}|${allTimeSince}|projects:${projectsEnabled !== false ? 'on' : 'off'}`;
+  const base = `${normalizeClientsCsv(clientsCsv)}|${allTimeSince}|projects:${projectsEnabled !== false ? 'on' : 'off'}`;
+  const pricing = customPricingFingerprint(customModelPricing);
+  return pricing.length > 0 ? `${base}|pricing:${JSON.stringify(pricing)}` : base;
 }
 
 // Force a full scan at least this often even when the anchor is otherwise
@@ -1150,7 +1180,8 @@ function startCollector(options) {
     try {
       const saved = readJson(anchorPath, null);
       if (saved && saved.dateKey === localTodayKey()) {
-        const fp = configFingerprint(clients, allTimeSince, options.projectsEnabled);
+        const currentPricing = resolveCustomModelPricing(options.customModelPricing, log);
+        const fp = configFingerprint(clients, allTimeSince, options.projectsEnabled, currentPricing);
         if (saved.configFingerprint === fp) {
           anchor = { dateKey: saved.dateKey, today: saved.today, month: saved.month, allTime: saved.allTime };
           // Don't restore a persisted WSL snapshot when WSL scanning is now off —
@@ -1185,10 +1216,12 @@ function startCollector(options) {
     const todayKey = localTodayKey();
     const anchored = Boolean(tickOptions.todayOnly && anchor && anchor.dateKey === todayKey);
     const refreshWsl = Boolean(tickOptions.refreshWsl);
+    const customModelPricing = resolveCustomModelPricing(options.customModelPricing, log);
     try {
       let captured = null;
       const summary = await collectUsageOnce({
         ...options,
+        customModelPricing,
         clients,
         allTimeSince,
         commandTimeoutMs,
@@ -1265,7 +1298,7 @@ function startCollector(options) {
               allTime: anchor.allTime,
               wslBundle: wslAnchor,
               wslStatus: wslStatusAnchor,
-              configFingerprint: configFingerprint(clients, allTimeSince, options.projectsEnabled),
+              configFingerprint: configFingerprint(clients, allTimeSince, options.projectsEnabled, customModelPricing),
               fullScanAt: new Date().toISOString()
             }));
           } catch (_) {}

--- a/src/shared/tokscaleCustomPricing.js
+++ b/src/shared/tokscaleCustomPricing.js
@@ -2,6 +2,8 @@
 
 const { readJson, writeJsonAtomic } = require('./config');
 
+const TOKENS_PER_MILLION = 1_000_000;
+
 // '' / null / undefined => unset (undefined). Numbers >= 0 accepted (0 = explicit free).
 // Negative / NaN => unset.
 function toUnitPrice(value) {
@@ -31,6 +33,34 @@ function normalizeCustomPricingSetting(value) {
     byId.set(modelId, { modelId, inputPerM, outputPerM, cacheReadPerM });
   }
   return [...byId.values()];
+}
+
+// Build an App-side row cost resolver from the GUI setting. Tokscale treats
+// provider-reported costs as authoritative for some clients, so writing its
+// custom-pricing.json alone cannot guarantee an override. This resolver mirrors
+// tokscale's pricing buckets and is applied before Token Monitor aggregates the
+// row into periods, models, clients, and sessions.
+function createCustomPricingCostResolver(settingValue) {
+  const byModel = new Map();
+  for (const entry of normalizeCustomPricingSetting(settingValue)) {
+    byModel.set(entry.modelId.toLowerCase(), entry);
+  }
+  if (byModel.size === 0) return null;
+
+  return ({ model, input = 0, output = 0, cacheRead = 0, reasoning = 0 } = {}) => {
+    const modelId = String(model || '').trim().toLowerCase();
+    const pricing = byModel.get(modelId);
+    if (!pricing) return undefined;
+    const inputTokens = Math.max(0, Number(input) || 0);
+    const outputTokens = Math.max(0, Number(output) || 0);
+    const cacheReadTokens = Math.max(0, Number(cacheRead) || 0);
+    const reasoningTokens = Math.max(0, Number(reasoning) || 0);
+    return (
+      inputTokens * (pricing.inputPerM ?? 0)
+      + (outputTokens + reasoningTokens) * (pricing.outputPerM ?? 0)
+      + cacheReadTokens * (pricing.cacheReadPerM ?? 0)
+    ) / TOKENS_PER_MILLION;
+  };
 }
 
 // Cleaned entries -> tokscale `models` map (per-million keys), omitting unset fields.
@@ -84,6 +114,7 @@ function applyCustomPricing(settingValue, { pricingPath, sidecarPath }) {
 
 module.exports = {
   normalizeCustomPricingSetting,
+  createCustomPricingCostResolver,
   buildTokscaleModels,
   mergeManaged,
   applyCustomPricing

--- a/src/shared/usage.js
+++ b/src/shared/usage.js
@@ -409,13 +409,13 @@ function addSession(period, session) {
   mergeSession(period.sessions[key], session);
 }
 
-function sessionFromRow(row) {
+function sessionFromRow(row, resolvedCost = costValue(row)) {
   const client = detectClient(row);
   const id = detectSessionId(row);
   if (!client || !id) return null;
   const session = emptySession(client, id);
   session.totalTokens = Math.max(0, Math.round(tokenValue(row)));
-  session.costUsd = costValue(row);
+  session.costUsd = resolvedCost;
   session.messageCount = Math.max(0, Math.round(firstNumber(row, MESSAGE_COUNT_KEYS)));
   Object.assign(session, sessionTokenComponents(row));
   session.startedAt = normalizeIsoTimestamp(firstString(row, STARTED_AT_KEYS));
@@ -553,7 +553,20 @@ function normalizePeriod(input, options = {}) {
   return period;
 }
 
-function extractUsageFromTokscale(json) {
+function resolvedRowCost(row, context, costResolver) {
+  const originalCost = costValue(row);
+  if (typeof costResolver !== 'function') return originalCost;
+  try {
+    const resolved = costResolver({ ...context, row, originalCost });
+    return typeof resolved === 'number' && Number.isFinite(resolved) && resolved >= 0
+      ? resolved
+      : originalCost;
+  } catch (_) {
+    return originalCost;
+  }
+}
+
+function extractUsageFromTokscale(json, options = {}) {
   const rows = [];
   collectUsageRows(json, rows);
   if (rows.length === 0 && json && typeof json === 'object') {
@@ -573,12 +586,22 @@ function extractUsageFromTokscale(json) {
   for (const row of rows) {
     const client = detectClient(row);
     const tokens = tokenValue(row);
-    const cost = costValue(row);
-    const cacheRead = Math.max(0, Math.round(firstNumber(row, CACHE_READ_TOKEN_KEYS)));
-    const cacheWrite = Math.max(0, Math.round(firstNumber(row, CACHE_WRITE_TOKEN_KEYS)));
-    const output = Math.max(0, Math.round(firstNumber(row, OUTPUT_TOKEN_KEYS)));
+    const components = sessionTokenComponents(row);
+    const cacheRead = components.cacheReadTokens;
+    const cacheWrite = components.cacheWriteTokens;
+    const output = components.outputTokens;
     let model = detectModel(row);
     if (client === 'cursor' && model === 'auto') model = 'cursor-auto';
+    const cost = resolvedRowCost(row, {
+      client,
+      model,
+      provider: normalizeProviderName(row.provider),
+      input: components.inputTokens,
+      output: components.outputTokens,
+      cacheRead: components.cacheReadTokens,
+      cacheWrite: components.cacheWriteTokens,
+      reasoning: components.reasoningTokens
+    }, options.costResolver);
     period.totalTokens += Math.max(0, Math.round(tokens));
     period.costUsd += cost;
     period.cacheReadTokens += cacheRead;
@@ -606,7 +629,7 @@ function extractUsageFromTokscale(json) {
       if (!period.clientModelCosts[client]) period.clientModelCosts[client] = {};
       period.clientModelCosts[client][model] = (period.clientModelCosts[client][model] || 0) + cost;
     }
-    const session = sessionFromRow(row);
+    const session = sessionFromRow(row, cost);
     if (session) addSession(period, session);
   }
   return period;

--- a/src/shared/wslUsage.js
+++ b/src/shared/wslUsage.js
@@ -192,6 +192,7 @@ function probeWslState(deps = {}) {
 
 async function collectWslUsage(options = {}, deps = {}) {
   const { clients, trackedClients = clients, allTimeSince, commandTimeoutMs, now, runTokscale, logger, decoratePeriods } = options;
+  const extractUsage = (json) => extractUsageFromTokscale(json, { costResolver: options.costResolver });
   const buildProma = options.buildPromaPeriods || buildPromaPeriods;
   const collectProma = options.collectPromaRows || collectPromaRows;
   const existsSync = deps.existsSync || fs.existsSync;
@@ -228,9 +229,9 @@ async function collectWslUsage(options = {}, deps = {}) {
           promaOptions.pricingByModel = options.promaPricingByModel;
         }
         const proma = buildProma(promaOptions);
-        bundle.today = mergePeriods(bundle.today, extractUsageFromTokscale(proma.today));
-        bundle.month = mergePeriods(bundle.month, extractUsageFromTokscale(proma.month));
-        bundle.allTime = mergePeriods(bundle.allTime, extractUsageFromTokscale(proma.allTime));
+        bundle.today = mergePeriods(bundle.today, extractUsage(proma.today));
+        bundle.month = mergePeriods(bundle.month, extractUsage(proma.month));
+        bundle.allTime = mergePeriods(bundle.allTime, extractUsage(proma.allTime));
       } catch (error) {
         if (typeof logger === 'function') logger(`wsl Proma usage parse failed for ${home}: ${error.message}`);
       }
@@ -245,9 +246,9 @@ async function collectWslUsage(options = {}, deps = {}) {
       const monthJson = await runTokscale({ clients: clientsCsv, flags: ['--month', '--home', home], commandTimeoutMs });
       const allTimeJson = await runTokscale({ clients: clientsCsv, flags: ['--since', allTimeSince, '--home', home], commandTimeoutMs });
       const periods = {
-        today: extractUsageFromTokscale(todayJson),
-        month: extractUsageFromTokscale(monthJson),
-        allTime: extractUsageFromTokscale(allTimeJson)
+        today: extractUsage(todayJson),
+        month: extractUsage(monthJson),
+        allTime: extractUsage(allTimeJson)
       };
       if (typeof decoratePeriods === 'function') decoratePeriods(periods, home);
       bundle.today = mergePeriods(bundle.today, periods.today);

--- a/tests/electron/dailyHistoryArchiveWiring.test.js
+++ b/tests/electron/dailyHistoryArchiveWiring.test.js
@@ -20,6 +20,11 @@ test('every Electron collector mode yields daily-history writes to an external a
   assert.equal((main.match(/usageOptions:\s*electronUsageConfig\(/g) || []).length, 3);
 });
 
+test('every Electron collector mode reads live GUI custom pricing', () => {
+  assert.match(main, /getCustomModelPricing:\s*\(\) => settings\.customModelPricing \|\| \[\]/);
+  assert.equal((main.match(/usageOptions:\s*electronUsageConfig\(/g) || []).length, 3);
+});
+
 test('clearing retained session usage also clears retained daily history', () => {
   assert.match(main, /clearSessionUsageArchive\(\);\s*clearDailyHistoryArchive\(\);/);
 });

--- a/tests/electron/runtimeConfig.test.js
+++ b/tests/electron/runtimeConfig.test.js
@@ -49,6 +49,19 @@ test('limits config resolves managed credentials at dispatch time through contex
   assert.deepEqual(limits.mimoManagedAccounts, [{ id: 'mimo', cookieHeader: 'allowlisted' }]);
 });
 
+test('usage config keeps custom pricing live through a dispatch-time getter', () => {
+  let pricing = [{ modelId: 'mimo-v2.5-pro', inputPerM: 0.4, outputPerM: 0.8 }];
+  const getCustomModelPricing = () => pricing;
+  const usage = usageConfigFromSettings({ customModelPricing: [{ modelId: 'stale' }] }, {
+    getCustomModelPricing
+  });
+
+  assert.equal(usage.customModelPricing, getCustomModelPricing);
+  assert.deepEqual(usage.customModelPricing(), pricing);
+  pricing = [{ modelId: 'mimo-v2.5-pro', inputPerM: 1, outputPerM: 2 }];
+  assert.deepEqual(usage.customModelPricing(), pricing);
+});
+
 test('settings classifier separates structural, limits reconfigure, sink, and provider invalidation changes', () => {
   const previous = {
     hubMode: 'local',

--- a/tests/shared/collectorAnchorPersistence.test.js
+++ b/tests/shared/collectorAnchorPersistence.test.js
@@ -59,6 +59,26 @@ test('configFingerprint handles undefined and empty clients', () => {
   assert.match(c, /\|undefined\|projects:on$/, 'undefined allTimeSince produces string "undefined"');
 });
 
+test('configFingerprint invalidates anchors when effective custom pricing changes', () => {
+  const base = configFingerprint('micode', '2024-01-01');
+  const first = configFingerprint('micode', '2024-01-01', true, [
+    { modelId: 'MIMO-V2.5-PRO', inputPerM: 0.4, outputPerM: 0.8 },
+    { modelId: 'other', inputPerM: 1, outputPerM: 2 }
+  ]);
+  const reordered = configFingerprint('micode', '2024-01-01', true, [
+    { modelId: 'other', inputPerM: 1, outputPerM: 2 },
+    { modelId: 'mimo-v2.5-pro', inputPerM: 0.4, outputPerM: 0.8 }
+  ]);
+  const changed = configFingerprint('micode', '2024-01-01', true, [
+    { modelId: 'mimo-v2.5-pro', inputPerM: 0.5, outputPerM: 0.8 },
+    { modelId: 'other', inputPerM: 1, outputPerM: 2 }
+  ]);
+
+  assert.notEqual(first, base);
+  assert.equal(first, reordered, 'order and model-id case should not invalidate an equivalent anchor');
+  assert.notEqual(first, changed, 'a price change must invalidate the old-cost anchor');
+});
+
 test('anchored tick with valid anchor runs todayOnly scan and derives month/allTime', async () => {
   const dateKey = localTodayKey();
 

--- a/tests/shared/customPricingOverride.test.js
+++ b/tests/shared/customPricingOverride.test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { collectUsageOnce } = require('../../src/shared/collector');
+
+const MIMO_ROW = {
+  client: 'micode',
+  sessionId: 'session-1',
+  model: 'mimo-v2.5-pro',
+  provider: 'mimo',
+  input: 1000,
+  output: 500,
+  cacheRead: 100,
+  cacheWrite: 10,
+  reasoning: 50,
+  messageCount: 1,
+  cost: 0.05
+};
+
+test('GUI custom pricing overrides provider-reported cost across every usage rollup', async () => {
+  const summary = await collectUsageOnce({
+    clients: 'micode',
+    allTimeSince: '2024-01-01',
+    deviceId: 'pricing-test',
+    historyEnabled: false,
+    projectsEnabled: false,
+    wslScanEnabled: false,
+    runTokscale: async () => ({ entries: [MIMO_ROW] }),
+    customModelPricing: [{
+      modelId: 'mimo-v2.5-pro',
+      inputPerM: 0.4,
+      outputPerM: 0.8,
+      cacheReadPerM: 0.003
+    }]
+  });
+
+  // Mirrors tokscale's pricing buckets:
+  // input + (output + reasoning) + cache read; cache write is free when unset.
+  const expected = (1000 * 0.4 + (500 + 50) * 0.8 + 100 * 0.003) / 1_000_000;
+
+  for (const period of [summary.today, summary.month, summary.allTime]) {
+    assert.ok(Math.abs(period.costUsd - expected) < 1e-12);
+    assert.ok(Math.abs(period.clientCosts.micode - expected) < 1e-12);
+    assert.ok(Math.abs(period.modelCosts['mimo-v2.5-pro'] - expected) < 1e-12);
+    assert.ok(Math.abs(period.clientModelCosts.micode['mimo-v2.5-pro'] - expected) < 1e-12);
+    assert.ok(Math.abs(period.sessions['micode:session-1'].costUsd - expected) < 1e-12);
+    assert.ok(Math.abs(period.sessions['micode:session-1'].modelCosts['mimo-v2.5-pro'] - expected) < 1e-12);
+  }
+});

--- a/tests/shared/tokscaleCustomPricing.test.js
+++ b/tests/shared/tokscaleCustomPricing.test.js
@@ -8,6 +8,7 @@ const path = require('node:path');
 
 const {
   normalizeCustomPricingSetting,
+  createCustomPricingCostResolver,
   buildTokscaleModels,
   mergeManaged,
   applyCustomPricing
@@ -44,6 +45,30 @@ test('normalize dedupes by modelId, last wins; empty string is "unset" not 0', (
 test('normalize accepts explicit 0 cache-read (free) but omits unset fields', () => {
   const out = normalizeCustomPricingSetting([{ modelId: 'm', outputPerM: 0.8, cacheReadPerM: 0 }]);
   assert.deepEqual(out, [{ modelId: 'm', inputPerM: undefined, outputPerM: 0.8, cacheReadPerM: 0 }]);
+});
+
+test('App-side resolver overrides a model case-insensitively with tokscale pricing buckets', () => {
+  const resolveCost = createCustomPricingCostResolver([{
+    modelId: 'MiMo-V2.5-Pro',
+    inputPerM: 0.4,
+    outputPerM: 0.8,
+    cacheReadPerM: 0.003
+  }]);
+
+  assert.equal(resolveCost({
+    model: 'mimo-v2.5-pro',
+    input: 1000,
+    output: 500,
+    cacheRead: 100,
+    cacheWrite: 10,
+    reasoning: 50
+  }), (1000 * 0.4 + (500 + 50) * 0.8 + 100 * 0.003) / 1_000_000);
+  assert.equal(resolveCost({ model: 'other', input: 1000 }), undefined);
+});
+
+test('App-side resolver is absent when the setting has no valid overrides', () => {
+  assert.equal(createCustomPricingCostResolver([]), null);
+  assert.equal(createCustomPricingCostResolver([{ modelId: 'm', inputPerM: 0, outputPerM: 0 }]), null);
 });
 
 test('buildTokscaleModels emits per-million keys, omitting undefined fields', () => {

--- a/tests/shared/usage.test.js
+++ b/tests/shared/usage.test.js
@@ -804,6 +804,42 @@ test('extractUsageFromTokscale keeps model usage grouped by client', () => {
   assert.equal(period.clientModels.codex['gpt-5'], 50);
 });
 
+test('extractUsageFromTokscale uses one resolved row cost for period and session rollups', () => {
+  const row = {
+    client: 'MiCode',
+    sessionId: 'session-1',
+    model: 'mimo-v2.5-pro',
+    provider: 'mimo',
+    input: 10,
+    output: 5,
+    cost: 99
+  };
+  const seen = [];
+  const period = extractUsageFromTokscale([row], {
+    costResolver: (context) => {
+      seen.push(context);
+      return 0.25;
+    }
+  });
+
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].model, 'mimo-v2.5-pro');
+  assert.equal(seen[0].provider, 'mimo');
+  assert.equal(seen[0].originalCost, 99);
+  assert.equal(period.costUsd, 0.25);
+  assert.equal(period.clientCosts.micode, 0.25);
+  assert.equal(period.modelCosts['mimo-v2.5-pro'], 0.25);
+  assert.equal(period.sessions['micode:session-1'].costUsd, 0.25);
+  assert.equal(period.sessions['micode:session-1'].modelCosts['mimo-v2.5-pro'], 0.25);
+});
+
+test('extractUsageFromTokscale retains reported cost when a resolver declines or fails', () => {
+  const row = { client: 'Codex', model: 'gpt-5', input: 10, cost: 0.75 };
+  assert.equal(extractUsageFromTokscale([row], { costResolver: () => undefined }).costUsd, 0.75);
+  assert.equal(extractUsageFromTokscale([row], { costResolver: () => { throw new Error('bad resolver'); } }).costUsd, 0.75);
+  assert.equal(extractUsageFromTokscale([row], { costResolver: () => Number.NaN }).costUsd, 0.75);
+});
+
 test('extractUsageFromTokscale keeps session usage grouped by client and model', () => {
   const period = extractUsageFromTokscale({
     groupBy: 'client,session,model',

--- a/tests/shared/usageRuntime.test.js
+++ b/tests/shared/usageRuntime.test.js
@@ -151,3 +151,43 @@ test('refreshClient rejects unsupported targeted usage clients', async () => {
     runtime.stop();
   }
 });
+
+test('manual refresh reads live custom pricing without rebuilding the usage runtime', async () => {
+  let pricing = [{ modelId: 'mimo-v2.5-pro', inputPerM: 1, outputPerM: 2 }];
+  const updates = [];
+  const runtime = startCollector({
+    clients: 'micode',
+    allTimeSince: '2024-01-01',
+    commandTimeoutMs: 1000,
+    deviceId: 'pricing-runtime',
+    intervalMs: 60000,
+    watchEnabled: false,
+    historyEnabled: false,
+    projectsEnabled: false,
+    wslScanEnabled: false,
+    anchorPersistenceEnabled: false,
+    customModelPricing: () => pricing,
+    runTokscale: async () => ({
+      entries: [{
+        client: 'micode',
+        model: 'mimo-v2.5-pro',
+        input: 1000,
+        output: 500,
+        cost: 99
+      }]
+    }),
+    onUpdate: (summary, reason) => updates.push({ summary, reason })
+  });
+
+  try {
+    await waitFor(() => updates.length >= 1);
+    assert.equal(updates.at(-1).summary.allTime.costUsd, (1000 * 1 + 500 * 2) / 1_000_000);
+
+    pricing = [{ modelId: 'mimo-v2.5-pro', inputPerM: 3, outputPerM: 4 }];
+    await runtime.tick('manual');
+    assert.equal(updates.at(-1).reason, 'manual');
+    assert.equal(updates.at(-1).summary.allTime.costUsd, (1000 * 3 + 500 * 4) / 1_000_000);
+  } finally {
+    runtime.stop();
+  }
+});

--- a/tests/shared/wslUsage.test.js
+++ b/tests/shared/wslUsage.test.js
@@ -262,6 +262,32 @@ test('collectWslUsage sums two homes per period', async () => {
   assert.deepEqual(bundle.today.clients, { claude: 15 });
 });
 
+test('collectWslUsage applies the injected row cost resolver to every period', async () => {
+  const home = '\\\\wsl$\\Ubuntu\\home\\alice';
+  const deps = {
+    platform: 'win32',
+    exec: (cmd) => (cmd === 'reg' ? 'Lxss' : 'Ubuntu\n'),
+    readdirSync: () => ['alice'],
+    existsSync: (p) => p === `${home}\\.local\\share\\mimocode\\mimocode.db`
+  };
+  const runTokscale = async () => ({
+    entries: [{ client: 'micode', sessionId: 's1', model: 'mimo-v2.5-pro', input: 10, cost: 99 }]
+  });
+  const { bundle } = await collectWslUsage({
+    clients: 'micode',
+    allTimeSince: '2025-01-01',
+    commandTimeoutMs: 1000,
+    runTokscale,
+    costResolver: () => 0.125
+  }, deps);
+
+  for (const period of [bundle.today, bundle.month, bundle.allTime]) {
+    assert.equal(period.costUsd, 0.125);
+    assert.equal(period.modelCosts['mimo-v2.5-pro'], 0.125);
+    assert.equal(period.sessions['micode:s1'].costUsd, 0.125);
+  }
+});
+
 test('collectWslUsage decorates each home before merging periods', async () => {
   const homes = ['\\\\wsl$\\Ubuntu\\home\\alice'];
   const decorated = [];

--- a/worker/src/shared/usage.js
+++ b/worker/src/shared/usage.js
@@ -412,13 +412,13 @@ function addSession(period, session) {
   mergeSession(period.sessions[key], session);
 }
 
-function sessionFromRow(row) {
+function sessionFromRow(row, resolvedCost = costValue(row)) {
   const client = detectClient(row);
   const id = detectSessionId(row);
   if (!client || !id) return null;
   const session = emptySession(client, id);
   session.totalTokens = Math.max(0, Math.round(tokenValue(row)));
-  session.costUsd = costValue(row);
+  session.costUsd = resolvedCost;
   session.messageCount = Math.max(0, Math.round(firstNumber(row, MESSAGE_COUNT_KEYS)));
   Object.assign(session, sessionTokenComponents(row));
   session.startedAt = normalizeIsoTimestamp(firstString(row, STARTED_AT_KEYS));
@@ -556,7 +556,20 @@ function normalizePeriod(input, options = {}) {
   return period;
 }
 
-function extractUsageFromTokscale(json) {
+function resolvedRowCost(row, context, costResolver) {
+  const originalCost = costValue(row);
+  if (typeof costResolver !== 'function') return originalCost;
+  try {
+    const resolved = costResolver({ ...context, row, originalCost });
+    return typeof resolved === 'number' && Number.isFinite(resolved) && resolved >= 0
+      ? resolved
+      : originalCost;
+  } catch (_) {
+    return originalCost;
+  }
+}
+
+function extractUsageFromTokscale(json, options = {}) {
   const rows = [];
   collectUsageRows(json, rows);
   if (rows.length === 0 && json && typeof json === 'object') {
@@ -576,12 +589,22 @@ function extractUsageFromTokscale(json) {
   for (const row of rows) {
     const client = detectClient(row);
     const tokens = tokenValue(row);
-    const cost = costValue(row);
-    const cacheRead = Math.max(0, Math.round(firstNumber(row, CACHE_READ_TOKEN_KEYS)));
-    const cacheWrite = Math.max(0, Math.round(firstNumber(row, CACHE_WRITE_TOKEN_KEYS)));
-    const output = Math.max(0, Math.round(firstNumber(row, OUTPUT_TOKEN_KEYS)));
+    const components = sessionTokenComponents(row);
+    const cacheRead = components.cacheReadTokens;
+    const cacheWrite = components.cacheWriteTokens;
+    const output = components.outputTokens;
     let model = detectModel(row);
     if (client === 'cursor' && model === 'auto') model = 'cursor-auto';
+    const cost = resolvedRowCost(row, {
+      client,
+      model,
+      provider: normalizeProviderName(row.provider),
+      input: components.inputTokens,
+      output: components.outputTokens,
+      cacheRead: components.cacheReadTokens,
+      cacheWrite: components.cacheWriteTokens,
+      reasoning: components.reasoningTokens
+    }, options.costResolver);
     period.totalTokens += Math.max(0, Math.round(tokens));
     period.costUsd += cost;
     period.cacheReadTokens += cacheRead;
@@ -609,7 +632,7 @@ function extractUsageFromTokscale(json) {
       if (!period.clientModelCosts[client]) period.clientModelCosts[client] = {};
       period.clientModelCosts[client][model] = (period.clientModelCosts[client][model] || 0) + cost;
     }
-    const session = sessionFromRow(row);
+    const session = sessionFromRow(row, cost);
     if (session) addSession(period, session);
   }
   return period;


### PR DESCRIPTION
## Summary

- Recalculate matching Tokscale rows inside Token Monitor before period, client, model, project, and session aggregation.
- Give GUI custom prices precedence over provider-reported authoritative costs, while preserving the reported cost for models without an override.
- Read the live setting on every collector tick, invalidate persisted anchors when effective prices change, and apply the same resolver to local, Proma, and WSL usage.
- Keep the Worker’s generated shared usage module synchronized.

## Root cause

Tokscale now preserves provider-reported costs for some clients. That is correct as an upstream default, but it means writing `custom-pricing.json` cannot force an override for MiMo even though the Token Monitor UI promises one. Token Monitor now enforces the user’s explicit override at its own row-processing boundary, without modifying or forking Tokscale.

The custom-pricing layout repair remains isolated in #236.

## Validation

- `npm run sync:worker`
- `npm run verify` — 1697 passed, 0 failed, 1 skipped
- Regression coverage for provider-authoritative MiMo costs, every usage rollup, live setting refresh, persisted anchors, fallback behavior, and WSL

Fixes #224


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces user-defined custom model pricing across all usage paths by resolving row costs before aggregation. Reads live pricing each tick and invalidates anchors when prices change to keep totals correct.

- **Bug Fixes**
  - Apply an App-side cost resolver from `customModelPricing` to override provider-reported costs; fall back to reported cost when no override exists.
  - Read pricing via a getter in Electron, plumb through runtime config, and pass to local, Proma, WSL, and Worker usage paths.
  - Include effective pricing in the anchor fingerprint to invalidate persisted anchors on price changes.
  - Use the same resolved row cost for period, client, model, client-model, and session rollups.
  - Add targeted tests for overrides, anchor invalidation, WSL/local/Proma paths, and live manual refresh.

<sup>Written for commit 606ff54ffdac31a0ecf53bc5d2def3244e50c4a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

