### PR TITLE
refactor(limits): share the note row and tooltip builders

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -2144,45 +2144,14 @@ function codexResetCreditsNode(resetCredits) {
     });
     expiryGroup.append(timeline);
     if (expirationDates.length > 1) {
-      const infoWrap = document.createElement('span');
-      infoWrap.className = 'limit-detail-tooltip-wrap';
-      infoWrap.classList.toggle('has-opened', state.limitDetailTooltipHasOpened);
-      const info = document.createElement('span');
-      info.className = 'limit-detail-tooltip-trigger';
-      info.textContent = 'i';
-      info.tabIndex = 0;
-      info.setAttribute('aria-label', expirationDates.map((date, index) => `Reset ${index + 1}: ${codexResetCreditExpiryDetailLabel(date)}`).join(', '));
-      const tooltip = document.createElement('span');
-      tooltip.className = 'limit-detail-tooltip';
-      tooltip.setAttribute('role', 'tooltip');
-      expirationDates.forEach((date) => {
-        const row = document.createElement('span');
-        row.className = 'limit-detail-tooltip-row';
-        const label = document.createElement('span');
-        label.textContent = expiryDateLabel(date);
-        const tooltipExpiry = document.createElement('span');
-        tooltipExpiry.textContent = codexResetCreditExpiryLabel(date);
-        row.append(label, tooltipExpiry);
-        tooltip.append(row);
-      });
-      const markResetCreditsTooltipOpened = () => {
-        state.limitDetailTooltipHasOpened = true;
-        state.limitDetailTooltipActive = true;
-        infoWrap.classList.add('has-opened');
-      };
-      const releaseResetCreditsTooltip = () => {
-        requestAnimationFrame(() => {
-          if (limitDetailTooltipShouldHoldRender()) return;
-          state.limitDetailTooltipActive = false;
-          flushPendingLimitDetailTooltipRender();
-        });
-      };
-      infoWrap.addEventListener('pointerenter', markResetCreditsTooltipOpened);
-      infoWrap.addEventListener('focusin', markResetCreditsTooltipOpened);
-      infoWrap.addEventListener('pointerleave', releaseResetCreditsTooltip);
-      infoWrap.addEventListener('focusout', releaseResetCreditsTooltip);
-      infoWrap.append(info, tooltip);
-      expiryGroup.append(infoWrap);
+      // A date paired with a bare duration doesn't read as `<name>: <value>`, so
+      // the spoken label is supplied rather than derived from the cells.
+      const infoNode = limitDetailInfoNode(
+        expirationDates.map((date) => [expiryDateLabel(date), codexResetCreditExpiryLabel(date)]),
+        '',
+        expirationDates.map((date, index) => `Reset ${index + 1}: ${codexResetCreditExpiryDetailLabel(date)}`).join(', ')
+      );
+      if (infoNode) expiryGroup.append(infoNode);
     }
     line.append(expiryGroup);
   }
@@ -2200,11 +2169,39 @@ function openrouterSpendEntries(balance) {
   ].filter(([, value]) => value !== null);
 }
 
+// The meter-less note row every balance/spend provider draws: a label on the
+// left, then an optional summary and an optional ⓘ tooltip on the right. The
+// wording stays with the callers — each provider says something different about
+// the same layout — so the spoken label is `label` plus whatever parts they pass.
+function limitNoteRowNode({ label, summary = '', detailEntries = null, ariaParts = [] }) {
+  const item = document.createElement('div');
+  item.className = 'limit-window limit-window-wide limit-window-note limit-spend';
+  const line = document.createElement('div');
+  line.className = 'limit-window-text limit-spend-line';
+  const labelNode = document.createElement('span');
+  labelNode.textContent = label;
+  const right = document.createElement('span');
+  right.className = 'limit-spend-right';
+  if (summary) {
+    const summaryNode = document.createElement('span');
+    summaryNode.className = 'limit-spend-summary';
+    summaryNode.textContent = summary;
+    right.append(summaryNode);
+  }
+  const infoNode = detailEntries ? limitDetailInfoNode(detailEntries, 'limit-spend-info-wrap') : null;
+  if (infoNode) right.append(infoNode);
+  line.append(labelNode, right);
+  item.append(line);
+  item.setAttribute('aria-label', [label, ...ariaParts].join(', '));
+  return item;
+}
+
 // Entries are rows of cells: `[label, value]`, or `[label, middle, value]` when
 // a row carries an extra field. Rows are grid cells (`display: contents`), so a
 // short row would slide into the next row's columns — pad every row to the
