### PR TITLE
fix(limits): stop a missing taskkill from crashing the main process

### DIFF
--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -2375,6 +2375,13 @@ function codexLoginSpawnSpec(command, platform = process.platform) {
   };
 }
 
+// Absolute path on purpose: a bare `taskkill` is resolved through PATH, and a user
+// PATH that lost %SystemRoot%\System32 turns every tree-kill into a spawn ENOENT.
+function windowsTaskkillCommand(env = process.env) {
+  const root = env.SystemRoot || env.SYSTEMROOT || env.windir || 'C:\\Windows';
+  return path.win32.join(root, 'System32', 'taskkill.exe');
+}
+
 function killCodexLoginProcess(child, platform = process.platform, deps = {}) {
   if (!child || typeof child.kill !== 'function') return;
   const spawnFn = deps.spawn || spawn;
@@ -2382,7 +2389,17 @@ function killCodexLoginProcess(child, platform = process.platform, deps = {}) {
     // Login spawns a browser/callback helper, so kill the whole tree, not just codex.
     if (platform === 'win32') {
       if (child.pid) {
-        try { spawnFn('taskkill', ['/pid', String(child.pid), '/t', '/f'], { windowsHide: true }); } catch (_) {}
+        try {
+          const killer = spawnFn(
+            windowsTaskkillCommand(deps.env || process.env),
+            ['/pid', String(child.pid), '/t', '/f'],
+            { windowsHide: true }
+          );
+          // spawn() reports a missing or blocked taskkill.exe asynchronously as an
+          // 'error' event, so the enclosing try/catch never sees it. Without a
+          // listener the EventEmitter rethrows and crashes the main process.
+          killer?.on?.('error', () => {});
+        } catch (_) {}
       }
       child.kill();
       return;
@@ -2440,7 +2457,7 @@ function runCodexLoginWithCommand(command, options = {}, deps = {}) {
       resolve({ outcome, exitCode: exitCode ?? null, output: output.trim() });
     };
     const onAbort = () => {
-      killCodexLoginProcess(child, platform, { spawn: spawnFn });
+      killCodexLoginProcess(child, platform, { spawn: spawnFn, env });
       finish('cancelled', null);
     };
     child.stdout?.on('data', append);
@@ -2453,7 +2470,7 @@ function runCodexLoginWithCommand(command, options = {}, deps = {}) {
       return;
     }
     timer = setTimer(() => {
-      killCodexLoginProcess(child, platform, { spawn: spawnFn });
+      killCodexLoginProcess(child, platform, { spawn: spawnFn, env });
       finish('timedOut', null);
     }, timeoutMs);
   });

--- a/tests/shared/limitCollector.codexLogin.test.js
+++ b/tests/shared/limitCollector.codexLogin.test.js
@@ -15,6 +15,10 @@ function fakeChild() {
   return child;
 }
 
+function isTaskkill(command) {
+  return /taskkill(\.exe)?$/i.test(String(command));
+}
+
 // A no-op timer so the success/failure paths never arm a real timeout.
 const noopTimers = { setTimeout: () => 0, clearTimeout: () => {} };
 
@@ -181,9 +185,9 @@ test('runCodexLogin tree-kills the login process with taskkill on Windows timeou
     {
       platform: 'win32',
       codexCommand: 'codex.cmd',
-      env: {},
+      env: { SystemRoot: 'D:\\Windows' },
       spawn: (command, args) => {
-        if (command === 'taskkill') { killCalls.push(args); return fakeChild(); }
+        if (isTaskkill(command)) { killCalls.push({ command, args }); return fakeChild(); }
         return child;
       },
       setTimeout: (cb) => { timeoutCb = cb; return 9; },
@@ -196,7 +200,41 @@ test('runCodexLogin tree-kills the login process with taskkill on Windows timeou
 
   assert.equal(result.outcome, 'timedOut');
   assert.equal(killCalls.length, 1);
-  assert.deepEqual(killCalls[0], ['/pid', '4321', '/t', '/f']);
+  // Absolute path, so a user PATH that lost System32 can't make this ENOENT.
+  assert.equal(killCalls[0].command, 'D:\\Windows\\System32\\taskkill.exe');
+  assert.deepEqual(killCalls[0].args, ['/pid', '4321', '/t', '/f']);
+});
+
+test('runCodexLogin survives a taskkill spawn that fails with ENOENT', async () => {
+  let timeoutCb = null;
+  let killer = null;
+  const child = fakeChild();
+  child.pid = 4321;
+  const promise = runCodexLogin(
+    { homePath: 'C:/managed/home', timeoutMs: 50 },
+    {
+      platform: 'win32',
+      codexCommand: 'codex.cmd',
+      env: {},
+      spawn: (command) => {
+        if (isTaskkill(command)) { killer = fakeChild(); return killer; }
+        return child;
+      },
+      setTimeout: (cb) => { timeoutCb = cb; return 9; },
+      clearTimeout: () => {}
+    }
+  );
+
+  timeoutCb();
+  const result = await promise;
+
+  assert.equal(result.outcome, 'timedOut');
+  assert.equal(child.killed, true);
+  // Node reports a missing taskkill.exe asynchronously as an 'error' event on the
+  // spawned child, so the caller's try/catch never sees it. With no listener the
+  // EventEmitter rethrows and takes the Electron main process down (issue #288).
+  const enoent = Object.assign(new Error('spawn taskkill ENOENT'), { code: 'ENOENT' });
+  assert.doesNotThrow(() => killer.emit('error', enoent));
 });
 
 test('runCodexLogin reports launchFailed when spawning throws', async () => {


### PR DESCRIPTION
Fixes #288.

## The crash

`killCodexLoginProcess()` tree-kills on Windows with a fire-and-forget `spawn('taskkill', …)` wrapped in `try/catch`. That wrapper cannot work: `spawn()` reports an unresolvable executable **asynchronously**, as an `'error'` event on the returned child, never as a synchronous throw. Nothing listened for it, so the EventEmitter rethrew and Electron showed its "A JavaScript error occurred in the main process" dialog with the exact stack from the issue:

```
Error: spawn taskkill ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:287:19)
    at onErrorNT (node:internal/child_process:508:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
```

Two things made this worse than it looks:

- **It is not confined to `codex login`.** `readCodexRpcWithCommand()` calls the same helper in its `finally`, so *every* Codex limits probe on Windows went through it — the live CLI account as well as managed ones. On an affected machine the dialog reappears every refresh cycle.
- **The macOS/Linux branch is genuinely safe**, which is probably why the gap went unnoticed: it uses `process.kill()`, which *does* throw synchronously and *is* caught.

`taskkill.exe` lives in `%SystemRoot%\System32`; the bare command name is resolved through `PATH`, so any user whose `PATH` has lost System32 hits ENOENT every time.

## The fix

1. Attach a no-op `'error'` listener to the spawned killer. `child.kill()` already ran regardless of the taskkill outcome, so the worst-case degradation is a single-process kill instead of a tree kill — no crash either way.
2. Resolve taskkill as `%SystemRoot%\System32\taskkill.exe` (falling back to `C:\Windows`) instead of relying on `PATH`, so the ENOENT stops happening in the first place and tree-kill keeps working on affected machines. `env` is now threaded into the two login call sites so an injected env is honoured.

I audited every other `spawn` call site in `src/shared/` (collector, cursorAuth, kiroLimits, grokLimits, antigravityProbe, tokscaleUpdater) — all of them attach an `'error'` handler. This was the only one that did not, so it is a single point fix rather than a systemic pattern.

## Tests

Both tests were written first and watched fail:

- `runCodexLogin survives a taskkill spawn that fails with ENOENT` — new; failed with `Got unwanted exception: "spawn taskkill ENOENT"` before the fix.
- `runCodexLogin tree-kills the login process with taskkill on Windows timeout` — updated to assert the absolute System32 path; failed with `actual: 'taskkill'` before the fix.

`npm run verify` — lint clean, 2050 passing / 0 failing / 1 pre-existing skip.

No UI change, so no screenshots.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a Windows-only main-process crash when `taskkill` isn’t found by handling `spawn()` errors and resolving `taskkill.exe` via `%SystemRoot%\System32`. Keeps tree-kill working even with a broken `PATH` and stops repeated crashes during Codex limits probes. Fixes #288.

- **Bug Fixes**
  - Attach a no-op `'error'` listener to the spawned `taskkill` process to avoid unhandled ENOENT.
  - Resolve `taskkill.exe` from `%SystemRoot%\System32` (fallback `C:\Windows`) instead of `PATH`; thread `env` into call sites.
  - Maintain `child.kill()` as a fallback so worst case is a single-process kill.
  - Add tests for ENOENT handling and absolute `taskkill.exe` path.

<sup>Written for commit 12bc70790c6d421216351429b6fd40706ad5c9bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

