### PR TITLE
fix(dashboard): localize compact cost units

### DIFF
--- a/src/electron/renderer/dashboard.html
+++ b/src/electron/renderer/dashboard.html
@@ -62,8 +62,9 @@
     <script src="usageCharts.js"></script>
     <script src="themePresets.js"></script>
     <script src="i18n.js"></script>
-    <script src="../../shared/currency.js"></script>
     <script src="../../shared/compactTokens.js"></script>
+    <script src="../../shared/currency.js"></script>
+    <script src="../../shared/compactMoney.js"></script>
     <script src="../motionPreference.js"></script>
     <script src="dashboard.js"></script>
   </body>

--- a/src/electron/renderer/dashboard.js
+++ b/src/electron/renderer/dashboard.js
@@ -4,6 +4,7 @@ const charts = window.TokenMonitorUsageCharts;
 const themePresetsApi = window.TokenMonitorThemePresets;
 const i18n = window.TokenMonitorI18n;
 const currencyApi = window.TokenMonitorCurrency;
+const compactMoneyApi = window.TokenMonitorCompactMoney;
 const compactTokenApi = window.TokenMonitorCompactTokens;
 const motionPreferenceApi = window.TokenMonitorMotionPreference;
 const reducedMotionMedia = window.matchMedia?.('(prefers-reduced-motion: reduce)');
