### PR TITLE
fix(window): restore maximized state after restart

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -24,8 +24,9 @@ const motionPreferenceApi = require('./motionPreference');
 const { createClaudeWebFetch } = require('./claudeWebFetch');
 const {
   normalWindowBounds,
-  persistWindowMaximizedState,
+  persistWindowState,
   restoreWindowMaximized,
+  restoreWindowMaximizedForReveal,
   shouldPersistWindowBounds
 } = require('./windowState');
 
@@ -3872,11 +3873,11 @@ function loadWindowFile(target, options = {}) {
     if (revealed) return;
     revealed = true;
     if (settings?.trayMode) return; // stay hidden until tray click
-    if (options.restoreMaximized === true) {
-      restoreWindowMaximized(target, settings, {
-        collapsedFloatingBubble: options.collapsedFloatingBubble === true
-      });
-    }
+    if (restoreWindowMaximizedForReveal(target, settings, {
+      restoreMaximized: options.restoreMaximized === true,
+      inactive: options.inactive === true,
+      collapsedFloatingBubble: options.collapsedFloatingBubble === true
+    })) return;
     revealWindow(target, { inactive: options.inactive === true });
   };
   const waitForContent = options.waitForContent === true;
@@ -3965,14 +3966,10 @@ function createWindow(boundsOverride, options = {}) {
   }
   win.on('maximize', () => {
     stopPersistBoundsTimer();
-    const bounds = normalWindowBounds(win);
-    if (bounds) persistWindowBounds(bounds);
-    persistWindowMaximizedState(settings, saveSettings, true);
+    persistWindowState(settings, saveSettings, normalWindowBounds(win), true);
   });
   win.on('unmaximize', () => {
-    const bounds = normalWindowBounds(win);
-    if (bounds) persistWindowBounds(bounds);
-    persistWindowMaximizedState(settings, saveSettings, false);
+    persistWindowState(settings, saveSettings, normalWindowBounds(win), false);
     persistBoundsSoon();
   });
   win.webContents.setWindowOpenHandler(({ url }) => {
@@ -4266,6 +4263,7 @@ app.whenReady().then(() => {
     const previousCustomModelPricing = JSON.stringify(settings.customModelPricing || []);
     const normalizedCurrency = patch.currency !== undefined ? normalizeCurrency(patch.currency, settings.currency) : normalizeCurrency(settings.currency);
     const normalizedPatch = { ...patch, currency: normalizedCurrency };
+    delete normalizedPatch.windowMaximized;
     delete normalizedPatch.codexManagedAccounts;
     delete normalizedPatch.mimoManagedAccounts;
     delete normalizedPatch.openrouterProfiles;
@@ -4347,7 +4345,7 @@ app.whenReady().then(() => {
       maskLimitAccountEmails: parseBoolean(patch.maskLimitAccountEmails ?? settings.maskLimitAccountEmails, false),
       claudePrepaidBalanceEnabled: parseBoolean(patch.claudePrepaidBalanceEnabled ?? settings.claudePrepaidBalanceEnabled, true),
       showLimitUsed: parseBoolean(patch.showLimitUsed ?? settings.showLimitUsed, false),
-      windowMaximized: parseBoolean(patch.windowMaximized ?? settings.windowMaximized, false),
+      windowMaximized: parseBoolean(settings.windowMaximized, false),
       zoomFactor: clampZoom(patch.zoomFactor ?? settings.zoomFactor),
       ...normalizeTrayModeSettings({
         showTrayIcon: patch.showTrayIcon ?? settings.showTrayIcon,

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -25,6 +25,7 @@ const { createClaudeWebFetch } = require('./claudeWebFetch');
 const {
   normalWindowBounds,
   persistWindowState,
+  rebuildWindowBounds,
   restoreWindowMaximized,
   restoreWindowMaximizedForReveal,
   shouldPersistWindowBounds
@@ -4173,9 +4174,7 @@ function normalizeManualCookie(input) {
 
 function rebuildWindow() {
   if (!mainWindow) return;
-  const bounds = floatingBubbleState.collapsed && floatingBubbleState.expandedBounds
-    ? floatingBubbleState.expandedBounds
-    : mainWindow.getBounds();
+  const bounds = rebuildWindowBounds(mainWindow, floatingBubbleState);
   const wasFocused = mainWindow.isFocused();
   const old = mainWindow;
   floatingBubbleState.collapsed = false;

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -23,12 +23,16 @@ const { createDefaultTrayLayout, normalizeTrayLayout } = require('../shared/tray
 const motionPreferenceApi = require('./motionPreference');
 const { createClaudeWebFetch } = require('./claudeWebFetch');
 const {
+  expandedBoundsForCollapse,
   normalWindowBounds,
   persistWindowState,
   rebuildWindowBounds,
   restoreWindowMaximized,
   restoreWindowMaximizedForReveal,
-  shouldPersistWindowBounds
+  setWindowMaximizable,
+  shouldPersistWindowBounds,
+  shouldTrackWindowMaximized,
+  suspendWindowMaximized
 } = require('./windowState');
 
 // Install EPIPE suppression before anything that might log. Without this,
@@ -1656,10 +1660,13 @@ function collapseFloatingBubble(plan) {
 }
 
 function maybeCollapseFloatingBubble(bounds) {
+  // The display comes from where the window actually sits, but the bounds the
+  // plan remembers as "expanded" must be the normal ones: collapsing a
+  // maximized window would otherwise persist the whole screen as its size.
   const display = displayForBounds(bounds);
   if (!display) return false;
   const collapsedArea = collapsedAreaForDisplay(display);
-  const plan = floatingBubbleCollapsePlan(bounds, display.workArea, settings, {
+  const plan = floatingBubbleCollapsePlan(expandedBoundsForCollapse(mainWindow, bounds), display.workArea, settings, {
     collapsed: floatingBubbleState.collapsed,
     suppressNextCollapse: floatingBubbleState.suppressNextCollapse,
     collapsedArea,
@@ -3308,6 +3315,11 @@ function enterTrayMode() {
   applyMacActivationPolicy();
   if (mainWindow && !mainWindow.isDestroyed()) {
     if (typeof mainWindow.setSkipTaskbar === 'function') mainWindow.setSkipTaskbar(true);
+    // settings.trayMode is already true here, so this unmaximize is ignored by
+    // the native handler and settings.windowMaximized keeps describing the
+    // window exitTrayMode() will hand back.
+    suspendWindowMaximized(mainWindow);
+    setWindowMaximizable(mainWindow, false);
     applyMacSpaceBehavior(true);
     mainWindow.hide();
   }
@@ -3317,6 +3329,7 @@ function exitTrayMode() {
   applyMacActivationPolicy({ mainWindowVisible: true });
   if (mainWindow && !mainWindow.isDestroyed()) {
     if (typeof mainWindow.setSkipTaskbar === 'function') mainWindow.setSkipTaskbar(false);
+    setWindowMaximizable(mainWindow, true);
     applyMacSpaceBehavior(false);
     const restore = restoredBounds() || DEFAULT_WINDOW;
     mainWindow.setBounds({
@@ -3943,6 +3956,8 @@ function createWindow(boundsOverride, options = {}) {
     icon: APP_ICON_PATH,
     skipTaskbar: collapsedFloatingBubble || Boolean(settings?.trayMode),
     ...(collapsedFloatingBubble ? { fullscreenable: false, maximizable: false, minimizable: false } : {}),
+    // Keeps a popover unmaximizable across rebuilds, which never re-run enterTrayMode().
+    ...(settings?.trayMode ? { maximizable: false } : {}),
     ...floatingBubbleWindowChrome(process.platform, collapsedFloatingBubble),
     ...(process.platform === 'darwin' && glass ? { vibrancy: 'hud', visualEffectState: 'active' } : {}),
     ...(process.platform === 'win32' && glass && !windowsAccent ? { backgroundMaterial: 'acrylic' } : {}),
@@ -3966,10 +3981,18 @@ function createWindow(boundsOverride, options = {}) {
     try { win.setBackgroundMaterial('acrylic'); } catch (_) {}
   }
   win.on('maximize', () => {
+    if (!shouldTrackWindowMaximized(settings, floatingBubbleState)) {
+      // A tray popover is sized from getBounds() on every open, so a maximized
+      // one would open full-screen. setMaximizable() covers Windows and macOS;
+      // it is a no-op on Linux, which is why this bounce still has to exist.
+      if (settings?.trayMode) suspendWindowMaximized(win);
+      return;
+    }
     stopPersistBoundsTimer();
     persistWindowState(settings, saveSettings, normalWindowBounds(win), true);
   });
   win.on('unmaximize', () => {
+    if (!shouldTrackWindowMaximized(settings, floatingBubbleState)) return;
     persistWindowState(settings, saveSettings, normalWindowBounds(win), false);
     persistBoundsSoon();
   });

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -22,6 +22,12 @@ const { exportFileSet, exportSignature, EXPORT_FILENAMES } = require('../shared/
 const { createDefaultTrayLayout, normalizeTrayLayout } = require('../shared/trayLayout');
 const motionPreferenceApi = require('./motionPreference');
 const { createClaudeWebFetch } = require('./claudeWebFetch');
+const {
+  normalWindowBounds,
+  persistWindowMaximizedState,
+  restoreWindowMaximized,
+  shouldPersistWindowBounds
+} = require('./windowState');
 
 // Install EPIPE suppression before anything that might log. Without this,
 // a closed parent pipe turns the next log call into an unhandled 'error'
@@ -337,6 +343,7 @@ function defaultSettings() {
     claudePrepaidBalanceEnabled: parseBoolean(process.env.TOKEN_MONITOR_CLAUDE_PREPAID_BALANCE, true),
     showLimitUsed: parseBoolean(process.env.TOKEN_MONITOR_SHOW_LIMIT_USED, false),
     windowBounds: null,
+    windowMaximized: false,
     zoomFactor: 1,
     showTrayIcon: true,
     trayMode: false,
@@ -1701,6 +1708,7 @@ function expandFloatingBubble(options = {}) {
   sendFloatingBubbleState();
   if (options.focus !== false) {
     mainWindow.show();
+    restoreWindowMaximized(mainWindow, settings);
   }
   return true;
 }
@@ -1734,11 +1742,15 @@ function syncFloatingBubbleAvailability() {
 
 function persistBoundsSoon() {
   if (!mainWindow || mainWindow.isDestroyed()) return;
-  if (mainWindow.isMinimized() || mainWindow.isFullScreen()) return;
+  if (!shouldPersistWindowBounds(mainWindow)) {
+    stopPersistBoundsTimer();
+    return;
+  }
   stopPersistBoundsTimer();
   persistBoundsTimer = setTimeout(() => {
     persistBoundsTimer = null;
     if (!mainWindow || mainWindow.isDestroyed()) return;
+    if (!shouldPersistWindowBounds(mainWindow)) return;
     const next = mainWindow.getBounds();
     const prev = settings.windowBounds || {};
     if (settings?.trayMode) {
@@ -1916,6 +1928,7 @@ function readSettings() {
     }
     merged.showHomeLimitBars = parseBoolean(merged.showHomeLimitBars, false);
     merged.showHomeLimitProviderNames = parseBoolean(merged.showHomeLimitProviderNames, false);
+    merged.windowMaximized = parseBoolean(merged.windowMaximized, false);
     merged.automaticAppUpdates = parseBoolean(merged.automaticAppUpdates, false);
     if (saved.homeLimitProviderOrder !== undefined) {
       merged.homeLimitProviderOrder = migrateHomeLimitProviderOrder(saved.homeLimitProviderOrder);
@@ -2836,7 +2849,10 @@ function focusExistingWindow() {
   else {
     applyMacSpaceBehavior(false);
     if (floatingBubbleState.collapsed) expandFloatingBubble();
-    else mainWindow.show();
+    else {
+      mainWindow.show();
+      restoreWindowMaximized(mainWindow, settings);
+    }
   }
 }
 
@@ -3308,6 +3324,7 @@ function exitTrayMode() {
     });
     applyWindowSettings();
     mainWindow.show();
+    restoreWindowMaximized(mainWindow, settings);
   }
   if (!shouldCreateTray(settings)) destroyTray();
   else ensureTray();
@@ -3855,6 +3872,11 @@ function loadWindowFile(target, options = {}) {
     if (revealed) return;
     revealed = true;
     if (settings?.trayMode) return; // stay hidden until tray click
+    if (options.restoreMaximized === true) {
+      restoreWindowMaximized(target, settings, {
+        collapsedFloatingBubble: options.collapsedFloatingBubble === true
+      });
+    }
     revealWindow(target, { inactive: options.inactive === true });
   };
   const waitForContent = options.waitForContent === true;
@@ -3941,6 +3963,18 @@ function createWindow(boundsOverride, options = {}) {
     console.warn('[window] AccentBlurBehind unavailable; falling back to Acrylic');
     try { win.setBackgroundMaterial('acrylic'); } catch (_) {}
   }
+  win.on('maximize', () => {
+    stopPersistBoundsTimer();
+    const bounds = normalWindowBounds(win);
+    if (bounds) persistWindowBounds(bounds);
+    persistWindowMaximizedState(settings, saveSettings, true);
+  });
+  win.on('unmaximize', () => {
+    const bounds = normalWindowBounds(win);
+    if (bounds) persistWindowBounds(bounds);
+    persistWindowMaximizedState(settings, saveSettings, false);
+    persistBoundsSoon();
+  });
   win.webContents.setWindowOpenHandler(({ url }) => {
     if (isAllowedExternalUrl(url)) shell.openExternal(url);
     return { action: 'deny' };
@@ -3980,6 +4014,8 @@ function createWindow(boundsOverride, options = {}) {
   loadWindowFile(win, {
     waitForContent: options.waitForContent === true,
     inactive: options.inactive === true,
+    collapsedFloatingBubble,
+    restoreMaximized: !collapsedFloatingBubble,
     query: {
       ...floatingBubbleInitialRendererQuery(floatingBubbleState, {
         collapsedWindow: collapsedFloatingBubble,
@@ -4311,6 +4347,7 @@ app.whenReady().then(() => {
       maskLimitAccountEmails: parseBoolean(patch.maskLimitAccountEmails ?? settings.maskLimitAccountEmails, false),
       claudePrepaidBalanceEnabled: parseBoolean(patch.claudePrepaidBalanceEnabled ?? settings.claudePrepaidBalanceEnabled, true),
       showLimitUsed: parseBoolean(patch.showLimitUsed ?? settings.showLimitUsed, false),
+      windowMaximized: parseBoolean(patch.windowMaximized ?? settings.windowMaximized, false),
       zoomFactor: clampZoom(patch.zoomFactor ?? settings.zoomFactor),
       ...normalizeTrayModeSettings({
         showTrayIcon: patch.showTrayIcon ?? settings.showTrayIcon,

--- a/src/electron/windowState.js
+++ b/src/electron/windowState.js
@@ -1,0 +1,60 @@
+'use strict';
+
+function isWindowMaximized(window) {
+  return Boolean(
+    window &&
+    !(typeof window.isDestroyed === 'function' && window.isDestroyed()) &&
+    typeof window.isMaximized === 'function' &&
+    window.isMaximized()
+  );
+}
+
+function normalWindowBounds(window) {
+  if (!window || (typeof window.isDestroyed === 'function' && window.isDestroyed())) return null;
+  if (typeof window.isMinimized === 'function' && window.isMinimized()) return null;
+  if (typeof window.isFullScreen === 'function' && window.isFullScreen()) return null;
+  const getBounds = isWindowMaximized(window) && typeof window.getNormalBounds === 'function'
+    ? window.getNormalBounds
+    : window.getBounds;
+  if (typeof getBounds !== 'function') return null;
+  try {
+    const bounds = getBounds.call(window);
+    return bounds && typeof bounds === 'object' ? bounds : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function shouldPersistWindowBounds(window) {
+  return Boolean(normalWindowBounds(window) && !isWindowMaximized(window));
+}
+
+function shouldRestoreWindowMaximized(settings = {}, options = {}) {
+  if (settings.trayMode === true || options.collapsedFloatingBubble === true) return false;
+  return settings.windowMaximized === true;
+}
+
+function restoreWindowMaximized(window, settings = {}, options = {}) {
+  if (!shouldRestoreWindowMaximized(settings, options)) return false;
+  if (!window || (typeof window.isDestroyed === 'function' && window.isDestroyed())) return false;
+  if (typeof window.maximize !== 'function' || isWindowMaximized(window)) return false;
+  window.maximize();
+  return true;
+}
+
+function persistWindowMaximizedState(settings, saveSettings, maximized) {
+  const next = maximized === true;
+  if (settings.windowMaximized === next) return false;
+  settings.windowMaximized = next;
+  saveSettings();
+  return true;
+}
+
+module.exports = {
+  isWindowMaximized,
+  normalWindowBounds,
+  persistWindowMaximizedState,
+  restoreWindowMaximized,
+  shouldPersistWindowBounds,
+  shouldRestoreWindowMaximized
+};

--- a/src/electron/windowState.js
+++ b/src/electron/windowState.js
@@ -74,10 +74,19 @@ function persistWindowState(settings, saveSettings, bounds, maximized) {
   return true;
 }
 
+function rebuildWindowBounds(window, state = {}) {
+  if (state.collapsed === true && state.expandedBounds) return state.expandedBounds;
+  const bounds = normalWindowBounds(window);
+  if (bounds) return bounds;
+  if (window && typeof window.getBounds === 'function') return window.getBounds();
+  return null;
+}
+
 module.exports = {
   isWindowMaximized,
   normalWindowBounds,
   persistWindowState,
+  rebuildWindowBounds,
   restoreWindowMaximized,
   restoreWindowMaximizedForReveal,
   shouldPersistWindowBounds,

--- a/src/electron/windowState.js
+++ b/src/electron/windowState.js
@@ -29,6 +29,36 @@ function shouldPersistWindowBounds(window) {
   return Boolean(normalWindowBounds(window) && !isWindowMaximized(window));
 }
 
+// Tray popovers are re-anchored and re-sized on every open, and a collapsed
+// floating bubble persists through settings.floatingBubbleBounds — in both
+// modes the native maximize/unmaximize events describe a window that is no
+// longer the normal one, so they must not rewrite the normal window state.
+function shouldTrackWindowMaximized(settings = {}, bubbleState = {}) {
+  return settings.trayMode !== true && bubbleState.collapsed !== true;
+}
+
+// Drops the native maximized state while leaving settings.windowMaximized
+// alone, so the flag still describes the window the user will come back to.
+function suspendWindowMaximized(window) {
+  if (!isWindowMaximized(window) || typeof window.unmaximize !== 'function') return false;
+  window.unmaximize();
+  return true;
+}
+
+function setWindowMaximizable(window, maximizable) {
+  if (!window || (typeof window.isDestroyed === 'function' && window.isDestroyed())) return false;
+  if (typeof window.setMaximizable !== 'function') return false;
+  window.setMaximizable(maximizable === true);
+  return true;
+}
+
+// The bounds a collapse should remember as the expanded window. A maximized
+// window's getBounds() is the whole screen, so remembering it would lose the
+// size the user gets back when they unmaximize.
+function expandedBoundsForCollapse(window, currentBounds) {
+  return normalWindowBounds(window) || currentBounds || null;
+}
+
 function shouldRestoreWindowMaximized(settings = {}, options = {}) {
   if (settings.trayMode === true || options.collapsedFloatingBubble === true) return false;
   return settings.windowMaximized === true;
@@ -83,12 +113,16 @@ function rebuildWindowBounds(window, state = {}) {
 }
 
 module.exports = {
+  expandedBoundsForCollapse,
   isWindowMaximized,
   normalWindowBounds,
   persistWindowState,
   rebuildWindowBounds,
   restoreWindowMaximized,
   restoreWindowMaximizedForReveal,
+  setWindowMaximizable,
   shouldPersistWindowBounds,
-  shouldRestoreWindowMaximized
+  shouldRestoreWindowMaximized,
+  shouldTrackWindowMaximized,
+  suspendWindowMaximized
 };

--- a/src/electron/windowState.js
+++ b/src/electron/windowState.js
@@ -42,10 +42,34 @@ function restoreWindowMaximized(window, settings = {}, options = {}) {
   return true;
 }
 
-function persistWindowMaximizedState(settings, saveSettings, maximized) {
-  const next = maximized === true;
-  if (settings.windowMaximized === next) return false;
-  settings.windowMaximized = next;
+function restoreWindowMaximizedForReveal(window, settings = {}, options = {}) {
+  const restored = options.restoreMaximized === true && restoreWindowMaximized(window, settings, options);
+  if (!restored) return false;
+  if (
+    options.inactive !== true &&
+    typeof window.isFocused === 'function' &&
+    !window.isFocused() &&
+    typeof window.focus === 'function'
+  ) {
+    window.focus();
+  }
+  return true;
+}
+
+function sameWindowBounds(first, second) {
+  return first?.x === second?.x &&
+    first?.y === second?.y &&
+    first?.width === second?.width &&
+    first?.height === second?.height;
+}
+
+function persistWindowState(settings, saveSettings, bounds, maximized) {
+  const nextMaximized = maximized === true;
+  const boundsChanged = Boolean(bounds) && !sameWindowBounds(settings.windowBounds, bounds);
+  const maximizedChanged = settings.windowMaximized !== nextMaximized;
+  if (!boundsChanged && !maximizedChanged) return false;
+  if (boundsChanged) settings.windowBounds = bounds;
+  if (maximizedChanged) settings.windowMaximized = nextMaximized;
   saveSettings();
   return true;
 }
@@ -53,8 +77,9 @@ function persistWindowMaximizedState(settings, saveSettings, maximized) {
 module.exports = {
   isWindowMaximized,
   normalWindowBounds,
-  persistWindowMaximizedState,
+  persistWindowState,
   restoreWindowMaximized,
+  restoreWindowMaximizedForReveal,
   shouldPersistWindowBounds,
   shouldRestoreWindowMaximized
 };

--- a/tests/electron/windowState.test.js
+++ b/tests/electron/windowState.test.js
@@ -7,6 +7,7 @@ const {
   isWindowMaximized,
   normalWindowBounds,
   persistWindowState,
+  rebuildWindowBounds,
   restoreWindowMaximized,
   restoreWindowMaximizedForReveal,
   shouldPersistWindowBounds,
@@ -97,6 +98,30 @@ test('persists changed bounds and maximization state in one save', () => {
   assert.equal(persistWindowState(settings, saveSettings, bounds, true), false);
   assert.equal(saves, 1);
   assert.equal(persistWindowState(settings, saveSettings, bounds, false), true);
+  assert.equal(settings.windowMaximized, false);
+  assert.equal(saves, 2);
+});
+
+test('keeps normal bounds across a maximized rebuild and unmaximize', () => {
+  const normalBounds = { x: 40, y: 50, width: 360, height: 700 };
+  const screenBounds = { x: 0, y: 0, width: 1920, height: 1080 };
+  const oldWindow = fakeWindow({ maximized: true, bounds: screenBounds, normalBounds });
+  const rebuiltBounds = rebuildWindowBounds(oldWindow);
+  assert.deepEqual(rebuiltBounds, normalBounds);
+
+  const rebuiltState = { bounds: rebuiltBounds, normalBounds: rebuiltBounds };
+  const rebuiltWindow = fakeWindow(rebuiltState);
+  const settings = { windowBounds: screenBounds, windowMaximized: true };
+  let saves = 0;
+  const saveSettings = () => { saves += 1; };
+
+  assert.equal(restoreWindowMaximized(rebuiltWindow, settings), true);
+  persistWindowState(settings, saveSettings, normalWindowBounds(rebuiltWindow), true);
+  assert.deepEqual(settings.windowBounds, normalBounds);
+
+  rebuiltState.maximized = false;
+  persistWindowState(settings, saveSettings, normalWindowBounds(rebuiltWindow), false);
+  assert.deepEqual(settings.windowBounds, normalBounds);
   assert.equal(settings.windowMaximized, false);
   assert.equal(saves, 2);
 });

--- a/tests/electron/windowState.test.js
+++ b/tests/electron/windowState.test.js
@@ -6,8 +6,9 @@ const test = require('node:test');
 const {
   isWindowMaximized,
   normalWindowBounds,
-  persistWindowMaximizedState,
+  persistWindowState,
   restoreWindowMaximized,
+  restoreWindowMaximizedForReveal,
   shouldPersistWindowBounds,
   shouldRestoreWindowMaximized
 } = require('../../src/electron/windowState');
@@ -20,8 +21,10 @@ function fakeWindow(state = {}) {
     getNormalBounds: () => normalBounds,
     isDestroyed: () => state.destroyed === true,
     isFullScreen: () => state.fullScreen === true,
+    isFocused: () => state.focused === true,
     isMaximized: () => state.maximized === true,
     isMinimized: () => state.minimized === true,
+    focus: () => { state.focused = true; },
     maximize: () => { state.maximized = true; }
   };
 }
@@ -65,17 +68,35 @@ test('restores maximization outside tray and collapsed modes', () => {
   assert.equal(restoreWindowMaximized(fakeWindow(), { windowMaximized: true }, { collapsedFloatingBubble: true }), false);
 });
 
-test('persists a changed maximization state once', () => {
-  const settings = { windowMaximized: false };
+test('restores maximization and focuses a normal cold-start window', () => {
+  const state = {};
+  const window = fakeWindow(state);
+  assert.equal(restoreWindowMaximizedForReveal(window, { windowMaximized: true }, { restoreMaximized: true }), true);
+  assert.equal(state.maximized, true);
+  assert.equal(state.focused, true);
+});
+
+test('does not focus an inactive maximized replacement window', () => {
+  const state = {};
+  const window = fakeWindow(state);
+  assert.equal(restoreWindowMaximizedForReveal(window, { windowMaximized: true }, { restoreMaximized: true, inactive: true }), true);
+  assert.equal(state.maximized, true);
+  assert.equal(state.focused, undefined);
+});
+
+test('persists changed bounds and maximization state in one save', () => {
+  const bounds = { x: 40, y: 50, width: 360, height: 700 };
+  const settings = { windowBounds: null, windowMaximized: false };
   let saves = 0;
   const saveSettings = () => { saves += 1; };
 
-  assert.equal(persistWindowMaximizedState(settings, saveSettings, true), true);
+  assert.equal(persistWindowState(settings, saveSettings, bounds, true), true);
+  assert.deepEqual(settings.windowBounds, bounds);
   assert.equal(settings.windowMaximized, true);
   assert.equal(saves, 1);
-  assert.equal(persistWindowMaximizedState(settings, saveSettings, true), false);
+  assert.equal(persistWindowState(settings, saveSettings, bounds, true), false);
   assert.equal(saves, 1);
-  assert.equal(persistWindowMaximizedState(settings, saveSettings, false), true);
+  assert.equal(persistWindowState(settings, saveSettings, bounds, false), true);
   assert.equal(settings.windowMaximized, false);
   assert.equal(saves, 2);
 });

--- a/tests/electron/windowState.test.js
+++ b/tests/electron/windowState.test.js
@@ -1,18 +1,25 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const test = require('node:test');
 
 const {
+  expandedBoundsForCollapse,
   isWindowMaximized,
   normalWindowBounds,
   persistWindowState,
   rebuildWindowBounds,
   restoreWindowMaximized,
   restoreWindowMaximizedForReveal,
+  setWindowMaximizable,
   shouldPersistWindowBounds,
-  shouldRestoreWindowMaximized
+  shouldRestoreWindowMaximized,
+  shouldTrackWindowMaximized,
+  suspendWindowMaximized
 } = require('../../src/electron/windowState');
+const { floatingBubbleCollapsePlan } = require('../../src/electron/floatingBubble');
 
 function fakeWindow(state = {}) {
   const bounds = state.bounds || { x: 20, y: 30, width: 340, height: 650 };
@@ -26,7 +33,9 @@ function fakeWindow(state = {}) {
     isMaximized: () => state.maximized === true,
     isMinimized: () => state.minimized === true,
     focus: () => { state.focused = true; },
-    maximize: () => { state.maximized = true; }
+    maximize: () => { state.maximized = true; },
+    setMaximizable: (value) => { state.maximizable = value; },
+    unmaximize: () => { state.maximized = false; }
   };
 }
 
@@ -124,4 +133,93 @@ test('keeps normal bounds across a maximized rebuild and unmaximize', () => {
   assert.deepEqual(settings.windowBounds, normalBounds);
   assert.equal(settings.windowMaximized, false);
   assert.equal(saves, 2);
+});
+
+test('collapsing a maximized window remembers its normal bounds, not the screen', () => {
+  const workArea = { x: 0, y: 0, width: 1920, height: 1040 };
+  const normalBounds = { x: 300, y: 200, width: 360, height: 700 };
+  const screenBounds = { x: 0, y: 0, width: 1920, height: 1040 };
+  const window = fakeWindow({ maximized: true, bounds: screenBounds, normalBounds });
+  const settings = { floatingBubbleEnabled: true };
+
+  // Mirrors maybeCollapseFloatingBubble(): the display still comes from the
+  // window's current bounds, the remembered expanded bounds do not.
+  const plan = floatingBubbleCollapsePlan(
+    expandedBoundsForCollapse(window, screenBounds),
+    workArea,
+    settings,
+    { collapsedArea: workArea }
+  );
+
+  assert.deepEqual(plan.expandedBounds, normalBounds);
+  assert.notDeepEqual(plan.expandedBounds, screenBounds);
+  assert.equal(expandedBoundsForCollapse(fakeWindow({ bounds: normalBounds }), screenBounds), normalBounds);
+});
+
+test('entering tray mode drops native maximization but keeps the saved flag', () => {
+  const settings = { trayMode: true, windowMaximized: true, windowBounds: { x: 40, y: 50, width: 360, height: 700 } };
+  const state = { maximized: true };
+  const window = fakeWindow(state);
+
+  assert.equal(suspendWindowMaximized(window), true);
+  assert.equal(state.maximized, false);
+  assert.equal(setWindowMaximizable(window, false), true);
+  assert.equal(state.maximizable, false);
+  // The unmaximize this fires is ignored, so the flag still describes the
+  // window the user gets back when they leave tray mode.
+  assert.equal(shouldTrackWindowMaximized(settings, {}), false);
+  assert.equal(settings.windowMaximized, true);
+
+  settings.trayMode = false;
+  assert.equal(setWindowMaximizable(window, true), true);
+  assert.equal(restoreWindowMaximized(window, settings), true);
+  assert.equal(state.maximized, true);
+});
+
+test('tray and collapsed windows never rewrite the normal window state', () => {
+  assert.equal(shouldTrackWindowMaximized({}, {}), true);
+  assert.equal(shouldTrackWindowMaximized({ trayMode: true }, {}), false);
+  assert.equal(shouldTrackWindowMaximized({}, { collapsed: true }), false);
+
+  const windowBounds = { x: 40, y: 50, width: 360, height: 700 };
+  const settings = { trayMode: true, windowMaximized: false, windowBounds };
+  let saves = 0;
+  const saveSettings = () => { saves += 1; };
+  const state = { maximized: true, bounds: { x: 0, y: 0, width: 1920, height: 1040 } };
+  const window = fakeWindow(state);
+
+  // Mirrors the native handlers in createWindow().
+  const onMaximize = () => {
+    if (!shouldTrackWindowMaximized(settings, {})) {
+      if (settings.trayMode) suspendWindowMaximized(window);
+      return;
+    }
+    persistWindowState(settings, saveSettings, normalWindowBounds(window), true);
+  };
+  const onUnmaximize = () => {
+    if (!shouldTrackWindowMaximized(settings, {})) return;
+    persistWindowState(settings, saveSettings, normalWindowBounds(window), false);
+  };
+
+  onMaximize();
+  onUnmaximize();
+  assert.equal(state.maximized, false);
+  assert.equal(saves, 0);
+  assert.equal(settings.windowMaximized, false);
+  assert.deepEqual(settings.windowBounds, windowBounds);
+});
+
+test('main.js keeps tray and collapsed windows off the normal window state path', () => {
+  const main = fs.readFileSync(path.join(__dirname, '../../src/electron/main.js'), 'utf8');
+  const collapse = main.match(/function maybeCollapseFloatingBubble[\s\S]*?\n}\n/)[0];
+  const maximize = main.match(/win\.on\('maximize'[\s\S]*?\n {2}\}\);/)[0];
+  const unmaximize = main.match(/win\.on\('unmaximize'[\s\S]*?\n {2}\}\);/)[0];
+  const enterTray = main.match(/function enterTrayMode[\s\S]*?\n}\n/)[0];
+  const exitTray = main.match(/function exitTrayMode[\s\S]*?\n}\n/)[0];
+
+  assert.match(collapse, /floatingBubbleCollapsePlan\(expandedBoundsForCollapse\(mainWindow, bounds\)/);
+  assert.match(maximize, /^[\s\S]*?if \(!shouldTrackWindowMaximized\(settings, floatingBubbleState\)\)[\s\S]*suspendWindowMaximized\(win\)[\s\S]*persistWindowState/);
+  assert.match(unmaximize, /^[\s\S]*?if \(!shouldTrackWindowMaximized\(settings, floatingBubbleState\)\) return;[\s\S]*persistWindowState/);
+  assert.match(enterTray, /suspendWindowMaximized\(mainWindow\)[\s\S]*setWindowMaximizable\(mainWindow, false\)/);
+  assert.match(exitTray, /setWindowMaximizable\(mainWindow, true\)[\s\S]*restoreWindowMaximized\(mainWindow, settings\)/);
 });

--- a/tests/electron/windowState.test.js
+++ b/tests/electron/windowState.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  isWindowMaximized,
+  normalWindowBounds,
+  persistWindowMaximizedState,
+  restoreWindowMaximized,
+  shouldPersistWindowBounds,
+  shouldRestoreWindowMaximized
+} = require('../../src/electron/windowState');
+
+function fakeWindow(state = {}) {
+  const bounds = state.bounds || { x: 20, y: 30, width: 340, height: 650 };
+  const normalBounds = state.normalBounds || { x: 40, y: 50, width: 360, height: 700 };
+  return {
+    getBounds: () => bounds,
+    getNormalBounds: () => normalBounds,
+    isDestroyed: () => state.destroyed === true,
+    isFullScreen: () => state.fullScreen === true,
+    isMaximized: () => state.maximized === true,
+    isMinimized: () => state.minimized === true,
+    maximize: () => { state.maximized = true; }
+  };
+}
+
+test('detects the native maximized state without assuming a platform', () => {
+  assert.equal(isWindowMaximized(fakeWindow({ maximized: true })), true);
+  assert.equal(isWindowMaximized(fakeWindow()), false);
+  assert.equal(isWindowMaximized({}), false);
+});
+
+test('uses normal bounds while maximized and current bounds otherwise', () => {
+  const normalBounds = { x: 40, y: 50, width: 360, height: 700 };
+  const currentBounds = { x: 0, y: 0, width: 1920, height: 1080 };
+  assert.deepEqual(normalWindowBounds(fakeWindow({ maximized: true, bounds: currentBounds, normalBounds })), normalBounds);
+  assert.deepEqual(normalWindowBounds(fakeWindow({ bounds: currentBounds })), currentBounds);
+  assert.equal(normalWindowBounds(fakeWindow({ minimized: true })), null);
+  assert.equal(normalWindowBounds(fakeWindow({ fullScreen: true })), null);
+});
+
+test('does not persist bounds for minimized, fullscreen, or maximized windows', () => {
+  assert.equal(shouldPersistWindowBounds(fakeWindow()), true);
+  assert.equal(shouldPersistWindowBounds(fakeWindow({ minimized: true })), false);
+  assert.equal(shouldPersistWindowBounds(fakeWindow({ fullScreen: true })), false);
+  assert.equal(shouldPersistWindowBounds(fakeWindow({ maximized: true })), false);
+});
+
+test('restores persisted maximization except for collapsed floating bubbles', () => {
+  assert.equal(shouldRestoreWindowMaximized({ windowMaximized: true }), true);
+  assert.equal(shouldRestoreWindowMaximized({ windowMaximized: true, trayMode: true }), false);
+  assert.equal(shouldRestoreWindowMaximized({ windowMaximized: true }, { collapsedFloatingBubble: true }), false);
+  assert.equal(shouldRestoreWindowMaximized({ windowMaximized: false }), false);
+});
+
+test('restores maximization outside tray and collapsed modes', () => {
+  const state = {};
+  const window = fakeWindow(state);
+  assert.equal(restoreWindowMaximized(window, { windowMaximized: true }), true);
+  assert.equal(state.maximized, true);
+  assert.equal(restoreWindowMaximized(window, { windowMaximized: true }), false);
+  assert.equal(restoreWindowMaximized(fakeWindow(), { windowMaximized: true, trayMode: true }), false);
+  assert.equal(restoreWindowMaximized(fakeWindow(), { windowMaximized: true }, { collapsedFloatingBubble: true }), false);
+});
+
+test('persists a changed maximization state once', () => {
+  const settings = { windowMaximized: false };
+  let saves = 0;
+  const saveSettings = () => { saves += 1; };
+
+  assert.equal(persistWindowMaximizedState(settings, saveSettings, true), true);
+  assert.equal(settings.windowMaximized, true);
+  assert.equal(saves, 1);
+  assert.equal(persistWindowMaximizedState(settings, saveSettings, true), false);
+  assert.equal(saves, 1);
+  assert.equal(persistWindowMaximizedState(settings, saveSettings, false), true);
+  assert.equal(settings.windowMaximized, false);
+  assert.equal(saves, 2);
+});


### PR DESCRIPTION
## Summary

- Persist the main window's native maximized state separately from its normal bounds.
- Restore maximization after renderer readiness while preserving active-start focus and inactive replacement behavior; keep tray and floating-bubble windows unmaximized.
- Save normal bounds and maximized state together during transitions, with native window events as the sole owner of the maximized flag.
- Preserve the saved normal bounds when rebuilding a maximized window for native material or backdrop changes.

## Verification

- `npm run verify`

Closes #176
