### PR TITLE
refactor(limits): align the last two providers onto the shared browser agent

### DIFF
--- a/src/shared/browserUserAgent.js
+++ b/src/shared/browserUserAgent.js
@@ -6,9 +6,10 @@
 // lives here so bumping the version is a single edit instead of a hunt through
 // every collector, and so a stale copy can't survive in one of them.
 //
-// A provider that genuinely needs a different agent should declare its own
-// instead of widening this one: `cursorProbe` and `mimoLimits` already send
-// their own, older strings.
+// This is the only browser agent in the tree, and a test keeps it that way. A
+// provider that identifies as a specific client rather than a browser — Codex,
+// Grok and Copilot each name their own — is a different thing and does not
+// belong here.
 const BROWSER_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36';
 
 module.exports = { BROWSER_USER_AGENT };

--- a/src/shared/cursorProbe.js
+++ b/src/shared/cursorProbe.js
@@ -2,6 +2,7 @@
 
 const https = require('node:https');
 const { abortError } = require('./probeDeadline');
+const { BROWSER_USER_AGENT } = require('./browserUserAgent');
 
 const USAGE_SUMMARY_URL = 'https://cursor.com/api/usage-summary';
 const AUTH_ME_URL = 'https://cursor.com/api/auth/me';
@@ -11,7 +12,7 @@ const DEFAULT_HEADERS = {
   'Accept': '*/*',
   'Accept-Language': 'en-US,en;q=0.9',
   'Referer': 'https://www.cursor.com/settings',
-  'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+  'User-Agent': BROWSER_USER_AGENT
 };
 
 function clampPercent(n) {

--- a/src/shared/mimoLimits.js
+++ b/src/shared/mimoLimits.js
@@ -3,6 +3,7 @@
 const crypto = require('node:crypto');
 const { hashKey } = require('./hashKey');
 const { normalizeLimitProvider } = require('./limits');
+const { BROWSER_USER_AGENT } = require('./browserUserAgent');
 
 const MIMO_PLATFORM_CONSOLE_URL = 'https://platform.xiaomimimo.com/#/console/balance';
 const MIMO_API_BASE_URL = 'https://platform.xiaomimimo.com/api/v1';
@@ -184,7 +185,7 @@ function requestHeaders(cookieHeader) {
     Cookie: cookieHeader,
     Origin: 'https://platform.xiaomimimo.com',
     Referer: MIMO_PLATFORM_CONSOLE_URL,
-    'User-Agent': 'Mozilla/5.0 AppleWebKit/537.36 Chrome/143 Safari/537.36'
+    'User-Agent': BROWSER_USER_AGENT
   };
 }
 