@@ -235,9 +236,6 @@ function applyVendorColorOverrides(overrides) {
 function formatCompact(value) {
   return compactTokenApi.formatCompactTokens(value, effectiveCompactTokenUnits(), state.locale);
 }
-function formatCompactNumber(value) {
-  return compactTokenApi.formatCompactTokens(value, 'western', state.locale);
-}
 function formatDurationCompact(ms) {
   const totalMinutes = Math.max(0, Math.round(Number(ms || 0) / 60000));
   const hours = Math.floor(totalMinutes / 60);
@@ -248,9 +246,12 @@ function formatDurationCompact(ms) {
 }
 function formatCost(usd) { return currencyApi.formatCurrencyFromUsd(usd, currencyApi.normalizeCurrency(state.currency)); }
 function formatCostCompact(usd) {
-  const code = currencyApi.normalizeCurrency(state.currency);
-  const sym = (currencyApi.CURRENCY_RATES[code] || {}).symbol || '$';
-  return `${sym}${formatCompactNumber(currencyApi.convertUsd(usd, code))}`;
+  return compactMoneyApi.formatCompactCurrencyFromUsd(
+    usd,
+    state.currency,
+    effectiveCompactTokenUnits(),
+    state.locale
+  );
 }
 function shortDate(key) { const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(String(key)); return m ? `${Number(m[2])}/${Number(m[3])}` : String(key); }
 function axisEvery(list) { return Math.max(1, Math.ceil(list.length / 9)); }

--- a/src/shared/compactMoney.js
+++ b/src/shared/compactMoney.js
@@ -1,0 +1,29 @@
+'use strict';
+
+(function exposeCompactMoney(root, factory) {
+  const api = factory(
+    typeof module === 'object' && module.exports ? require('./currency') : root?.TokenMonitorCurrency,
+    typeof module === 'object' && module.exports ? require('./compactTokens') : root?.TokenMonitorCompactTokens
+  );
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  if (root) root.TokenMonitorCompactMoney = api;
+})(typeof window !== 'undefined' ? window : null, function createCompactMoneyApi(currencyApi, compactTokenApi) {
+  function formatCompactCurrencyFromUsd(value, currency = 'USD', unitSystem = 'western', locale = 'en') {
+    const code = currencyApi.normalizeCurrency(currency);
+    const amount = currencyApi.convertUsd(value, code);
+    const rounded = Math.round(Number(amount || 0));
+    const threshold = compactTokenApi.compactTokenUnitThreshold(unitSystem, locale);
+
+    // Keep the currency formatter's precision for values that do not need a
+    // unit. This matters for small costs such as $0.1250, which would become
+    // an incorrect bare "$0" if they went through the token formatter.
+    if (!Number.isFinite(rounded) || Math.abs(rounded) < threshold) {
+      return currencyApi.formatCurrencyFromUsd(value, code);
+    }
+
+    const symbol = currencyApi.CURRENCY_RATES[code]?.symbol || `${code} `;
+    return `${symbol}${compactTokenApi.formatCompactTokens(amount, unitSystem, locale)}`;
+  }
+
+  return { formatCompactCurrencyFromUsd };
+});

--- a/src/shared/compactMoney.js
+++ b/src/shared/compactMoney.js
@@ -10,14 +10,13 @@
 })(typeof window !== 'undefined' ? window : null, function createCompactMoneyApi(currencyApi, compactTokenApi) {
   function formatCompactCurrencyFromUsd(value, currency = 'USD', unitSystem = 'western', locale = 'en') {
     const code = currencyApi.normalizeCurrency(currency);
-    const amount = currencyApi.convertUsd(value, code);
-    const rounded = Math.round(Number(amount || 0));
+    const amount = Number(currencyApi.convertUsd(value, code));
     const threshold = compactTokenApi.compactTokenUnitThreshold(unitSystem, locale);
 
     // Keep the currency formatter's precision for values that do not need a
     // unit. This matters for small costs such as $0.1250, which would become
     // an incorrect bare "$0" if they went through the token formatter.
-    if (!Number.isFinite(rounded) || Math.abs(rounded) < threshold) {
+    if (!Number.isFinite(amount) || Math.abs(amount) < threshold) {
       return currencyApi.formatCurrencyFromUsd(value, code);
     }
 

--- a/tests/electron/dashboardWindow.test.js
+++ b/tests/electron/dashboardWindow.test.js
@@ -92,11 +92,15 @@ test('dashboard.html wires the shared modules and the two panels', () => {
   assert.match(html, /<script src="\.\.\/\.\.\/shared\/currency\.js"><\/script>/);
   assert.match(html, /<script src="\.\.\/\.\.\/shared\/compactMoney\.js"><\/script>/);
   assert.match(html, /<script src="dashboard\.js"><\/script>/);
+  const scriptOrder = [
+    '<script src="../../shared/compactTokens.js"></script>',
+    '<script src="../../shared/currency.js"></script>',
+    '<script src="../../shared/compactMoney.js"></script>',
+    '<script src="dashboard.js"></script>'
+  ].map((script) => html.indexOf(script));
+  assert.ok(scriptOrder.every((index) => index >= 0), 'dashboard should include every compact money dependency');
   assert.ok(
-    html.indexOf('../../shared/compactTokens.js')
-      < html.indexOf('../../shared/currency.js')
-      && html.indexOf('../../shared/currency.js')
-        < html.indexOf('../../shared/compactMoney.js'),
+    scriptOrder.every((index, position) => position === 0 || scriptOrder[position - 1] < index),
     'compact money should load after its token and currency dependencies'
   );
   assert.match(html, /id="trendsTab"/);

--- a/tests/electron/dashboardWindow.test.js
+++ b/tests/electron/dashboardWindow.test.js
@@ -90,7 +90,15 @@ test('dashboard.html wires the shared modules and the two panels', () => {
   assert.match(html, /<script src="usageCharts\.js"><\/script>/);
   assert.match(html, /<script src="i18n\.js"><\/script>/);
   assert.match(html, /<script src="\.\.\/\.\.\/shared\/currency\.js"><\/script>/);
+  assert.match(html, /<script src="\.\.\/\.\.\/shared\/compactMoney\.js"><\/script>/);
   assert.match(html, /<script src="dashboard\.js"><\/script>/);
+  assert.ok(
+    html.indexOf('../../shared/compactTokens.js')
+      < html.indexOf('../../shared/currency.js')
+      && html.indexOf('../../shared/currency.js')
+        < html.indexOf('../../shared/compactMoney.js'),
+    'compact money should load after its token and currency dependencies'
+  );
   assert.match(html, /id="trendsTab"/);
   assert.match(html, /id="activityTab"/);
   assert.match(html, /id="dashChart"/);
@@ -194,9 +202,10 @@ test('dashboard shares localized token units and repaints when the setting or la
   const handler = /window\.tokenMonitor\.onSettingsPush\?\.\(\(next\)\s*=>\s*\{([\s\S]*?)\n\}\);/.exec(js);
   assert.ok(handler, 'dashboard should subscribe to settings pushes');
   assert.match(html, /<script src="\.\.\/\.\.\/shared\/compactTokens\.js"><\/script>/);
+  assert.match(js, /const compactMoneyApi = window\.TokenMonitorCompactMoney/);
   assert.match(js, /const compactTokenApi = window\.TokenMonitorCompactTokens/);
   assert.match(js, /compactTokenApi\.formatCompactTokens\(value, effectiveCompactTokenUnits\(\), state\.locale\)/);
-  assert.match(js, /formatCompactNumber\(currencyApi\.convertUsd\(usd, code\)\)/);
+  assert.match(js, /compactMoneyApi\.formatCompactCurrencyFromUsd\(\s*usd,\s*state\.currency,\s*effectiveCompactTokenUnits\(\),\s*state\.locale/s);
   assert.match(js, /state\.locale = i18n\.resolveLocale\(settings\.locale \|\| settings\.language, navigator\.languages\)/);
   assert.match(handler[1], /nextLocale = i18n\.resolveLocale\(next\.locale \|\| next\.language, navigator\.languages\)/);
   assert.match(handler[1], /nextCompactTokenUnits = compactTokenApi\.normalizeCompactTokenUnits\(next\.compactTokenUnits\)/);

--- a/tests/shared/compactMoney.test.js
+++ b/tests/shared/compactMoney.test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const currency = require('../../src/shared/currency');
+const { formatCompactCurrencyFromUsd } = require('../../src/shared/compactMoney');
+const compactMoneyPath = require.resolve('../../src/shared/compactMoney');
+
+test('compact currency follows localized compact units', () => {
+  currency.configureRates({ CNY: 6.8 });
+
+  assert.equal(formatCompactCurrencyFromUsd(9_102.941176, 'CNY', 'localized', 'zh-TW'), '¥6.19萬');
+  assert.equal(formatCompactCurrencyFromUsd(61_900, 'USD', 'localized', 'zh-CN'), '$6.19万');
+
+  currency.configureRates(null);
+});
+
+test('compact currency keeps western units when the locale does not support localized units', () => {
+  assert.equal(formatCompactCurrencyFromUsd(61_900, 'USD', 'localized', 'en'), '$61.9K');
+});
+
+test('compact money module does not pollute the Node global scope', () => {
+  delete globalThis.TokenMonitorCompactMoney;
+  delete require.cache[compactMoneyPath];
+  require(compactMoneyPath);
+  assert.equal(Object.hasOwn(globalThis, 'TokenMonitorCompactMoney'), false);
+});
+
+test('compact currency preserves exact currency precision below the unit threshold', () => {
+  assert.equal(formatCompactCurrencyFromUsd(0.125, 'USD', 'localized', 'zh-TW'), '$0.1250');
+  assert.equal(formatCompactCurrencyFromUsd(999, 'USD', 'localized', 'zh-TW'), '$999.00');
+});

--- a/tests/shared/compactMoney.test.js
+++ b/tests/shared/compactMoney.test.js
@@ -8,12 +8,13 @@ const { formatCompactCurrencyFromUsd } = require('../../src/shared/compactMoney'
 const compactMoneyPath = require.resolve('../../src/shared/compactMoney');
 
 test('compact currency follows localized compact units', () => {
-  currency.configureRates({ CNY: 6.8 });
-
-  assert.equal(formatCompactCurrencyFromUsd(9_102.941176, 'CNY', 'localized', 'zh-TW'), '¥6.19萬');
-  assert.equal(formatCompactCurrencyFromUsd(61_900, 'USD', 'localized', 'zh-CN'), '$6.19万');
-
-  currency.configureRates(null);
+  currency.configureRates({ CNY: 7.25 });
+  try {
+    assert.equal(formatCompactCurrencyFromUsd(10_000, 'CNY', 'localized', 'zh-TW'), '¥7.25萬');
+    assert.equal(formatCompactCurrencyFromUsd(61_900, 'USD', 'localized', 'zh-CN'), '$6.19万');
+  } finally {
+    currency.configureRates(null);
+  }
 });
 
 test('compact currency keeps western units when the locale does not support localized units', () => {
@@ -30,4 +31,6 @@ test('compact money module does not pollute the Node global scope', () => {
 test('compact currency preserves exact currency precision below the unit threshold', () => {
   assert.equal(formatCompactCurrencyFromUsd(0.125, 'USD', 'localized', 'zh-TW'), '$0.1250');
   assert.equal(formatCompactCurrencyFromUsd(999, 'USD', 'localized', 'zh-TW'), '$999.00');
+  assert.equal(formatCompactCurrencyFromUsd(999.5, 'USD', 'western', 'en'), '$999.50');
+  assert.equal(formatCompactCurrencyFromUsd(9_999.5, 'USD', 'localized', 'zh-TW'), '$9999.50');
 });


### PR DESCRIPTION
## Summary

- Align the Dashboard compact total cost with the selected Token unit system and locale.
- Reuse the shared compact-token formatter through a currency-aware adapter.
- Preserve exact formatting for small monetary values.
- Add formatter and Dashboard script-order regression coverage.

## Validation

- `npm run verify` — 2229 passed, 0 failed, 1 skipped
- `npm run sync:worker` — passed with no Worker drift

## Scope

Only the Dashboard usage-cost card is changed. Other cost and quota/balance displays retain their existing semantics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Dashboard usage-cost card’s compact cost display with the selected token unit system and locale. Compact currency now localizes units and keeps precise formatting for small amounts based on the converted amount.

- **Bug Fixes**
  - Added `compactMoney` adapter to format currency from USD using shared compact-token units.
  - Applies compact units only when the converted amount meets the unit threshold; otherwise shows exact currency (e.g., $0.1250).
  - Ensured script load order: `compactTokens` → `currency` → `compactMoney`; updated `dashboard.js` to call `formatCompactCurrencyFromUsd`.
  - Added tests for localized units, threshold behavior on converted amounts, script order, and module scoping.

<sup>Written for commit 8578a3ae1b98dee95d91534737b6bdba7b1a1581. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

