### PR TITLE
fix(renderer): stop element blur from cancelling a drag

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -6396,8 +6396,13 @@ function setLimitProviderDragListeners(active) {
   window[method]('pointermove', onLimitProviderPointerMove, true);
   window[method]('pointerup', onLimitProviderPointerUp, true);
   window[method]('pointercancel', onLimitProviderDragAbort, true);
-  window[method]('blur', onLimitProviderDragAbort, true);
   window[method]('keydown', onLimitProviderDragKeydown, true);
+  // Deliberately not capture. `blur` does not bubble, so a capture listener on
+  // `window` is the standard way to observe *every* element's blur — including
+  // the one the press itself causes when focus leaves whatever the user last
+  // clicked. That cancelled the drag before it could start. Without capture only
+  // the window's own blur arrives, which is the case worth aborting on.
+  window[method]('blur', onLimitProviderDragAbort);
 }
 
 // Order matters: freeze the accordion, collapse, and only then measure. With

--- a/src/electron/renderer/trayComposer.js
+++ b/src/electron/renderer/trayComposer.js
@@ -1040,7 +1040,10 @@
       window.addEventListener('pointermove', moveDrag, true);
       window.addEventListener('pointerup', endDrag, true);
       window.addEventListener('pointercancel', cancelDrag, true);
-      window.addEventListener('blur', cancelDrag, true);
+      // Not capture: see the note on the limit provider drag. A capture `blur`
+      // listener on `window` also catches every element's blur, so the press
+      // moving focus off the last-clicked control killed the drag immediately.
+      window.addEventListener('blur', cancelDrag);
       itemEl.addEventListener('lostpointercapture', cancelDrag, { once: true });
       try { itemEl.setPointerCapture?.(event.pointerId); } catch (_) {}
     }
@@ -1105,7 +1108,7 @@
       window.removeEventListener('pointermove', moveDrag, true);
       window.removeEventListener('pointerup', endDrag, true);
       window.removeEventListener('pointercancel', cancelDrag, true);
-      window.removeEventListener('blur', cancelDrag, true);
+      window.removeEventListener('blur', cancelDrag);
       itemEl.removeEventListener('lostpointercapture', cancelDrag);
       try {
         if (itemEl.hasPointerCapture?.(pointerId)) itemEl.releasePointerCapture(pointerId);

--- a/tests/electron/limitProviderDrag.test.js
+++ b/tests/electron/limitProviderDrag.test.js
@@ -153,6 +153,17 @@ test('the drag captures the pointer and releases it before the reorder', () => {
   assert.match(body, /removeEventListener\('lostpointercapture', onLimitProviderDragAbort\)/);
 });
 
+// `blur` does not bubble, so a capture listener on `window` is the standard way
+// to observe every element's blur — which is exactly wrong here. The press moves
+// focus off whatever was clicked last, and that blur cancelled the drag before
+// it began: the first drag after opening settings or collapsing the section
+// always failed, then every later one worked because focus sat on the body.
+test('only the window own blur aborts the drag', () => {
+  const app = readRendererFile('app.js');
+  assert.match(app, /window\[method\]\('blur', onLimitProviderDragAbort\);/);
+  assert.doesNotMatch(app, /'blur', onLimitProviderDragAbort, true/);
+});
+
 test('the drag suppresses the click that would otherwise toggle the checkbox', () => {
   const app = readRendererFile('app.js');
   assert.match(app, /function suppressNextLimitProviderClick\(\)/);

--- a/tests/electron/trayComposer.test.js
+++ b/tests/electron/trayComposer.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const test = require('node:test');
 
 const trayLayoutApi = require('../../src/shared/trayLayout');
@@ -328,4 +330,17 @@ test('a custom surface keeps the editor affordances instead of a preview', () =>
   assert.equal(root.classList.contains('is-editing'), true);
   assert.equal(strip.children.at(-1).className, 'tray-composer-add');
   assert.equal(strip.children[0].children[0].textContent, 'Add your first item');
+});
+
+// A capture listener on `window` sees every element's blur, not just the
+// window's. The press moves focus off whatever was clicked last, so the chip
+// drag died on its own first pointerdown whenever a control still held focus.
+test('only the window own blur cancels the chip drag', () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'src', 'electron', 'renderer', 'trayComposer.js'),
+    'utf8'
+  );
+  assert.match(source, /window\.addEventListener\('blur', cancelDrag\);/);
+  assert.match(source, /window\.removeEventListener\('blur', cancelDrag\);/);
+  assert.doesNotMatch(source, /'blur', cancelDrag, true/);
 });


### PR DESCRIPTION
The first drag after clicking anything always failed. In the AI Tool Limits list that is one dead drag after opening settings and another after every collapse of the section; in the tray composer it is the first chip drag after pressing Customize. Every drag after the first one works, until something takes focus again.

## Cause

Both drags abort on `blur` registered with capture on `window`:

```js
window.addEventListener('blur', cancelDrag, true);
```

`blur` does not bubble, so a capture listener on `window` is the standard way to observe **every** element's blur, not the window's. That turns the abort into a self-inflicted one: `pointerdown` is dispatched and arms the gesture, then the browser runs the press's default action and moves focus off whatever was clicked last, and that element's `blur` reaches the listener a moment later. Focus then rests on `<body>`, which fires no blur, so every later press survives.

The two entry points map exactly onto the symptom — opening settings leaves the settings button focused, and collapsing or expanding a section leaves its heading button focused.

Registering without capture leaves only the window's own blur, which reaches an `AT_TARGET` listener regardless of the capture flag. That is the case the abort was written for: the app losing focus mid-drag.

## Scope

The tray composer carries the same line from #251, so its first chip drag has been failing since that shipped — the Customize button holds focus while the chips appear. Confirmed by reproduction, fixed here in the same commit. The other five preference lists drag from a handle and register no blur listener, so they were never affected.

## Verification

Reproduced and re-checked at runtime by driving an isolated Electron instance over CDP with real `Input.dispatchMouseEvent` presses, so the focus change happens as a genuine default action rather than being simulated:

| Scenario | Before | After |
|---|---|---|
| Limits, nothing focused | pass | pass |
| Limits, section heading focused | **fail** | pass |
| Limits, settings button focused | **fail** | pass |
| Tray composer, nothing focused | pass | pass |
| Tray composer, section heading focused | **fail** | pass |

The interaction suite for the limits drag grew two scenarios: one asserting a drag survives the blur of a previously focused control, one asserting a window blur still cancels it. The first fails on the unfixed build and the second passes on both, so the fix is covered without the intended behaviour being quietly dropped.

Also added source guards in `tests/electron/limitProviderDrag.test.js` and `tests/electron/trayComposer.test.js` pinning the non-capture registration, since the capture flag is the kind of detail that gets re-added while tidying a listener block.

`npm run verify` — 2000 tests, 1999 pass, 0 fail, 1 skipped.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix drag interactions to cancel only when the window loses focus, not when any element blurs. This removes the “first drag fails after clicking” bug in Limits and Tray Composer while keeping abort-on-window-blur.

- **Bug Fixes**
  - Switched `blur` listeners on `window` to non-capture in `src/electron/renderer/app.js` and `src/electron/renderer/trayComposer.js` (and matching removals).
  - Added tests to pin non-capture registration and cover behavior: drags survive prior control blur and still cancel on real window blur.
  - Verified fixes: first drag now works after opening settings, collapsing/expanding sections, and pressing Customize in the tray composer.

<sup>Written for commit 458b3b164e646c4b51f97bf4db9699a72d5e7f68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

