### PR TITLE
fix(limits): unblock Claude Web limits on the headless agent

### DIFF
--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -80,6 +80,15 @@ const CODEX_RESET_CREDITS_PATH = '/wham/rate-limit-reset-credits';
 const CODEX_EMPTY_QUOTA_RETRY_DELAY_MS = 300;
 const CODEX_RPC_TIMEOUT_MS = 20_000;
 const TOKEN_MONITOR_USER_AGENT = `token-monitor/${appVersion()} (+https://github.com/Javis603/token-monitor)`;
+// claude.ai sits behind Cloudflare, which answers any non-browser user-agent with
+// `403 cf-mitigated: challenge` before the request reaches the API. An honest
+// `token-monitor/<version>` agent is challenged just as hard as sending none at
+// all, so this has to read as a browser. Applied only on the undici path: the
+// widget routes this provider through Electron's `net.request`, whose Chromium
+// agent already passes and, unlike this constant, tracks the bundled Chromium
+// version instead of going stale. Matches the agent the other web-session
+// providers already send.
+const CLAUDE_WEB_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36';
 
 function nowIso(nowMs) {
   return new Date(nowMs).toISOString();
@@ -649,10 +658,13 @@ async function fetchJson(url, headers, deps = {}, options = {}) {
 }
 
 function fetchClaudeWebJson(url, headers, deps = {}, options = {}) {
-  const webDeps = typeof deps.claudeWebFetch === 'function'
-    ? { ...deps, fetch: deps.claudeWebFetch }
-    : deps;
-  return fetchJson(url, headers, webDeps, {
+  const viaChromium = typeof deps.claudeWebFetch === 'function';
+  const webDeps = viaChromium ? { ...deps, fetch: deps.claudeWebFetch } : deps;
+  // Chromium sends its own browser agent, and setting one here would override it
+  // with a version that no longer matches the runtime. undici sends none at all,
+  // which Cloudflare challenges, so that path has to supply one.
+  const webHeaders = viaChromium ? headers : { ...headers, 'user-agent': CLAUDE_WEB_USER_AGENT };
+  return fetchJson(url, webHeaders, webDeps, {
     forbiddenIsUnauthorized: true,
     onResponse: options.onResponse
   });

--- a/tests/shared/limitCollector.claude.test.js
+++ b/tests/shared/limitCollector.claude.test.js
@@ -149,13 +149,59 @@ test('Claude Web source takes precedence and carries stable account metadata', a
   assert.equal(first.requests.length, 4);
   assert.equal(first.requests[3].url.endsWith('/prepaid/credits'), true);
   assert.equal(first.requests[0].options.headers.cookie, 'sessionKey=sk-ant-first-cookie');
+  // This collector runs on undici, so it carries the browser agent. Pinned
+  // verbatim: Cloudflare challenges every non-browser user-agent on this host, so
+  // swapping in the honest `token-monitor/<version>` agent would 403 the whole
+  // provider on the headless agent.
   assert.deepEqual(first.requests[0].options.headers, {
     accept: 'application/json',
+    'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36',
     cookie: 'sessionKey=sk-ant-first-cookie'
   });
+  // Cloudflare challenges per request, so every hop needs the agent, not just the
+  // first one that happens to be asserted above.
+  assert.equal(
+    first.requests.every(({ options }) => /Chrome\/[\d.]+ Safari/.test(options.headers['user-agent'] || '')),
+    true,
+    'every Claude Web request should carry the browser user-agent'
+  );
   assert.equal(first.requests[0].url.endsWith('/api/organizations'), true);
   assert.equal(first.requests[1].url.endsWith('/api/organizations/organization-web/usage'), true);
   assert.equal(first.requests[2].url.endsWith('/api/account'), true);
+});
+
+test('Claude Web leaves the user-agent to Chromium when the widget supplies the transport', async () => {
+  const requests = [];
+  await fetchClaudeLimits({ claudeWebCookie: 'sessionKey=sk-ant-widget' }, {
+    now: () => Date.parse('2026-07-25T00:00:00Z'),
+    stat: async () => {
+      throw new Error('OAuth credentials must not be read when Web is configured');
+    },
+    fetch: async () => {
+      throw new Error('the widget transport must be used when one is supplied');
+    },
+    claudeWebFetch: async (url, options) => {
+      requests.push({ url, options });
+      if (url.endsWith('/api/organizations')) {
+        return { ok: true, json: async () => [{ uuid: 'organization-web', name: 'Example Workspace' }] };
+      }
+      if (url.endsWith('/prepaid/credits')) {
+        return { ok: true, json: async () => ({ amount: 0, currency: 'USD' }) };
+      }
+      if (url.endsWith('/api/account')) {
+        return { ok: true, json: async () => ({ email_address: 'owner@example.com' }) };
+      }
+      return { ok: true, json: async () => ({ five_hour: { utilization: 10 } }) };
+    }
+  });
+
+  // Electron's net.request already sends a browser agent that tracks the bundled
+  // Chromium; setting one here would pin the widget to a stale version instead.
+  assert.ok(requests.length > 0);
+  for (const { url, options } of requests) {
+    assert.equal(options.headers['user-agent'], undefined, `${url} should carry no user-agent`);
+  }
+  assert.equal(requests[0].options.headers.cookie, 'sessionKey=sk-ant-widget');
 });
 
 test('Claude Web follows a renewed sessionKey across sequential requests and reports it for persistence', async () => {


### PR DESCRIPTION
## Summary

The headless agent could not read Claude Web limits at all. `claude.ai` sits behind Cloudflare, which answers any non-browser user-agent with `403 cf-mitigated: challenge` before the request reaches the API. The agent runs on undici and sent no user-agent, so every refresh was challenged. Because `fetchClaudeWebJson` passes `forbiddenIsUnauthorized: true`, the 403 was reported as unauthorized, so the visible symptom was a Claude Web cookie that looked expired while it was actually fine.

The widget was never affected: `createClaudeWebFetch` routes this provider through Electron's `net.request`, and Chromium supplies its own browser agent.

## What changed

The user-agent is added in `fetchClaudeWebJson`, which already branches on which transport is in play, and only on the undici side. `createClaudeWebSession().headers()` is untouched, so the headers the widget sends are byte-identical to before.

Scoping it to undici also keeps the widget off a hardcoded agent. Electron's own agent tracks the bundled Chromium (currently 150), while the constant added here would pin the widget to 143 and go stale on every Electron upgrade.

## Verification

Measured against `claude.ai/api/organizations` from bare Node:

| user-agent | result |
|---|---|
| none (previous behaviour) | `403`, `cf-mitigated: challenge` |
| `token-monitor/<version>` | `403`, `cf-mitigated: challenge` |
| browser agent (this change) | `200`, JSON |

An honest agent is challenged just as hard as sending none, which is why this uses the same agent the other web-session providers already send.

The widget transport was checked separately against a loopback server: with no explicit user-agent, Electron sends `…Chrome/150.0.7871.129 Electron/43.2.0 Safari/537.36`, and setting one overrides it. That path is deliberately left alone.

Tests pin both halves: undici requests must carry the browser agent on every hop, and requests made through the widget transport must carry none. Each guard was checked by breaking the code and confirming it fails.

`npm run verify` passes: 1956 pass, 0 fail, 1 skipped.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks Claude Web limit collection on the headless agent by sending a browser user-agent on `undici` requests. The widget/Electron path is unchanged so Chromium keeps its own agent.

- **Bug Fixes**
  - Add a Chrome-like `user-agent` in `fetchClaudeWebJson` only for the `undici` path to bypass Cloudflare’s 403 challenge and stop the false “expired cookie” symptom.
  - Tests pin behavior: headless requests always include the browser UA; widget transport sets none so Chromium’s default remains in effect.

<sup>Written for commit e1f2ec6f95d54709c54c6d229a534912e868bc86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

