### PR TITLE
feat(mac): prompt to move app to Applications

### DIFF
--- a/src/electron/macosAppInstall.js
+++ b/src/electron/macosAppInstall.js
@@ -1,0 +1,62 @@
+'use strict';
+
+function shouldOfferMacAppInstall({ app, platform = process.platform } = {}) {
+  return platform === 'darwin'
+    && Boolean(app?.isPackaged)
+    && typeof app.isInApplicationsFolder === 'function'
+    && !app.isInApplicationsFolder();
+}
+
+function replaceExistingApp(dialog, appName, conflictType) {
+  const running = conflictType === 'existsAndRunning';
+  const response = dialog.showMessageBoxSync({
+    type: 'warning',
+    buttons: ['Replace', 'Cancel'],
+    defaultId: 1,
+    cancelId: 1,
+    noLink: true,
+    message: `${appName} is already in Applications`,
+    detail: running
+      ? 'The installed copy is currently open. Close it, then try moving this copy again.'
+      : 'Replace the existing copy with this one?'
+  });
+  return !running && response === 0;
+}
+
+async function offerMacAppInstall({ app, dialog, appName, platform = process.platform } = {}) {
+  if (!shouldOfferMacAppInstall({ app, platform })) return false;
+
+  const { response } = await dialog.showMessageBox({
+    type: 'question',
+    buttons: ['Move to Applications', 'Not now'],
+    defaultId: 0,
+    cancelId: 1,
+    noLink: true,
+    message: `Move ${appName} to Applications?`,
+    detail: 'This installs the app in the standard macOS location. It will reopen after the move.'
+  });
+  if (response !== 0) return false;
+
+  try {
+    // Electron copies the bundle when it is running from a read-only DMG, then
+    // relaunches the copy. The explicit conflict handler never replaces an
+    // installed app without the user's approval.
+    return app.moveToApplicationsFolder({
+      conflictHandler: (conflictType) => replaceExistingApp(dialog, appName, conflictType)
+    });
+  } catch (error) {
+    await dialog.showMessageBox({
+      type: 'error',
+      buttons: ['OK'],
+      message: `Could not move ${appName} to Applications`,
+      detail: error?.message || String(error)
+    });
+    return false;
+  }
+}
+
+module.exports = {
+  offerMacAppInstall,
+  replaceExistingApp,
+  shouldOfferMacAppInstall
+};

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -186,6 +186,7 @@ const {
   moveFloatingBubbleBounds
 } = require('./floatingBubble');
 const { applyWindowsChrome } = require('./windowsChrome');
+const { offerMacAppInstall } = require('./macosAppInstall');
 const { setMoveToActiveSpace } = require('./macosSpaceBehavior');
 const {
   WINDOWS_BACKDROP_ACCENT,
@@ -4149,9 +4150,10 @@ function rebuildWindow() {
   });
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
   if (process.platform === 'darwin' && app.dock) app.dock.setIcon(APP_ICON_PATH);
   ensureSettingsLoaded();
