### PR TITLE
fix(limits): resolve the Claude Web plan label

### DIFF
--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -927,7 +927,13 @@ function selectClaudeWebOrganization(organizations) {
     || null;
 }
 
+// Exact matches only. Everything read off a membership is scoped to its own
+// organization, so falling back to "whichever membership came first" labels the
+// organization we resolved usage for with a different one's plan and name. On a
+// multi-organization account that is not a near miss, it is the wrong answer.
+// The selected organization carries the same fields and is always available.
 function claudeWebMembership(accountBody, organizationId) {
+  if (!organizationId) return null;
   const account = accountBody?.account && typeof accountBody.account === 'object'
     ? accountBody.account
     : accountBody;
@@ -938,7 +944,7 @@ function claudeWebMembership(accountBody, organizationId) {
       : [];
   return memberships.find((membership) => (
     claudeWebOrganizationId(membership?.organization || membership) === organizationId
-  )) || memberships[0] || null;
+  )) || null;
 }
 
 function claudeStableIdentity(accountId, organizationId, accountEmail) {

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -313,7 +313,9 @@ function planLabelFromParts(...parts) {
 function claudeRateLimitTierLabel(rateLimitTier) {
   const raw = cleanPlanText(rateLimitTier, []);
   if (!raw) return '';
-  const words = raw.split(/\s+/).filter((word) => !['default', 'claude', 'ai'].includes(word));
+  // `raven` is the internal codename an enterprise tier carries (`default_raven`),
+  // not something to render: without it that tier would read as a plan called Raven.
+  const words = raw.split(/\s+/).filter((word) => !['default', 'claude', 'ai', 'raven'].includes(word));
   if (words.length === 0) return '';
   return planLabelFromParts(words.join(' '));
 }
@@ -906,30 +908,35 @@ function claudeWebOrganizationCapabilities(organization) {
 // On a personal claude.ai account the plan is not on the membership at all:
 // `seat_tier` is null and neither `rate_limit_tier` nor `billing_type` exists
 // at that level. The organization's capability list carries it, and it is the
-// same list that already decides which organization to read.
-// Returns the shared alias key rather than a display string, so a plan read
-// here renders identically to the same plan read from OAuth credentials.
-// `raven` is claude.ai's own name for a team subscription.
-function claudeCapabilityPlan(capabilities) {
+// same list that already decides which organization to read. Returns the shared
+// alias key rather than a display string, so a plan read here renders
+// identically to the same plan read from OAuth credentials.
+//
+// `raven` covers Team and Enterprise together; `raven_type` separates them, and
+// claude.ai treats a raven organization without one as unknown rather than as
+// Team. This mirrors that: a capability that cannot name the plan yields
+// nothing and lets the seat tier answer instead.
+function claudeCapabilityPlan(capabilities, organization) {
   if (capabilities.has('claude_max')) return 'max';
   if (capabilities.has('claude_pro')) return 'pro';
-  if (capabilities.has('raven')) return 'team';
-  return '';
+  if (!capabilities.has('raven')) return '';
+  const ravenType = String(organization?.raven_type || '').trim().toLowerCase();
+  if (!ravenType) return '';
+  return ravenType === 'enterprise' ? 'enterprise' : 'team';
 }
 
-// A seat tier is `<plan>_<seat level>` (`enterprise_standard`). Only the plan
-// half belongs in a plan label: keeping the seat level renders "Enterprise
-// Standard" where the same account over OAuth renders "Enterprise". A value
-// whose first word is not a known plan passes through untouched rather than
-// being guessed at.
+// A seat tier is `<plan>_<seat level>` (`enterprise_standard`), and only the
+// plan half belongs in a plan label: keeping the level renders "Enterprise
+// Standard" where the same account over OAuth renders "Enterprise".
 //
-// `unassigned` is dropped outright. It is the placeholder claude.ai substitutes
-// for a member holding no seat (`seat_tier ?? "unassigned"`), never a plan.
+// A value with no recognized plan in front contributes nothing. A bare seat
+// level says which seat someone holds, not which plan they are on, so rendering
+// it puts membership bookkeeping where the plan goes: `standard` would read as
+// a plan called Standard, and `unassigned` (what claude.ai substitutes for a
+// member holding no seat) as one called Unassigned.
 function claudeSeatTier(membership) {
-  const seat = cleanPlanText(membership?.seat_tier);
-  if (!seat || seat === 'unassigned') return '';
-  const [plan] = seat.split(' ');
-  return PLAN_LABEL_ALIASES[plan] ? plan : membership.seat_tier;
+  const [plan] = cleanPlanText(membership?.seat_tier).split(' ');
+  return PLAN_LABEL_ALIASES[plan] ? plan : '';
 }
 
 function selectClaudeWebOrganization(organizations) {
@@ -999,18 +1006,18 @@ function claudeWebAccountIdentity(accountBody, organization) {
   if (!stableIdentity) {
     throw claudeIdentityUnavailable('Claude Web account did not include a stable account identity');
   }
-  // The organization we resolved usage for, not the membership's own copy: the
-  // membership lookup falls back to the first entry when nothing matches, and
-  // that entry can belong to a different organization entirely.
+  // The organization we resolved usage for, falling back to the membership's
+  // own copy only when no organization was passed in at all.
   const planOrganization = organization && typeof organization === 'object'
     ? organization
     : memberOrganization;
-  // `billing_type` is deliberately not consulted. It is a payment method
-  // (`apple_subscription`), never a plan, so reading it would label a Pro
-  // account "Apple subscription".
+  // The organization states the plan; a seat tier only implies one, so it
+  // answers second. `billing_type` is deliberately not consulted at all: it is
+  // a payment method (`apple_subscription`), never a plan, so reading it would
+  // label a Pro account "Apple subscription".
   const accountLabel = claudePlanLabelFromParts(
-    claudeSeatTier(membership)
-      || claudeCapabilityPlan(claudeWebOrganizationCapabilities(planOrganization))
+    claudeCapabilityPlan(claudeWebOrganizationCapabilities(planOrganization), planOrganization)
+      || claudeSeatTier(membership)
       || account?.subscription_type,
     membership?.rate_limit_tier || planOrganization?.rate_limit_tier || account?.rate_limit_tier
   );

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -906,10 +906,22 @@ function claudeWebOrganizationCapabilities(organization) {
 // `seat_tier` is null and neither `rate_limit_tier` nor `billing_type` exists
 // at that level. The organization's capability list carries it, and it is the
 // same list that already decides which organization to read.
+// Returns the shared alias key rather than a display string, so a plan read
+// here renders identically to the same plan read from OAuth credentials.
+// `raven` is claude.ai's own name for a team subscription.
 function claudeCapabilityPlan(capabilities) {
   if (capabilities.has('claude_max')) return 'max';
   if (capabilities.has('claude_pro')) return 'pro';
+  if (capabilities.has('raven')) return 'team';
   return '';
+}
+
+// `unassigned` is the placeholder claude.ai substitutes for a member with no
+// seat (`seat_tier ?? "unassigned"`), not a plan anyone is on. Rendering it
+// would put the word "Unassigned" where the plan belongs.
+function claudeSeatTier(membership) {
+  const seat = String(membership?.seat_tier || '').trim();
+  return seat.toLowerCase() === 'unassigned' ? '' : seat;
 }
 
 function selectClaudeWebOrganization(organizations) {
@@ -989,7 +1001,7 @@ function claudeWebAccountIdentity(accountBody, organization) {
   // (`apple_subscription`), never a plan, so reading it would label a Pro
   // account "Apple subscription".
   const accountLabel = claudePlanLabelFromParts(
-    membership?.seat_tier
+    claudeSeatTier(membership)
       || claudeCapabilityPlan(claudeWebOrganizationCapabilities(planOrganization))
       || account?.subscription_type,
     membership?.rate_limit_tier || planOrganization?.rate_limit_tier || account?.rate_limit_tier

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -291,21 +291,22 @@ function displayPlanText(raw, maxWords = 3) {
   return visible.map(displayPlanWord).join(' ');
 }
 
+const PLAN_LABEL_ALIASES = {
+  free: 'Free',
+  plus: 'Plus',
+  pro: 'Pro',
+  max: 'Max',
+  team: 'Team',
+  teams: 'Team',
+  enterprise: 'Enterprise',
+  ultra: 'Ultra'
+};
+
 function planLabelFromParts(...parts) {
   const text = parts.map((part) => String(part || '')).find(Boolean) || '';
   const raw = cleanPlanText(text);
   if (!raw || raw.includes('@')) return '';
-  const aliases = {
-    free: 'Free',
-    plus: 'Plus',
-    pro: 'Pro',
-    max: 'Max',
-    team: 'Team',
-    teams: 'Team',
-    enterprise: 'Enterprise',
-    ultra: 'Ultra'
-  };
-  if (aliases[raw]) return aliases[raw];
+  if (PLAN_LABEL_ALIASES[raw]) return PLAN_LABEL_ALIASES[raw];
   return displayPlanText(raw);
 }
 
@@ -916,12 +917,19 @@ function claudeCapabilityPlan(capabilities) {
   return '';
 }
 
-// `unassigned` is the placeholder claude.ai substitutes for a member with no
-// seat (`seat_tier ?? "unassigned"`), not a plan anyone is on. Rendering it
-// would put the word "Unassigned" where the plan belongs.
+// A seat tier is `<plan>_<seat level>` (`enterprise_standard`). Only the plan
+// half belongs in a plan label: keeping the seat level renders "Enterprise
+// Standard" where the same account over OAuth renders "Enterprise". A value
+// whose first word is not a known plan passes through untouched rather than
+// being guessed at.
+//
+// `unassigned` is dropped outright. It is the placeholder claude.ai substitutes
+// for a member holding no seat (`seat_tier ?? "unassigned"`), never a plan.
 function claudeSeatTier(membership) {
-  const seat = String(membership?.seat_tier || '').trim();
-  return seat.toLowerCase() === 'unassigned' ? '' : seat;
+  const seat = cleanPlanText(membership?.seat_tier);
+  if (!seat || seat === 'unassigned') return '';
+  const [plan] = seat.split(' ');
+  return PLAN_LABEL_ALIASES[plan] ? plan : membership.seat_tier;
 }
 
 function selectClaudeWebOrganization(organizations) {

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -902,6 +902,16 @@ function claudeWebOrganizationCapabilities(organization) {
   );
 }
 
+// On a personal claude.ai account the plan is not on the membership at all:
+// `seat_tier` is null and neither `rate_limit_tier` nor `billing_type` exists
+// at that level. The organization's capability list carries it, and it is the
+// same list that already decides which organization to read.
+function claudeCapabilityPlan(capabilities) {
+  if (capabilities.has('claude_max')) return 'max';
+  if (capabilities.has('claude_pro')) return 'pro';
+  return '';
+}
+
 function selectClaudeWebOrganization(organizations) {
   const candidates = organizations.filter((candidate) => claudeWebOrganizationId(candidate));
   const hasChatCapability = (candidate) => (
@@ -963,9 +973,20 @@ function claudeWebAccountIdentity(accountBody, organization) {
   if (!stableIdentity) {
     throw claudeIdentityUnavailable('Claude Web account did not include a stable account identity');
   }
+  // The organization we resolved usage for, not the membership's own copy: the
+  // membership lookup falls back to the first entry when nothing matches, and
+  // that entry can belong to a different organization entirely.
+  const planOrganization = organization && typeof organization === 'object'
+    ? organization
+    : memberOrganization;
+  // `billing_type` is deliberately not consulted. It is a payment method
+  // (`apple_subscription`), never a plan, so reading it would label a Pro
+  // account "Apple subscription".
   const accountLabel = claudePlanLabelFromParts(
-    membership?.seat_tier || membership?.billing_type || account?.subscription_type,
-    membership?.rate_limit_tier || account?.rate_limit_tier
+    membership?.seat_tier
+      || claudeCapabilityPlan(claudeWebOrganizationCapabilities(planOrganization))
+      || account?.subscription_type,
+    membership?.rate_limit_tier || planOrganization?.rate_limit_tier || account?.rate_limit_tier
   );
   return {
     accountKey: hashKey('claude-account', stableIdentity),

--- a/tests/shared/limitCollector.claude.test.js
+++ b/tests/shared/limitCollector.claude.test.js
@@ -1559,8 +1559,7 @@ test('a personal Pro account takes its plan from the organization capabilities',
     uuid: 'org-personal',
     name: 'Personal',
     capabilities: ['chat', 'claude_pro'],
-    rate_limit_tier: 'default_claude_ai',
-    billing_type: 'apple_subscription'
+    rate_limit_tier: 'default_claude_ai'
   }), 'Pro');
 });
 

--- a/tests/shared/limitCollector.claude.test.js
+++ b/tests/shared/limitCollector.claude.test.js
@@ -1574,6 +1574,17 @@ test('a personal Max account keeps the rate limit tier refinement', async () => 
   }), 'Max 20x');
 });
 
+test('the Max variant comes from the rate limit tier, not the capability', async () => {
+  // There is no `claude_max_5x` capability: claude.ai reports plain `claude_max`
+  // for both variants and separates them on `rate_limit_tier`.
+  assert.equal(await personalPlanLabel({
+    uuid: 'org-personal',
+    name: 'Personal',
+    capabilities: ['chat', 'claude_max'],
+    rate_limit_tier: 'default_claude_max_5x'
+  }), 'Max 5x');
+});
+
 test('a billing type is never mistaken for a plan', async () => {
   // `apple_subscription` is how the subscription is paid for, not what it is.
   assert.equal(await personalPlanLabel({

--- a/tests/shared/limitCollector.claude.test.js
+++ b/tests/shared/limitCollector.claude.test.js
@@ -1515,6 +1515,76 @@ test('an exhausted prepaid pool still reports a zero balance', async () => {
   assert.equal(credits[0].showMeter, false);
 });
 
+function fakeClaudeWebIdentityFetch(organization, account) {
+  return async (url) => {
+    const headers = { get: () => '', getSetCookie: () => [] };
+    if (url.endsWith('/api/organizations')) {
+      return { ok: true, status: 200, headers, json: async () => [organization] };
+    }
+    if (url.endsWith('/api/account')) {
+      return { ok: true, status: 200, headers, json: async () => account };
+    }
+    if (url.includes('/prepaid/credits')) {
+      return { ok: true, status: 200, headers, json: async () => ({ amount: 0, currency: 'USD' }) };
+    }
+    return { ok: true, status: 200, headers, json: async () => CREDITS_OFF };
+  };
+}
+
+// What claude.ai actually returns for a personal subscription: the plan is
+// nowhere on the membership, only in the organization's capability list.
+const PERSONAL_ACCOUNT = {
+  uuid: 'account-personal',
+  email_address: 'owner@example.com',
+  memberships: [{
+    role: 'admin',
+    seat_tier: null,
+    organization: { uuid: 'org-personal', name: 'Personal' }
+  }]
+};
+
+async function personalPlanLabel(organization) {
+  const provider = await fetchClaudeLimits(
+    { claudeWebCookie: 'sessionKey=sk-ant-sid01-plan' },
+    {
+      providerRuntimeState: new Map(),
+      claudeWebFetch: fakeClaudeWebIdentityFetch(organization, PERSONAL_ACCOUNT)
+    }
+  );
+  return provider.accountLabel;
+}
+
+test('a personal Pro account takes its plan from the organization capabilities', async () => {
+  assert.equal(await personalPlanLabel({
+    uuid: 'org-personal',
+    name: 'Personal',
+    capabilities: ['chat', 'claude_pro'],
+    rate_limit_tier: 'default_claude_ai',
+    billing_type: 'apple_subscription'
+  }), 'Pro');
+});
+
+test('a personal Max account keeps the rate limit tier refinement', async () => {
+  assert.equal(await personalPlanLabel({
+    uuid: 'org-personal',
+    name: 'Personal',
+    capabilities: ['chat', 'claude_max'],
+    rate_limit_tier: 'default_claude_max_20x',
+    billing_type: 'stripe'
+  }), 'Max 20x');
+});
+
+test('a billing type is never mistaken for a plan', async () => {
+  // `apple_subscription` is how the subscription is paid for, not what it is.
+  assert.equal(await personalPlanLabel({
+    uuid: 'org-personal',
+    name: 'Personal',
+    capabilities: ['chat'],
+    rate_limit_tier: 'default_claude_ai',
+    billing_type: 'apple_subscription'
+  }), '');
+});
+
 test('the prepaid TTL follows the limits refresh interval at twice its length', async () => {
   const providerRuntimeState = new Map();
   let nowMs = Date.parse('2026-07-27T00:00:00Z');

--- a/tests/shared/limitCollector.claude.test.js
+++ b/tests/shared/limitCollector.claude.test.js
@@ -1614,6 +1614,44 @@ test('the Max variant comes from the rate limit tier, not the capability', async
   }), 'Max 5x');
 });
 
+test('a team organization is recognized by its raven capability', async () => {
+  // claude.ai names this one itself: `isTeamSubscriber: capabilities.includes("raven")`.
+  // There is no team-specific rate limit tier, so the capability is the only signal.
+  assert.equal(await personalPlanLabel({
+    uuid: 'org-personal',
+    name: 'Personal',
+    capabilities: ['chat', 'raven'],
+    rate_limit_tier: 'default_claude_ai'
+  }), 'Team');
+});
+
+test('an unassigned seat is not a plan', async () => {
+  const provider = await fetchClaudeLimits(
+    { claudeWebCookie: 'sessionKey=sk-ant-sid01-seat' },
+    {
+      providerRuntimeState: new Map(),
+      claudeWebFetch: fakeClaudeWebIdentityFetch(
+        {
+          uuid: 'org-team',
+          name: 'Team Org',
+          capabilities: ['chat', 'raven'],
+          rate_limit_tier: 'default_claude_ai'
+        },
+        {
+          uuid: 'account-seat',
+          email_address: 'owner@example.com',
+          memberships: [{
+            // What claude.ai substitutes for a member holding no seat.
+            seat_tier: 'unassigned',
+            organization: { uuid: 'org-team', name: 'Team Org' }
+          }]
+        }
+      )
+    }
+  );
+  assert.equal(provider.accountLabel, 'Team');
+});
+
 test('a billing type is never mistaken for a plan', async () => {
   // `apple_subscription` is how the subscription is paid for, not what it is.
   assert.equal(await personalPlanLabel({

--- a/tests/shared/limitCollector.claude.test.js
+++ b/tests/shared/limitCollector.claude.test.js
@@ -1569,9 +1569,38 @@ test('a personal Max account keeps the rate limit tier refinement', async () => 
     uuid: 'org-personal',
     name: 'Personal',
     capabilities: ['chat', 'claude_max'],
-    rate_limit_tier: 'default_claude_max_20x',
-    billing_type: 'stripe'
+    rate_limit_tier: 'default_claude_max_20x'
   }), 'Max 20x');
+});
+
+test('a membership from another organization never supplies the plan', async () => {
+  const provider = await fetchClaudeLimits(
+    { claudeWebCookie: 'sessionKey=sk-ant-sid01-multi' },
+    {
+      providerRuntimeState: new Map(),
+      claudeWebFetch: fakeClaudeWebIdentityFetch(
+        {
+          uuid: 'org-selected',
+          name: 'Selected Max Org',
+          capabilities: ['chat', 'claude_max'],
+          rate_limit_tier: 'default_claude_max_20x'
+        },
+        {
+          uuid: 'account-multi',
+          email_address: 'owner@example.com',
+          // The account is a member of a different organization than the one
+          // usage was resolved for, so nothing here may describe the plan.
+          memberships: [{
+            seat_tier: 'team',
+            rate_limit_tier: 'default_claude_ai',
+            organization: { uuid: 'org-other', name: 'Unrelated Org', capabilities: ['chat', 'raven'] }
+          }]
+        }
+      )
+    }
+  );
+  assert.equal(provider.accountLabel, 'Max 20x');
+  assert.equal(provider.accountName, 'Selected Max Org');
 });
 
 test('the Max variant comes from the rate limit tier, not the capability', async () => {

--- a/tests/shared/limitCollector.claude.test.js
+++ b/tests/shared/limitCollector.claude.test.js
@@ -1652,6 +1652,35 @@ test('an unassigned seat is not a plan', async () => {
   assert.equal(provider.accountLabel, 'Team');
 });
 
+async function seatTierLabel(seatTier) {
+  const provider = await fetchClaudeLimits(
+    { claudeWebCookie: 'sessionKey=sk-ant-sid01-seat' },
+    {
+      providerRuntimeState: new Map(),
+      claudeWebFetch: fakeClaudeWebIdentityFetch(
+        { uuid: 'org-team', name: 'Team Org', capabilities: ['chat'], rate_limit_tier: 'default_claude_ai' },
+        {
+          uuid: 'account-seat',
+          email_address: 'owner@example.com',
+          memberships: [{ seat_tier: seatTier, organization: { uuid: 'org-team', name: 'Team Org' } }]
+        }
+      )
+    }
+  );
+  return provider.accountLabel;
+}
+
+test('a seat tier reports its plan, not its seat level', async () => {
+  // OAuth reports `enterprise` and renders "Enterprise"; the Web seat tier is
+  // `<plan>_<seat level>`, and the seat level does not belong in a plan label.
+  assert.equal(await seatTierLabel('enterprise_standard'), 'Enterprise');
+  assert.equal(await seatTierLabel('max_premium'), 'Max');
+});
+
+test('an unrecognized seat tier is passed through rather than guessed at', async () => {
+  assert.equal(await seatTierLabel('bespoke_thing'), 'Bespoke Thing');
+});
+
 test('a billing type is never mistaken for a plan', async () => {
   // `apple_subscription` is how the subscription is paid for, not what it is.
   assert.equal(await personalPlanLabel({

--- a/tests/shared/limitCollector.claude.test.js
+++ b/tests/shared/limitCollector.claude.test.js
@@ -1613,55 +1613,17 @@ test('the Max variant comes from the rate limit tier, not the capability', async
   }), 'Max 5x');
 });
 
-test('a team organization is recognized by its raven capability', async () => {
-  // claude.ai names this one itself: `isTeamSubscriber: capabilities.includes("raven")`.
-  // There is no team-specific rate limit tier, so the capability is the only signal.
-  assert.equal(await personalPlanLabel({
-    uuid: 'org-personal',
-    name: 'Personal',
-    capabilities: ['chat', 'raven'],
-    rate_limit_tier: 'default_claude_ai'
-  }), 'Team');
-});
-
-test('an unassigned seat is not a plan', async () => {
+async function planLabelFor(organization, seatTier) {
   const provider = await fetchClaudeLimits(
     { claudeWebCookie: 'sessionKey=sk-ant-sid01-seat' },
     {
       providerRuntimeState: new Map(),
       claudeWebFetch: fakeClaudeWebIdentityFetch(
-        {
-          uuid: 'org-team',
-          name: 'Team Org',
-          capabilities: ['chat', 'raven'],
-          rate_limit_tier: 'default_claude_ai'
-        },
+        { uuid: 'org-1', name: 'Org', ...organization },
         {
           uuid: 'account-seat',
           email_address: 'owner@example.com',
-          memberships: [{
-            // What claude.ai substitutes for a member holding no seat.
-            seat_tier: 'unassigned',
-            organization: { uuid: 'org-team', name: 'Team Org' }
-          }]
-        }
-      )
-    }
-  );
-  assert.equal(provider.accountLabel, 'Team');
-});
-
-async function seatTierLabel(seatTier) {
-  const provider = await fetchClaudeLimits(
-    { claudeWebCookie: 'sessionKey=sk-ant-sid01-seat' },
-    {
-      providerRuntimeState: new Map(),
-      claudeWebFetch: fakeClaudeWebIdentityFetch(
-        { uuid: 'org-team', name: 'Team Org', capabilities: ['chat'], rate_limit_tier: 'default_claude_ai' },
-        {
-          uuid: 'account-seat',
-          email_address: 'owner@example.com',
-          memberships: [{ seat_tier: seatTier, organization: { uuid: 'org-team', name: 'Team Org' } }]
+          memberships: [{ seat_tier: seatTier, organization: { uuid: 'org-1', name: 'Org' } }]
         }
       )
     }
@@ -1669,15 +1631,45 @@ async function seatTierLabel(seatTier) {
   return provider.accountLabel;
 }
 
-test('a seat tier reports its plan, not its seat level', async () => {
-  // OAuth reports `enterprise` and renders "Enterprise"; the Web seat tier is
-  // `<plan>_<seat level>`, and the seat level does not belong in a plan label.
-  assert.equal(await seatTierLabel('enterprise_standard'), 'Enterprise');
-  assert.equal(await seatTierLabel('max_premium'), 'Max');
+const TEAM_ORG = { capabilities: ['chat', 'raven'], raven_type: 'team', rate_limit_tier: 'default_claude_ai' };
+
+test('a team organization is recognized by its raven capability and type', async () => {
+  // `raven` covers Team and Enterprise together, and `raven_type` separates
+  // them. There is no team-specific rate limit tier, so this is the only signal.
+  assert.equal(await planLabelFor(TEAM_ORG, null), 'Team');
+  assert.equal(
+    await planLabelFor({ capabilities: ['chat', 'raven'], raven_type: 'enterprise', rate_limit_tier: 'default_raven' }, null),
+    'Enterprise'
+  );
 });
 
-test('an unrecognized seat tier is passed through rather than guessed at', async () => {
-  assert.equal(await seatTierLabel('bespoke_thing'), 'Bespoke Thing');
+test('a seat level never outranks the plan its organization states', async () => {
+  // A seat says which seat someone holds, not which plan the organization is on.
+  assert.equal(await planLabelFor(TEAM_ORG, 'standard'), 'Team');
+  // `unassigned` is what claude.ai substitutes for a member holding no seat.
+  assert.equal(await planLabelFor(TEAM_ORG, 'unassigned'), 'Team');
+  // And when the two disagree outright, the organization wins: claude.ai
+  // resolves the plan from the organization alone and never from the seat.
+  assert.equal(await planLabelFor(TEAM_ORG, 'enterprise_standard'), 'Team');
+});
+
+test('a seat tier reports its plan when the organization states none', async () => {
+  // Anthropic documents seat tiers as fully qualified `<plan>_<seat level>`
+  // identifiers, of which `enterprise_standard` and `enterprise_tier_1` are two.
+  // OAuth reports a bare `enterprise` and renders "Enterprise"; keeping the seat
+  // level here would render "Enterprise Standard" for the same account.
+  const unnamed = { capabilities: ['chat', 'raven'], raven_type: null, rate_limit_tier: 'default_raven' };
+  assert.equal(await planLabelFor(unnamed, 'enterprise_standard'), 'Enterprise');
+  assert.equal(await planLabelFor(unnamed, 'enterprise_tier_1'), 'Enterprise');
+});
+
+test('nothing is claimed when no source names a plan', async () => {
+  // A bare seat level, an organization whose raven type is missing, and the
+  // `default_raven` tier itself all describe something other than the plan.
+  const unnamed = { capabilities: ['chat', 'raven'], raven_type: null, rate_limit_tier: 'default_raven' };
+  assert.equal(await planLabelFor(unnamed, 'standard'), '');
+  assert.equal(await planLabelFor(unnamed, null), '');
+  assert.equal(await planLabelFor({ capabilities: ['chat'], rate_limit_tier: 'default_claude_ai' }, 'bespoke_thing'), '');
 });
 
 test('a billing type is never mistaken for a plan', async () => {


### PR DESCRIPTION
A Claude row backed by a Web session showed no plan label, while the same account read over OAuth or the CLI showed one. Web is the only source that was missing this; OAuth reads `subscriptionType` from the credentials store and the CLI parses the `Plan:` line, and both already resolve Pro, Max, Team and Enterprise.

The reason is that a personal claude.ai subscription puts nothing about the plan on the membership. `seat_tier` is `null`, and `rate_limit_tier` and `billing_type` do not exist at that level at all, so every input to the label derivation was empty:

```
membership.seat_tier        = null
membership.rate_limit_tier  = undefined
membership.billing_type     = undefined
account.subscription_type   = undefined
account.rate_limit_tier     = undefined
```

The organization carries it instead, in the same `capabilities` list that already decides which organization to read:

```
organization.capabilities    = ["chat", "claude_pro"]
organization.rate_limit_tier = "default_claude_ai"
organization.raven_type      = null
organization.billing_type    = "apple_subscription"
```

## What resolves the plan now

The organization states the plan and answers first; a seat tier only implies one and answers second.

- `claude_pro` and `claude_max` name the plan directly, and the organization's `rate_limit_tier` refines Max into `Max 20x` or `Max 5x`.
- `raven` covers Team and Enterprise together, so `raven_type` separates them: `enterprise` is Enterprise, any other value is Team. A raven organization carrying no type resolves to neither, matching claude.ai, which calls that state unknown.
- A seat tier is a fully qualified `<plan>_<seat level>` identifier, so its leading plan word answers when the organization named nothing.

The capability lookup yields the shared alias key rather than a display string, so a plan resolved here renders identically to the same plan resolved from OAuth credentials.

## Before and after

Same scenarios run against `main` and this branch:

| Scenario | Before | After |
| --- | --- | --- |
| Pro | `""` | `"Pro"` |
| Max 20x | `""` | `"Max 20x"` |
| Max 5x | `""` | `"Max 5x"` |
| Team, no seat | `""` | `"Team"` |
| Team, seat `standard` | `"Standard"` | `"Team"` |
| Team, seat `unassigned` | `"Unassigned"` | `"Team"` |
| Enterprise, seat `enterprise_standard` | `"Enterprise Standard"` | `"Enterprise"` |
| Raven type absent, seat `enterprise_tier_1` | `"Enterprise Tier 1"` | `"Enterprise"` |
| Raven type absent, seat `standard` | `"Standard"` | `""` |
| Unrecognized seat `bespoke_thing` | `"Bespoke Thing"` | `""` |
| No paid capability | `""` | `""` |
| Membership from another organization | `"Team" / "Unrelated Org"` | `"Max 20x" / "Selected Org"` |

## Details worth calling out

- **Only an exactly matching membership may describe the plan.** The lookup used to fall back to the first membership when no organization matched, and everything read off a membership is scoped to that membership's own organization, so a multi-organization account displayed another organization's plan and name over the usage it was actually reporting. Nothing is lost by dropping the fallback: the organization resolved for usage carries the same fields and is always available.
- **A seat level is not a plan.** It says which seat someone holds, not what the organization is on, so a seat tier contributes only when a known plan word leads it. Bare levels like `standard`, and `unassigned` (what claude.ai substitutes for a member holding no seat), name no plan and therefore report none.
- **The seat tier split is defensive normalization, not a verified contract.** Anthropic documents seat tiers as fully qualified identifiers and gives `enterprise_standard` and `enterprise_tier_1` as examples while reserving the right to add more, so unrecognized values report nothing rather than a plan named after a seat.
- **`raven` also joins the words a rate limit tier drops**, since the enterprise tier is literally `default_raven` and would otherwise render as a plan called Raven.
- **`billing_type` is dropped rather than repointed at the organization.** It is a payment method, so reading it would label a Pro account "Apple subscription".
- **No plan is inferred from absence.** An organization with no paid capability reports nothing rather than "Free": unlike OAuth, where `subscriptionType` states the free tier outright, on this path an empty capability list also covers organization shapes we have not observed.

The only change outside the Web path is moving the plan alias table to module scope so the seat tier check reads the same vocabulary instead of a second copy that would drift from it. It is a pure move: same keys, same values, same lookup order.

Verified against a live personal Pro account before and after. `npm run verify`: 1947 pass, 0 fail, 1 skipped.
