### PR TITLE
fix(limits): read MiMo and Kimi quota ratios as ratios

### DIFF
--- a/src/shared/kimiLimits.js
+++ b/src/shared/kimiLimits.js
@@ -285,11 +285,24 @@ function objectAt(body, keys) {
   return null;
 }
 
-function ratioPercent(value) {
+// Every caller passes one of Kimi's `*Ratio` fields, which are 0-1 fractions.
+// A value past 1 therefore means the quota is over-consumed, not that the API
+// switched to a 0-100 scale — guessing the latter turns a spent window into a
+// nearly full one (see the MiMo report in #292). Kept unclamped here so callers
+// that combine two ratios can do the arithmetic before saturating.
+function rawRatioPercent(value) {
   const ratio = numberOrNull(value);
   if (ratio === null || ratio < 0) return null;
-  const percent = ratio <= 1 ? ratio * 100 : ratio;
-  return Math.max(0, Math.min(100, percent));
+  return ratio * 100;
+}
+
+function clampPercent(value) {
+  return Math.max(0, Math.min(100, value));
+}
+
+function ratioPercent(value) {
+  const percent = rawRatioPercent(value);
+  return percent === null ? null : clampPercent(percent);
 }
 
 function ratioLabel(value) {
@@ -340,13 +353,19 @@ function parseKimiMembershipStats(rawBody) {
     && (!feature || feature === 'FEATURE_OMNI')
     && (!type || type === 'SUBSCRIPTION');
   if (compatibleBalance) {
-    const usedPercent = ratioPercent(balance.amountUsedRatio ?? balance.amount_used_ratio);
-    if (usedPercent !== null) {
-      const codeUsedPercent = ratioPercent(balance.kimiCodeUsedRatio ?? balance.kimi_code_used_ratio);
-      const safeCodePercent = codeUsedPercent === null ? null : Math.min(usedPercent, codeUsedPercent);
+    const rawUsedPercent = rawRatioPercent(balance.amountUsedRatio ?? balance.amount_used_ratio);
+    if (rawUsedPercent !== null) {
+      const usedPercent = clampPercent(rawUsedPercent);
+      // The meter saturates at 100%, but this breakdown is plain text and every
+      // number in it means "share of the monthly pool". Clamping the parts too
+      // would report a spend the account never made (and collapse the Kimi side
+      // to zero against a capped Code), so an over-consumed pool reads honestly
+      // as `Code 120%` instead.
+      const rawCodePercent = rawRatioPercent(balance.kimiCodeUsedRatio ?? balance.kimi_code_used_ratio);
+      const safeCodePercent = rawCodePercent === null ? null : Math.min(rawUsedPercent, rawCodePercent);
       const detail = safeCodePercent === null
         ? ''
-        : `Kimi ${ratioLabel(Math.max(0, usedPercent - safeCodePercent))}% · Code ${ratioLabel(safeCodePercent)}%`;
+        : `Kimi ${ratioLabel(Math.max(0, rawUsedPercent - safeCodePercent))}% · Code ${ratioLabel(safeCodePercent)}%`;
       windows.push({
         kind: 'billing',
         label: 'Monthly',

--- a/src/shared/mimoLimits.js
+++ b/src/shared/mimoLimits.js
@@ -81,11 +81,19 @@ function unwrapApiBody(value) {
   return value.data && typeof value.data === 'object' ? value.data : value;
 }
 
+// MiMo reports `percent` as a 0-1 ratio, so it overshoots 1 once the request
+// that exhausts the plan pushes used past limit. Inferring the scale from the
+// value ("<= 1 must be a ratio, above that must already be a percentage") reads
+// that 1.005 as 1% used and paints a spent plan as 99% left (#292), so treat
+// the field as the ratio it is — and prefer used/limit, which carry no scale
+// ambiguity at all, whenever the item reports both.
 function normalizePercent(value, used, limit) {
+  if (used !== null && limit !== null && limit > 0) {
+    return Math.max(0, Math.min(100, (used / limit) * 100));
+  }
   const explicit = numberFrom(value);
-  if (explicit !== null) return Math.max(0, Math.min(100, explicit <= 1 ? explicit * 100 : explicit));
-  if (used !== null && limit !== null && limit > 0) return Math.max(0, Math.min(100, (used / limit) * 100));
-  return null;
+  if (explicit === null) return null;
+  return Math.max(0, Math.min(100, explicit * 100));
 }
 
 function parseMimoBalance(body) {

--- a/tests/shared/kimiLimits.test.js
+++ b/tests/shared/kimiLimits.test.js
@@ -51,6 +51,27 @@ test('parseKimiMembershipStats returns 5-hour, weekly, and one shared monthly wi
   assert.equal(usage.windows[2].detail, 'Kimi 11.12% · Code 5%');
 });
 
+test('parseKimiMembershipStats treats a ratio above 1 as an exhausted window', () => {
+  // These fields are ratios, so anything past 1 is over-consumption. Reading an
+  // out-of-range value as an already-scaled percentage flipped a spent quota
+  // into a nearly full one (the MiMo shape of #292).
+  const usage = parseKimiMembershipStats({
+    ratelimitCode5h: { ratio: 1.02, enabled: true },
+    subscriptionBalance: {
+      feature: 'FEATURE_OMNI',
+      type: 'SUBSCRIPTION',
+      amountUsedRatio: 1.5,
+      kimiCodeUsedRatio: 1.2
+    }
+  });
+
+  assert.deepEqual(usage.windows.map((window) => window.usedPercent), [100, 100]);
+  assert.deepEqual(usage.windows.map((window) => window.remainingPercent), [0, 0]);
+  // Only the meter saturates. The breakdown keeps both real shares, so the
+  // Kimi side isn't erased and Code isn't credited with a spend it never made.
+  assert.equal(usage.windows[1].detail, 'Kimi 30% · Code 120%');
+});
+
 test('parseKimiUsage accepts snake_case / *Value detail and window field aliases', () => {
   // Real-world APIs in this codebase frequently mix camelCase and snake_case
   // (Qoder's usedValue/limitValue, z.ai's currentValue, etc). Kimi's

--- a/tests/shared/mimoLimits.test.js
+++ b/tests/shared/mimoLimits.test.js
@@ -93,6 +93,25 @@ test('MiMo parsers match the official balance and Token Plan shapes', () => {
   });
 });
 
+test('MiMo usage parser reads an over-consumed plan as fully used', () => {
+  // MiMo reports `percent` as a 0-1 ratio, and a spent plan overshoots it: the
+  // request that exhausts the quota pushes used past limit, so percent lands at
+  // 1.005. Reading that as "1% used" rendered an empty plan as 99% left (#292).
+  assert.deepEqual(parseMimoPlanUsage({ data: { monthUsage: { items: [{
+    name: 'month_total_token', used: 10_050_000, limit: 10_000_000, percent: 1.005
+  }] } } }), { used: 10_050_000, limit: 10_000_000, usedPercent: 100 });
+  // Same overshoot with no `used` to fall back on.
+  assert.deepEqual(parseMimoPlanUsage({ data: { monthUsage: { items: [{
+    name: 'month_total_token', limit: 10_000_000, percent: 1.02
+  }] } } }), { used: null, limit: 10_000_000, usedPercent: 100 });
+});
+
+test('MiMo usage parser prefers used/limit over the reported ratio', () => {
+  assert.deepEqual(parseMimoPlanUsage({ data: { monthUsage: { items: [{
+    name: 'month_total_token', used: 25, limit: 100, percent: 0.9
+  }] } } }), { used: 25, limit: 100, usedPercent: 25 });
+});
+
 test('MiMo usage parser selects only the exact month_total_token item', () => {
   assert.deepEqual(parseMimoPlanUsage({ data: { monthUsage: { items: [
     { name: 'model_a', used: 10, limit: 100 },
@@ -164,6 +183,28 @@ test('fetchMimoLimits requests fixed official endpoints concurrently with minimi
   for (const call of calls) {
     assert.equal(call.cookie, 'api-platform_ph=optional; api-platform_serviceToken=secret; userId=123');
   }
+});
+
+test('fetchMimoLimits reports an exhausted Token Plan as 0% left', async () => {
+  const [provider] = await fetchMimoLimits({ mimoManagedAccounts: [managed()] }, {
+    fetch: async (url) => {
+      if (url.endsWith('/balance')) return response({ code: 0, data: { balance: '0.34', currency: 'USD' } });
+      if (url.endsWith('/tokenPlan/detail')) return response({ code: 0, data: {
+        planCode: 'MiMo Lite', status: 'active', currentPeriodEnd: '2099-01-01 00:00:00'
+      } });
+      if (url.endsWith('/tokenPlan/usage')) return response({ code: 0, data: {
+        monthUsage: { items: [{
+          name: 'month_total_token', used: 10_050_000, limit: 10_000_000, percent: 1.005
+        }] }
+      } });
+      return response({ code: 0, data: {} });
+    }
+  });
+  const [plan] = planWindows(provider);
+  assert.equal(plan.usedPercent, 100);
+  assert.equal(plan.remainingPercent, 0);
+  assert.equal(plan.remaining, 0);
+  assert.equal(provider.balance.planPercent, 100);
 });
 
 test('fetchMimoLimits keeps balance when optional Token Plan endpoints fail', async () => {


### PR DESCRIPTION
A MiMo Token Plan that had been fully consumed rendered as `99% left`.

MiMo reports Token Plan usage as a 0-1 ratio, and the request that exhausts a plan pushes `used` past `limit`, so the ratio lands just above 1. Both the MiMo and Kimi collectors inferred the field's scale from its value (`ratio <= 1 ? ratio * 100 : ratio`) and read anything above 1 as an already-scaled percentage, so `1.0025` became "1% used". That heuristic is also the reason the bug stayed hidden: a plan sitting exactly at its limit still reports `1.0` and reads correctly, so only an overshoot flips the meter.

## Changes

- MiMo derives the percentage from `used` / `limit` whenever the item reports both, since those carry no scale ambiguity, and falls back to the ratio otherwise. The aggregate item reports both in practice, so the primary path is what runs.
- Kimi has no `used` / `limit` companion, so it treats its `*Ratio` fields as the fractions they are.
- Kimi's monthly breakdown splits the pool before saturating. Clamping both parts first collapsed the difference to zero, which credited the entire spend to Code and erased the Kimi side's real share. Only the meter saturates now; the text keeps both true values.

## Behaviour

Verified by running the old and new parsers side by side. Four of the six cases are unchanged; only inputs above 100% move.

| Case | Input | Before | After |
|---|---|---|---|
| MiMo normal | 50M / 200M, `percent 0.25` | `75.00% left` | `75.00% left` |
| MiMo exactly spent | 200M / 200M, `percent 1.0` | `0% left` | `0% left` |
| **MiMo over-consumed** | 200.5M / 200M, `percent 1.0025` | **`99.00% left`** | **`0% left`** |
| MiMo ratio-only fallback | no `used`, `percent 1.02` | `98.98% left` | `0% left` |
| Kimi normal | pool 0.1612 / code 0.05 | `83.88% left`, `Kimi 11.12% · Code 5%` | unchanged |
| **Kimi over-consumed** | pool 1.5 / code 1.2 | `98.50% left`, `Kimi 0.3% · Code 1.2%` | `0% left`, `Kimi 30% · Code 120%` |

## Testing

`npm run verify`: lint clean, 2058 tests, 2057 pass, 1 skip, 0 fail.

Four new cases cover the MiMo overshoot with and without `used`, `used` / `limit` winning over a conflicting ratio, the end-to-end MiMo record for the reported scenario, and the Kimi over-consumed split.

Fixes #292
