### PR TITLE
test(limits): bound waitFor by elapsed time instead of a poll count

### DIFF
--- a/tests/shared/limitsRuntime.test.js
+++ b/tests/shared/limitsRuntime.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { performance } = require('node:perf_hooks');
 const test = require('node:test');
 
 const { createLimitsRuntime } = require('../../src/shared/limitsRuntime');
@@ -20,13 +21,14 @@ function deferred() {
 // buys an amount of wall-clock that depends entirely on how fast the machine is:
 // 100 of them cover barely over a millisecond here, so a runner even slightly
 // quicker exhausted them before a `setTimeout(..., 1)` could fire. Polling on a
-// timer also guarantees the timers phase runs between checks.
+// timer also guarantees the timers phase runs between checks. The 2 s / 5 ms
+// shape and the monotonic clock match the other polling helpers in tests/shared.
 async function waitFor(predicate, message = 'condition', timeoutMs = 2000) {
-  const deadline = Date.now() + timeoutMs;
+  const deadline = performance.now() + timeoutMs;
   for (;;) {
     if (predicate()) return;
-    if (Date.now() >= deadline) assert.fail(`Timed out waiting for ${message} after ${timeoutMs}ms`);
-    await new Promise((resolve) => setTimeout(resolve, 1));
+    if (performance.now() >= deadline) assert.fail(`Timed out waiting for ${message} after ${timeoutMs}ms`);
+    await new Promise((resolve) => setTimeout(resolve, 5));
   }
 }
 

--- a/tests/shared/limitsRuntime.test.js
+++ b/tests/shared/limitsRuntime.test.js
@@ -15,12 +15,19 @@ function deferred() {
   return { promise, reject, resolve };
 }
 
-async function waitFor(predicate, message = 'condition') {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+// Bounded by elapsed time, not by a poll count. Several of these conditions are
+// reached by a timer the runtime sets, and a fixed number of setImmediate turns
+// buys an amount of wall-clock that depends entirely on how fast the machine is:
+// 100 of them cover barely over a millisecond here, so a runner even slightly
+// quicker exhausted them before a `setTimeout(..., 1)` could fire. Polling on a
+// timer also guarantees the timers phase runs between checks.
+async function waitFor(predicate, message = 'condition', timeoutMs = 2000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
     if (predicate()) return;
-    await new Promise((resolve) => setImmediate(resolve));
+    if (Date.now() >= deadline) assert.fail(`Timed out waiting for ${message} after ${timeoutMs}ms`);
+    await new Promise((resolve) => setTimeout(resolve, 1));
   }
-  assert.fail(`Timed out waiting for ${message}`);
 }
 
 function providerRow(provider, accountKey, label, options = {}) {


### PR DESCRIPTION
## Summary

`reset boundaries enqueue the exact provider/account scope only once` failed on Ubuntu Node 24 during #274's CI while passing on Ubuntu 22, macOS 24 and Windows 24. It is not specific to that test or that PR.

The `waitFor` helper in `tests/shared/limitsRuntime.test.js` gave up after 100 `setImmediate` turns. A poll count is not a duration: how much wall-clock those 100 turns buy depends entirely on how fast the machine is. Several of the conditions it waits for are reached by a timer the runtime sets, and the reset-boundary case sets one for 1 ms.

Measured locally, 100 `setImmediate` round-trips take 1.32–1.59 ms — the test was clearing a 1.00 ms bar by roughly a third of a millisecond. `main` has been green because those runners happened to be slow enough, not because the test was sound. It can resurface on anyone's PR.

## Change

The helper now polls against a real deadline. A faster machine simply polls more times instead of running out of them, and polling on a timer guarantees the timers phase runs between checks.

The 2 s timeout, 5 ms interval and monotonic clock are not new choices: `usageRuntime`, `collectorLoadGuards` and `collectorAnchorPersistence` already poll this way in `tests/shared`, and `collectorLoadGuards` already measures with `performance.now()`. This makes the four readable as one pattern.

One helper, 25 call sites in that file. The three helpers above were already bounded by time rather than by a poll count, so this defect was unique to this one.

## Verification

Demonstrated against the actual failure mode by raising the boundary's `delayMs` from 1 to 50, which reproduces on this machine what a faster runner sees at 1 ms:

| helper | `delayMs: 50` |
|---|---|
| old (100 `setImmediate` turns) | FAIL |
| new (deadline) | PASS |

Re-checked after moving to `performance.now()` and the 5 ms interval, to confirm the consistency pass did not weaken the fix: still PASS.

`npm run verify` passes: 1966 pass, 0 fail, 1 skipped. The 5 ms interval is not free — `limitsRuntime.test.js` goes from roughly 127 ms to 230 ms locally, adding about 100 ms to the 2.2 s suite. That is test time only, and it buys consistency with the sibling helpers and an end to reruns caused by a machine being too fast.
