### PR TITLE
feat(deepseek): show detailed spend history

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -2160,7 +2160,7 @@ function codexResetCreditsNode(resetCredits) {
   return item;
 }
 
-function openrouterSpendEntries(balance) {
+function providerSpendEntries(balance) {
   return [
     ['Today', optionalFiniteNumber(balance?.todaySpend)],
     ['Week', optionalFiniteNumber(balance?.weekSpend)],
@@ -2249,8 +2249,8 @@ function limitDetailInfoNode(entries, extraClass = '', ariaLabel = '') {
   return infoWrap;
 }
 
-function openrouterSpendNode(balance) {
-  const entries = openrouterSpendEntries(balance);
+function providerSpendNode(balance) {
+  const entries = providerSpendEntries(balance);
   if (entries.length === 0) return null;
   const currency = balance?.currency || 'USD';
   const preferredSummary = entries.filter(([label]) => label === 'Today' || label === 'Month');
@@ -2925,7 +2925,7 @@ function renderProviderWindows(provider, color) {
       if (!hasMeter) node.classList.add('limit-window-no-reset');
       windows.append(node);
     }
-    const spendNode = openrouterSpendNode(balance);
+    const spendNode = providerSpendNode(balance);
     if (spendNode) windows.append(spendNode);
   } else if (provider.provider === 'thirdparty') {
     windows.classList.add('limit-windows-thirdparty');
@@ -2979,16 +2979,8 @@ function renderProviderWindows(provider, color) {
       balanceNode.classList.add('limit-window-wide', 'limit-window-no-reset');
       windows.append(balanceNode);
 
-      const parts = [];
-      if (Number.isFinite(Number(balance.todaySpend))) parts.push(`Today ${formatMoney(balance.todaySpend, currency)}`);
-      if (Number.isFinite(Number(balance.monthSpend))) {
-        parts.push(`Month ${formatMoney(balance.monthSpend, currency)}`);
-      }
-      if (parts.length) {
-        const spendNode = limitWindowNode('Spend', { showMeter: false }, color, 0.6, parts.join(' · '));
-        spendNode.classList.add('limit-window-wide', 'limit-window-note');
-        windows.append(spendNode);
-      }
+      const spendNode = providerSpendNode(balance);
+      if (spendNode) windows.append(spendNode);
     }
   } else if (provider.provider === 'mimo') {
     windows.classList.add('limit-windows-mimo');

--- a/src/shared/deepseekBalanceHistory.js
+++ b/src/shared/deepseekBalanceHistory.js
@@ -144,13 +144,20 @@ function compactLegacyEntries(store, now) {
 
 function computeCompactConsumption(entry, now) {
   const todayKey = localDayKey(now);
+  const weekStart = new Date(now);
+  weekStart.setHours(0, 0, 0, 0);
+  weekStart.setDate(weekStart.getDate() - 6);
+  const weekStartKey = localDayKey(weekStart.getTime());
   const monthKey = localMonthKey(now);
+  let weekSpend = 0;
   let monthSpend = 0;
   for (const [key, amount] of Object.entries(entry.dailySpend || {})) {
+    if (key >= weekStartKey && key <= todayKey) weekSpend += Number(amount) || 0;
     if (key.startsWith(monthKey)) monthSpend += Number(amount) || 0;
   }
   return {
     todaySpend: round2(entry.dailySpend?.[todayKey] || 0),
+    weekSpend: round2(weekSpend),
     monthSpend: round2(monthSpend),
     allTimeSpend: round2(entry.allTimeSpend || 0),
     trackingSince: new Date(Number(entry.trackingSince)).toISOString(),

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -3351,6 +3351,7 @@ async function fetchDeepSeekLimits(options = {}, deps = {}) {
         amount: row.amount,
         currency: row.currency,
         todaySpend: spend.todaySpend,
+        weekSpend: spend.weekSpend,
         monthSpend: spend.monthSpend,
         allTimeSpend: spend.allTimeSpend,
         trackingSince: spend.trackingSince,

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -181,6 +181,22 @@ function runLocalLiveCodexProvider(source, state) {
   );
 }
 
+function runProviderSpendNode(source, balance) {
+  const optionalNumber = functionBody(source, 'optionalFiniteNumber', 'formatLimitWindowValue');
+  const spendEntries = functionBody(source, 'providerSpendEntries', 'limitNoteRowNode');
+  const spendNode = functionBody(source, 'providerSpendNode', 'thirdPartySpendNode');
+  const context = {
+    formatMoney: (value, currency) => `${currency} ${Number(value).toFixed(2)}`,
+    limitNoteRowNode: (options) => options
+  };
+  vm.runInNewContext(
+    `${optionalNumber}\n${spendEntries}\n${spendNode}\n`
+      + `result = providerSpendNode(${JSON.stringify(balance)});`,
+    context
+  );
+  return JSON.parse(JSON.stringify(context.result));
+}
+
 test('Limits and Home share reset expiry while preserving the existing reset copy', () => {
   const app = readRendererFile('app.js');
   const formatReset = functionBody(app, 'formatReset', 'formatDuration');
@@ -948,6 +964,43 @@ test('DeepSeek main Limits row preserves the intentional month-spend balance met
   assert.match(balanceWindow, /provider\?\.balance\?\.monthSpend/);
   assert.doesNotMatch(renderProviderWindows, /formatMoney\(balance\.amount, currency\)\} left/);
   assert.match(styles, /\.limit-window-no-reset \.limit-reset\s*\{/);
+});
+
+test('shared spend presentation preserves zeroes and omits missing periods', () => {
+  const app = readRendererFile('app.js');
+  const complete = runProviderSpendNode(app, {
+    currency: 'CNY',
+    todaySpend: 0,
+    weekSpend: 1.25,
+    monthSpend: 2.5,
+    allTimeSpend: 3.75
+  });
+
+  assert.equal(complete.label, 'Spend');
+  assert.equal(complete.summary, 'Today CNY 0.00 · Month CNY 2.50');
+  assert.deepEqual(complete.detailEntries, [
+    ['Today', 'CNY 0.00'],
+    ['Week', 'CNY 1.25'],
+    ['Month', 'CNY 2.50'],
+    ['All time', 'CNY 3.75']
+  ]);
+  assert.deepEqual(complete.ariaParts, [
+    'Today CNY 0.00',
+    'Week CNY 1.25',
+    'Month CNY 2.50',
+    'All time CNY 3.75'
+  ]);
+
+  const missingWeek = runProviderSpendNode(app, {
+    currency: 'CNY',
+    todaySpend: 0,
+    weekSpend: null,
+    monthSpend: 2.5,
+    allTimeSpend: 3.75
+  });
+  assert.equal(missingWeek.summary, 'Today CNY 0.00 · Month CNY 2.50');
+  assert.deepEqual(missingWeek.detailEntries.map(([label]) => label), ['Today', 'Month', 'All time']);
+  assert.equal(missingWeek.ariaParts.some((part) => part.startsWith('Week ')), false);
 });
 
 test('Balance and token quota values omit the redundant left suffix', () => {

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -746,7 +746,7 @@ test('Codex renders manual reset credits below session and weekly windows', () =
   // Sliced to the next function, not to `renderLimitProviderHead`: the wider slice
   // swept in the shared tooltip builder, so these assertions passed on code that
   // isn't Codex's.
-  const codexResetCreditsNode = functionBody(app, 'codexResetCreditsNode', 'openrouterSpendEntries');
+  const codexResetCreditsNode = functionBody(app, 'codexResetCreditsNode', 'providerSpendEntries');
   const limitDetailTooltipShouldHoldRender = functionBody(app, 'limitDetailTooltipShouldHoldRender', 'flushPendingLimitDetailTooltipRender');
   const renderLimits = functionBody(app, 'renderLimits', 'serviceStatusLabel');
 
@@ -872,7 +872,7 @@ test('Claude prepaid grants keep three cells when a grant has no usable expiry',
 test('The detail tooltip widens its grid and pads short rows for three-column entries', () => {
   const app = readRendererFile('app.js');
   const styles = readRendererFile('styles.css');
-  const infoNode = functionBody(app, 'limitDetailInfoNode', 'openrouterSpendNode');
+  const infoNode = functionBody(app, 'limitDetailInfoNode', 'providerSpendNode');
   const grantRows = functionBody(app, 'claudePrepaidGrantRows', 'claudeBalanceNode');
   const balanceNode = functionBody(app, 'claudeBalanceNode', 'optionalFiniteNumber');
 
@@ -938,7 +938,9 @@ test('DeepSeek main Limits row preserves the intentional month-spend balance met
 
   assert.match(renderProviderWindows, /\{ remainingPercent: creditsMeterPercent\(provider, null\) \},/);
   assert.match(renderProviderWindows, /balanceNode\.classList\.add\('limit-window-wide', 'limit-window-no-reset'\);/);
-  assert.match(renderProviderWindows, /const spendNode = limitWindowNode\('Spend', \{ showMeter: false \}, color, 0\.6,/);
+  assert.match(renderProviderWindows, /const spendNode = providerSpendNode\(balance\);/);
+  assert.match(app, /\['Week', optionalFiniteNumber\(balance\?\.weekSpend\)\]/);
+  assert.match(app, /\['All time', optionalFiniteNumber\(balance\?\.allTimeSpend\)\]/);
   assert.doesNotMatch(renderProviderWindows, /Month \(since tracking\)/);
   assert.doesNotMatch(renderProviderWindows, /monthSinceTracking \? 'Month \(since tracking\)' : 'Month'/);
   // The month-spend denominator now lives in the shared balance module.

--- a/tests/electron/openrouterSettings.test.js
+++ b/tests/electron/openrouterSettings.test.js
@@ -88,7 +88,7 @@ test('OpenRouter Limits presentation shows a real balance meter and compact spen
     app,
     /if \(id === 'openrouter' && Array\.isArray\(visibleProviders\) && visibleProviders\.length > 1\) \{\s*nodes\.push\(renderOpenRouterAccountGroup\(label, visibleProviders, color\)\);\s*continue;\s*\}/
   );
-  assert.match(app, /function openrouterSpendEntries\(balance\)/);
+  assert.match(app, /function providerSpendEntries\(balance\)/);
   assert.match(app, /\['Week', optionalFiniteNumber\(balance\?\.weekSpend\)\]/);
   assert.match(app, /\['All time', optionalFiniteNumber\(balance\?\.allTimeSpend\)\]/);
   assert.match(app, /summaryNode\.className = 'limit-spend-summary'/);
@@ -98,6 +98,7 @@ test('OpenRouter Limits presentation shows a real balance meter and compact spen
   assert.match(app, /info\.tabIndex = 0/);
   assert.match(app, /const release = \(\) => \{\s*requestAnimationFrame\(\(\) => \{\s*if \(limitDetailTooltipShouldHoldRender\(\)\) return;/);
   assert.match(app, /entries\.map\(\(\[entryLabel, value\]\) => \[entryLabel, formatMoney\(value, currency\)\]\)/);
+  assert.match(app, /const spendNode = providerSpendNode\(balance\)/);
   assert.match(app, /function openrouterCreditsWindow\(provider\)/);
   assert.match(app, /windows\.find\(\(window\) => window\?\.metric === 'credits'\)/);
   assert.match(app, /windows\.find\(\(window\) => !window\?\.metric && window\?\.label === 'Credits'\)/);

--- a/tests/shared/deepseekBalanceHistory.test.js
+++ b/tests/shared/deepseekBalanceHistory.test.js
@@ -25,6 +25,7 @@ test('recordConsumption: persists a compact balance anchor and daily spend', () 
   recordConsumption({ accountKey: 'sha256:abc', currency: 'CNY', paid: 10, now: t0, storePath: '/x' }, store);
   const r = recordConsumption({ accountKey: 'sha256:abc', currency: 'CNY', paid: 7, now: t1, storePath: '/x' }, store);
   assert.equal(r.todaySpend, 3);
+  assert.equal(r.weekSpend, 3);
   assert.deepEqual(store.peek()['sha256:abc'], {
     version: 2,
     currency: 'CNY',
@@ -66,6 +67,7 @@ test('recordConsumption: keeps an old balance anchor while pruning daily spend o
   assert.equal(store.peek().k.allTimeSpend, 3);
   assert.deepEqual(store.peek().k.dailySpend, { '2026-06-07': 1 });
   assert.equal(result.todaySpend, 1);
+  assert.equal(result.weekSpend, 1);
   assert.equal(result.monthSpend, 1);
   assert.equal(result.allTimeSpend, 3);
   assert.equal(result.trackingSince, new Date(old).toISOString());
@@ -221,4 +223,31 @@ test('recordConsumption: all-time spend survives daily bucket pruning', () => {
   assert.deepEqual(store.peek().k.dailySpend, { '2026-06-07': 1 });
   assert.equal(store.peek().k.allTimeSpend, 13);
   assert.equal(result.allTimeSpend, 13);
+});
+
+test('recordConsumption: week spend covers the latest seven local dates across a month boundary', () => {
+  const now = new Date(2026, 6, 2, 9, 0, 0).getTime();
+  const store = memoryStore({
+    k: {
+      version: 2,
+      currency: 'CNY',
+      trackingSince: new Date(2026, 5, 25, 9, 0, 0).getTime(),
+      lastPaid: 20,
+      allTimeSpend: 15,
+      dailySpend: {
+        '2026-06-25': 1,
+        '2026-06-26': 2,
+        '2026-06-30': 3,
+        '2026-07-01': 4,
+        '2026-07-02': 5
+      }
+    }
+  });
+
+  const result = recordConsumption({ accountKey: 'k', currency: 'CNY', paid: 20, now, storePath: '/x' }, store);
+
+  assert.equal(result.todaySpend, 5);
+  assert.equal(result.weekSpend, 14);
+  assert.equal(result.monthSpend, 9);
+  assert.equal(result.allTimeSpend, 15);
 });

--- a/tests/shared/deepseekLimits.test.js
+++ b/tests/shared/deepseekLimits.test.js
@@ -78,6 +78,7 @@ test('fetchDeepSeekLimits returns ok with balance + spend, never leaks the key',
   assert.equal(r.balance.currency, 'CNY');
   assert.equal(r.balance.amount, 7);
   assert.equal(r.balance.todaySpend, 3);
+  assert.equal(r.balance.weekSpend, 3);
   assert.equal(r.balance.allTimeSpend, 3);
   assert.equal(r.balance.trackingSince, new Date(t0).toISOString());
   assert.match(r.accountKey, /^sha256:/);

--- a/tests/shared/deepseekLimitsNormalize.test.js
+++ b/tests/shared/deepseekLimitsNormalize.test.js
@@ -18,6 +18,7 @@ test('normalizeLimitProvider accepts deepseek + api source + balance block', () 
       amount: 4.61,
       currency: 'CNY',
       todaySpend: 0.32,
+      weekSpend: 4.8,
       monthSpend: 18.4,
       allTimeSpend: 27.5,
       trackingSince: '2026-05-01T00:00:00Z',
@@ -32,6 +33,7 @@ test('normalizeLimitProvider accepts deepseek + api source + balance block', () 
   assert.equal(p.balance.amount, 4.61);
   assert.equal(p.balance.currency, 'CNY');
   assert.equal(p.balance.todaySpend, 0.32);
+  assert.equal(p.balance.weekSpend, 4.8);
   assert.equal(p.balance.allTimeSpend, 27.5);
   assert.equal(p.balance.trackingSince, '2026-05-01T00:00:00.000Z');
   assert.equal(p.balance.monthSinceTracking, true);


### PR DESCRIPTION
## Summary

- reuse the shared spend note and accessible detail tooltip for DeepSeek
- add rolling seven-local-day spend derived from the retained daily balance history
- preserve the stored all-time total while surfacing Today, Week, Month, and All time details

## Testing

- `npm run verify` (1968 passed, 1 skipped)
