### PR TITLE
fix(updater): install Windows updates silently

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -3432,7 +3432,9 @@ function installDownloadedAppUpdate() {
     latest
   })) return deriveAppUpdateState();
   quitRequested = true;
-  autoUpdater.quitAndInstall(false, true);
+  // isSilent: skip the NSIS installer UI on Windows so the update feels seamless
+  // (per-user install needs no elevation); isForceRunAfter relaunches the app.
+  autoUpdater.quitAndInstall(true, true);
   return deriveAppUpdateState();
 }
 


### PR DESCRIPTION
## What

When applying a downloaded update on Windows, `quitAndInstall(false, true)` ran the one-click NSIS installer with its default UI, so clicking **Restart to update** flashed an installer progress window before the app relaunched. macOS (Squirrel.Mac) already swaps the bundle with no visible installer, so the two platforms felt inconsistent.

This passes `isSilent=true` so the install runs without that window. The build is a per-user install (`perMachine` defaults to `false` → `%LOCALAPPDATA%`), so it needs no elevation and stays reliable when silent. Windows now behaves like macOS: click restart → no installer UI → the app reopens on the new version.

The in-app download progress (the slow part) is unchanged — it's still shown via our own `download-progress` handler.

## Note

This only affects the final install step, which is Windows-only and exercised by a real signed release build, so it can't be observed by CI. The change is covered at the unit/lint level; the end-to-end effect should be confirmed on the next Windows release update.

## Verification

- `npm run verify` — lint clean, 1698 pass / 0 fail


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install Windows updates silently so users no longer see the NSIS installer window after clicking “Restart to update.” We now call `autoUpdater.quitAndInstall(true, true)` to run the per-user installer without UI or elevation and relaunch on the new version.

<sup>Written for commit ae628685ae63f910088e4382fcc6dcb50136f8c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

