### PR TITLE
fix(sessions): read WSL session details on Windows

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -2,7 +2,6 @@
 
 const fs = require('node:fs');
 const crypto = require('node:crypto');
-const os = require('node:os');
 const path = require('node:path');
 const { app, BrowserWindow, clipboard, dialog, globalShortcut, ipcMain, nativeImage, net, Notification, screen, session, shell } = require('electron');
 const { autoUpdater } = require('electron-updater');
@@ -124,7 +123,7 @@ const {
   normalizeMimoCookieHeader
 } = require('../shared/mimoLimits');
 const { historyPreview, historyRevision } = require('../shared/history');
-const { readSessionDetail } = require('../shared/sessionDetail');
+const { readSessionDetailForPlatform } = require('../shared/sessionDetailResolver');
 const { startDiscordRpc, stopDiscordRpc, updateDiscordRpc } = require('./discordRpc');
 const linuxAutostart = require('./linuxAutostart');
 const { codexAccountIdForProvider, localLiveCodexProvider } = require('./renderer/accountIdentity');
@@ -4563,7 +4562,7 @@ app.whenReady().then(() => {
   });
   ipcMain.handle('session:getDetail', (_event, args) => {
     const { client, sessionId, period, sessionCost } = args || {};
-    return readSessionDetail({ client, sessionId, period, sessionCost, home: os.homedir() });
+    return readSessionDetailForPlatform({ client, sessionId, period, sessionCost });
   });
   ipcMain.handle('stream:status', () => ({ connected: streamConnected, mode, ...(streamFailure || {}) }));
   ipcMain.handle('serviceStatus:get', (_event, options) => serviceStatusClient.getServiceStatus({

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -3725,16 +3725,17 @@ function stopServiceStatusTicker() {
 }
 
 async function openSessionDetail({ client, sessionId, sessionCost, title }) {
-  state.openSession = { client, sessionId, sessionCost, title, detail: null };
+  const request = { client, sessionId, sessionCost, title, period: state.period, detail: null };
+  state.openSession = request;
   renderSessionDetail({ loading: true });
   try {
-    const detail = await window.tokenMonitor.getSessionDetail({ client, sessionId, period: state.period, sessionCost });
-    if (state.openSession && state.openSession.sessionId === sessionId) {
-      state.openSession.detail = detail;
+    const detail = await window.tokenMonitor.getSessionDetail({ client, sessionId, period: request.period, sessionCost });
+    if (state.openSession === request) {
+      request.detail = detail;
       renderSessionDetail({ detail });
     }
   } catch (_) {
-    if (state.openSession && state.openSession.sessionId === sessionId) renderSessionDetail({ error: true });
+    if (state.openSession === request) renderSessionDetail({ error: true });
   }
 }
 

--- a/src/shared/sessionDetailResolver.js
+++ b/src/shared/sessionDetailResolver.js
@@ -7,6 +7,7 @@ const { readSessionDetail } = require('./sessionDetail');
 const { wslUsageHomes } = require('./wslUsage');
 
 const WSL_JSONL_CLIENTS = new Set(['claude', 'codex']);
+const SESSION_DETAIL_WORKER_TIMEOUT_MS = 20_000;
 
 function resolveSessionDetailForPlatform(args = {}, deps = {}) {
   const readDetail = deps.readSessionDetail || readSessionDetail;
@@ -45,16 +46,39 @@ function workerError(payload) {
 function runSessionDetailWorker(args = {}, deps = {}) {
   const WorkerClass = deps.Worker || Worker;
   const workerPath = deps.workerPath || require.resolve('./sessionDetailWorker');
+  const configuredTimeoutMs = Number(deps.timeoutMs ?? SESSION_DETAIL_WORKER_TIMEOUT_MS);
+  const timeoutMs = Number.isFinite(configuredTimeoutMs) && configuredTimeoutMs > 0
+    ? Math.trunc(configuredTimeoutMs)
+    : SESSION_DETAIL_WORKER_TIMEOUT_MS;
+  const setTimer = deps.setTimeout || setTimeout;
+  const clearTimer = deps.clearTimeout || clearTimeout;
 
   return new Promise((resolve, reject) => {
     const worker = new WorkerClass(workerPath, { workerData: args });
     let settled = false;
+    let timer = null;
 
     function finish(callback, value) {
       if (settled) return;
       settled = true;
+      if (timer !== null) {
+        clearTimer(timer);
+        timer = null;
+      }
       callback(value);
     }
+
+    function terminateWorker() {
+      try {
+        const termination = worker.terminate();
+        termination?.catch?.(() => {});
+      } catch (_) {}
+    }
+
+    timer = setTimer(() => {
+      finish(reject, new Error(`Session detail worker timed out after ${timeoutMs}ms`));
+      terminateWorker();
+    }, timeoutMs);
 
     worker.once('message', (message) => {
       if (message?.ok) finish(resolve, message.detail);
@@ -73,4 +97,8 @@ function readSessionDetailForPlatform(args = {}, deps = {}) {
   return runSessionDetailWorker(args, deps);
 }
 
-module.exports = { readSessionDetailForPlatform, resolveSessionDetailForPlatform, runSessionDetailWorker };
+module.exports = {
+  readSessionDetailForPlatform,
+  resolveSessionDetailForPlatform,
+  runSessionDetailWorker
+};

--- a/src/shared/sessionDetailResolver.js
+++ b/src/shared/sessionDetailResolver.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const os = require('node:os');
+
+const { readSessionDetail } = require('./sessionDetail');
+const { wslUsageHomes } = require('./wslUsage');
+
+const WSL_JSONL_CLIENTS = new Set(['claude', 'codex']);
+
+function readSessionDetailForPlatform(args = {}, deps = {}) {
+  const readDetail = deps.readSessionDetail || readSessionDetail;
+  const nativeHome = (deps.homedir || os.homedir)();
+  const nativeDetail = readDetail({ ...args, home: nativeHome });
+  const platform = deps.platform || process.platform;
+
+  if (nativeDetail.found || platform !== 'win32' || !WSL_JSONL_CLIENTS.has(args.client)) {
+    return nativeDetail;
+  }
+
+  let wslHomes;
+  try {
+    wslHomes = (deps.wslUsageHomes || wslUsageHomes)();
+  } catch (_) {
+    return nativeDetail;
+  }
+
+  const searched = new Set([nativeHome]);
+  for (const home of wslHomes || []) {
+    if (!home || searched.has(home)) continue;
+    searched.add(home);
+    const detail = readDetail({ ...args, home });
+    if (detail.found) return detail;
+  }
+  return nativeDetail;
+}
+
+module.exports = { readSessionDetailForPlatform };

--- a/src/shared/sessionDetailResolver.js
+++ b/src/shared/sessionDetailResolver.js
@@ -1,13 +1,14 @@
 'use strict';
 
 const os = require('node:os');
+const { Worker } = require('node:worker_threads');
 
 const { readSessionDetail } = require('./sessionDetail');
 const { wslUsageHomes } = require('./wslUsage');
 
 const WSL_JSONL_CLIENTS = new Set(['claude', 'codex']);
 
-function readSessionDetailForPlatform(args = {}, deps = {}) {
+function resolveSessionDetailForPlatform(args = {}, deps = {}) {
   const readDetail = deps.readSessionDetail || readSessionDetail;
   const nativeHome = (deps.homedir || os.homedir)();
   const nativeDetail = readDetail({ ...args, home: nativeHome });
@@ -34,4 +35,42 @@ function readSessionDetailForPlatform(args = {}, deps = {}) {
   return nativeDetail;
 }
 
-module.exports = { readSessionDetailForPlatform };
+function workerError(payload) {
+  const error = new Error(payload?.message || 'Session detail worker failed');
+  if (payload?.name) error.name = payload.name;
+  if (payload?.stack) error.stack = payload.stack;
+  return error;
+}
+
+function runSessionDetailWorker(args = {}, deps = {}) {
+  const WorkerClass = deps.Worker || Worker;
+  const workerPath = deps.workerPath || require.resolve('./sessionDetailWorker');
+
+  return new Promise((resolve, reject) => {
+    const worker = new WorkerClass(workerPath, { workerData: args });
+    let settled = false;
+
+    function finish(callback, value) {
+      if (settled) return;
+      settled = true;
+      callback(value);
+    }
+
+    worker.once('message', (message) => {
+      if (message?.ok) finish(resolve, message.detail);
+      else finish(reject, workerError(message?.error));
+    });
+    worker.once('messageerror', (error) => finish(reject, error));
+    worker.once('error', (error) => finish(reject, error));
+    worker.once('exit', (code) => {
+      const suffix = code === 0 ? 'without returning a result' : `with code ${code}`;
+      finish(reject, new Error(`Session detail worker exited ${suffix}`));
+    });
+  });
+}
+
+function readSessionDetailForPlatform(args = {}, deps = {}) {
+  return runSessionDetailWorker(args, deps);
+}
+
+module.exports = { readSessionDetailForPlatform, resolveSessionDetailForPlatform, runSessionDetailWorker };

--- a/src/shared/sessionDetailWorker.js
+++ b/src/shared/sessionDetailWorker.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const { parentPort, workerData } = require('node:worker_threads');
+
+const { resolveSessionDetailForPlatform } = require('./sessionDetailResolver');
+
+try {
+  const detail = resolveSessionDetailForPlatform(workerData);
+  parentPort.postMessage({ ok: true, detail });
+} catch (error) {
+  parentPort.postMessage({
+    ok: false,
+    error: {
+      name: error?.name,
+      message: error?.message,
+      stack: error?.stack
+    }
+  });
+}

--- a/src/shared/sessionFiles.js
+++ b/src/shared/sessionFiles.js
@@ -38,7 +38,9 @@ function resolveSessionFile(client, sessionId, home) {
   const id = String(sessionId || '');
   if (!id) return '';
   if (client === 'claude') {
-    return findSessionFiles(path.join(home, '.claude', 'projects'), [id]).get(id) || '';
+    const projectFile = findSessionFiles(path.join(home, '.claude', 'projects'), [id]).get(id);
+    if (projectFile) return projectFile;
+    return findSessionFiles(path.join(home, '.claude', 'transcripts'), [id]).get(id) || '';
   }
   if (client === 'codex') {
     const direct = codexSessionFile(home, id);

--- a/tests/electron/sessionDetail.test.js
+++ b/tests/electron/sessionDetail.test.js
@@ -1,9 +1,42 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const test = require('node:test');
+const vm = require('node:vm');
 
 const { exchangeRows, formatToolList } = require('../../src/electron/renderer/sessionDetail');
+
+const rendererSource = fs.readFileSync(path.join(__dirname, '../../src/electron/renderer/app.js'), 'utf8');
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function sessionDetailHarness(getSessionDetail) {
+  const start = rendererSource.indexOf('async function openSessionDetail(');
+  const end = rendererSource.indexOf('\nfunction toggleDetailSort', start);
+  assert.ok(start >= 0 && end > start, 'openSessionDetail should be present');
+  const renders = [];
+  const state = { period: 'today', openSession: null };
+  const context = {
+    state,
+    renderSessionDetail: (args) => renders.push(args),
+    window: { tokenMonitor: { getSessionDetail } }
+  };
+  vm.runInNewContext(
+    `${rendererSource.slice(start, end)}\nglobalThis.testOpenSessionDetail = openSessionDetail;`,
+    context
+  );
+  return { openSessionDetail: context.testOpenSessionDetail, renders, state };
+}
 
 const detail = {
   found: true,
@@ -57,4 +90,32 @@ test('exchangeRows sorts by tokens when sortBy=tokens', () => {
 test('formatToolList dedupes and truncates', () => {
   assert.equal(formatToolList(['Read', 'Read', 'Bash']), 'Read · Bash');
   assert.equal(formatToolList([]), '');
+});
+
+test('openSessionDetail ignores a stale period result that completes last', async () => {
+  const pending = [];
+  const requests = [];
+  const { openSessionDetail, renders, state } = sessionDetailHarness((args) => {
+    const job = deferred();
+    requests.push(args);
+    pending.push(job);
+    return job.promise;
+  });
+  const session = { client: 'claude', sessionId: 'same-session', sessionCost: 0.25, title: 'Session' };
+
+  const todayRequest = openSessionDetail(session);
+  state.period = 'month';
+  const monthRequest = openSessionDetail(session);
+
+  assert.equal(requests[0].period, 'today');
+  assert.equal(requests[1].period, 'month');
+
+  pending[1].resolve({ found: true, marker: 'month' });
+  await monthRequest;
+  pending[0].resolve({ found: true, marker: 'today' });
+  await todayRequest;
+
+  assert.equal(state.openSession.period, 'month');
+  assert.equal(state.openSession.detail.marker, 'month');
+  assert.deepEqual(renders.filter((render) => render.detail).map((render) => render.detail.marker), ['month']);
 });

--- a/tests/fixtures/sessionDetailThreadWorker.js
+++ b/tests/fixtures/sessionDetailThreadWorker.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { parentPort, threadId, workerData } = require('node:worker_threads');
+
+parentPort.postMessage({ ok: true, detail: { ...workerData, threadId } });

--- a/tests/shared/sessionDetailResolver.test.js
+++ b/tests/shared/sessionDetailResolver.test.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const { readSessionDetailForPlatform } = require('../../src/shared/sessionDetailResolver');
+
+function missing(args) {
+  return { found: false, client: args.client, sessionId: args.sessionId, exchanges: [] };
+}
+
+test('reads a Claude transcript from a discovered WSL home', (t) => {
+  const nativeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-native-detail-'));
+  const wslHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-wsl-detail-'));
+  t.after(() => fs.rmSync(nativeHome, { recursive: true, force: true }));
+  t.after(() => fs.rmSync(wslHome, { recursive: true, force: true }));
+  const sessionId = 'wsl-session';
+  const transcriptDir = path.join(wslHome, '.claude', 'projects', '-workspace');
+  fs.mkdirSync(transcriptDir, { recursive: true });
+  fs.writeFileSync(path.join(transcriptDir, `${sessionId}.jsonl`), [
+    JSON.stringify({ type: 'user', timestamp: '2026-07-31T00:00:00.000Z', message: { content: 'from WSL' } }),
+    JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-07-31T00:00:01.000Z',
+      message: {
+        usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 2, cache_creation_input_tokens: 1 },
+        content: []
+      }
+    })
+  ].join('\n'));
+
+  const detail = readSessionDetailForPlatform(
+    { client: 'claude', sessionId, period: 'total', sessionCost: 0.25 },
+    {
+      platform: 'win32',
+      homedir: () => nativeHome,
+      wslUsageHomes: () => [wslHome]
+    }
+  );
+
+  assert.equal(detail.found, true);
+  assert.equal(detail.exchanges[0].promptPreview, 'from WSL');
+  assert.equal(detail.totals.totalTokens, 18);
+  assert.equal(detail.totals.costUsd, 0.25);
+});
+
+test('returns a native Claude detail without enumerating WSL homes', () => {
+  let enumerated = false;
+  const detail = readSessionDetailForPlatform(
+    { client: 'claude', sessionId: 'native' },
+    {
+      platform: 'win32',
+      homedir: () => 'C:\\Users\\me',
+      readSessionDetail: (args) => ({ ...missing(args), found: true, home: args.home }),
+      wslUsageHomes: () => { enumerated = true; return []; }
+    }
+  );
+
+  assert.equal(detail.found, true);
+  assert.equal(detail.home, 'C:\\Users\\me');
+  assert.equal(enumerated, false);
+});
+
+for (const client of ['claude', 'codex']) {
+  test(`falls back to running WSL homes for ${client} JSONL details on Windows`, () => {
+    const homes = [];
+    const detail = readSessionDetailForPlatform(
+      { client, sessionId: 'wsl-session' },
+      {
+        platform: 'win32',
+        homedir: () => 'C:\\Users\\me',
+        readSessionDetail: (args) => {
+          homes.push(args.home);
+          return args.home.endsWith('\\ubuntu') ? { ...missing(args), found: true, home: args.home } : missing(args);
+        },
+        wslUsageHomes: () => ['\\\\wsl$\\Ubuntu\\home\\first', '\\\\wsl$\\Ubuntu\\home\\ubuntu']
+      }
+    );
+
+    assert.equal(detail.found, true);
+    assert.equal(detail.home, '\\\\wsl$\\Ubuntu\\home\\ubuntu');
+    assert.deepEqual(homes, [
+      'C:\\Users\\me',
+      '\\\\wsl$\\Ubuntu\\home\\first',
+      '\\\\wsl$\\Ubuntu\\home\\ubuntu'
+    ]);
+  });
+}
+
+test('does not inspect WSL homes for non-Windows or SQLite-backed clients', () => {
+  for (const [platform, client] of [['linux', 'claude'], ['win32', 'opencode']]) {
+    let enumerated = false;
+    const detail = readSessionDetailForPlatform(
+      { client, sessionId: 'missing' },
+      {
+        platform,
+        homedir: () => '/native',
+        readSessionDetail: missing,
+        wslUsageHomes: () => { enumerated = true; return ['should-not-run']; }
+      }
+    );
+
+    assert.equal(detail.found, false);
+    assert.equal(enumerated, false);
+  }
+});
+
+test('returns the native not-found result when WSL discovery fails', () => {
+  const nativeDetail = { found: false, client: 'claude', sessionId: 'missing', exchanges: [], marker: 'native' };
+  const detail = readSessionDetailForPlatform(
+    { client: 'claude', sessionId: 'missing' },
+    {
+      platform: 'win32',
+      homedir: () => 'C:\\Users\\me',
+      readSessionDetail: () => nativeDetail,
+      wslUsageHomes: () => { throw new Error('WSL unavailable'); }
+    }
+  );
+
+  assert.equal(detail, nativeDetail);
+});

--- a/tests/shared/sessionDetailResolver.test.js
+++ b/tests/shared/sessionDetailResolver.test.js
@@ -197,6 +197,34 @@ test('the production worker entry returns session detail', async () => {
   });
 });
 
+test('terminates and rejects a session detail worker that exceeds its deadline', async () => {
+  let onTimeout;
+  let timeoutDelay;
+  let terminated = false;
+  class HangingWorker {
+    once() { return this; }
+    terminate() {
+      terminated = true;
+      return Promise.resolve(0);
+    }
+  }
+
+  const result = runSessionDetailWorker(
+    { client: 'claude', sessionId: 'blocked-wsl' },
+    {
+      Worker: HangingWorker,
+      timeoutMs: 25,
+      setTimeout: (callback, delay) => { onTimeout = callback; timeoutDelay = delay; return 1; },
+      clearTimeout: () => {}
+    }
+  );
+
+  assert.equal(timeoutDelay, 25);
+  onTimeout();
+  await assert.rejects(result, /Session detail worker timed out after 25ms/);
+  assert.equal(terminated, true);
+});
+
 test('the public session detail resolver uses the worker boundary', async () => {
   let workerArgs;
   class FakeWorker {

--- a/tests/shared/sessionDetailResolver.test.js
+++ b/tests/shared/sessionDetailResolver.test.js
@@ -6,7 +6,11 @@ const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 
-const { readSessionDetailForPlatform } = require('../../src/shared/sessionDetailResolver');
+const {
+  readSessionDetailForPlatform,
+  resolveSessionDetailForPlatform,
+  runSessionDetailWorker
+} = require('../../src/shared/sessionDetailResolver');
 
 function missing(args) {
   return { found: false, client: args.client, sessionId: args.sessionId, exchanges: [] };
@@ -32,7 +36,7 @@ test('reads a Claude transcript from a discovered WSL home', (t) => {
     })
   ].join('\n'));
 
-  const detail = readSessionDetailForPlatform(
+  const detail = resolveSessionDetailForPlatform(
     { client: 'claude', sessionId, period: 'total', sessionCost: 0.25 },
     {
       platform: 'win32',
@@ -47,9 +51,56 @@ test('reads a Claude transcript from a discovered WSL home', (t) => {
   assert.equal(detail.totals.costUsd, 0.25);
 });
 
+test('reads a Claude transcript from the alternate root in a discovered WSL home', (t) => {
+  const nativeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-native-detail-'));
+  const wslHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-wsl-detail-'));
+  t.after(() => fs.rmSync(nativeHome, { recursive: true, force: true }));
+  t.after(() => fs.rmSync(wslHome, { recursive: true, force: true }));
+  const sessionId = 'alternate-wsl-session';
+  const transcriptDir = path.join(wslHome, '.claude', 'transcripts');
+  fs.mkdirSync(transcriptDir, { recursive: true });
+  fs.writeFileSync(path.join(transcriptDir, `${sessionId}.jsonl`), [
+    JSON.stringify({ type: 'user', timestamp: '2026-07-31T00:00:00.000Z', message: { content: 'from alternate root' } }),
+    JSON.stringify({ type: 'assistant', timestamp: '2026-07-31T00:00:01.000Z', message: { usage: { input_tokens: 4, output_tokens: 2 }, content: [] } })
+  ].join('\n'));
+
+  const detail = resolveSessionDetailForPlatform(
+    { client: 'claude', sessionId, period: 'total' },
+    { platform: 'win32', homedir: () => nativeHome, wslUsageHomes: () => [wslHome] }
+  );
+
+  assert.equal(detail.found, true);
+  assert.equal(detail.exchanges[0].promptPreview, 'from alternate root');
+  assert.equal(detail.totals.totalTokens, 6);
+});
+
+test('reads a Codex transcript from its dated path in a discovered WSL home', (t) => {
+  const nativeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-native-detail-'));
+  const wslHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-wsl-detail-'));
+  t.after(() => fs.rmSync(nativeHome, { recursive: true, force: true }));
+  t.after(() => fs.rmSync(wslHome, { recursive: true, force: true }));
+  const sessionId = 'rollout-2026-07-31T12-34-56-real-codex';
+  const transcriptDir = path.join(wslHome, '.codex', 'sessions', '2026', '07', '31');
+  fs.mkdirSync(transcriptDir, { recursive: true });
+  fs.writeFileSync(path.join(transcriptDir, `${sessionId}.jsonl`), [
+    JSON.stringify({ type: 'event_msg', timestamp: '2026-07-31T00:00:00.000Z', payload: { type: 'user_message', message: 'from Codex WSL' } }),
+    JSON.stringify({ type: 'event_msg', timestamp: '2026-07-31T00:00:01.000Z', payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 10, cached_input_tokens: 3, output_tokens: 5, reasoning_output_tokens: 2, total_tokens: 15 } } } })
+  ].join('\n'));
+
+  const detail = resolveSessionDetailForPlatform(
+    { client: 'codex', sessionId, period: 'total', sessionCost: 0.1 },
+    { platform: 'win32', homedir: () => nativeHome, wslUsageHomes: () => [wslHome] }
+  );
+
+  assert.equal(detail.found, true);
+  assert.equal(detail.exchanges[0].promptPreview, 'from Codex WSL');
+  assert.equal(detail.totals.totalTokens, 15);
+  assert.equal(detail.totals.costUsd, 0.1);
+});
+
 test('returns a native Claude detail without enumerating WSL homes', () => {
   let enumerated = false;
-  const detail = readSessionDetailForPlatform(
+  const detail = resolveSessionDetailForPlatform(
     { client: 'claude', sessionId: 'native' },
     {
       platform: 'win32',
@@ -67,7 +118,7 @@ test('returns a native Claude detail without enumerating WSL homes', () => {
 for (const client of ['claude', 'codex']) {
   test(`falls back to running WSL homes for ${client} JSONL details on Windows`, () => {
     const homes = [];
-    const detail = readSessionDetailForPlatform(
+    const detail = resolveSessionDetailForPlatform(
       { client, sessionId: 'wsl-session' },
       {
         platform: 'win32',
@@ -93,7 +144,7 @@ for (const client of ['claude', 'codex']) {
 test('does not inspect WSL homes for non-Windows or SQLite-backed clients', () => {
   for (const [platform, client] of [['linux', 'claude'], ['win32', 'opencode']]) {
     let enumerated = false;
-    const detail = readSessionDetailForPlatform(
+    const detail = resolveSessionDetailForPlatform(
       { client, sessionId: 'missing' },
       {
         platform,
@@ -110,7 +161,7 @@ test('does not inspect WSL homes for non-Windows or SQLite-backed clients', () =
 
 test('returns the native not-found result when WSL discovery fails', () => {
   const nativeDetail = { found: false, client: 'claude', sessionId: 'missing', exchanges: [], marker: 'native' };
-  const detail = readSessionDetailForPlatform(
+  const detail = resolveSessionDetailForPlatform(
     { client: 'claude', sessionId: 'missing' },
     {
       platform: 'win32',
@@ -121,4 +172,49 @@ test('returns the native not-found result when WSL discovery fails', () => {
   );
 
   assert.equal(detail, nativeDetail);
+});
+
+test('runs session detail lookup in a worker thread', async () => {
+  const detail = await runSessionDetailWorker(
+    { expected: 'worker-result' },
+    { workerPath: path.join(__dirname, '..', 'fixtures', 'sessionDetailThreadWorker.js') }
+  );
+
+  assert.equal(detail.expected, 'worker-result');
+  assert.ok(detail.threadId > 0);
+});
+
+test('the production worker entry returns session detail', async () => {
+  const detail = await readSessionDetailForPlatform({ client: 'hermes', sessionId: 'missing', period: 'total' });
+
+  assert.deepEqual(detail, {
+    found: false,
+    client: 'hermes',
+    sessionId: 'missing',
+    period: 'total',
+    exchanges: [],
+    totals: { totalTokens: 0, costUsd: 0, exchangeCount: 0, turnCount: 0 }
+  });
+});
+
+test('the public session detail resolver uses the worker boundary', async () => {
+  let workerArgs;
+  class FakeWorker {
+    constructor(_workerPath, options) {
+      workerArgs = options.workerData;
+      this.listeners = new Map();
+      queueMicrotask(() => this.listeners.get('message')?.({ ok: true, detail: { found: false } }));
+    }
+
+    once(event, listener) {
+      this.listeners.set(event, listener);
+      return this;
+    }
+  }
+
+  const args = { client: 'claude', sessionId: 'missing' };
+  const result = readSessionDetailForPlatform(args, { Worker: FakeWorker });
+  assert.ok(result instanceof Promise);
+  assert.deepEqual(await result, { found: false });
+  assert.equal(workerArgs, args);
 });

--- a/tests/shared/sessionFiles.test.js
+++ b/tests/shared/sessionFiles.test.js
@@ -27,6 +27,17 @@ test('resolves a claude session file by walking projects', () => {
   } finally { cleanup(home); }
 });
 
+test('resolves a claude session file from the alternate transcripts root', () => {
+  const home = tmpHome();
+  try {
+    const dir = path.join(home, '.claude', 'transcripts');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'alternate-123.jsonl');
+    fs.writeFileSync(file, '{}\n');
+    assert.equal(resolveSessionFile('claude', 'alternate-123', home), file);
+  } finally { cleanup(home); }
+});
+
 test('resolves a codex rollout via the dated path', () => {
   const home = tmpHome();
   try {


### PR DESCRIPTION
## Summary

- Keep native transcript lookup as the fast path.
- On Windows, fall back to running WSL homes when a Claude or Codex JSONL session is not available under the native home.
- Preserve the existing not-found behavior and avoid WSL fallback for non-Windows and SQLite-backed clients.

## Testing

- `npm run verify` (2,060 passed, 1 skipped)

Fixes #289



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows session detail lookup by falling back to running WSL homes when the native home lacks a `claude` or `codex` JSONL transcript. Run the lookup in a worker with a 20s timeout, and ignore stale responses so the active period isn’t overwritten.

- **Bug Fixes**
  - Windows: try native home first, then WSL homes for `claude`/`codex` JSONL; supports `.claude/projects` and `.claude/transcripts`.
  - Skip WSL enumeration when native detail is found or on non-Windows/SQLite clients.
  - Ignore stale renderer results by tying each lookup to the open request.
  - Time out the worker after 20s and terminate on stall to prevent indefinite loading on UNC/WSL paths.

- **Refactors**
  - Run session detail resolution in a worker; IPC now calls worker-based `readSessionDetailForPlatform`.

<sup>Written for commit b508ed3bca241e23c7556065ea951354c9818cc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



