### PR TITLE
feat(renderer): animate hold-to-boost token rate

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -1345,6 +1345,7 @@ function prefersReducedMotion() {
 }
 
 function settleMotionAnimations() {
+  cancelTokenRateBoost(undefined, { suppressClick: false });
   cancelNumberAnimation();
   numberAnimValue = state.currentTotal;
   els.totalTokens.textContent = formatNumber(state.currentTotal);

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -737,6 +737,7 @@ function tokenRateText(rate, burn) {
 }
 function renderTokenRate() {
   if (!els.tokenRateReveal) return;
+  tokenRateBoost.refresh();
   const { burn, rate } = currentTokenRateValue();
   const boost = tokenRateBoost.getSnapshot();
   const displayRate = boost ? boost.displayRate : rate;

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -455,14 +455,16 @@ document.addEventListener('pointerdown', (event) => {
   }
 });
 
-document.addEventListener('pointerup', () => {
+document.addEventListener('pointerup', (event) => {
+  stopTokenRateBoost(event);
   clearViewSwitcherLongPress();
   if (viewSwitcherLongPressTriggered) {
     setTimeout(() => { viewSwitcherLongPressTriggered = false; }, 0);
   }
 });
 
-document.addEventListener('pointercancel', () => {
+document.addEventListener('pointercancel', (event) => {
+  stopTokenRateBoost(event);
   clearViewSwitcherLongPress();
   viewSwitcherLongPressTriggered = false;
 });
@@ -711,6 +713,27 @@ function positiveNumber(value) {
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
 }
+const TOKEN_RATE_BOOST_DOUBLING_MS = 520;
+const TOKEN_RATE_HOLD_THRESHOLD_MS = 180;
+const TOKEN_RATE_SETTLE_MS = 720;
+let tokenRateBoost = null;
+let tokenRateBoostAnimation = 0;
+let ignoreNextTokenRateClick = false;
+
+function tokenRateBoostValue(baseRate, elapsedMs) {
+  const base = Math.max(1, positiveNumber(baseRate));
+  const elapsed = Math.max(0, Number(elapsedMs) || 0);
+  return base * 2 ** (elapsed / TOKEN_RATE_BOOST_DOUBLING_MS);
+}
+function tokenRateSettleValue(fromRate, toRate, elapsedMs) {
+  const from = Math.max(0, Number(fromRate) || 0);
+  const to = Math.max(0, Number(toRate) || 0);
+  const elapsed = Math.max(0, Number(elapsedMs) || 0);
+  const progress = Math.min(1, elapsed / TOKEN_RATE_SETTLE_MS);
+  const eased = 1 - Math.pow(1 - progress, 3);
+  return from + (to - from) * eased;
+}
+
 // Estimated output tokens per second of model-busy time — roughly the unit an inference
 // benchmark reports, so the number is sanity-checkable against a known model's streaming
 // speed. An estimate, not a measurement: tokscale times a message as a whole rather than
@@ -741,20 +764,106 @@ function tokenBurnPerMinute(period) {
   if (!durationMs || !timed) return 0;
   return timed * 60000 / durationMs;
 }
-function renderTokenRate() {
-  if (!els.tokenRateReveal) return;
+function currentTokenRateValue() {
   const period = state.stats?.periods?.[state.period];
   const burn = state.settings?.tokenRateMode === 'burn';
-  const rate = burn ? tokenBurnPerMinute(period) : tokenRatePerSecond(period);
+  return { burn, rate: burn ? tokenBurnPerMinute(period) : tokenRatePerSecond(period) };
+}
+function tokenRateText(rate, burn) {
   // formatCompact rounds, so a sub-0.5 rate would render as a bare "0". Treat that as no
   // data and stay hidden rather than claim a zero pace.
-  const text = Math.round(rate) > 0
+  return Math.round(rate) > 0
     ? t(burn ? 'home.tokenRateBurn' : 'home.tokenRate', {
       value: formatCompact(rate, effectiveCompactTokenUnits(), currentLocale())
     })
     : '';
+}
+function renderTokenRate() {
+  if (!els.tokenRateReveal) return;
+  const { burn, rate } = currentTokenRateValue();
+  const displayRate = tokenRateBoost
+    ? tokenRateBoostDisplayRate(tokenRateBoostNow())
+    : rate;
+  const text = tokenRateText(displayRate, burn);
   els.tokenRateReveal.textContent = text;
   els.tokenRateReveal.classList.toggle('has-value', Boolean(text));
+  els.tokenRateReveal.classList.toggle('boosting', tokenRateBoost?.phase === 'boosting');
+  els.tokenRateReveal.classList.toggle('settling', tokenRateBoost?.phase === 'settling');
+}
+function tokenRateBoostNow() {
+  return typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+}
+function tokenRateBoostDisplayRate(now) {
+  if (tokenRateBoost?.phase === 'settling') {
+    return tokenRateSettleValue(
+      tokenRateBoost.settleFromRate,
+      tokenRateBoost.settleToRate,
+      now - tokenRateBoost.settledAt
+    );
+  }
+  return tokenRateBoostValue(tokenRateBoost.baseRate, now - tokenRateBoost.startedAt);
+}
+function updateTokenRateBoost() {
+  if (!tokenRateBoost) return;
+  const now = tokenRateBoostNow();
+  if (tokenRateBoost.phase === 'settling' && now - tokenRateBoost.settledAt >= TOKEN_RATE_SETTLE_MS) {
+    tokenRateBoost = null;
+    tokenRateBoostAnimation = 0;
+    renderTokenRate();
+    return;
+  }
+  renderTokenRate();
+  tokenRateBoostAnimation = requestAnimationFrame(updateTokenRateBoost);
+}
+function cancelTokenRateBoostAnimation() {
+  if (tokenRateBoostAnimation) cancelAnimationFrame(tokenRateBoostAnimation);
+  tokenRateBoostAnimation = 0;
+}
+function startTokenRateBoost(event) {
+  if (event.button !== undefined && event.button !== 0) return;
+  ignoreNextTokenRateClick = false;
+  if (tokenRateBoost || prefersReducedMotion()) return;
+  if (!els.shell?.classList.contains('title-icon-only') && !els.shell?.classList.contains('title-collapsed')) return;
+  const { rate } = currentTokenRateValue();
+  tokenRateBoost = {
+    phase: 'boosting',
+    baseRate: Math.max(1, rate),
+    pointerId: event.pointerId,
+    startedAt: tokenRateBoostNow()
+  };
+  try { event.currentTarget?.setPointerCapture?.(event.pointerId); } catch (_) {}
+  renderTokenRate();
+  tokenRateBoostAnimation = requestAnimationFrame(updateTokenRateBoost);
+}
+function stopTokenRateBoost(event) {
+  if (!tokenRateBoost || tokenRateBoost.phase === 'settling') return;
+  if (event?.pointerId !== undefined && event.pointerId !== tokenRateBoost.pointerId) return;
+  const elapsed = tokenRateBoostNow() - tokenRateBoost.startedAt;
+  const suppressClick = (event?.type === 'pointerup' || event?.type === 'lostpointercapture') && elapsed >= TOKEN_RATE_HOLD_THRESHOLD_MS;
+  if (elapsed < TOKEN_RATE_HOLD_THRESHOLD_MS) {
+    tokenRateBoost = null;
+    cancelTokenRateBoostAnimation();
+    renderTokenRate();
+    return;
+  }
+  const { rate: settleToRate } = currentTokenRateValue();
+  tokenRateBoost = {
+    ...tokenRateBoost,
+    phase: 'settling',
+    settleFromRate: tokenRateBoostValue(tokenRateBoost.baseRate, elapsed),
+    settleToRate,
+    settledAt: tokenRateBoostNow()
+  };
+  if (suppressClick) ignoreNextTokenRateClick = true;
+  renderTokenRate();
+  if (!tokenRateBoostAnimation) tokenRateBoostAnimation = requestAnimationFrame(updateTokenRateBoost);
+}
+function suppressTokenRateClickAfterHold(event) {
+  if (!ignoreNextTokenRateClick) return;
+  ignoreNextTokenRateClick = false;
+  event.stopImmediatePropagation();
 }
 // The title mark is the only pixel of the reveal that can take a click: a drag region does
 // not deliver mouse events, so this control and its hover target are the same no-drag island.
@@ -764,8 +873,8 @@ function renderTokenRate() {
 // is shown, and Chromium then derives :focus-visible from that activation rather than from
 // any click, so the reveal reopens with a focus ring on a window the user just summoned with
 // the pointer nowhere near the title. The renderer cannot even clean that up, because it
-// receives no blur, focus or visibilitychange event across a real hide and show. This is a
-// hover-only enhancement layered on a pointer affordance, not a keyboard path that regressed.
+// receives no blur, focus or visibilitychange event across a real hide and show. Short clicks
+// still switch the reading; a sustained pointer hold is the transient boost affordance.
 function toggleTokenRateMode() {
   const next = state.settings?.tokenRateMode === 'burn' ? 'speed' : 'burn';
   // Repaint before the settings round trip. saveSettings re-syncs the entire settings form,
@@ -9369,6 +9478,7 @@ els.backHomeButton?.addEventListener('click', (event) => {
 });
 
 window.addEventListener('blur', () => {
+  stopTokenRateBoost();
   clearViewSwitcherLongPress();
   clearViewSwitcherHoverClose();
   viewSwitcherLongPressTriggered = false;
@@ -9484,8 +9594,16 @@ els.hubModeOptions.addEventListener('change', async (event) => {
   await refreshStats();
 });
 
-// Both, not just the mark: either one reveals the reading on hover, so a click that only
-// worked on one of them would leave the other looking broken.
+// Both, not just the mark: either one reveals the reading on hover, so a click or hold that
+// only worked on one of them would leave the other looking broken. The suppression listener
+// must be registered before the existing toggle listener so a long hold does not also toggle
+// the persisted speed/burn framing when its pointerup synthesizes a click.
+els.appTitleMark?.addEventListener('pointerdown', startTokenRateBoost);
+els.liveDot?.addEventListener('pointerdown', startTokenRateBoost);
+els.appTitleMark?.addEventListener('lostpointercapture', stopTokenRateBoost);
+els.liveDot?.addEventListener('lostpointercapture', stopTokenRateBoost);
+els.appTitleMark?.addEventListener('click', suppressTokenRateClickAfterHold);
+els.liveDot?.addEventListener('click', suppressTokenRateClickAfterHold);
 els.appTitleMark?.addEventListener('click', toggleTokenRateMode);
 els.liveDot?.addEventListener('click', toggleTokenRateMode);
 
@@ -10019,7 +10137,10 @@ const statsRenderScheduler = statsRenderSchedulerApi.createStatsRenderScheduler(
   isHidden: () => document.hidden,
   render: renderStatsUpdate
 });
-document.addEventListener('visibilitychange', () => statsRenderScheduler.flush());
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) stopTokenRateBoost();
+  statsRenderScheduler.flush();
+});
 
 window.tokenMonitor.onStatsPush?.((payload) => {
   if (!payload) return;

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -7,6 +7,8 @@ const windowsGlassApi = window.TokenMonitorWindowsGlass;
 const glassRenderingApi = window.TokenMonitorGlassRendering;
 const wslStatusPresentationApi = window.TokenMonitorWslStatusPresentation;
 const statsRenderSchedulerApi = window.TokenMonitorStatsRenderScheduler;
+const tokenRateApi = window.TokenMonitorTokenRate;
+const { tokenRatePerSecond, tokenBurnPerMinute } = tokenRateApi;
 const reducedMotionMedia = window.matchMedia?.('(prefers-reduced-motion: reduce)');
 const clientsWithIcon = new Set([
   'claude', 'codex', 'gemini', 'cursor', 'opencode', 'openclaw', 'hermes', 'antigravity', 'cline', 'kimi', 'qwen', 'grok', 'copilot', 'pi', 'zed', 'kilocode', 'micode', 'zcode', 'kiro', 'codebuddy', 'workbuddy', 'proma',
@@ -456,7 +458,7 @@ document.addEventListener('pointerdown', (event) => {
 });
 
 document.addEventListener('pointerup', (event) => {
-  stopTokenRateBoost(event);
+  releaseTokenRateBoost(event);
   clearViewSwitcherLongPress();
   if (viewSwitcherLongPressTriggered) {
     setTimeout(() => { viewSwitcherLongPressTriggered = false; }, 0);
@@ -464,7 +466,7 @@ document.addEventListener('pointerup', (event) => {
 });
 
 document.addEventListener('pointercancel', (event) => {
-  stopTokenRateBoost(event);
+  cancelTokenRateBoost(event);
   clearViewSwitcherLongPress();
   viewSwitcherLongPressTriggered = false;
 });
@@ -709,66 +711,21 @@ function hideTotalCompact() {
   els.totalTokensCompact.textContent = '';
   els.totalTokensCompact.classList.add('hidden');
 }
-function positiveNumber(value) {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
-}
-const TOKEN_RATE_BOOST_DOUBLING_MS = 520;
-const TOKEN_RATE_HOLD_THRESHOLD_MS = 180;
-const TOKEN_RATE_SETTLE_MS = 720;
-let tokenRateBoost = null;
-let tokenRateBoostAnimation = 0;
-let ignoreNextTokenRateClick = false;
-
-function tokenRateBoostValue(baseRate, elapsedMs) {
-  const base = Math.max(1, positiveNumber(baseRate));
-  const elapsed = Math.max(0, Number(elapsedMs) || 0);
-  return base * 2 ** (elapsed / TOKEN_RATE_BOOST_DOUBLING_MS);
-}
-function tokenRateSettleValue(fromRate, toRate, elapsedMs) {
-  const from = Math.max(0, Number(fromRate) || 0);
-  const to = Math.max(0, Number(toRate) || 0);
-  const elapsed = Math.max(0, Number(elapsedMs) || 0);
-  const progress = Math.min(1, elapsed / TOKEN_RATE_SETTLE_MS);
-  const eased = 1 - Math.pow(1 - progress, 3);
-  return from + (to - from) * eased;
-}
-
-// Estimated output tokens per second of model-busy time — roughly the unit an inference
-// benchmark reports, so the number is sanity-checkable against a known model's streaming
-// speed. An estimate, not a measurement: tokscale times a message as a whole rather than
-// its decode phase, and does not break output out per timed message, so the collector counts
-// an entry's output whenever that entry reported a duration (see timedOutputTokens in usage.js).
-//
-// Output rather than total tokens because cache reads dominate the total (typically >90%)
-// and were never generated, which would inflate the rate by two orders of magnitude and
-// read as a bug.
-//
-// Numerator and denominator describe the same entries, so this stays correct when periods are
-// summed across clients and devices — an all-output numerator over a timed-only denominator
-// would read high on any device running a client that reports no durations. Both ride the same
-// tokscale scan as the headline total, so it never divides a live numerator by a stale
-// denominator — the reason it dropped History activeTimeMs.
-function tokenRatePerSecond(period) {
-  const durationMs = positiveNumber(period?.timedDurationMs);
-  const timedOutput = positiveNumber(period?.timedOutputTokens);
-  if (!durationMs || !timedOutput) return 0;
-  return timedOutput * 1000 / durationMs;
-}
-// Every token per minute of the same model-busy window — the burn framing rather than the
-// speed one. This needs no coverage correction: timedTokens is exactly what the timed
-// messages carried, so numerator and denominator describe the identical set of messages.
-function tokenBurnPerMinute(period) {
-  const durationMs = positiveNumber(period?.timedDurationMs);
-  const timed = positiveNumber(period?.timedTokens);
-  if (!durationMs || !timed) return 0;
-  return timed * 60000 / durationMs;
-}
 function currentTokenRateValue() {
   const period = state.stats?.periods?.[state.period];
   const burn = state.settings?.tokenRateMode === 'burn';
-  return { burn, rate: burn ? tokenBurnPerMinute(period) : tokenRatePerSecond(period) };
+  return {
+    burn,
+    mode: burn ? 'burn' : 'speed',
+    rate: burn ? tokenBurnPerMinute(period) : tokenRatePerSecond(period)
+  };
 }
+const tokenRateBoost = tokenRateApi.createTokenRateBoostController({
+  readValue: currentTokenRateValue,
+  canStart: () => els.shell?.classList.contains('title-icon-only') || els.shell?.classList.contains('title-collapsed'),
+  prefersReducedMotion,
+  onChange: () => renderTokenRate()
+});
 function tokenRateText(rate, burn) {
   // formatCompact rounds, so a sub-0.5 rate would render as a bare "0". Treat that as no
   // data and stay hidden rather than claim a zero pace.
@@ -781,88 +738,26 @@ function tokenRateText(rate, burn) {
 function renderTokenRate() {
   if (!els.tokenRateReveal) return;
   const { burn, rate } = currentTokenRateValue();
-  const displayRate = tokenRateBoost
-    ? tokenRateBoostDisplayRate(tokenRateBoostNow())
-    : rate;
-  const text = tokenRateText(displayRate, burn);
+  const boost = tokenRateBoost.getSnapshot();
+  const displayRate = boost ? boost.displayRate : rate;
+  const text = tokenRateText(displayRate, boost ? boost.mode === 'burn' : burn);
   els.tokenRateReveal.textContent = text;
   els.tokenRateReveal.classList.toggle('has-value', Boolean(text));
-  els.tokenRateReveal.classList.toggle('boosting', tokenRateBoost?.phase === 'boosting');
-  els.tokenRateReveal.classList.toggle('settling', tokenRateBoost?.phase === 'settling');
-}
-function tokenRateBoostNow() {
-  return typeof performance !== 'undefined' && typeof performance.now === 'function'
-    ? performance.now()
-    : Date.now();
-}
-function tokenRateBoostDisplayRate(now) {
-  if (tokenRateBoost?.phase === 'settling') {
-    return tokenRateSettleValue(
-      tokenRateBoost.settleFromRate,
-      tokenRateBoost.settleToRate,
-      now - tokenRateBoost.settledAt
-    );
-  }
-  return tokenRateBoostValue(tokenRateBoost.baseRate, now - tokenRateBoost.startedAt);
-}
-function updateTokenRateBoost() {
-  if (!tokenRateBoost) return;
-  const now = tokenRateBoostNow();
-  if (tokenRateBoost.phase === 'settling' && now - tokenRateBoost.settledAt >= TOKEN_RATE_SETTLE_MS) {
-    tokenRateBoost = null;
-    tokenRateBoostAnimation = 0;
-    renderTokenRate();
-    return;
-  }
-  renderTokenRate();
-  tokenRateBoostAnimation = requestAnimationFrame(updateTokenRateBoost);
-}
-function cancelTokenRateBoostAnimation() {
-  if (tokenRateBoostAnimation) cancelAnimationFrame(tokenRateBoostAnimation);
-  tokenRateBoostAnimation = 0;
+  els.tokenRateReveal.classList.toggle('boosting', boost?.phase === 'boosting');
+  els.tokenRateReveal.classList.toggle('settling', boost?.phase === 'settling');
 }
 function startTokenRateBoost(event) {
-  if (event.button !== undefined && event.button !== 0) return;
-  ignoreNextTokenRateClick = false;
-  if (tokenRateBoost || prefersReducedMotion()) return;
-  if (!els.shell?.classList.contains('title-icon-only') && !els.shell?.classList.contains('title-collapsed')) return;
-  const { rate } = currentTokenRateValue();
-  tokenRateBoost = {
-    phase: 'boosting',
-    baseRate: Math.max(1, rate),
-    pointerId: event.pointerId,
-    startedAt: tokenRateBoostNow()
-  };
+  if (!tokenRateBoost.start(event)) return;
   try { event.currentTarget?.setPointerCapture?.(event.pointerId); } catch (_) {}
-  renderTokenRate();
-  tokenRateBoostAnimation = requestAnimationFrame(updateTokenRateBoost);
 }
-function stopTokenRateBoost(event) {
-  if (!tokenRateBoost || tokenRateBoost.phase === 'settling') return;
-  if (event?.pointerId !== undefined && event.pointerId !== tokenRateBoost.pointerId) return;
-  const elapsed = tokenRateBoostNow() - tokenRateBoost.startedAt;
-  const suppressClick = (event?.type === 'pointerup' || event?.type === 'lostpointercapture') && elapsed >= TOKEN_RATE_HOLD_THRESHOLD_MS;
-  if (elapsed < TOKEN_RATE_HOLD_THRESHOLD_MS) {
-    tokenRateBoost = null;
-    cancelTokenRateBoostAnimation();
-    renderTokenRate();
-    return;
-  }
-  const { rate: settleToRate } = currentTokenRateValue();
-  tokenRateBoost = {
-    ...tokenRateBoost,
-    phase: 'settling',
-    settleFromRate: tokenRateBoostValue(tokenRateBoost.baseRate, elapsed),
-    settleToRate,
-    settledAt: tokenRateBoostNow()
-  };
-  if (suppressClick) ignoreNextTokenRateClick = true;
-  renderTokenRate();
-  if (!tokenRateBoostAnimation) tokenRateBoostAnimation = requestAnimationFrame(updateTokenRateBoost);
+function releaseTokenRateBoost(event) {
+  tokenRateBoost.release(event);
+}
+function cancelTokenRateBoost(event, options) {
+  tokenRateBoost.cancel(event, options);
 }
 function suppressTokenRateClickAfterHold(event) {
-  if (!ignoreNextTokenRateClick) return;
-  ignoreNextTokenRateClick = false;
+  if (!tokenRateBoost.consumeClick()) return;
   event.stopImmediatePropagation();
 }
 // The title mark is the only pixel of the reveal that can take a click: a drag region does
@@ -872,10 +767,13 @@ function suppressTokenRateClickAfterHold(event) {
 // control here is worse than no keyboard path: the window assigns focus to a control when it
 // is shown, and Chromium then derives :focus-visible from that activation rather than from
 // any click, so the reveal reopens with a focus ring on a window the user just summoned with
-// the pointer nowhere near the title. The renderer cannot even clean that up, because it
-// receives no blur, focus or visibilitychange event across a real hide and show. Short clicks
-// still switch the reading; a sustained pointer hold is the transient boost affordance.
+// the pointer nowhere near the title. Visibility cancellation keeps transient state from
+// surviving a hide/show, but it does not make this hover-only reading a useful keyboard control.
+// Short clicks still switch the reading; a sustained pointer hold is the transient boost affordance.
 function toggleTokenRateMode() {
+  // A mode switch during settling would relabel the old reading with the new unit. End the
+  // transient state first; the next render then starts from the selected framing's real rate.
+  tokenRateBoost.cancel(undefined, { suppressClick: false });
   const next = state.settings?.tokenRateMode === 'burn' ? 'speed' : 'burn';
   // Repaint before the settings round trip. saveSettings re-syncs the entire settings form,
   // which is orders of magnitude heavier than this label and would make the switch lag.
@@ -9478,7 +9376,7 @@ els.backHomeButton?.addEventListener('click', (event) => {
 });
 
 window.addEventListener('blur', () => {
-  stopTokenRateBoost();
+  cancelTokenRateBoost();
   clearViewSwitcherLongPress();
   clearViewSwitcherHoverClose();
   viewSwitcherLongPressTriggered = false;
@@ -9600,8 +9498,15 @@ els.hubModeOptions.addEventListener('change', async (event) => {
 // the persisted speed/burn framing when its pointerup synthesizes a click.
 els.appTitleMark?.addEventListener('pointerdown', startTokenRateBoost);
 els.liveDot?.addEventListener('pointerdown', startTokenRateBoost);
-els.appTitleMark?.addEventListener('lostpointercapture', stopTokenRateBoost);
-els.liveDot?.addEventListener('lostpointercapture', stopTokenRateBoost);
+els.appTitleMark?.addEventListener('lostpointercapture', (event) => {
+  // A normal pointerup has already entered settling before capture is released. Only an
+  // unexpected loss while boosting is a cancellation; otherwise the release animation would
+  // be cut off immediately by the browser's follow-up lostpointercapture event.
+  cancelTokenRateBoost(event, { preserveSettling: true });
+});
+els.liveDot?.addEventListener('lostpointercapture', (event) => {
+  cancelTokenRateBoost(event, { preserveSettling: true });
+});
 els.appTitleMark?.addEventListener('click', suppressTokenRateClickAfterHold);
 els.liveDot?.addEventListener('click', suppressTokenRateClickAfterHold);
 els.appTitleMark?.addEventListener('click', toggleTokenRateMode);
@@ -10138,7 +10043,7 @@ const statsRenderScheduler = statsRenderSchedulerApi.createStatsRenderScheduler(
   render: renderStatsUpdate
 });
 document.addEventListener('visibilitychange', () => {
-  if (document.hidden) stopTokenRateBoost();
+  if (document.hidden) cancelTokenRateBoost();
   statsRenderScheduler.flush();
 });
 

--- a/src/electron/renderer/index.html
+++ b/src/electron/renderer/index.html
@@ -1425,6 +1425,7 @@
     <script src="../../shared/compactTokens.js"></script>
     <script src="../../shared/trayText.js"></script>
     <script src="../../shared/trayLayout.js"></script>
+    <script src="tokenRatePresentation.js"></script>
     <script src="../motionPreference.js"></script>
     <script src="../windowsBackdropMode.js"></script>
     <script src="windowsGlass.js"></script>

--- a/src/electron/renderer/styles.css
+++ b/src/electron/renderer/styles.css
@@ -315,6 +315,20 @@ body.is-windows.floating-bubble-collapsed-right .floating-bubble-tab {
   color: var(--text);
   opacity: 0.82;
 }
+.shell.title-collapsed .token-rate-reveal.boosting,
+.shell.title-icon-only .token-rate-reveal.boosting {
+  max-width: 18ch;
+  color: var(--accent);
+  opacity: 0.96;
+  text-shadow: 0 0 8px rgba(var(--accent-rgb), 0.35);
+}
+.shell.title-collapsed .token-rate-reveal.settling,
+.shell.title-icon-only .token-rate-reveal.settling {
+  max-width: 18ch;
+  color: var(--text);
+  opacity: 0.82;
+  text-shadow: none;
+}
 @media (prefers-reduced-motion: reduce) {
   .token-rate-reveal { transition: none; }
 }

--- a/src/electron/renderer/tokenRatePresentation.js
+++ b/src/electron/renderer/tokenRatePresentation.js
@@ -1,0 +1,229 @@
+'use strict';
+
+(function exposeTokenRate(root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  if (root) root.TokenMonitorTokenRate = api;
+})(typeof window !== 'undefined' ? window : null, function createTokenRateApi() {
+  const TOKEN_RATE_BOOST_DOUBLING_MS = 520;
+  const TOKEN_RATE_HOLD_THRESHOLD_MS = 180;
+  const TOKEN_RATE_SETTLE_MS = 720;
+  const TOKEN_RATE_MAX_DISPLAY_RATE = 1e12;
+
+  function positiveNumber(value) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  }
+
+  function tokenRateBoostValue(baseRate, elapsedMs, maxRate = TOKEN_RATE_MAX_DISPLAY_RATE) {
+    const base = positiveNumber(baseRate);
+    const cap = positiveNumber(maxRate) || TOKEN_RATE_MAX_DISPLAY_RATE;
+    if (!base) return 0;
+    if (base >= cap) return cap;
+    const elapsed = Math.max(0, Number(elapsedMs) || 0);
+    const maxElapsed = TOKEN_RATE_BOOST_DOUBLING_MS * Math.log2(cap / base);
+    const boundedElapsed = Math.min(elapsed, maxElapsed);
+    return Math.min(cap, base * 2 ** (boundedElapsed / TOKEN_RATE_BOOST_DOUBLING_MS));
+  }
+
+  function tokenRateSettleValue(fromRate, toRate, elapsedMs) {
+    const from = Math.max(0, Number(fromRate) || 0);
+    const to = Math.max(0, Number(toRate) || 0);
+    const elapsed = Math.max(0, Number(elapsedMs) || 0);
+    const progress = Math.min(1, elapsed / TOKEN_RATE_SETTLE_MS);
+    const eased = 1 - Math.pow(1 - progress, 3);
+    return from + (to - from) * eased;
+  }
+
+  function tokenRatePerSecond(period) {
+    const durationMs = positiveNumber(period?.timedDurationMs);
+    const timedOutput = positiveNumber(period?.timedOutputTokens);
+    if (!durationMs || !timedOutput) return 0;
+    return timedOutput * 1000 / durationMs;
+  }
+
+  function tokenBurnPerMinute(period) {
+    const durationMs = positiveNumber(period?.timedDurationMs);
+    const timed = positiveNumber(period?.timedTokens);
+    if (!durationMs || !timed) return 0;
+    return timed * 60000 / durationMs;
+  }
+
+  function defaultNow() {
+    return typeof performance !== 'undefined' && typeof performance.now === 'function'
+      ? performance.now()
+      : Date.now();
+  }
+
+  function defaultRequestFrame(callback) {
+    if (typeof requestAnimationFrame === 'function') return requestAnimationFrame(callback);
+    return setTimeout(callback, 16);
+  }
+
+  function defaultCancelFrame(frameId) {
+    if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(frameId);
+    else clearTimeout(frameId);
+  }
+
+  function createTokenRateBoostController({
+    readValue,
+    canStart = () => true,
+    prefersReducedMotion = () => false,
+    onChange = () => {},
+    now = defaultNow,
+    requestFrame = defaultRequestFrame,
+    cancelFrame = defaultCancelFrame,
+    maxDisplayRate = TOKEN_RATE_MAX_DISPLAY_RATE
+  } = {}) {
+    if (typeof readValue !== 'function') throw new TypeError('readValue must be a function');
+    if (typeof canStart !== 'function') throw new TypeError('canStart must be a function');
+    if (typeof prefersReducedMotion !== 'function') throw new TypeError('prefersReducedMotion must be a function');
+    if (typeof onChange !== 'function') throw new TypeError('onChange must be a function');
+    if (typeof now !== 'function') throw new TypeError('now must be a function');
+    if (typeof requestFrame !== 'function') throw new TypeError('requestFrame must be a function');
+    if (typeof cancelFrame !== 'function') throw new TypeError('cancelFrame must be a function');
+
+    const displayCap = positiveNumber(maxDisplayRate) || TOKEN_RATE_MAX_DISPLAY_RATE;
+    let state = null;
+    let frameId = null;
+    let suppressNextClick = false;
+
+    function currentTime() {
+      const value = Number(now());
+      return Number.isFinite(value) ? value : Date.now();
+    }
+
+    function currentValue() {
+      const value = readValue() || {};
+      return {
+        rate: positiveNumber(value.rate),
+        mode: value.mode === 'burn' || value.burn === true ? 'burn' : 'speed'
+      };
+    }
+
+    function cancelScheduledFrame() {
+      if (frameId !== null) cancelFrame(frameId);
+      frameId = null;
+    }
+
+    function notify() {
+      onChange();
+    }
+
+    function snapshot() {
+      if (!state) return null;
+      const timestamp = currentTime();
+      const elapsed = Math.max(0, timestamp - state.startedAt);
+      const displayRate = state.phase === 'settling'
+        ? tokenRateSettleValue(state.settleFromRate, state.settleToRate, timestamp - state.settledAt)
+        : tokenRateBoostValue(state.baseRate, elapsed, displayCap);
+      return { ...state, displayRate, elapsedMs: elapsed };
+    }
+
+    function schedule() {
+      if (!state || frameId !== null) return;
+      frameId = requestFrame(step);
+    }
+
+    function step() {
+      frameId = null;
+      if (!state) return;
+      const timestamp = currentTime();
+      if (state.phase === 'settling' && timestamp - state.settledAt >= TOKEN_RATE_SETTLE_MS) {
+        state = null;
+        notify();
+        return;
+      }
+      notify();
+      schedule();
+    }
+
+    function matchesPointer(event) {
+      return event?.pointerId === undefined || event.pointerId === state?.pointerId;
+    }
+
+    function start(event) {
+      if (event?.button !== undefined && event.button !== 0) return false;
+      if (state || !canStart() || prefersReducedMotion()) return false;
+      const value = currentValue();
+      if (!(value.rate > 0)) return false;
+      state = {
+        phase: 'boosting',
+        baseRate: value.rate,
+        mode: value.mode,
+        pointerId: event?.pointerId,
+        startedAt: currentTime()
+      };
+      notify();
+      schedule();
+      return true;
+    }
+
+    function release(event) {
+      if (!state || state.phase !== 'boosting' || !matchesPointer(event)) return false;
+      const timestamp = currentTime();
+      const elapsed = Math.max(0, timestamp - state.startedAt);
+      if (elapsed < TOKEN_RATE_HOLD_THRESHOLD_MS) {
+        state = null;
+        cancelScheduledFrame();
+        notify();
+        return false;
+      }
+      const value = currentValue();
+      state = {
+        ...state,
+        phase: 'settling',
+        settleFromRate: tokenRateBoostValue(state.baseRate, elapsed, displayCap),
+        settleToRate: value.rate,
+        settledAt: timestamp
+      };
+      suppressNextClick = true;
+      notify();
+      schedule();
+      return true;
+    }
+
+    function cancel(event, { preserveSettling = false, suppressClick = true } = {}) {
+      if (event?.pointerId !== undefined && !matchesPointer(event)) return false;
+      if (preserveSettling && state?.phase === 'settling') return false;
+      const hadState = Boolean(state);
+      if (!hadState) {
+        if (!suppressClick) suppressNextClick = false;
+        return false;
+      }
+      state = null;
+      cancelScheduledFrame();
+      if (suppressClick) suppressNextClick = true;
+      else suppressNextClick = false;
+      notify();
+      return true;
+    }
+
+    function consumeClick() {
+      if (!suppressNextClick) return false;
+      suppressNextClick = false;
+      return true;
+    }
+
+    return {
+      cancel,
+      consumeClick,
+      getSnapshot: snapshot,
+      release,
+      start
+    };
+  }
+
+  return {
+    TOKEN_RATE_BOOST_DOUBLING_MS,
+    TOKEN_RATE_HOLD_THRESHOLD_MS,
+    TOKEN_RATE_MAX_DISPLAY_RATE,
+    TOKEN_RATE_SETTLE_MS,
+    createTokenRateBoostController,
+    positiveNumber,
+    tokenBurnPerMinute,
+    tokenRateBoostValue,
+    tokenRatePerSecond,
+    tokenRateSettleValue
+  };
+});

--- a/src/electron/renderer/tokenRatePresentation.js
+++ b/src/electron/renderer/tokenRatePresentation.js
@@ -32,11 +32,14 @@
     return Math.min(cap, base * 2 ** (boundedElapsed / TOKEN_RATE_BOOST_DOUBLING_MS));
   }
 
-  function tokenRateSettleValue(fromRate, toRate, elapsedMs) {
+  function tokenRateSettleValue(fromRate, toRate, elapsedMs, durationMs = TOKEN_RATE_SETTLE_MS) {
     const from = cappedTokenRate(fromRate);
     const to = cappedTokenRate(toRate);
     const elapsed = Math.max(0, Number(elapsedMs) || 0);
-    const progress = Math.min(1, elapsed / TOKEN_RATE_SETTLE_MS);
+    const duration = Number(durationMs);
+    const progress = duration >= 0 && Number.isFinite(duration) && duration > 0
+      ? Math.min(1, elapsed / duration)
+      : duration === 0 ? 1 : Math.min(1, elapsed / TOKEN_RATE_SETTLE_MS);
     const eased = 1 - Math.pow(1 - progress, 3);
     return cappedTokenRate(from + (to - from) * eased);
   }
@@ -120,8 +123,9 @@
       if (!state) return null;
       const timestamp = currentTime();
       const elapsed = Math.max(0, timestamp - state.startedAt);
+      const settleDuration = state.settleDurationMs ?? TOKEN_RATE_SETTLE_MS;
       const displayRate = state.phase === 'settling'
-        ? tokenRateSettleValue(state.settleFromRate, state.settleToRate, timestamp - state.settledAt)
+        ? tokenRateSettleValue(state.settleFromRate, state.settleToRate, timestamp - state.settledAt, settleDuration)
         : tokenRateBoostValue(state.baseRate, elapsed, displayCap);
       return { ...state, displayRate, elapsedMs: elapsed };
     }
@@ -135,13 +139,39 @@
       frameId = null;
       if (!state) return;
       const timestamp = currentTime();
-      if (state.phase === 'settling' && timestamp - state.settledAt >= TOKEN_RATE_SETTLE_MS) {
+      if (state.phase === 'settling' && timestamp - state.settledAt >= (state.settleDurationMs ?? TOKEN_RATE_SETTLE_MS)) {
         state = null;
         notify();
         return;
       }
       notify();
       schedule();
+    }
+
+    function refresh() {
+      if (!state || state.phase !== 'settling') return false;
+      const timestamp = currentTime();
+      const elapsed = Math.max(0, timestamp - state.settledAt);
+      const duration = state.settleDurationMs ?? TOKEN_RATE_SETTLE_MS;
+      if (elapsed >= duration) return false;
+
+      const value = currentValue();
+      if (value.mode !== state.mode) {
+        state = null;
+        cancelScheduledFrame();
+        suppressNextClick = false;
+        return true;
+      }
+      if (value.rate === state.settleToRate) return false;
+
+      state = {
+        ...state,
+        settleFromRate: tokenRateSettleValue(state.settleFromRate, state.settleToRate, elapsed, duration),
+        settleToRate: value.rate,
+        settledAt: timestamp,
+        settleDurationMs: duration - elapsed
+      };
+      return true;
     }
 
     function matchesPointer(event) {
@@ -194,7 +224,8 @@
         phase: 'settling',
         settleFromRate: tokenRateBoostValue(state.baseRate, elapsed, displayCap),
         settleToRate: value.rate,
-        settledAt: timestamp
+        settledAt: timestamp,
+        settleDurationMs: TOKEN_RATE_SETTLE_MS
       };
       suppressNextClick = true;
       notify();
@@ -228,6 +259,7 @@
       cancel,
       consumeClick,
       getSnapshot: snapshot,
+      refresh,
       release,
       start
     };

--- a/src/electron/renderer/tokenRatePresentation.js
+++ b/src/electron/renderer/tokenRatePresentation.js
@@ -144,6 +144,10 @@
 
     function start(event) {
       if (event?.button !== undefined && event.button !== 0) return false;
+      // A new primary pointer sequence cannot belong to a canceled gesture. Clear a guard that
+      // was left behind when blur/pointercancel produced no follow-up click; if the canceled
+      // gesture does produce one, consumeClick() runs before this next pointerdown instead.
+      suppressNextClick = false;
       if (state || !canStart() || prefersReducedMotion()) return false;
       const value = currentValue();
       if (!(value.rate > 0)) return false;

--- a/src/electron/renderer/tokenRatePresentation.js
+++ b/src/electron/renderer/tokenRatePresentation.js
@@ -148,6 +148,12 @@
       // was left behind when blur/pointercancel produced no follow-up click; if the canceled
       // gesture does produce one, consumeClick() runs before this next pointerdown instead.
       suppressNextClick = false;
+      if (state?.phase === 'settling') {
+        // A second hold is a new gesture, not a mode click. Interrupt the old release animation
+        // so the new pointer can own the controller immediately.
+        state = null;
+        cancelScheduledFrame();
+      }
       if (state || !canStart() || prefersReducedMotion()) return false;
       const value = currentValue();
       if (!(value.rate > 0)) return false;

--- a/src/electron/renderer/tokenRatePresentation.js
+++ b/src/electron/renderer/tokenRatePresentation.js
@@ -157,15 +157,15 @@
       // gesture does produce one, consumeClick() runs before this next pointerdown instead.
       suppressNextClick = false;
       if (!enabled || reduced) return false;
+      if (state && state.phase !== 'settling') return false;
+      const value = currentValue();
+      if (!(value.rate > 0)) return false;
       if (state?.phase === 'settling') {
         // A second hold is a new gesture, not a mode click. Interrupt the old release animation
         // so the new pointer can own the controller immediately.
         state = null;
         cancelScheduledFrame();
       }
-      if (state) return false;
-      const value = currentValue();
-      if (!(value.rate > 0)) return false;
       state = {
         phase: 'boosting',
         baseRate: value.rate,

--- a/src/electron/renderer/tokenRatePresentation.js
+++ b/src/electron/renderer/tokenRatePresentation.js
@@ -15,6 +15,12 @@
     return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
   }
 
+  function cappedTokenRate(value) {
+    const parsed = Number(value);
+    if (Number.isNaN(parsed) || parsed <= 0) return 0;
+    return Math.min(TOKEN_RATE_MAX_DISPLAY_RATE, parsed);
+  }
+
   function tokenRateBoostValue(baseRate, elapsedMs, maxRate = TOKEN_RATE_MAX_DISPLAY_RATE) {
     const base = positiveNumber(baseRate);
     const cap = positiveNumber(maxRate) || TOKEN_RATE_MAX_DISPLAY_RATE;
@@ -27,26 +33,26 @@
   }
 
   function tokenRateSettleValue(fromRate, toRate, elapsedMs) {
-    const from = Math.max(0, Number(fromRate) || 0);
-    const to = Math.max(0, Number(toRate) || 0);
+    const from = cappedTokenRate(fromRate);
+    const to = cappedTokenRate(toRate);
     const elapsed = Math.max(0, Number(elapsedMs) || 0);
     const progress = Math.min(1, elapsed / TOKEN_RATE_SETTLE_MS);
     const eased = 1 - Math.pow(1 - progress, 3);
-    return from + (to - from) * eased;
+    return cappedTokenRate(from + (to - from) * eased);
   }
 
   function tokenRatePerSecond(period) {
     const durationMs = positiveNumber(period?.timedDurationMs);
     const timedOutput = positiveNumber(period?.timedOutputTokens);
     if (!durationMs || !timedOutput) return 0;
-    return timedOutput * 1000 / durationMs;
+    return cappedTokenRate(timedOutput * 1000 / durationMs);
   }
 
   function tokenBurnPerMinute(period) {
     const durationMs = positiveNumber(period?.timedDurationMs);
     const timed = positiveNumber(period?.timedTokens);
     if (!durationMs || !timed) return 0;
-    return timed * 60000 / durationMs;
+    return cappedTokenRate(timed * 60000 / durationMs);
   }
 
   function defaultNow() {
@@ -96,7 +102,7 @@
     function currentValue() {
       const value = readValue() || {};
       return {
-        rate: positiveNumber(value.rate),
+        rate: Math.min(displayCap, cappedTokenRate(value.rate)),
         mode: value.mode === 'burn' || value.burn === true ? 'burn' : 'speed'
       };
     }
@@ -144,17 +150,20 @@
 
     function start(event) {
       if (event?.button !== undefined && event.button !== 0) return false;
+      const enabled = canStart();
+      const reduced = prefersReducedMotion();
       // A new primary pointer sequence cannot belong to a canceled gesture. Clear a guard that
       // was left behind when blur/pointercancel produced no follow-up click; if the canceled
       // gesture does produce one, consumeClick() runs before this next pointerdown instead.
       suppressNextClick = false;
+      if (!enabled || reduced) return false;
       if (state?.phase === 'settling') {
         // A second hold is a new gesture, not a mode click. Interrupt the old release animation
         // so the new pointer can own the controller immediately.
         state = null;
         cancelScheduledFrame();
       }
-      if (state || !canStart() || prefersReducedMotion()) return false;
+      if (state) return false;
       const value = currentValue();
       if (!(value.rate > 0)) return false;
       state = {
@@ -229,6 +238,7 @@
     TOKEN_RATE_HOLD_THRESHOLD_MS,
     TOKEN_RATE_MAX_DISPLAY_RATE,
     TOKEN_RATE_SETTLE_MS,
+    cappedTokenRate,
     createTokenRateBoostController,
     positiveNumber,
     tokenBurnPerMinute,

--- a/tests/electron/motionPreference.test.js
+++ b/tests/electron/motionPreference.test.js
@@ -43,6 +43,7 @@ test('appearance exposes and persists the three-state motion control', () => {
 
 test('enabling reduced motion settles active row counters immediately', () => {
   const app = read('app.js');
+  assert.match(app, /function settleMotionAnimations\(\) \{[\s\S]*?cancelTokenRateBoost\(undefined, \{ suppressClick: false \}\)/);
   assert.match(app, /const rowNumberAnimations = new Map\(\)/);
   assert.match(app, /for \(const \[el, motion\] of rowNumberAnimations\)[\s\S]*?cancelAnimationFrame\(motion\.handle\)[\s\S]*?rowNumberAnimations\.clear\(\)/);
   assert.match(app, /rowBarAnimations\.clear\(\)/);

--- a/tests/electron/statsRenderScheduler.test.js
+++ b/tests/electron/statsRenderScheduler.test.js
@@ -79,11 +79,19 @@ test('renderer wires visibility scheduling without deferring tray icon updates',
   const statsPush = app.match(/window\.tokenMonitor\.onStatsPush\?\.\(\(payload\) => \{[\s\S]*?\n\}\);/)?.[0] || '';
   const schedulerIndex = html.indexOf('<script src="statsRenderScheduler.js"></script>');
   const appIndex = html.indexOf('<script src="app.js"></script>');
+  const visibilityListenerStart = app.indexOf("document.addEventListener('visibilitychange'");
+  const visibilityListenerEnd = app.indexOf('window.tokenMonitor.onStatsPush', visibilityListenerStart);
+  const visibilityListener = visibilityListenerStart >= 0 && visibilityListenerEnd > visibilityListenerStart
+    ? app.slice(visibilityListenerStart, visibilityListenerEnd)
+    : '';
 
   assert.notEqual(schedulerIndex, -1);
   assert.notEqual(appIndex, -1);
   assert.ok(schedulerIndex < appIndex);
-  assert.match(app, /document\.addEventListener\('visibilitychange', \(\) => statsRenderScheduler\.flush\(\)\);/);
+  assert.notEqual(visibilityListenerStart, -1);
+  assert.notEqual(visibilityListenerEnd, -1);
+  assert.match(visibilityListener, /stopTokenRateBoost\(\)/);
+  assert.match(visibilityListener, /statsRenderScheduler\.flush\(\)/);
   assert.match(
     statsPush,
     /state\.stats = overlayAllTimeSessions\(payload\.data\.stats\);[\s\S]*statsRenderScheduler\.request\(\);[\s\S]*maybeUpdateBarsIcon\(\);/

--- a/tests/electron/statsRenderScheduler.test.js
+++ b/tests/electron/statsRenderScheduler.test.js
@@ -90,7 +90,7 @@ test('renderer wires visibility scheduling without deferring tray icon updates',
   assert.ok(schedulerIndex < appIndex);
   assert.notEqual(visibilityListenerStart, -1);
   assert.notEqual(visibilityListenerEnd, -1);
-  assert.match(visibilityListener, /stopTokenRateBoost\(\)/);
+  assert.match(visibilityListener, /cancelTokenRateBoost\(\)/);
   assert.match(visibilityListener, /statsRenderScheduler\.flush\(\)/);
   assert.match(
     statsPush,

--- a/tests/electron/tokenRate.test.js
+++ b/tests/electron/tokenRate.test.js
@@ -22,16 +22,17 @@ function tokenRateFunctions() {
   return tokenRateApi;
 }
 
-function createBoostHarness({ rate = 100, mode = 'speed', reducedMotion = false } = {}) {
+function createBoostHarness({ rate = 100, mode = 'speed', reducedMotion = false, canStart = true } = {}) {
   let now = 0;
   let nextFrameId = 0;
+  let enabled = canStart;
   let controller;
   const frames = new Map();
   const changes = [];
   const value = { rate, mode };
   controller = tokenRateApi.createTokenRateBoostController({
     readValue: () => value,
-    canStart: () => true,
+    canStart: () => enabled,
     prefersReducedMotion: () => reducedMotion,
     now: () => now,
     requestFrame: (callback) => {
@@ -53,6 +54,7 @@ function createBoostHarness({ rate = 100, mode = 'speed', reducedMotion = false 
       callback();
     },
     frames,
+    setCanStart(value) { enabled = value; },
     value
   };
 }
@@ -103,7 +105,7 @@ test('the burn reading reads zero without throughput data', () => {
 });
 
 test('holding the title mark accelerates from the real rate and keeps rising', () => {
-  const { tokenRateBoostValue, tokenRateSettleValue } = tokenRateFunctions();
+  const { tokenRateBoostValue, tokenRateSettleValue, tokenRatePerSecond, tokenBurnPerMinute } = tokenRateFunctions();
   assert.equal(tokenRateBoostValue(0, 0), 0);
   assert.equal(tokenRateBoostValue(100, -1), 100);
   assert.ok(tokenRateBoostValue(100, 520) >= 200);
@@ -115,6 +117,9 @@ test('holding the title mark accelerates from the real rate and keeps rising', (
   assert.equal(tokenRateSettleValue(boosted, 100, 720), 100);
   assert.equal(tokenRateBoostValue(100, Number.POSITIVE_INFINITY), tokenRateApi.TOKEN_RATE_MAX_DISPLAY_RATE);
   assert.ok(Number.isFinite(tokenRateBoostValue(100, 30_000)));
+  assert.equal(tokenRatePerSecond({ timedOutputTokens: Number.MAX_VALUE, timedDurationMs: 1 }), tokenRateApi.TOKEN_RATE_MAX_DISPLAY_RATE);
+  assert.equal(tokenBurnPerMinute({ timedTokens: Number.MAX_VALUE, timedDurationMs: 1 }), tokenRateApi.TOKEN_RATE_MAX_DISPLAY_RATE);
+  assert.equal(tokenRateSettleValue(Number.POSITIVE_INFINITY, 100, 0), tokenRateApi.TOKEN_RATE_MAX_DISPLAY_RATE);
 });
 
 test('the boost controller cancels pointercancel and blur immediately', () => {
@@ -196,6 +201,19 @@ test('a new hold interrupts settling and suppresses its own click', () => {
   assert.equal(harness.controller.release({ type: 'pointerup', pointerId: 2 }), true);
   assert.equal(harness.controller.getSnapshot().phase, 'settling');
   assert.equal(harness.controller.consumeClick(), true);
+});
+
+test('a failed new hold does not clear settling without a repaint', () => {
+  const harness = createBoostHarness();
+  assert.equal(harness.controller.start({ button: 0, pointerId: 1 }), true);
+  harness.advance(1_000);
+  assert.equal(harness.controller.release({ type: 'pointerup', pointerId: 1 }), true);
+  const changesBeforeFailedStart = harness.changes.length;
+
+  harness.setCanStart(false);
+  assert.equal(harness.controller.start({ button: 0, pointerId: 2 }), false);
+  assert.equal(harness.controller.getSnapshot().phase, 'settling');
+  assert.equal(harness.changes.length, changesBeforeFailedStart);
 });
 
 test('lost pointer capture cancels boosting but preserves a normal release settlement', () => {
@@ -302,7 +320,9 @@ test('the token-rate hold has release, cancellation, reduced-motion, and click-g
   assert.match(app, /document\.addEventListener\('pointercancel', \(event\) => \{\s*cancelTokenRateBoost\(event\)/);
   assert.match(app, /window\.addEventListener\('blur', \(\) => \{\s*cancelTokenRateBoost\(\)/);
   assert.match(app, /if \(document\.hidden\) cancelTokenRateBoost\(\)/);
-  assert.match(tokenRatePresentation, /if \(state \|\| !canStart\(\) \|\| prefersReducedMotion\(\)\) return false/);
+  assert.match(tokenRatePresentation, /const enabled = canStart\(\);/);
+  assert.match(tokenRatePresentation, /const reduced = prefersReducedMotion\(\);/);
+  assert.match(tokenRatePresentation, /if \(!enabled \|\| reduced\) return false/);
   assert.match(tokenRatePresentation, /if \(!\(value\.rate > 0\)\) return false/);
   assert.match(tokenRatePresentation, /if \(state\?\.phase === 'settling'\) \{[\s\S]*?cancelScheduledFrame\(\)/);
   assert.match(app, /cancelTokenRateBoost\(event, \{ preserveSettling: true \}\)/);

--- a/tests/electron/tokenRate.test.js
+++ b/tests/electron/tokenRate.test.js
@@ -184,6 +184,20 @@ test('a held pointer settles to the latest rate and suppresses only the next cli
   assert.equal(harness.controller.getSnapshot(), null);
 });
 
+test('a new hold interrupts settling and suppresses its own click', () => {
+  const harness = createBoostHarness();
+  assert.equal(harness.controller.start({ button: 0, pointerId: 1 }), true);
+  harness.advance(1_000);
+  assert.equal(harness.controller.release({ type: 'pointerup', pointerId: 1 }), true);
+  assert.equal(harness.controller.consumeClick(), true);
+
+  assert.equal(harness.controller.start({ button: 0, pointerId: 2 }), true);
+  harness.advance(300);
+  assert.equal(harness.controller.release({ type: 'pointerup', pointerId: 2 }), true);
+  assert.equal(harness.controller.getSnapshot().phase, 'settling');
+  assert.equal(harness.controller.consumeClick(), true);
+});
+
 test('lost pointer capture cancels boosting but preserves a normal release settlement', () => {
   const canceled = createBoostHarness();
   assert.equal(canceled.controller.start({ button: 0, pointerId: 1 }), true);
@@ -290,6 +304,7 @@ test('the token-rate hold has release, cancellation, reduced-motion, and click-g
   assert.match(app, /if \(document\.hidden\) cancelTokenRateBoost\(\)/);
   assert.match(tokenRatePresentation, /if \(state \|\| !canStart\(\) \|\| prefersReducedMotion\(\)\) return false/);
   assert.match(tokenRatePresentation, /if \(!\(value\.rate > 0\)\) return false/);
+  assert.match(tokenRatePresentation, /if \(state\?\.phase === 'settling'\) \{[\s\S]*?cancelScheduledFrame\(\)/);
   assert.match(app, /cancelTokenRateBoost\(event, \{ preserveSettling: true \}\)/);
   assert.match(app, /function suppressTokenRateClickAfterHold\(event\)/);
   assert.match(tokenRatePresentation, /function consumeClick\(\)/);

--- a/tests/electron/tokenRate.test.js
+++ b/tests/electron/tokenRate.test.js
@@ -130,6 +130,19 @@ test('the boost controller cancels pointercancel and blur immediately', () => {
   }
 });
 
+test('a canceled gesture without a click does not suppress the next short click', () => {
+  const harness = createBoostHarness();
+  assert.equal(harness.controller.start({ button: 0, pointerId: 1 }), true);
+  harness.advance(300);
+  assert.equal(harness.controller.cancel({ type: 'pointercancel', pointerId: 1 }), true);
+  assert.equal(harness.controller.getSnapshot(), null);
+
+  assert.equal(harness.controller.start({ button: 0, pointerId: 2 }), true);
+  harness.advance(100);
+  assert.equal(harness.controller.release({ type: 'pointerup', pointerId: 2 }), false);
+  assert.equal(harness.controller.consumeClick(), false);
+});
+
 test('the boost controller does not start without a usable rate', () => {
   const harness = createBoostHarness({ rate: 0 });
   assert.equal(harness.controller.start({ button: 0, pointerId: 1 }), false);

--- a/tests/electron/tokenRate.test.js
+++ b/tests/electron/tokenRate.test.js
@@ -4,34 +4,57 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
-const vm = require('node:vm');
 
 const rendererDir = path.join(__dirname, '..', '..', 'src', 'electron', 'renderer');
 const app = fs.readFileSync(path.join(rendererDir, 'app.js'), 'utf8');
+const tokenRatePresentation = fs.readFileSync(path.join(rendererDir, 'tokenRatePresentation.js'), 'utf8');
 const html = fs.readFileSync(path.join(rendererDir, 'index.html'), 'utf8');
 const css = fs.readFileSync(path.join(rendererDir, 'styles.css'), 'utf8');
+const tokenRateApi = require(path.join(rendererDir, 'tokenRatePresentation.js'));
 
 const main = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'electron', 'main.js'), 'utf8');
 
 function tokenRateSource() {
-  const start = app.indexOf('function positiveNumber(');
-  const end = app.indexOf('function renderTokenRate(', start);
-  assert.notEqual(start, -1, 'token-rate helpers should exist');
-  assert.notEqual(end, -1, 'renderTokenRate should follow the rate helpers');
-  return app.slice(start, end);
+  return tokenRatePresentation;
 }
 
 function tokenRateFunctions() {
-  const context = {};
-  vm.runInNewContext(
-    `${tokenRateSource()}
-     this.tokenRatePerSecond = tokenRatePerSecond;
-     this.tokenBurnPerMinute = tokenBurnPerMinute;
-     this.tokenRateBoostValue = tokenRateBoostValue;
-     this.tokenRateSettleValue = tokenRateSettleValue;`,
-    context
-  );
-  return context;
+  return tokenRateApi;
+}
+
+function createBoostHarness({ rate = 100, mode = 'speed', reducedMotion = false } = {}) {
+  let now = 0;
+  let nextFrameId = 0;
+  let controller;
+  const frames = new Map();
+  const changes = [];
+  const value = { rate, mode };
+  controller = tokenRateApi.createTokenRateBoostController({
+    readValue: () => value,
+    canStart: () => true,
+    prefersReducedMotion: () => reducedMotion,
+    now: () => now,
+    requestFrame: (callback) => {
+      const frameId = ++nextFrameId;
+      frames.set(frameId, callback);
+      return frameId;
+    },
+    cancelFrame: (frameId) => frames.delete(frameId),
+    onChange: () => changes.push(controller.getSnapshot())
+  });
+  return {
+    advance(ms) { now += ms; },
+    changes,
+    controller,
+    frame() {
+      const [frameId, callback] = frames.entries().next().value || [];
+      assert.notEqual(frameId, undefined, 'a frame should be scheduled');
+      frames.delete(frameId);
+      callback();
+    },
+    frames,
+    value
+  };
 }
 
 test('token rate is timed output tokens per second of timed model duration', () => {
@@ -81,7 +104,7 @@ test('the burn reading reads zero without throughput data', () => {
 
 test('holding the title mark accelerates from the real rate and keeps rising', () => {
   const { tokenRateBoostValue, tokenRateSettleValue } = tokenRateFunctions();
-  assert.equal(tokenRateBoostValue(0, 0), 1);
+  assert.equal(tokenRateBoostValue(0, 0), 0);
   assert.equal(tokenRateBoostValue(100, -1), 100);
   assert.ok(tokenRateBoostValue(100, 520) >= 200);
   assert.ok(tokenRateBoostValue(100, 1000) > 300);
@@ -90,6 +113,89 @@ test('holding the title mark accelerates from the real rate and keeps rising', (
   assert.ok(tokenRateSettleValue(boosted, 100, 360) < boosted);
   assert.ok(tokenRateSettleValue(boosted, 100, 360) > 100);
   assert.equal(tokenRateSettleValue(boosted, 100, 720), 100);
+  assert.equal(tokenRateBoostValue(100, Number.POSITIVE_INFINITY), tokenRateApi.TOKEN_RATE_MAX_DISPLAY_RATE);
+  assert.ok(Number.isFinite(tokenRateBoostValue(100, 30_000)));
+});
+
+test('the boost controller cancels pointercancel and blur immediately', () => {
+  for (const cancelEvent of [{ type: 'pointercancel', pointerId: 7 }, undefined]) {
+    const harness = createBoostHarness();
+    assert.equal(harness.controller.start({ button: 0, pointerId: 7 }), true);
+    harness.advance(300);
+    assert.equal(harness.controller.cancel(cancelEvent), true);
+    assert.equal(harness.controller.getSnapshot(), null);
+    assert.equal(harness.frames.size, 0);
+    assert.equal(harness.controller.consumeClick(), true);
+    assert.equal(harness.controller.consumeClick(), false);
+  }
+});
+
+test('the boost controller does not start without a usable rate', () => {
+  const harness = createBoostHarness({ rate: 0 });
+  assert.equal(harness.controller.start({ button: 0, pointerId: 1 }), false);
+  assert.equal(harness.controller.getSnapshot(), null);
+  assert.equal(harness.frames.size, 0);
+});
+
+test('reduced motion disables the transient boost', () => {
+  const harness = createBoostHarness({ reducedMotion: true });
+  assert.equal(harness.controller.start({ button: 0, pointerId: 1 }), false);
+  assert.equal(harness.controller.getSnapshot(), null);
+  assert.equal(harness.frames.size, 0);
+});
+
+test('a short click clears the transient state without suppressing the mode toggle', () => {
+  const harness = createBoostHarness();
+  assert.equal(harness.controller.start({ button: 0, pointerId: 1 }), true);
+  harness.advance(100);
+  assert.equal(harness.controller.release({ type: 'pointerup', pointerId: 1 }), false);
+  assert.equal(harness.controller.getSnapshot(), null);
+  assert.equal(harness.controller.consumeClick(), false);
+});
+
+test('a held pointer settles to the latest rate and suppresses only the next click', () => {
+  const harness = createBoostHarness();
+  assert.equal(harness.controller.start({ button: 0, pointerId: 1 }), true);
+  harness.advance(2_000);
+  harness.value.rate = 40;
+  assert.equal(harness.controller.release({ type: 'pointerup', pointerId: 1 }), true);
+  assert.equal(harness.controller.getSnapshot().phase, 'settling');
+  assert.equal(harness.controller.getSnapshot().settleToRate, 40);
+  assert.equal(harness.controller.consumeClick(), true);
+  assert.equal(harness.controller.consumeClick(), false);
+  harness.advance(360);
+  harness.frame();
+  assert.equal(harness.controller.getSnapshot().phase, 'settling');
+  harness.advance(360);
+  harness.frame();
+  assert.equal(harness.controller.getSnapshot(), null);
+});
+
+test('lost pointer capture cancels boosting but preserves a normal release settlement', () => {
+  const canceled = createBoostHarness();
+  assert.equal(canceled.controller.start({ button: 0, pointerId: 1 }), true);
+  canceled.advance(300);
+  assert.equal(canceled.controller.cancel({ type: 'lostpointercapture', pointerId: 1 }, { preserveSettling: true }), true);
+  assert.equal(canceled.controller.getSnapshot(), null);
+
+  const released = createBoostHarness();
+  assert.equal(released.controller.start({ button: 0, pointerId: 1 }), true);
+  released.advance(300);
+  assert.equal(released.controller.release({ type: 'pointerup', pointerId: 1 }), true);
+  assert.equal(released.controller.cancel({ type: 'lostpointercapture', pointerId: 1 }, { preserveSettling: true }), false);
+  assert.equal(released.controller.getSnapshot().phase, 'settling');
+});
+
+test('mode changes cancel settling before the next interaction uses the new unit', () => {
+  const harness = createBoostHarness();
+  assert.equal(harness.controller.start({ button: 0, pointerId: 1 }), true);
+  harness.advance(1_000);
+  assert.equal(harness.controller.release({ type: 'pointerup', pointerId: 1 }), true);
+  assert.equal(harness.controller.getSnapshot().mode, 'speed');
+  assert.equal(harness.controller.cancel(undefined, { suppressClick: false }), true);
+  harness.value.mode = 'burn';
+  assert.equal(harness.controller.start({ button: 0, pointerId: 2 }), true);
+  assert.equal(harness.controller.getSnapshot().mode, 'burn');
 });
 
 test('the reveal mode is a persisted setting that defaults to speed', () => {
@@ -100,6 +206,10 @@ test('the reveal mode is a persisted setting that defaults to speed', () => {
   // Hover and click must cover the same surface, so both reveal triggers toggle.
   assert.match(app, /els\.appTitleMark\?\.addEventListener\('click', toggleTokenRateMode\)/);
   assert.match(app, /els\.liveDot\?\.addEventListener\('click', toggleTokenRateMode\)/);
+  const presentationIndex = html.indexOf('<script src="tokenRatePresentation.js"></script>');
+  const appIndex = html.indexOf('<script src="app.js"></script>');
+  assert.notEqual(presentationIndex, -1);
+  assert.ok(presentationIndex < appIndex);
 });
 
 test('every element that reveals on hover is also clickable and shows a pointer', () => {
@@ -136,14 +246,13 @@ test('the reveal triggers stay non-focusable', () => {
   // Making either trigger focusable reopens the reveal on its own: the window assigns focus to
   // a control when it is shown, and Chromium derives :focus-visible from that activation rather
   // than from any click, so the reading and a focus ring appear on a freshly summoned window
-  // with the pointer nowhere near the title. The renderer cannot undo it either — it receives
-  // no blur, focus or visibilitychange event across a real hide and show. Pointer-only is the
-  // design, so the markup must stay inert.
+  // with the pointer nowhere near the title. Pointer-only is the design, so the markup must stay
+  // inert; the separate visibility cancellation path only protects transient hold state.
   //
   // This asserts the markup rather than the behaviour because the behaviour is not observable
-  // from here — it needs a real Electron window, and the renderer is not told when one is
-  // hidden or shown. Making these focusable is not banned forever: it needs evidence that a
-  // hidden-then-shown window no longer opens the reveal or draws a ring on its own.
+  // from here — it needs a real Electron window. Making these focusable is not banned forever:
+  // it needs evidence that a hidden-then-shown window no longer opens the reveal or draws a ring
+  // on its own.
   const reason = 'focusable here reopens the reveal on window show; see the comment above';
   const triggers = [...html.matchAll(/<(\w+)([^>]*\bclass="(?:app-title-mark|live-dot)"[^>]*)>/g)];
   assert.equal(triggers.length, 2, 'both reveal triggers are present in the title');
@@ -156,17 +265,22 @@ test('the reveal triggers stay non-focusable', () => {
 
 test('the token-rate hold has release, cancellation, reduced-motion, and click-guard paths', () => {
   assert.match(app, /function startTokenRateBoost\(event\)/);
-  assert.match(app, /function stopTokenRateBoost\(event\)/);
-  assert.match(app, /const TOKEN_RATE_BOOST_DOUBLING_MS = 520/);
-  assert.match(app, /const TOKEN_RATE_SETTLE_MS = 720/);
-  assert.match(app, /function tokenRateSettleValue\(fromRate, toRate, elapsedMs\)/);
-  assert.match(app, /phase: 'settling'/);
-  assert.match(app, /tokenRateBoostAnimation = requestAnimationFrame\(updateTokenRateBoost\)/);
-  assert.match(app, /document\.addEventListener\('pointercancel', \(event\) => \{\s*stopTokenRateBoost\(event\)/);
-  assert.match(app, /window\.addEventListener\('blur', \(\) => \{\s*stopTokenRateBoost\(\)/);
-  assert.match(app, /if \(document\.hidden\) stopTokenRateBoost\(\)/);
-  assert.match(app, /if \(tokenRateBoost \|\| prefersReducedMotion\(\)\) return/);
+  assert.match(app, /function releaseTokenRateBoost\(event\)/);
+  assert.match(app, /function cancelTokenRateBoost\(event, options\)/);
+  assert.match(tokenRatePresentation, /const TOKEN_RATE_BOOST_DOUBLING_MS = 520/);
+  assert.match(tokenRatePresentation, /const TOKEN_RATE_SETTLE_MS = 720/);
+  assert.match(tokenRatePresentation, /function tokenRateSettleValue\(fromRate, toRate, elapsedMs\)/);
+  assert.match(tokenRatePresentation, /phase: 'settling'/);
+  assert.match(tokenRatePresentation, /requestFrame\(step\)/);
+  assert.match(app, /document\.addEventListener\('pointercancel', \(event\) => \{\s*cancelTokenRateBoost\(event\)/);
+  assert.match(app, /window\.addEventListener\('blur', \(\) => \{\s*cancelTokenRateBoost\(\)/);
+  assert.match(app, /if \(document\.hidden\) cancelTokenRateBoost\(\)/);
+  assert.match(tokenRatePresentation, /if \(state \|\| !canStart\(\) \|\| prefersReducedMotion\(\)\) return false/);
+  assert.match(tokenRatePresentation, /if \(!\(value\.rate > 0\)\) return false/);
+  assert.match(app, /cancelTokenRateBoost\(event, \{ preserveSettling: true \}\)/);
   assert.match(app, /function suppressTokenRateClickAfterHold\(event\)/);
+  assert.match(tokenRatePresentation, /function consumeClick\(\)/);
+  assert.match(app, /tokenRateBoost\.cancel\(undefined, \{ suppressClick: false \}\)/);
   assert.match(css, /\.shell\.title-icon-only \.token-rate-reveal\.boosting/);
   assert.match(css, /\.shell\.title-icon-only \.token-rate-reveal\.settling/);
   assert.match(css, /color: var\(--accent\)/);

--- a/tests/electron/tokenRate.test.js
+++ b/tests/electron/tokenRate.test.js
@@ -189,6 +189,29 @@ test('a held pointer settles to the latest rate and suppresses only the next cli
   assert.equal(harness.controller.getSnapshot(), null);
 });
 
+test('settling retargets from the current display to a live rate without extending the animation', () => {
+  const harness = createBoostHarness();
+  assert.equal(harness.controller.start({ button: 0, pointerId: 1 }), true);
+  harness.advance(1_000);
+  assert.equal(harness.controller.release({ type: 'pointerup', pointerId: 1 }), true);
+
+  harness.advance(240);
+  const beforeRetarget = harness.controller.getSnapshot();
+  const currentDisplayRate = beforeRetarget.displayRate;
+  harness.value.rate = 500;
+  assert.equal(harness.controller.refresh(), true);
+
+  const afterRetarget = harness.controller.getSnapshot();
+  assert.equal(afterRetarget.settleToRate, 500);
+  assert.equal(afterRetarget.settleFromRate, currentDisplayRate);
+  assert.equal(afterRetarget.displayRate, currentDisplayRate);
+  assert.equal(afterRetarget.settleDurationMs, 480);
+
+  harness.advance(480);
+  harness.frame();
+  assert.equal(harness.controller.getSnapshot(), null);
+});
+
 test('a new hold interrupts settling and suppresses its own click', () => {
   const harness = createBoostHarness();
   assert.equal(harness.controller.start({ button: 0, pointerId: 1 }), true);
@@ -329,9 +352,10 @@ test('the token-rate hold has release, cancellation, reduced-motion, and click-g
   assert.match(app, /function cancelTokenRateBoost\(event, options\)/);
   assert.match(tokenRatePresentation, /const TOKEN_RATE_BOOST_DOUBLING_MS = 520/);
   assert.match(tokenRatePresentation, /const TOKEN_RATE_SETTLE_MS = 720/);
-  assert.match(tokenRatePresentation, /function tokenRateSettleValue\(fromRate, toRate, elapsedMs\)/);
+  assert.match(tokenRatePresentation, /function tokenRateSettleValue\(fromRate, toRate, elapsedMs, durationMs/);
   assert.match(tokenRatePresentation, /phase: 'settling'/);
   assert.match(tokenRatePresentation, /requestFrame\(step\)/);
+  assert.match(app, /tokenRateBoost\.refresh\(\);\s*const \{ burn, rate \} = currentTokenRateValue\(\)/);
   assert.match(app, /document\.addEventListener\('pointercancel', \(event\) => \{\s*cancelTokenRateBoost\(event\)/);
   assert.match(app, /window\.addEventListener\('blur', \(\) => \{\s*cancelTokenRateBoost\(\)/);
   assert.match(app, /if \(document\.hidden\) cancelTokenRateBoost\(\)/);

--- a/tests/electron/tokenRate.test.js
+++ b/tests/electron/tokenRate.test.js
@@ -216,6 +216,21 @@ test('a failed new hold does not clear settling without a repaint', () => {
   assert.equal(harness.changes.length, changesBeforeFailedStart);
 });
 
+test('a new hold with no rate does not clear settling without a repaint', () => {
+  const harness = createBoostHarness();
+  assert.equal(harness.controller.start({ button: 0, pointerId: 1 }), true);
+  harness.advance(1_000);
+  assert.equal(harness.controller.release({ type: 'pointerup', pointerId: 1 }), true);
+  const changesBeforeFailedStart = harness.changes.length;
+  assert.equal(harness.frames.size, 1);
+
+  harness.value.rate = 0;
+  assert.equal(harness.controller.start({ button: 0, pointerId: 2 }), false);
+  assert.equal(harness.controller.getSnapshot().phase, 'settling');
+  assert.equal(harness.changes.length, changesBeforeFailedStart);
+  assert.equal(harness.frames.size, 1);
+});
+
 test('lost pointer capture cancels boosting but preserves a normal release settlement', () => {
   const canceled = createBoostHarness();
   assert.equal(canceled.controller.start({ button: 0, pointerId: 1 }), true);

--- a/tests/electron/tokenRate.test.js
+++ b/tests/electron/tokenRate.test.js
@@ -26,7 +26,9 @@ function tokenRateFunctions() {
   vm.runInNewContext(
     `${tokenRateSource()}
      this.tokenRatePerSecond = tokenRatePerSecond;
-     this.tokenBurnPerMinute = tokenBurnPerMinute;`,
+     this.tokenBurnPerMinute = tokenBurnPerMinute;
+     this.tokenRateBoostValue = tokenRateBoostValue;
+     this.tokenRateSettleValue = tokenRateSettleValue;`,
     context
   );
   return context;
@@ -75,6 +77,19 @@ test('the burn reading reads zero without throughput data', () => {
   assert.equal(tokenBurnPerMinute({ totalTokens: 9000 }), 0);
   assert.equal(tokenBurnPerMinute({ timedTokens: 4500, timedDurationMs: 0 }), 0);
   assert.equal(tokenBurnPerMinute(undefined), 0);
+});
+
+test('holding the title mark accelerates from the real rate and keeps rising', () => {
+  const { tokenRateBoostValue, tokenRateSettleValue } = tokenRateFunctions();
+  assert.equal(tokenRateBoostValue(0, 0), 1);
+  assert.equal(tokenRateBoostValue(100, -1), 100);
+  assert.ok(tokenRateBoostValue(100, 520) >= 200);
+  assert.ok(tokenRateBoostValue(100, 1000) > 300);
+  assert.ok(tokenRateBoostValue(100, 2000) > tokenRateBoostValue(100, 1000));
+  const boosted = tokenRateBoostValue(100, 2000);
+  assert.ok(tokenRateSettleValue(boosted, 100, 360) < boosted);
+  assert.ok(tokenRateSettleValue(boosted, 100, 360) > 100);
+  assert.equal(tokenRateSettleValue(boosted, 100, 720), 100);
 });
 
 test('the reveal mode is a persisted setting that defaults to speed', () => {
@@ -137,6 +152,24 @@ test('the reveal triggers stay non-focusable', () => {
     assert.doesNotMatch(attrs, /tabindex/, reason);
   }
   assert.doesNotMatch(css, /app-title-mark:focus/, reason);
+});
+
+test('the token-rate hold has release, cancellation, reduced-motion, and click-guard paths', () => {
+  assert.match(app, /function startTokenRateBoost\(event\)/);
+  assert.match(app, /function stopTokenRateBoost\(event\)/);
+  assert.match(app, /const TOKEN_RATE_BOOST_DOUBLING_MS = 520/);
+  assert.match(app, /const TOKEN_RATE_SETTLE_MS = 720/);
+  assert.match(app, /function tokenRateSettleValue\(fromRate, toRate, elapsedMs\)/);
+  assert.match(app, /phase: 'settling'/);
+  assert.match(app, /tokenRateBoostAnimation = requestAnimationFrame\(updateTokenRateBoost\)/);
+  assert.match(app, /document\.addEventListener\('pointercancel', \(event\) => \{\s*stopTokenRateBoost\(event\)/);
+  assert.match(app, /window\.addEventListener\('blur', \(\) => \{\s*stopTokenRateBoost\(\)/);
+  assert.match(app, /if \(document\.hidden\) stopTokenRateBoost\(\)/);
+  assert.match(app, /if \(tokenRateBoost \|\| prefersReducedMotion\(\)\) return/);
+  assert.match(app, /function suppressTokenRateClickAfterHold\(event\)/);
+  assert.match(css, /\.shell\.title-icon-only \.token-rate-reveal\.boosting/);
+  assert.match(css, /\.shell\.title-icon-only \.token-rate-reveal\.settling/);
+  assert.match(css, /color: var\(--accent\)/);
 });
 
 test('the no-drag hit area stays scoped to the collapsed title states', () => {


### PR DESCRIPTION
## Summary

- Add a hold-to-boost interaction to the compact token-rate reveal.
- Use an exponential boost curve while holding, with the rate doubling every 520ms.
- Animate release back to the real rate over 720ms instead of snapping back.
- Preserve normal token-rate formatting and short-click speed/burn switching.
- Cancel safely on pointer cancellation, window blur, or hidden state.

## Verification

- `node --test tests/electron/tokenRate.test.js tests/electron/rendererMotion.test.js`
- `npm run lint`
- `node --check src/electron/renderer/app.js`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a press-and-hold boost for the compact token-rate reveal; releasing eases back to the real rate. Extracts the rate math and boost controller to `tokenRatePresentation.js`, and hardens gestures, including repeated holds and retargeting settling when the live rate changes.

- New Features
  - Hold the title mark or live dot to boost the displayed rate (2x every 520ms); release settles back over 720ms with easing; short clicks still toggle speed/burn.
  - Holds ≥180ms suppress the click; reduced motion disables boosting; boosting only when the title is collapsed or icon-only.
  - During settling, the display retargets to the latest real rate without extending the remaining animation.
  - `.boosting`/`.settling` styles and rAF updates; cancels on pointerup/pointercancel, window blur, or hidden visibility.

- Bug Fixes
  - Pointer capture: unexpected `lostpointercapture` cancels boosting; normal release preserves settling; failed new holds don’t clear settling.
  - Repeated holds: a new hold during settling interrupts and restarts boosting, suppressing only its own click.
  - Click guards and lifecycle: clear stale click guards when a hold is canceled without a click; register the suppression listener before the toggle; mode switches cancel settling first; visibilitychange cancels transient boost and flushes the stats scheduler.
  - Clamp edge-case rates to a safe max (`TOKEN_RATE_MAX_DISPLAY_RATE`) across boost/settle and `tokenRatePerSecond`/`tokenBurnPerMinute`; ignore zero rates.

<sup>Written for commit af2fcdcd5cf9432ca304b226fe89031bea34ecd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