-// widest one and widen the grid to match.
-function limitDetailInfoNode(entries, extraClass = '') {
+// widest one and widen the grid to match. `ariaLabel` overrides the spoken label
+// for callers whose cells don't read as `<name>: <value>` on their own.
+function limitDetailInfoNode(entries, extraClass = '', ariaLabel = '') {
   if (!Array.isArray(entries) || entries.length === 0) return null;
   const columns = entries.reduce((widest, entry) => Math.max(widest, entry.length), 0);
   const infoWrap = document.createElement('span');
@@ -2216,7 +2213,7 @@ function limitDetailInfoNode(entries, extraClass = '') {
   info.tabIndex = 0;
   info.setAttribute(
     'aria-label',
-    entries.map(([entryLabel, ...rest]) => `${entryLabel}: ${rest.filter(Boolean).join(' ')}`).join(', ')
+    ariaLabel || entries.map(([entryLabel, ...rest]) => `${entryLabel}: ${rest.filter(Boolean).join(' ')}`).join(', ')
   );
   const tooltip = document.createElement('span');
   tooltip.className = ['limit-detail-tooltip', columns > 2 ? 'limit-detail-tooltip-triple' : '']
@@ -2258,37 +2255,16 @@ function openrouterSpendNode(balance) {
   const currency = balance?.currency || 'USD';
   const preferredSummary = entries.filter(([label]) => label === 'Today' || label === 'Month');
   const summaryEntries = preferredSummary.length > 0 ? preferredSummary : entries.slice(0, 2);
-  const summaryText = summaryEntries
-    .map(([label, value]) => `${label} ${formatMoney(value, currency)}`)
-    .join(' · ');
-
-  const item = document.createElement('div');
-  item.className = 'limit-window limit-window-wide limit-window-note limit-spend';
-  const line = document.createElement('div');
-  line.className = 'limit-window-text limit-spend-line';
-  const label = document.createElement('span');
-  label.textContent = 'Spend';
-  const right = document.createElement('span');
-  right.className = 'limit-spend-right';
-  const summary = document.createElement('span');
-  summary.className = 'limit-spend-summary';
-  summary.textContent = summaryText;
-  right.append(summary);
-
-  if (entries.length > summaryEntries.length) {
-    right.append(limitDetailInfoNode(
-      entries.map(([entryLabel, value]) => [entryLabel, formatMoney(value, currency)]),
-      'limit-spend-info-wrap'
-    ));
-  }
-
-  line.append(label, right);
-  item.append(line);
-  item.setAttribute(
-    'aria-label',
-    ['Spend', ...entries.map(([entryLabel, value]) => `${entryLabel} ${formatMoney(value, currency)}`)].join(', ')
-  );
-  return item;
+  const formatted = entries.map(([entryLabel, value]) => [entryLabel, formatMoney(value, currency)]);
+  return limitNoteRowNode({
+    label: 'Spend',
+    summary: summaryEntries
+      .map(([label, value]) => `${label} ${formatMoney(value, currency)}`)
+      .join(' · '),
+    // Only worth a tooltip when it would say more than the summary already does.
+    detailEntries: entries.length > summaryEntries.length ? formatted : null,
+    ariaParts: formatted.map(([entryLabel, value]) => `${entryLabel} ${value}`)
+  });
 }
 
 function thirdPartySpendNode(provider, quotaWindow) {
@@ -2309,34 +2285,18 @@ function thirdPartySpendNode(provider, quotaWindow) {
     entries.push([t('settings.thirdparty.expires'), expiresAt.toLocaleDateString()]);
   }
   if (allTimeSpend === null && entries.length === 0) return null;
-
-  const item = document.createElement('div');
-  item.className = 'limit-window limit-window-wide limit-window-note limit-spend';
-  const line = document.createElement('div');
-  line.className = 'limit-window-text limit-spend-line';
-  const label = document.createElement('span');
-  label.textContent = allTimeSpend === null ? 'Details' : 'Spend';
-  const right = document.createElement('span');
-  right.className = 'limit-spend-right';
-  if (allTimeSpend !== null) {
-    const summary = document.createElement('span');
-    summary.className = 'limit-spend-summary';
-    summary.textContent = `All time ${formatMoney(allTimeSpend, currency)}`;
-    right.append(summary);
-  }
-  const infoNode = limitDetailInfoNode(entries, 'limit-spend-info-wrap');
-  if (infoNode) right.append(infoNode);
-  line.append(label, right);
-  item.append(line);
-  item.setAttribute(
-    'aria-label',
-    [
-      allTimeSpend === null ? 'Details' : 'Spend',
-      ...(allTimeSpend === null ? [] : [`All time ${formatMoney(allTimeSpend, currency)}`]),
+  // Without a spend figure the row has nothing to summarize, so it retitles
+  // itself and leans entirely on the tooltip.
+  const summary = allTimeSpend === null ? '' : `All time ${formatMoney(allTimeSpend, currency)}`;
+  return limitNoteRowNode({
+    label: allTimeSpend === null ? 'Details' : 'Spend',
+    summary,
+    detailEntries: entries,
+    ariaParts: [
+      ...(summary ? [summary] : []),
       ...entries.map(([entryLabel, value]) => `${entryLabel} ${value}`)
-    ].join(', ')
-  );
-  return item;
+    ]
+  });
 }
 
 // One tooltip row per prepaid grant: amount, expiry date, time left, the same
@@ -2374,30 +2334,12 @@ function claudeBalanceNode(provider) {
   const currency = balance?.currency || 'USD';
   const tranches = Array.isArray(balance.tranches) ? balance.tranches : [];
   const grants = claudePrepaidGrantRows(tranches, currency);
-  const entries = grants.map((grant) => grant.cells);
-
-  const item = document.createElement('div');
-  item.className = 'limit-window limit-window-wide limit-window-note limit-spend';
-  const line = document.createElement('div');
-  line.className = 'limit-window-text limit-spend-line';
-  const label = document.createElement('span');
-  label.textContent = 'Balance';
-  const right = document.createElement('span');
-  right.className = 'limit-spend-right';
-  const summary = document.createElement('span');
-  summary.className = 'limit-spend-summary';
-  summary.textContent = formatMoney(amount, currency);
-  right.append(summary);
-  const infoNode = limitDetailInfoNode(entries, 'limit-spend-info-wrap');
-  if (infoNode) right.append(infoNode);
-  line.append(label, right);
-  item.append(line);
-  item.setAttribute('aria-label', [
-    'Balance',
-    formatMoney(amount, currency),
-    ...grants.map((grant) => grant.aria)
-  ].join(', '));
-  return item;
+  return limitNoteRowNode({
+    label: 'Balance',
+    summary: formatMoney(amount, currency),
+    detailEntries: grants.map((grant) => grant.cells),
+    ariaParts: [formatMoney(amount, currency), ...grants.map((grant) => grant.aria)]
+  });
 }
 
 const {

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -743,7 +743,10 @@ test('Codex renders manual reset credits below session and weekly windows', () =
   const resetCreditExpiryLabel = functionBody(app, 'codexResetCreditExpiryLabel', 'codexResetCreditExpiryDetailLabel');
   const resetCreditExpiryDetailLabel = functionBody(app, 'codexResetCreditExpiryDetailLabel', 'expiryDateLabel');
   const resetCreditExpiryDateLabel = functionBody(app, 'expiryDateLabel', 'limitDetailTooltipShouldHoldRender');
-  const codexResetCreditsNode = functionBody(app, 'codexResetCreditsNode', 'renderLimitProviderHead');
+  // Sliced to the next function, not to `renderLimitProviderHead`: the wider slice
+  // swept in the shared tooltip builder, so these assertions passed on code that
+  // isn't Codex's.
+  const codexResetCreditsNode = functionBody(app, 'codexResetCreditsNode', 'openrouterSpendEntries');
   const limitDetailTooltipShouldHoldRender = functionBody(app, 'limitDetailTooltipShouldHoldRender', 'flushPendingLimitDetailTooltipRender');
   const renderLimits = functionBody(app, 'renderLimits', 'serviceStatusLabel');
 
@@ -767,17 +770,18 @@ test('Codex renders manual reset credits below session and weekly windows', () =
   assert.match(codexResetCreditsNode, /limit-reset-credits-time/);
   assert.match(codexResetCreditsNode, /limit-reset-credits-separator/);
   assert.match(codexResetCreditsNode, /separator\.textContent = '·'/);
-  assert.match(codexResetCreditsNode, /limit-detail-tooltip-wrap/);
-  assert.match(codexResetCreditsNode, /limit-detail-tooltip/);
   assert.match(codexResetCreditsNode, /expirationDates\.slice\(0, 3\)\.map\(codexResetCreditExpiryLabel\)/);
   assert.match(codexResetCreditsNode, /hiddenExpirationCount = expirationDates\.length - summaryParts\.length/);
   assert.match(codexResetCreditsNode, /summaryParts\.push\(`\+\$\{hiddenExpirationCount\}`\)/);
-  assert.match(codexResetCreditsNode, /expirationDates\.forEach/);
-  assert.match(codexResetCreditsNode, /label\.textContent = expiryDateLabel\(date\)/);
-  assert.match(codexResetCreditsNode, /tooltipExpiry\.textContent = codexResetCreditExpiryLabel\(date\)/);
-  assert.match(codexResetCreditsNode, /state\.limitDetailTooltipActive = true/);
-  assert.match(codexResetCreditsNode, /addEventListener\('pointerenter', markResetCreditsTooltipOpened\)/);
-  assert.match(codexResetCreditsNode, /if \(limitDetailTooltipShouldHoldRender\(\)\) return;/);
+  // The multi-expiry tooltip is the shared builder, not a second copy of its
+  // hover/focus wiring that has to be kept in step by hand.
+  assert.match(
+    codexResetCreditsNode,
+    /expirationDates\.map\(\(date\) => \[expiryDateLabel\(date\), codexResetCreditExpiryLabel\(date\)\]\)/
+  );
+  assert.match(codexResetCreditsNode, /`Reset \$\{index \+ 1\}: \$\{codexResetCreditExpiryDetailLabel\(date\)\}`/);
+  assert.doesNotMatch(codexResetCreditsNode, /addEventListener/);
+  assert.doesNotMatch(codexResetCreditsNode, /state\.limitDetailTooltip/);
   assert.match(codexResetCreditsNode, /formatCodexResetCreditsValue\(resetCredits\)/);
   assert.match(codexResetCreditsNode, /aria-label/);
   assert.match(limitDetailTooltipShouldHoldRender, /state\.limitDetailTooltipActive/);

--- a/tests/electron/openrouterSettings.test.js
+++ b/tests/electron/openrouterSettings.test.js
@@ -91,8 +91,9 @@ test('OpenRouter Limits presentation shows a real balance meter and compact spen
   assert.match(app, /function openrouterSpendEntries\(balance\)/);
   assert.match(app, /\['Week', optionalFiniteNumber\(balance\?\.weekSpend\)\]/);
   assert.match(app, /\['All time', optionalFiniteNumber\(balance\?\.allTimeSpend\)\]/);
-  assert.match(app, /summary\.className = 'limit-spend-summary'/);
-  assert.match(app, /function limitDetailInfoNode\(entries, extraClass = ''\)/);
+  assert.match(app, /summaryNode\.className = 'limit-spend-summary'/);
+  assert.match(app, /function limitDetailInfoNode\(entries, extraClass = '', ariaLabel = ''\)/);
+  assert.match(app, /function limitNoteRowNode\(\{ label, summary = '', detailEntries = null, ariaParts = \[\] \}\)/);
   assert.match(app, /tooltip\.className = \['limit-detail-tooltip', columns > 2 \? 'limit-detail-tooltip-triple' : ''\]/);
   assert.match(app, /info\.tabIndex = 0/);
   assert.match(app, /const release = \(\) => \{\s*requestAnimationFrame\(\(\) => \{\s*if \(limitDetailTooltipShouldHoldRender\(\)\) return;/);

--- a/tests/electron/thirdPartySettings.test.js
+++ b/tests/electron/thirdPartySettings.test.js
@@ -108,15 +108,15 @@ test('third-party Limits presentation uses compact scope labels and a details to
   assert.match(app, /balance\?\.requestCount/);
   assert.match(app, /settings\.thirdparty\.requests/);
   assert.match(app, /if \(allTimeSpend === null && entries\.length === 0\) return null/);
-  assert.match(app, /if \(allTimeSpend !== null\)/);
-  assert.match(app, /label\.textContent = allTimeSpend === null \? 'Details' : 'Spend'/);
+  assert.match(app, /const summary = allTimeSpend === null \? '' : `All time \$\{formatMoney\(allTimeSpend, currency\)\}`/);
+  assert.match(app, /label: allTimeSpend === null \? 'Details' : 'Spend'/);
   assert.match(balanceDisplay, /return symbol \? `\$\{symbol\}\$\{number\.toFixed\(2\)\}` : `\$\{code\} \$\{number\.toFixed\(2\)\}`/);
   assert.match(app, /`All time \$\{formatMoney\(allTimeSpend, currency\)\}`/);
   assert.match(app, /function renderNamedApiAccountGroup[\s\S]*?planText: options\.groupPlanText/);
   assert.match(app, /groupPlanText: t\('settings\.openrouter\.nAccounts', \{ count: providers\.length \}\)/);
   assert.match(app, /groupPlanText: t\('settings\.thirdparty\.nAccounts', \{ count: providers\.length \}\)/);
   assert.doesNotMatch(i18n, /settings\.thirdparty\.(?:spend|allTime)/);
-  assert.match(app, /limitDetailInfoNode\(entries, 'limit-spend-info-wrap'\)/);
+  assert.match(app, /limitDetailInfoNode\(detailEntries, 'limit-spend-info-wrap'\)/);
   assert.match(app, /function renderThirdPartyAccountGroup/);
   assert.match(app, /renderNamedApiAccountGroup\('thirdparty'/);
   assert.match(presentation, /thirdparty: \['Relay', 'API'\]/);


### PR DESCRIPTION
## Summary

Four providers drew the meter-less note row by hand. `openrouterSpendNode`, `thirdPartySpendNode` and `claudeBalanceNode` each rebuilt the same label / summary / ⓘ layout, and `codexResetCreditsNode` carried a second copy of the detail tooltip's hover and focus wiring, so a change to how the tooltip holds a render had to be made in two places or silently drift.

Two extractions, since the duplication came in two different shapes:

- `limitNoteRowNode` owns the shared row. Callers pass a label, an optional summary, optional tooltip entries and the parts of their spoken label, because each provider says something different about the same layout.
- Codex's tooltip now goes through `limitDetailInfoNode`. That builder takes an optional accessible label, since a date paired with a bare duration does not read as `<name>: <value>` the way the other callers' cells do.

Net 138 lines removed, 85 added.

## Verification

This is a refactor claiming no behaviour change, and matching source text does not prove that, so every one of these rows was rendered with the pre- and post-refactor builders in a real Chromium DOM and the markup diffed: 12 cases covering each branch (summary with and without a tooltip, third-party with spend only / details only / both, Claude with grants, with none and with an unexpiring grant, Codex with one expiry, with several, and with none). All 12 identical.

`outerHTML` cannot see event listeners, which is exactly what moved on the Codex path, so one case drives a real `pointerenter` and compares the resulting tooltip state and the trigger's accessible label. Also identical.

The comparison was then checked against deliberately broken versions of both paths to confirm it actually fails when the output changes. That check earned its keep: the first run reported the Codex cases as identical because the fixtures used the wrong field name and the builder was returning `null`, so all four were vacuously equal. Fixed, and the corrected fixtures do report the tampered Codex output as different.

`npm run verify` passes: 1956 pass, 0 fail, 1 skipped.

## Test changes

The Codex assertions were sliced as far as `renderLimitProviderHead`, which swept in `limitDetailInfoNode` and several other builders, so assertions like `limit-detail-tooltip-wrap` and `state.limitDetailTooltipActive` were passing on code that was not Codex's. They now stop at the next function and pin the delegation instead.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the limits UI to share the note row and tooltip builders across providers, removing hand‑rolled duplicates with no behavior changes. Codex reset credits now uses the shared tooltip with an optional accessible label.

- **Refactors**
  - Added `limitNoteRowNode` for the shared label/summary/ⓘ row; adopted by OpenRouter spend, third‑party spend/details, and Claude balance.
  - Delegated Codex reset credits tooltip to `limitDetailInfoNode`, which now accepts an optional `aria-label` for non name/value rows.
  - Verified identical DOM and a11y output (hover/focus) across 12 cases; all tests pass (1956/0/1).

<sup>Written for commit 6f1f726afe885b7199e8dc92a9351ebaf4e8e654. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