--- a/tests/shared/browserUserAgent.test.js
+++ b/tests/shared/browserUserAgent.test.js
@@ -76,9 +76,11 @@ test('no source file hard-codes a browser user-agent', () => {
   // Matching the shared string verbatim would only catch an identical copy,
   // which is the harmless kind. The damage comes from a provider pinning its own
   // Chrome version and silently rotting, so this matches any browser-shaped
-  // literal: there is now exactly one place allowed to hold one.
+  // literal: there is now exactly one place allowed to hold one. The opening
+  // quote is enough to identify a literal, and covering all three kinds matters
+  // because nothing in this repo enforces a quote style.
   const owners = sourceFiles()
-    .filter((file) => /'Mozilla\/5\.0[^']*'|"Mozilla\/5\.0[^"]*"/.test(file.text))
+    .filter((file) => /['"`]Mozilla\/5\.0/.test(file.text))
     .map((file) => file.name)
     .sort();
 

--- a/tests/shared/browserUserAgent.test.js
+++ b/tests/shared/browserUserAgent.test.js
@@ -1,24 +1,21 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
 const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
 
 const { BROWSER_USER_AGENT } = require('../../src/shared/browserUserAgent');
 const { fetchClaudeLimits } = require('../../src/shared/limitCollector');
+const { fetchMimoLimits } = require('../../src/shared/mimoLimits');
 const { fetchOllamaLimits } = require('../../src/shared/ollamaLimits');
 const { fetchQoderLimits } = require('../../src/shared/qoderLimits');
+const cursorProbe = require('../../src/shared/cursorProbe');
 const opencodeWeb = require('../../src/shared/opencodeWeb');
 
 const root = path.join(__dirname, '..', '..');
 
-// Files that deliberately send their own agent instead of the shared one.
-// Changing what a live provider presents to its host is a behaviour change, so
-// they stay listed here rather than being quietly folded in. `cursorProbe` is
-// still on Chrome 120 while the shared agent is on 143 — exactly the drift the
-// scan below exists to surface.
-const OWN_AGENT_FILES = ['src/shared/cursorProbe.js', 'src/shared/mimoLimits.js'];
 const SHARED_AGENT_FILE = 'src/shared/browserUserAgent.js';
 
 function jsFilesUnder(dir) {
@@ -75,17 +72,17 @@ test('the shared browser user-agent reads as a current browser', () => {
   assert.doesNotMatch(BROWSER_USER_AGENT, /token-monitor/i);
 });
 
-test('no source file hard-codes a browser user-agent outside the known set', () => {
+test('no source file hard-codes a browser user-agent', () => {
   // Matching the shared string verbatim would only catch an identical copy,
   // which is the harmless kind. The damage comes from a provider pinning its own
   // Chrome version and silently rotting, so this matches any browser-shaped
-  // literal and requires it to be declared.
+  // literal: there is now exactly one place allowed to hold one.
   const owners = sourceFiles()
     .filter((file) => /'Mozilla\/5\.0[^']*'|"Mozilla\/5\.0[^"]*"/.test(file.text))
     .map((file) => file.name)
     .sort();
 
-  assert.deepEqual(owners, [SHARED_AGENT_FILE, ...OWN_AGENT_FILES].sort());
+  assert.deepEqual(owners, [SHARED_AGENT_FILE]);
 });
 
 test('the shared agent is defined once and never copied verbatim', () => {
@@ -134,6 +131,42 @@ test('Ollama sends the shared agent on the wire', async () => {
     { env: {}, fetch }
   ));
   assert.deepEqual([...new Set(sent)], [BROWSER_USER_AGENT]);
+});
+
+test('MiMo sends the shared agent on the wire', async () => {
+  const sent = await outboundUserAgent((fetch) => fetchMimoLimits(
+    {
+      mimoManagedAccounts: [{
+        id: 'mimo-probe',
+        accountKey: 'sha256:mimo-probe',
+        cookieHeader: 'userId=1; api-platform_serviceToken=probe',
+        enabled: true
+      }]
+    },
+    { fetch }
+  ));
+  assert.deepEqual([...new Set(sent)], [BROWSER_USER_AGENT]);
+});
+
+test('Cursor sends the shared agent on the wire', async () => {
+  // cursorProbe talks through node:https rather than fetch, so its transport is
+  // injected instead. A 401 is the cheapest reply that settles the request.
+  let headers = null;
+  const httpsLib = {
+    request(options, onResponse) {
+      headers = options.headers;
+      queueMicrotask(() => onResponse({ statusCode: 401, on: () => {} }));
+      const request = new EventEmitter();
+      request.setTimeout = () => {};
+      request.destroy = () => {};
+      request.end = () => {};
+      return request;
+    }
+  };
+
+  await cursorProbe.requestJson(cursorProbe.AUTH_ME_URL, 'session-probe', { httpsLib });
+  assert.ok(headers, 'the probe should have issued a request');
+  assert.equal(headers['User-Agent'], BROWSER_USER_AGENT);
 });
 
 test('Qoder sends the shared agent on the wire', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #274, which left `cursorProbe` and `mimoLimits` declared as exceptions. They were exceptions for different reasons:

- **Cursor** was genuinely stale, pinned to Chrome 120 while everything else moved to 143. This is the exact drift #274's guard exists to surface.
- **MiMo** was not stale (already 143) but abbreviated, missing its platform and layout-engine tokens: `Mozilla/5.0 AppleWebKit/537.36 Chrome/143 Safari/537.36`.

Both now take the shared agent, so the guard collapses to its absolute form: exactly one file in the tree may hold a browser user-agent literal, and any new one fails. The declared-exception list is gone rather than merely shorter.

## Verification

This changes what a working provider presents to its host, so both were measured against the live services with real sessions before the change, not reasoned about. Every endpoint each collector actually calls returned a **byte-identical** response body under the old and new agents:

| Provider | Endpoints | Result |
|---|---|---|
| Cursor | `/api/auth/me`, `/api/usage-summary`, `/api/usage` | 200, byte-identical |
| MiMo | `/balance`, `/userProfile`, `/tokenPlan/detail`, `/tokenPlan/usage` | 200, byte-identical |

The comparison ran on real authenticated sessions; an earlier attempt was discarded because the MiMo session had expired and was comparing two identical rejections, which would have proved nothing about the authenticated path.

Both providers also gain outbound-header assertions alongside the four from #274. Cursor talks through `node:https` rather than `fetch`, so its assertion injects a transport (`httpsLib`) instead of a fetch. Each new guard was checked by reverting the provider to its old agent and confirming the test fails.

`npm run verify` passes: 1966 pass, 0 fail, 1 skipped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `cursorProbe` and `mimoLimits` to the shared browser user-agent, removing provider-specific strings and collapsing the guard to a single UA source. The test now enforces a single UA literal across the repo and catches all quote styles.

- **Refactors**
  - Replaced hard-coded UA in `src/shared/cursorProbe.js` and `src/shared/mimoLimits.js` with `BROWSER_USER_AGENT`.
  - Strengthened the UA guard in `tests/shared/browserUserAgent.test.js` to detect browser-shaped literals in single, double, or backtick quotes; removed the exception list and clarified the shared constant’s comment.
  - Added outbound header checks: MiMo via `fetch`, Cursor via injected `httpsLib` for `node:https`.

<sup>Written for commit a6ce2fb9277120dcc5114e876748841d79445844. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

