### PR TITLE
refactor(limits): share one browser user-agent across web-session providers

### DIFF
--- a/src/shared/browserUserAgent.js
+++ b/src/shared/browserUserAgent.js
@@ -1,0 +1,14 @@
+'use strict';
+
+// Several web-session providers reject clients that don't present as a browser —
+// claude.ai answers anything else with a Cloudflare challenge — so their requests
+// carry a browser agent rather than the honest `token-monitor/<version>` one. It
+// lives here so bumping the version is a single edit instead of a hunt through
+// every collector, and so a stale copy can't survive in one of them.
+//
+// A provider that genuinely needs a different agent should declare its own
+// instead of widening this one: `cursorProbe` and `mimoLimits` already send
+// their own, older strings.
+const BROWSER_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36';
+
+module.exports = { BROWSER_USER_AGENT };

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -6,6 +6,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { appVersion } = require('./appVersion');
+const { BROWSER_USER_AGENT } = require('./browserUserAgent');
 const {
   DEFAULT_LIMITS_REFRESH_MS,
   normalizeLimitProvider,
@@ -80,15 +81,6 @@ const CODEX_RESET_CREDITS_PATH = '/wham/rate-limit-reset-credits';
 const CODEX_EMPTY_QUOTA_RETRY_DELAY_MS = 300;
 const CODEX_RPC_TIMEOUT_MS = 20_000;
 const TOKEN_MONITOR_USER_AGENT = `token-monitor/${appVersion()} (+https://github.com/Javis603/token-monitor)`;
-// claude.ai sits behind Cloudflare, which answers any non-browser user-agent with
-// `403 cf-mitigated: challenge` before the request reaches the API. An honest
-// `token-monitor/<version>` agent is challenged just as hard as sending none at
-// all, so this has to read as a browser. Applied only on the undici path: the
-// widget routes this provider through Electron's `net.request`, whose Chromium
-// agent already passes and, unlike this constant, tracks the bundled Chromium
-// version instead of going stale. Matches the agent the other web-session
-// providers already send.
-const CLAUDE_WEB_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36';
 
 function nowIso(nowMs) {
   return new Date(nowMs).toISOString();
@@ -662,8 +654,10 @@ function fetchClaudeWebJson(url, headers, deps = {}, options = {}) {
   const webDeps = viaChromium ? { ...deps, fetch: deps.claudeWebFetch } : deps;
   // Chromium sends its own browser agent, and setting one here would override it
   // with a version that no longer matches the runtime. undici sends none at all,
-  // which Cloudflare challenges, so that path has to supply one.
-  const webHeaders = viaChromium ? headers : { ...headers, 'user-agent': CLAUDE_WEB_USER_AGENT };
+  // and claude.ai's Cloudflare answers both that and an honest
+  // `token-monitor/<version>` agent with `403 cf-mitigated: challenge`, so that
+  // path has to present as a browser.
+  const webHeaders = viaChromium ? headers : { ...headers, 'user-agent': BROWSER_USER_AGENT };
   return fetchJson(url, webHeaders, webDeps, {
     forbiddenIsUnauthorized: true,
     onResponse: options.onResponse

--- a/src/shared/ollamaLimits.js
+++ b/src/shared/ollamaLimits.js
@@ -2,9 +2,9 @@
 
 const { normalizeLimitProvider } = require('./limits');
 const { hashKey } = require('./hashKey');
+const { BROWSER_USER_AGENT } = require('./browserUserAgent');
 
 const OLLAMA_SETTINGS_URL = 'https://ollama.com/settings';
-const OLLAMA_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36';
 const VALIDATION_CACHE_MS = 30 * 1000;
 let validationCache = null;
 const OLLAMA_SESSION_COOKIE_NAMES = new Set([
@@ -202,7 +202,7 @@ async function requestSettings(fetchFn, cookieHeader, controller) {
         ...(shouldAttachOllamaCookie(url) ? { Cookie: cookieHeader } : {}),
         Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
         'Accept-Language': 'en-US,en;q=0.9',
-        'User-Agent': OLLAMA_USER_AGENT
+        'User-Agent': BROWSER_USER_AGENT
       },
       redirect: 'manual',
       ...(controller ? { signal: controller.signal } : {})

--- a/src/shared/opencodeWeb.js
+++ b/src/shared/opencodeWeb.js
@@ -1,12 +1,13 @@
 'use strict';
 
+const { BROWSER_USER_AGENT } = require('./browserUserAgent');
+
 const BASE_URL = 'https://opencode.ai';
 const SERVER_URL = 'https://opencode.ai/_server';
 // From codexbar 0.32.4 (its docs/opencode.md): opencode.ai TanStack server-function IDs (build hashes).
 // These can break when opencode.ai redeploys — keep in sync with codexbar if Zen stops resolving.
 const WORKSPACES_SERVER_ID = 'def39973159c7f0483d8793a822b8dbb10d067e12c65455fcb4608459ba0234f';
 const SUBSCRIPTION_SERVER_ID = '7abeebee372f304e050aaaf92be863f4a86490e382f8c79db68fd94040d691b4';
-const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36';
 
 const PCT_KEYS = ['usagePercent', 'usedPercent', 'percentUsed', 'percent', 'usage_percent', 'used_percent', 'utilization', 'utilizationPercent', 'utilization_percent', 'usage'];
 const RESET_SEC_KEYS = ['resetInSec', 'resetInSeconds', 'resetSeconds', 'reset_sec', 'reset_in_sec', 'resetsInSec', 'resetsInSeconds', 'resetIn', 'resetSec'];
@@ -39,7 +40,7 @@ function buildHeaders(serverId, cookieHeader, referer) {
     Cookie: cookieHeader,
     'X-Server-Id': serverId,
     'X-Server-Instance': `server-fn:${cryptoUuid()}`,
-    'User-Agent': USER_AGENT,
+    'User-Agent': BROWSER_USER_AGENT,
     Origin: BASE_URL,
     Referer: referer || BASE_URL,
     Accept: 'text/javascript, application/json;q=0.9, */*;q=0.8'
@@ -304,7 +305,7 @@ async function fetchGoPageText(workspaceId, cookieHeader, deps) {
     method: 'GET',
     headers: {
       Cookie: cookieHeader,
-      'User-Agent': USER_AGENT,
+      'User-Agent': BROWSER_USER_AGENT,
       Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
     }
   });

--- a/src/shared/qoderLimits.js
+++ b/src/shared/qoderLimits.js
@@ -3,10 +3,9 @@
 const { normalizeLimitProvider } = require('./limits');
 const { hashKey } = require('./hashKey');
 const { runWithProbeDeadline } = require('./probeDeadline');
+const { BROWSER_USER_AGENT } = require('./browserUserAgent');
 
 const QODER_FETCH_TIMEOUT_MS = 12_000;
-
-const QODER_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36';
 
 function cleanSecret(value) {
   let raw = value;
@@ -222,7 +221,7 @@ async function fetchQoderLimits(options = {}, deps = {}) {
     Cookie: cookie,
     Accept: 'application/json, text/plain, */*',
     'Accept-Language': 'en-US,en;q=0.9',
-    'User-Agent': QODER_USER_AGENT,
+    'User-Agent': BROWSER_USER_AGENT,
     Origin: origin,
     Referer: `${origin}/account/usage`,
     'X-Requested-With': 'XMLHttpRequest',

--- a/tests/shared/browserUserAgent.test.js
+++ b/tests/shared/browserUserAgent.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const { BROWSER_USER_AGENT } = require('../../src/shared/browserUserAgent');
+
+const root = path.join(__dirname, '..', '..');
+
+function jsFilesUnder(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...jsFilesUnder(full));
+    else if (entry.name.endsWith('.js')) out.push(full);
+  }
+  return out;
+}
+
+test('the shared browser user-agent reads as a current browser', () => {
+  // The whole point is to not look like a script: Cloudflare challenges anything
+  // that doesn't, so a well-meaning edit to an honest agent has to fail here.
+  assert.match(BROWSER_USER_AGENT, /^Mozilla\/5\.0 /);
+  assert.match(BROWSER_USER_AGENT, /Chrome\/\d+[\d.]* Safari\/[\d.]+$/);
+  assert.doesNotMatch(BROWSER_USER_AGENT, /token-monitor/i);
+});
+
+test('providers share one browser user-agent instead of copying the string', () => {
+  const owners = jsFilesUnder(path.join(root, 'src'))
+    .concat(jsFilesUnder(path.join(root, 'worker', 'src')))
+    .filter((file) => fs.readFileSync(file, 'utf8').includes(BROWSER_USER_AGENT))
+    .map((file) => path.relative(root, file));
+
+  // A second copy is how one collector ends up stranded on a stale Chrome
+  // version. `cursorProbe` and `mimoLimits` deliberately send their own, older
+  // agents, and stay out of this by not matching the shared string.
+  assert.deepEqual(owners, ['src/shared/browserUserAgent.js']);
+});
+
+test('every web-session provider takes its agent from the shared module', () => {
+  for (const file of [
+    'src/shared/limitCollector.js',
+    'src/shared/opencodeWeb.js',
+    'src/shared/ollamaLimits.js',
+    'src/shared/qoderLimits.js'
+  ]) {
+    const source = fs.readFileSync(path.join(root, file), 'utf8');
+    assert.match(source, /require\('\.\/browserUserAgent'\)/, `${file} should require the shared agent`);
+    assert.match(source, /BROWSER_USER_AGENT/, `${file} should use the shared agent`);
+  }
+});

--- a/tests/shared/browserUserAgent.test.js
+++ b/tests/shared/browserUserAgent.test.js
@@ -6,8 +6,20 @@ const path = require('node:path');
 const test = require('node:test');
 
 const { BROWSER_USER_AGENT } = require('../../src/shared/browserUserAgent');
+const { fetchClaudeLimits } = require('../../src/shared/limitCollector');
+const { fetchOllamaLimits } = require('../../src/shared/ollamaLimits');
+const { fetchQoderLimits } = require('../../src/shared/qoderLimits');
+const opencodeWeb = require('../../src/shared/opencodeWeb');
 
 const root = path.join(__dirname, '..', '..');
+
+// Files that deliberately send their own agent instead of the shared one.
+// Changing what a live provider presents to its host is a behaviour change, so
+// they stay listed here rather than being quietly folded in. `cursorProbe` is
+// still on Chrome 120 while the shared agent is on 143 — exactly the drift the
+// scan below exists to surface.
+const OWN_AGENT_FILES = ['src/shared/cursorProbe.js', 'src/shared/mimoLimits.js'];
+const SHARED_AGENT_FILE = 'src/shared/browserUserAgent.js';
 
 function jsFilesUnder(dir) {
   const out = [];
@@ -19,6 +31,42 @@ function jsFilesUnder(dir) {
   return out;
 }
 
+function sourceFiles() {
+  return jsFilesUnder(path.join(root, 'src'))
+    .concat(jsFilesUnder(path.join(root, 'worker', 'src')))
+    // Windows would otherwise report `src\shared\...` and never match.
+    .map((file) => ({ name: path.relative(root, file).split(path.sep).join('/'), text: fs.readFileSync(file, 'utf8') }));
+}
+
+function headerValue(init, name) {
+  const headers = init?.headers || {};
+  const key = Object.keys(headers).find((candidate) => candidate.toLowerCase() === name);
+  return key ? headers[key] : undefined;
+}
+
+const okResponse = {
+  ok: true,
+  status: 200,
+  headers: { get: () => null, getSetCookie: () => [] },
+  json: async () => ({}),
+  text: async () => ''
+};
+
+// Each provider only has to reach its first outbound request; what it makes of
+// the reply is another test's business.
+async function outboundUserAgent(send) {
+  const seen = [];
+  const fetch = async (_url, init) => {
+    seen.push(headerValue(init, 'user-agent'));
+    return okResponse;
+  };
+  try {
+    await send(fetch);
+  } catch (_) { /* the reply is deliberately useless */ }
+  assert.ok(seen.length > 0, 'provider should have made a request');
+  return seen;
+}
+
 test('the shared browser user-agent reads as a current browser', () => {
   // The whole point is to not look like a script: Cloudflare challenges anything
   // that doesn't, so a well-meaning edit to an honest agent has to fail here.
@@ -27,28 +75,52 @@ test('the shared browser user-agent reads as a current browser', () => {
   assert.doesNotMatch(BROWSER_USER_AGENT, /token-monitor/i);
 });
 
-test('providers share one browser user-agent instead of copying the string', () => {
-  const owners = jsFilesUnder(path.join(root, 'src'))
-    .concat(jsFilesUnder(path.join(root, 'worker', 'src')))
-    .filter((file) => fs.readFileSync(file, 'utf8').includes(BROWSER_USER_AGENT))
-    // Windows would otherwise report `src\shared\...` and never match.
-    .map((file) => path.relative(root, file).split(path.sep).join('/'));
+test('no source file hard-codes a browser user-agent outside the known set', () => {
+  // Matching the shared string verbatim would only catch an identical copy,
+  // which is the harmless kind. The damage comes from a provider pinning its own
+  // Chrome version and silently rotting, so this matches any browser-shaped
+  // literal and requires it to be declared.
+  const owners = sourceFiles()
+    .filter((file) => /'Mozilla\/5\.0[^']*'|"Mozilla\/5\.0[^"]*"/.test(file.text))
+    .map((file) => file.name)
+    .sort();
 
-  // A second copy is how one collector ends up stranded on a stale Chrome
-  // version. `cursorProbe` and `mimoLimits` deliberately send their own, older
-  // agents, and stay out of this by not matching the shared string.
-  assert.deepEqual(owners, ['src/shared/browserUserAgent.js']);
+  assert.deepEqual(owners, [SHARED_AGENT_FILE, ...OWN_AGENT_FILES].sort());
 });
 
-test('every web-session provider takes its agent from the shared module', () => {
-  for (const file of [
-    'src/shared/limitCollector.js',
-    'src/shared/opencodeWeb.js',
-    'src/shared/ollamaLimits.js',
-    'src/shared/qoderLimits.js'
-  ]) {
-    const source = fs.readFileSync(path.join(root, file), 'utf8');
-    assert.match(source, /require\('\.\/browserUserAgent'\)/, `${file} should require the shared agent`);
-    assert.match(source, /BROWSER_USER_AGENT/, `${file} should use the shared agent`);
-  }
+test('the shared agent is defined once and never copied verbatim', () => {
+  const copies = sourceFiles()
+    .filter((file) => file.text.includes(BROWSER_USER_AGENT))
+    .map((file) => file.name);
+
+  assert.deepEqual(copies, [SHARED_AGENT_FILE]);
+});
+
+test('Claude Web sends the shared agent on the wire', async () => {
+  const sent = await outboundUserAgent((fetch) => fetchClaudeLimits(
+    { claudeWebCookie: 'sessionKey=sk-ant-probe' },
+    { fetch, providerRuntimeState: new Map(), claudeIdentityCache: new Map() }
+  ));
+  assert.deepEqual([...new Set(sent)], [BROWSER_USER_AGENT]);
+});
+
+test('OpenCode Zen sends the shared agent on the wire', async () => {
+  const sent = await outboundUserAgent((fetch) => opencodeWeb.fetchZen('sess=1', { fetch }));
+  assert.deepEqual([...new Set(sent)], [BROWSER_USER_AGENT]);
+});
+
+test('Ollama sends the shared agent on the wire', async () => {
+  const sent = await outboundUserAgent((fetch) => fetchOllamaLimits(
+    { ollamaCookie: 'session=probe' },
+    { env: {}, fetch }
+  ));
+  assert.deepEqual([...new Set(sent)], [BROWSER_USER_AGENT]);
+});
+
+test('Qoder sends the shared agent on the wire', async () => {
+  const sent = await outboundUserAgent((fetch) => fetchQoderLimits(
+    { qoderCookie: 'session=probe', qoderSite: 'cn' },
+    { env: {}, fetch }
+  ));
+  assert.deepEqual([...new Set(sent)], [BROWSER_USER_AGENT]);
 });

--- a/tests/shared/browserUserAgent.test.js
+++ b/tests/shared/browserUserAgent.test.js
@@ -109,6 +109,25 @@ test('OpenCode Zen sends the shared agent on the wire', async () => {
   assert.deepEqual([...new Set(sent)], [BROWSER_USER_AGENT]);
 });
 
+test('OpenCode Go page sends the shared agent on the wire', async () => {
+  // The Go dashboard builds its own headers rather than going through
+  // `buildHeaders`, so the Zen case above does not cover it.
+  const seen = [];
+  const fetch = async (url, init) => {
+    seen.push({ url: String(url), ua: headerValue(init, 'user-agent') });
+    return String(url).includes(opencodeWeb.WORKSPACES_SERVER_ID)
+      ? { ...okResponse, text: async () => '{"id":"wrk_PROBE"}' }
+      : { ...okResponse, text: async () => '' };
+  };
+  try {
+    await opencodeWeb.fetchGoWeb('sess=1', { fetch });
+  } catch (_) { /* the reply is deliberately useless */ }
+
+  const goRequest = seen.find((entry) => entry.url.endsWith('/go'));
+  assert.ok(goRequest, 'the Go dashboard page should have been requested');
+  assert.equal(goRequest.ua, BROWSER_USER_AGENT);
+});
+
 test('Ollama sends the shared agent on the wire', async () => {
   const sent = await outboundUserAgent((fetch) => fetchOllamaLimits(
     { ollamaCookie: 'session=probe' },

--- a/tests/shared/browserUserAgent.test.js
+++ b/tests/shared/browserUserAgent.test.js
@@ -31,7 +31,8 @@ test('providers share one browser user-agent instead of copying the string', () 
   const owners = jsFilesUnder(path.join(root, 'src'))
     .concat(jsFilesUnder(path.join(root, 'worker', 'src')))
     .filter((file) => fs.readFileSync(file, 'utf8').includes(BROWSER_USER_AGENT))
-    .map((file) => path.relative(root, file));
+    // Windows would otherwise report `src\shared\...` and never match.
+    .map((file) => path.relative(root, file).split(path.sep).join('/'));
 
   // A second copy is how one collector ends up stranded on a stale Chrome
   // version. `cursorProbe` and `mimoLimits` deliberately send their own, older


### PR DESCRIPTION
## Summary

Follow-up to #272. Four collectors each carried their own copy of the same Chrome agent string — `limitCollector` (Claude Web), `opencodeWeb`, `ollamaLimits` and `qoderLimits` — all for the same reason: their hosts reject clients that don't present as a browser. Four copies means a version bump is four edits, and nothing catches the one that gets missed and leaves a collector stranded on a stale Chrome.

They now take it from `src/shared/browserUserAgent.js`.

## Scope

`cursorProbe` and `mimoLimits` also send browser-ish agents, but different strings, and they stay declared as exceptions here. Changing what a working provider presents to its host is a behaviour change, not a refactor, and it belongs in its own change with its own verification.

Worth flagging while it's in view: `cursorProbe` is exactly the failure this guards against, still pinned to Chrome 120 while the others moved to 143.

## Verification

Every guard below was checked by breaking the code and confirming it fails.

**The string is declared in one place.** The scan matches any browser-shaped literal, not just the shared value verbatim: an identical copy is the harmless kind, and the real damage comes from a provider pinning its own Chrome version and silently rotting. Any browser-shaped literal outside the declared set fails, which is what makes this worth having at all — without it the next copy re-creates the problem silently.

**The shared value still reads as a browser.** Fails if someone swaps in the honest `token-monitor/<version>` agent, which #272 measured getting challenged by Cloudflare just as hard as sending none.

**Each provider puts it on the wire.** Every shared provider is driven through an injected transport and asserted on the outbound header rather than on what its source looks like. That includes the OpenCode Go dashboard, which builds its own headers instead of going through `buildHeaders` and so was not covered by the Zen case.

`npm run verify` passes: 1964 pass, 0 fail, 1 skipped. CI green on Ubuntu 22/24, macOS 24 and Windows 24.
