### PR TITLE
fix(limits): remove redundant balance suffix

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -2377,7 +2377,7 @@ function formatLimitWindowValue(window, fillPercent, hasPercent, showUsed) {
 function formatHomeLimitWindowValue(window, showUsed) {
   if (window?.planStatus === 'expired') return t('limits.mimo.planExpired');
   if (window?.kind === 'balance') {
-    return `${formatMoney(window.amount, window.currency)} left`;
+    return formatMoney(window.amount, window.currency);
   }
   const percent = limitFillPercent(window?.remainingPercent, window?.usedPercent, showUsed);
   return `${formatPercent(percent)} ${limitModeSuffix(showUsed)}`;
@@ -2894,7 +2894,7 @@ function renderProviderWindows(provider, color) {
         { ...balanceWindow, label: 'Balance' },
         color,
         0.95,
-        `${formatMoney(balanceAmount, currency)} left`
+        formatMoney(balanceAmount, currency)
       );
       balanceNode.classList.add('limit-window-wide', 'limit-window-no-reset');
       windows.append(balanceNode);
@@ -2929,12 +2929,15 @@ function renderProviderWindows(provider, color) {
     const quotaWindow = thirdPartyQuotaWindow(provider);
     const balanceLabel = quotaWindow?.label || 'Balance';
     if (balanceAmount !== null) {
+      const balanceValue = formatMoney(balanceAmount, currency);
       const balanceNode = limitWindowNode(
         balanceLabel,
         { ...(quotaWindow || { showMeter: false }), label: balanceLabel },
         color,
         0.95,
-        `${formatMoney(balanceAmount, currency)} left`
+        String(balanceLabel).trim().toLowerCase() === 'balance'
+          ? balanceValue
+          : `${balanceValue} left`
       );
       balanceNode.classList.add('limit-window-wide', 'limit-window-no-reset');
       windows.append(balanceNode);
@@ -2963,7 +2966,7 @@ function renderProviderWindows(provider, color) {
     if (balance) {
       const currency = balance.currency;
       const balanceNode = limitWindowNode('Balance', balanceRemainingWindow(balance), color, 0.95,
-        `${formatMoney(balance.amount, currency)} left`);
+        formatMoney(balance.amount, currency));
       balanceNode.classList.add('limit-window-wide', 'limit-window-no-reset');
       windows.append(balanceNode);
 

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -807,7 +807,7 @@ test('Home uses explicit billing labels so Copilot Premium and Chat stay distinc
   assert.match(homeModule, /value\.textContent = window\.value \|\| formatHomeLimitWindowValue\(window, showUsed\);/);
   assert.match(homeModule, /limitProviderCompactWindowPeriodLabel\(row\.providerId, window, row\.windows\)/);
   assert.match(homeModule, /`\$\{periodLabel\} · \$\{resetLabel\}`/);
-  assert.match(valueFormatter, /`\$\{formatMoney\(window\.amount, window\.currency\)\} left`/);
+  assert.match(valueFormatter, /return formatMoney\(window\.amount, window\.currency\);/);
   assert.match(valueFormatter, /`\$\{formatPercent\(percent\)\} \$\{limitModeSuffix\(showUsed\)\}`/);
   assert.doesNotMatch(i18n, /home\.limit\.(balance|leftPercent|leftAmount)/);
 });
@@ -835,7 +835,17 @@ test('DeepSeek main Limits row preserves the intentional month-spend balance met
   assert.doesNotMatch(renderProviderWindows, /monthSinceTracking \? 'Month \(since tracking\)' : 'Month'/);
   assert.match(balanceWindow, /remainingPercent/);
   assert.match(balanceWindow, /amount \+ spend/);
+  assert.doesNotMatch(renderProviderWindows, /formatMoney\(balance\.amount, currency\)\} left/);
   assert.match(styles, /\.limit-window-no-reset \.limit-reset\s*\{/);
+});
+
+test('Balance values omit the redundant left suffix without changing quota copy', () => {
+  const app = readRendererFile('app.js');
+  const renderProviderWindows = functionBody(app, 'renderProviderWindows', 'renderLimitProviderRow');
+
+  assert.match(renderProviderWindows, /'Balance',\s*\{ \.\.\.balanceWindow, label: 'Balance' \},\s*color,\s*0\.95,\s*formatMoney\(balanceAmount, currency\)/);
+  assert.match(renderProviderWindows, /String\(balanceLabel\)\.trim\(\)\.toLowerCase\(\) === 'balance'\s*\? balanceValue\s*: `\$\{balanceValue\} left`/);
+  assert.doesNotMatch(renderProviderWindows, /`\$\{formatMoney\(balanceAmount, currency\)\} left`/);
 });
 
 test('MiMo main Limits row falls back to balance plan fields for Token Plan', () => {


### PR DESCRIPTION
## Summary

- remove the redundant `left` suffix from monetary values labeled `Balance`
- keep balance meters and quota-specific `left` copy unchanged
- cover the Home and main provider presentation paths

## Verification

- `npm run verify`
- visually verified in the Electron widget

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the redundant "left" suffix from Balance values on Limits and Home. Kept "left" for quota/usage windows and other non-Balance labels.

- **Bug Fixes**
  - Balance now shows just the amount (e.g., "$25.00") on Home and Limits; quota/usage windows still show "left".
  - Email masking is consistent across Home and Limits; accounts with the same visible email get a suffix.

- **Refactors**
  - Added `accountEmailLabel` and a shared `limitAccountTitle(...)` resolver with a provider map; one reader for `limitAccountEmailsMasked()`.
  - OpenRouter and third-party accounts show their profile name on Home, matching the Limits panel.

<sup>Written for commit 4dc6e480af4071f69bea7ede2443a6f8a2950a78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

