### PR TITLE
fix(macos): keep menu window on the active Space

### DIFF
--- a/src/electron/macosSpaceBehavior.js
+++ b/src/electron/macosSpaceBehavior.js
@@ -1,0 +1,67 @@
+'use strict';
+
+// Electron exposes the native NSView handle on macOS, but not AppKit's window
+// collectionBehavior. Use the Objective-C runtime for the one missing flag we
+// need, and keep the bridge lazy/best-effort so other platforms never load it.
+
+const NS_WINDOW_COLLECTION_BEHAVIOR_MOVE_TO_ACTIVE_SPACE = 1n << 1n;
+
+let macSpaceApi = null;
+
+function nativeHandleValue(win) {
+  const handle = win.getNativeWindowHandle();
+  return handle.length >= 8 ? handle.readBigUInt64LE() : BigInt(handle.readUInt32LE());
+}
+
+function createMacSpaceApi(koffi) {
+  const objc = koffi.load('/usr/lib/libobjc.A.dylib');
+  const selRegisterName = objc.func('sel_registerName', 'uintptr_t', ['str']);
+  const sendUintptr = objc.func('objc_msgSend', 'uintptr_t', ['uintptr_t', 'uintptr_t']);
+  const sendVoidWithUint64 = objc.func('objc_msgSend', 'void', ['uintptr_t', 'uintptr_t', 'uint64_t']);
+  const windowSelector = selRegisterName('window');
+  const collectionBehaviorSelector = selRegisterName('collectionBehavior');
+  const setCollectionBehaviorSelector = selRegisterName('setCollectionBehavior:');
+
+  return {
+    setMoveToActiveSpace(viewHandle, enabled) {
+      const nativeWindow = sendUintptr(viewHandle, windowSelector);
+      if (!nativeWindow) return false;
+      const current = BigInt(sendUintptr(nativeWindow, collectionBehaviorSelector));
+      const next = enabled
+        ? current | NS_WINDOW_COLLECTION_BEHAVIOR_MOVE_TO_ACTIVE_SPACE
+        : current & ~NS_WINDOW_COLLECTION_BEHAVIOR_MOVE_TO_ACTIVE_SPACE;
+      if (next !== current) {
+        sendVoidWithUint64(nativeWindow, setCollectionBehaviorSelector, next);
+      }
+      return true;
+    }
+  };
+}
+
+function loadMacSpaceApi() {
+  if (macSpaceApi !== null) return macSpaceApi;
+  try {
+    macSpaceApi = createMacSpaceApi(require('koffi'));
+  } catch {
+    macSpaceApi = false;
+  }
+  return macSpaceApi;
+}
+
+function setMoveToActiveSpace(win, enabled, options = {}) {
+  if ((options.platform || process.platform) !== 'darwin') return false;
+  if (!win || win.isDestroyed?.()) return false;
+  const api = options.api || loadMacSpaceApi();
+  if (!api) return false;
+  try {
+    return api.setMoveToActiveSpace(nativeHandleValue(win), enabled) === true;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = {
+  NS_WINDOW_COLLECTION_BEHAVIOR_MOVE_TO_ACTIVE_SPACE,
+  createMacSpaceApi,
+  setMoveToActiveSpace
+};

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -164,6 +164,7 @@ const {
   moveFloatingBubbleBounds
 } = require('./floatingBubble');
 const { applyWindowsChrome } = require('./windowsChrome');
+const { setMoveToActiveSpace } = require('./macosSpaceBehavior');
 const {
   WINDOWS_BACKDROP_ACCENT,
   normalizeWindowsBackdropMode
@@ -1408,7 +1409,6 @@ function expandFloatingBubble(options = {}) {
   sendFloatingBubbleState();
   if (options.focus !== false) {
     mainWindow.show();
-    mainWindow.focus();
   }
   return true;
 }
@@ -1832,6 +1832,32 @@ function applyMacActivationPolicy(state = {}) {
   if (!app.dock) return;
   if (mode === 'accessory') app.dock.hide();
   else app.dock.show();
+}
+
+function applyMacSpaceBehavior(trayMode = Boolean(settings?.trayMode)) {
+  if (process.platform !== 'darwin' || !mainWindow || mainWindow.isDestroyed()) return;
+  if (trayMode) {
+    setMoveToActiveSpace(mainWindow, false);
+    if (typeof mainWindow.setVisibleOnAllWorkspaces === 'function') {
+      mainWindow.setVisibleOnAllWorkspaces(true, {
+        visibleOnFullScreen: true,
+        skipTransformProcessType: true
+      });
+    }
+    if (typeof mainWindow.setHiddenInMissionControl === 'function') {
+      mainWindow.setHiddenInMissionControl(true);
+    }
+  } else {
+    if (typeof mainWindow.setVisibleOnAllWorkspaces === 'function') {
+      mainWindow.setVisibleOnAllWorkspaces(false);
+    }
+    if (typeof mainWindow.setHiddenInMissionControl === 'function') {
+      mainWindow.setHiddenInMissionControl(false);
+    }
+    // Apply this last because Electron's workspace/Mission Control setters also
+    // update NSWindow.collectionBehavior.
+    setMoveToActiveSpace(mainWindow, true);
+  }
 }
 
 function applyWindowSettings() {
@@ -2482,13 +2508,13 @@ async function startStatsStream(options = {}) {
 function showPopover() {
   if (!mainWindow || mainWindow.isDestroyed() || !tray) return;
   applyMacActivationPolicy();
+  applyMacSpaceBehavior(true);
   applyWindowSettings();
   const current = mainWindow.getBounds();
   const target = popoverBounds(tray, current.width, current.height);
   mainWindow.setBounds(target);
   suppressNextBlurHide = true;
   mainWindow.show();
-  mainWindow.focus();
   // The focus event itself may not fire a blur; the suppress flag covers the
   // case where macOS fires blur immediately after show because the click that
   // opened us still has the menu bar as the focused element.
@@ -2514,10 +2540,10 @@ function focusExistingWindow() {
   }
   if (mainWindow.isMinimized()) mainWindow.restore();
   if (settings?.trayMode) showPopover();
-  else if (floatingBubbleState.collapsed) expandFloatingBubble();
   else {
-    mainWindow.show();
-    mainWindow.focus();
+    applyMacSpaceBehavior(false);
+    if (floatingBubbleState.collapsed) expandFloatingBubble();
+    else mainWindow.show();
   }
 }
 
@@ -2916,11 +2942,7 @@ function enterTrayMode() {
   applyMacActivationPolicy();
   if (mainWindow && !mainWindow.isDestroyed()) {
     if (typeof mainWindow.setSkipTaskbar === 'function') mainWindow.setSkipTaskbar(true);
-    // Without this, .show() yanks the user back to the Space the window was last
-    // shown on instead of popping over the current Space / fullscreen app.
-    if (typeof mainWindow.setVisibleOnAllWorkspaces === 'function') {
-      mainWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
-    }
+    applyMacSpaceBehavior(true);
     mainWindow.hide();
   }
 }
@@ -2929,9 +2951,7 @@ function exitTrayMode() {
   applyMacActivationPolicy({ mainWindowVisible: true });
   if (mainWindow && !mainWindow.isDestroyed()) {
     if (typeof mainWindow.setSkipTaskbar === 'function') mainWindow.setSkipTaskbar(false);
-    if (typeof mainWindow.setVisibleOnAllWorkspaces === 'function') {
-      mainWindow.setVisibleOnAllWorkspaces(false);
-    }
+    applyMacSpaceBehavior(false);
     const restore = restoredBounds() || DEFAULT_WINDOW;
     mainWindow.setBounds({
       width: restore.width,
@@ -2940,7 +2960,6 @@ function exitTrayMode() {
     });
     applyWindowSettings();
     mainWindow.show();
-    mainWindow.focus();
   }
   if (!shouldCreateTray(settings)) destroyTray();
   else ensureTray();
@@ -3553,6 +3572,7 @@ function createWindow(boundsOverride, options = {}) {
   });
   mainWindow = win;
   mainWindowChrome = { collapsedFloatingBubble };
+  applyMacSpaceBehavior();
   applyWindowsChrome(win, { round: true });
   let windowsAccentFallback = false;
   if (windowsAccent && !applyWindowsAccentBlur(win)) {

--- a/tests/electron/macosSpaceBehavior.test.js
+++ b/tests/electron/macosSpaceBehavior.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  NS_WINDOW_COLLECTION_BEHAVIOR_MOVE_TO_ACTIVE_SPACE,
+  createMacSpaceApi,
+  setMoveToActiveSpace
+} = require('../../src/electron/macosSpaceBehavior');
+
+function fakeKoffi(initialBehavior) {
+  const selectors = new Map([
+    ['window', 11n],
+    ['collectionBehavior', 12n],
+    ['setCollectionBehavior:', 13n]
+  ]);
+  const calls = [];
+  return {
+    calls,
+    load() {
+      return {
+        func(name, returnType, argumentTypes) {
+          if (name === 'sel_registerName') return (selector) => selectors.get(selector);
+          if (name === 'objc_msgSend' && returnType === 'uintptr_t') {
+            return (receiver, selector) => selector === 11n ? 101n : initialBehavior;
+          }
+          if (name === 'objc_msgSend' && argumentTypes.length === 3) {
+            return (receiver, selector, behavior) => calls.push({ receiver, selector, behavior });
+          }
+          throw new Error(`Unexpected native function: ${name}`);
+        }
+      };
+    }
+  };
+}
+
+test('AppKit bridge adds and removes moveToActiveSpace without changing other flags', () => {
+  const addKoffi = fakeKoffi(8n);
+  assert.equal(createMacSpaceApi(addKoffi).setMoveToActiveSpace(100n, true), true);
+  assert.deepEqual(addKoffi.calls, [{
+    receiver: 101n,
+    selector: 13n,
+    behavior: 8n | NS_WINDOW_COLLECTION_BEHAVIOR_MOVE_TO_ACTIVE_SPACE
+  }]);
+
+  const removeKoffi = fakeKoffi(10n);
+  assert.equal(createMacSpaceApi(removeKoffi).setMoveToActiveSpace(100n, false), true);
+  assert.deepEqual(removeKoffi.calls, [{ receiver: 101n, selector: 13n, behavior: 8n }]);
+});
+
+test('native bridge is a no-op away from macOS', () => {
+  const win = {
+    getNativeWindowHandle() {
+      throw new Error('must not read a native handle');
+    }
+  };
+  assert.equal(setMoveToActiveSpace(win, true, { platform: 'linux' }), false);
+});
+
+test('main process reapplies the complete Space policy before showing either mode', () => {
+  const main = fs.readFileSync(path.join(__dirname, '../../src/electron/main.js'), 'utf8');
+  const policy = main.match(/function applyMacSpaceBehavior[\s\S]*?\n}\n\nfunction applyWindowSettings/)[0];
+  const popover = main.match(/function showPopover[\s\S]*?\n}\n\nfunction hidePopover/)[0];
+  const focusWindow = main.match(/function focusExistingWindow[\s\S]*?\n}\n\nfunction currentWindowToggleShortcutStatus/)[0];
+
+  assert.match(policy, /setMoveToActiveSpace\(mainWindow, false\)[\s\S]*setVisibleOnAllWorkspaces\(true, \{[\s\S]*visibleOnFullScreen: true,[\s\S]*skipTransformProcessType: true/);
+  assert.match(policy, /setVisibleOnAllWorkspaces\(false\)[\s\S]*setHiddenInMissionControl\(false\)[\s\S]*setMoveToActiveSpace\(mainWindow, true\)/);
+  assert.match(policy, /setHiddenInMissionControl\(true\)/);
+  assert.match(popover, /applyMacSpaceBehavior\(true\)[\s\S]*mainWindow\.show\(\)/);
+  assert.match(focusWindow, /applyMacSpaceBehavior\(false\)[\s\S]*mainWindow\.show\(\)/);
+  assert.doesNotMatch(main, /mainWindow\.show\(\);\s*mainWindow\.focus\(\);/);
+});


### PR DESCRIPTION
## 概要

修复 macOS 下点击菜单栏图标时，Token Monitor 偶尔切换到窗口原先所在 Space 后才显示的问题。

当前项目使用同一个 Electron `BrowserWindow` 支持普通窗口模式与托盘弹窗模式。本次修改为两种模式分别设置明确的 macOS Space 行为：

- 普通窗口模式：窗口被唤起时移动到当前活动 Space
- 托盘弹窗模式：窗口可在所有 Space 和全屏 Space 中显示

### 本次包含

- 新增 macOS 专用的 `macosSpaceBehavior` 模块
- 通过现有 `koffi` 依赖访问 `NSWindow.collectionBehavior`
- 普通窗口模式启用 `NSWindowCollectionBehaviorMoveToActiveSpace`
- 托盘模式继续使用 `setVisibleOnAllWorkspaces`
- 在窗口创建、模式切换和窗口显示前重新应用 Space 策略
- 删除 `show()` 后重复执行的显式 `focus()`
- 新增 macOS Space 行为相关测试
- 非 macOS 平台保持 no-op，不改变 Windows 和 Linux 行为

## 原因

普通窗口可能仍归属于上一次显示时所在的 macOS Space。

当用户位于另一个 Space 并点击菜单栏图标时，原有逻辑直接显示并聚焦该窗口，macOS 因此先切换到窗口原先所在的 Space。

Electron 没有直接提供 `NSWindowCollectionBehaviorMoveToActiveSpace` 接口。本次通过一个延迟加载、仅限 macOS、失败时安全降级的 Objective-C Runtime 桥接补充该行为。

## 实现方式

### 普通窗口模式

1. 关闭 `setVisibleOnAllWorkspaces`
2. 恢复 Mission Control 可见性
3. 最后启用 `NSWindowCollectionBehaviorMoveToActiveSpace`

执行顺序是有意安排的，因为 Electron 的工作区相关 setter 也会更新 `NSWindow.collectionBehavior`。

### 托盘弹窗模式

1. 清除 `NSWindowCollectionBehaviorMoveToActiveSpace`
2. 启用 `setVisibleOnAllWorkspaces`
3. 支持全屏 Space
4. 在 Mission Control 中隐藏弹窗窗口

## 验证

自动验证已完成：

- [x] 新增 Node 测试覆盖 collection behavior 位标志的添加与移除
- [x] `npm run verify`（1702 pass，0 fail）
- [x] `npm run dist:mac`（构建因缺少 Apple 签名证书失败，但 .app 已生成）

用户人工验证：

- [x] 打包后的 `.app` 跨多个普通 Space 验证
- [x] 全屏 Space 验证
- [x] Apple Silicon 验证
- [ ] Intel Mac 验证

## 改动范围

本 PR 只包含：

- `src/electron/macosSpaceBehavior.js`
- `src/electron/main.js`
- `tests/electron/macosSpaceBehavior.test.js`

不包含 fork 中的文档、自定义启动脚本或其他无关修改。

Fixes #140 

---

<details>
<summary>English version</summary>

## Summary

Fixes an issue on macOS where clicking the Token Monitor menu bar icon could switch to the Space where the window was previously shown before displaying it.

Token Monitor currently uses the same Electron `BrowserWindow` for both normal window mode and tray popover mode. This change gives each mode an explicit macOS Space policy:

- Normal window mode: move the window to the currently active Space when revealed
- Tray popover mode: keep the window available across all Spaces and fullscreen Spaces

### Included

- Add a macOS-specific `macosSpaceBehavior` module
- Access `NSWindow.collectionBehavior` through the existing `koffi` dependency
- Enable `NSWindowCollectionBehaviorMoveToActiveSpace` in normal window mode
- Continue using `setVisibleOnAllWorkspaces` in tray mode
- Reapply the Space policy during window creation, mode transitions, and window presentation
- Remove redundant explicit `focus()` calls after `show()`
- Add tests for the macOS Space behavior
- Keep the implementation as a no-op outside macOS, without changing Windows or Linux behavior

## Cause

The normal application window could remain associated with the macOS Space where it was last displayed.

When the user was on another Space and clicked the menu bar icon, the previous implementation immediately showed and focused that window. macOS therefore switched to the window's original Space.

Electron does not directly expose `NSWindowCollectionBehaviorMoveToActiveSpace`. This change adds a lazy, macOS-only Objective-C Runtime bridge that safely falls back if the native bridge is unavailable.

## Implementation

### Normal window mode

1. Disable `setVisibleOnAllWorkspaces`
2. Restore Mission Control visibility
3. Enable `NSWindowCollectionBehaviorMoveToActiveSpace` last

The order is intentional because Electron's workspace-related setters also update `NSWindow.collectionBehavior`.

### Tray popover mode

1. Remove `NSWindowCollectionBehaviorMoveToActiveSpace`
2. Enable `setVisibleOnAllWorkspaces`
3. Allow presentation over fullscreen Spaces
4. Hide the popover window from Mission Control

## Verification

Automatic verification completed:

- [x] Added Node tests covering addition and removal of the collection behavior bit
- [x] `npm run verify`（1702 pass，0 fail）
- [x] `npm run dist:mac`（build failed due to missing Apple signing certificate, but .app was generated）

User manual verification:

- [ ] Packaged `.app` verification across multiple normal Spaces
- [ ] Fullscreen Space verification
- [ ] Apple Silicon verification
- [ ] Intel Mac verification

## Scope

This PR contains only:

- `src/electron/macosSpaceBehavior.js`
- `src/electron/main.js`
- `tests/electron/macosSpaceBehavior.test.js`

It does not include documentation, custom launcher scripts, or other unrelated fork changes.

</details>