+  if (await offerMacAppInstall({ app, dialog, appName: APP_NAME })) return;
   session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
     callback({
       responseHeaders: {

--- a/tests/electron/macosAppInstall.test.js
+++ b/tests/electron/macosAppInstall.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  offerMacAppInstall,
+  replaceExistingApp,
+  shouldOfferMacAppInstall
+} = require('../../src/electron/macosAppInstall');
+
+function testApp({ packaged = true, inApplications = false, move = () => true } = {}) {
+  return {
+    isPackaged: packaged,
+    isInApplicationsFolder: () => inApplications,
+    moveToApplicationsFolder: move
+  };
+}
+
+function testDialog({ response = 0 } = {}) {
+  return {
+    showMessageBox: async () => ({ response }),
+    showMessageBoxSync: () => response
+  };
+}
+
+test('shouldOfferMacAppInstall only targets packaged apps outside Applications on macOS', () => {
+  assert.equal(shouldOfferMacAppInstall({ app: testApp(), platform: 'darwin' }), true);
+  assert.equal(shouldOfferMacAppInstall({ app: testApp({ inApplications: true }), platform: 'darwin' }), false);
+  assert.equal(shouldOfferMacAppInstall({ app: testApp({ packaged: false }), platform: 'darwin' }), false);
+  assert.equal(shouldOfferMacAppInstall({ app: testApp(), platform: 'win32' }), false);
+});
+
+test('offerMacAppInstall moves the app only after confirmation', async () => {
+  let moveOptions;
+  const moved = await offerMacAppInstall({
+    app: testApp({ move: (options) => { moveOptions = options; return true; } }),
+    dialog: testDialog(),
+    appName: 'Token Monitor',
+    platform: 'darwin'
+  });
+
+  assert.equal(moved, true);
+  assert.equal(typeof moveOptions.conflictHandler, 'function');
+});
+
+test('offerMacAppInstall leaves the app in place when the user declines', async () => {
+  let moveCalls = 0;
+  const moved = await offerMacAppInstall({
+    app: testApp({ move: () => { moveCalls += 1; return true; } }),
+    dialog: testDialog({ response: 1 }),
+    appName: 'Token Monitor',
+    platform: 'darwin'
+  });
+
+  assert.equal(moved, false);
+  assert.equal(moveCalls, 0);
+});
+
+test('replaceExistingApp only allows replacing a closed installed app after confirmation', () => {
+  assert.equal(replaceExistingApp(testDialog({ response: 0 }), 'Token Monitor', 'exists'), true);
+  assert.equal(replaceExistingApp(testDialog({ response: 1 }), 'Token Monitor', 'exists'), false);
+  assert.equal(replaceExistingApp(testDialog({ response: 0 }), 'Token Monitor', 'existsAndRunning'), false);
+});
+
+test('offerMacAppInstall reports a move error and continues running', async () => {
+  const messages = [];
+  const dialog = {
+    showMessageBox: async (options) => {
+      messages.push(options);
+      return { response: 0 };
+    },
+    showMessageBoxSync: () => 1
+  };
+  const moved = await offerMacAppInstall({
+    app: testApp({ move: () => { throw new Error('copy failed'); } }),
+    dialog,
+    appName: 'Token Monitor',
+    platform: 'darwin'
+  });
+
+  assert.equal(moved, false);
+  assert.equal(messages.length, 2);
+  assert.match(messages[1].message, /Could not move/);
+  assert.equal(messages[1].detail, 'copy failed');
+});


### PR DESCRIPTION
## Summary

- prompt packaged macOS builds to move into Applications when launched elsewhere
- use Electron's native move flow so the app is copied and relaunched automatically
- require confirmation before replacing an existing installation and surface move failures
- cover macOS-only gating, confirmation, conflicts, and error handling with tests

## Why

The GitHub release includes a DMG for manual installation and a ZIP required by the automatic updater. Users can bypass the DMG's drag-to-Applications view or mistakenly download the ZIP, then run the app directly from the mounted image or Downloads. Previously the app launched without explaining that it had not been installed.

## User impact

Packaged macOS builds started outside Applications now offer a native **Move to Applications** action. Development builds, other platforms, and already-installed copies are unaffected.

## Validation

- `npm run lint`
- `npm test` — 2045 passed, 1 skipped, 0 failed

## Screenshot

Not attached yet because the native prompt only appears in a signed packaged build running outside Applications; this PR remains draft for release-package smoke testing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prompt users on macOS to move the packaged app to Applications when launched from elsewhere. Uses the native move flow with conflict confirmation, auto-relaunch, and clear error handling.

- **New Features**
  - Show native “Move to Applications” when a packaged macOS build runs outside Applications.
  - Confirm before replacing an existing install; do not replace if that copy is running.
  - Auto-relaunch after a successful move; show an error message on failure.
  - Tests cover macOS gating, confirmation, conflicts, and errors.

<sup>Written for commit b795e8d13adc790708c9eb7008efa49960b8ba93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

