### PR TITLE
fix(subscriptions): refine inline editor interactions

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -3020,7 +3020,7 @@ function setSubscriptionFormOpen(open, formBase = null) {
   // then accepted, taking another device's edit to the same record with it. Null
   // while closed, so the paths that save without a form say so.
   state.subscriptionFormBase = open
-    ? (formBase || state.subscriptionFormBase || subscriptionSettingsVersion())
+    ? (formBase || subscriptionSettingsVersion())
     : null;
 }
 
@@ -3061,6 +3061,29 @@ function openSubscriptionEditor() {
 function closeSubscriptionEditor({ onClosed } = {}) {
   cancelSubscriptionEditorClose();
   const details = els.subscriptionAddDetails;
+  const editingId = String(state.subscriptionEditingId || '');
+  const activeElement = typeof document !== 'undefined' ? document.activeElement : null;
+  const editingRow = editingId && els.subscriptionList
+    ? [...els.subscriptionList.querySelectorAll('[data-subscription-id]')]
+      .find((row) => row.dataset?.subscriptionId === editingId)
+    : null;
+  const editingButton = editingRow?.querySelector('.subscription-row-edit');
+  // Keep the focus contract of a disclosure: when the editor closes, keyboard
+  // users return to the control that opened it. Do not steal focus from the Add
+  // mode switch or from a user who moved elsewhere while the close animation ran.
+  const shouldRestoreFocus = Boolean(
+    editingId && activeElement && (
+      activeElement === editingButton
+      || activeElement === details
+      || details?.contains?.(activeElement)
+    )
+  );
+  const restoreFocus = () => {
+    if (!shouldRestoreFocus) return;
+    const row = [...(els.subscriptionList?.querySelectorAll?.('[data-subscription-id]') || [])]
+      .find((candidate) => candidate.dataset?.subscriptionId === editingId);
+    row?.querySelector('.subscription-row-edit')?.focus();
+  };
   const transitionId = (state.subscriptionEditorTransitionId || 0) + 1;
   state.subscriptionEditorTransitionId = transitionId;
 
@@ -3069,6 +3092,7 @@ function closeSubscriptionEditor({ onClosed } = {}) {
     resetSubscriptionForm();
     if (typeof renderSubscriptionRows === 'function') renderSubscriptionRows();
     onClosed?.();
+    restoreFocus();
     return;
   }
 
@@ -3091,6 +3115,7 @@ function closeSubscriptionEditor({ onClosed } = {}) {
     resetSubscriptionForm();
     if (typeof renderSubscriptionRows === 'function') renderSubscriptionRows();
     onClosed?.();
+    restoreFocus();
   };
   details.addEventListener('transitionend', onTransitionEnd);
   subscriptionEditorCloseCleanup = cleanup;

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -2644,6 +2644,39 @@ function subscriptionRowMeta(subscription, account) {
   return parts.join(' · ');
 }
 
+function syncSubscriptionAddControl() {
+  const toggle = els.subscriptionAddToggle;
+  const form = els.subscriptionAddForm;
+  const details = els.subscriptionAddDetails;
+  if (!toggle || !form) return;
+
+  // While editing, this button is a mode switch, not the disclosure control for
+  // the editor that is currently parked beneath another row. Keeping the add
+  // action's disclosure state separate prevents a plus from turning into an x
+  // and avoids two controls claiming the same expanded region.
+  if (state.subscriptionEditingId) {
+    toggle.removeAttribute('aria-expanded');
+    toggle.removeAttribute('aria-controls');
+    form.classList.remove('expanded');
+    return;
+  }
+
+  const open = Boolean(details && !details.classList.contains('hidden'));
+  toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+  toggle.setAttribute('aria-controls', 'subscriptionAddDetails');
+  form.classList.toggle('expanded', open);
+}
+
+// Rebuild only the list-owned rows. The editor is a live child of this list
+// while editing, and removing it from the DOM would drop focus from whichever
+// field the user is typing in before positionSubscriptionEditor() can put it
+// back.
+function clearSubscriptionListChildren(listEl, preservedNode) {
+  for (const child of [...listEl.children]) {
+    if (child !== preservedNode) child.remove();
+  }
+}
+
 function positionSubscriptionEditor() {
   const listEl = els.subscriptionList;
   const form = els.subscriptionAddForm;
@@ -2660,6 +2693,7 @@ function positionSubscriptionEditor() {
   for (const row of listEl.querySelectorAll('[data-subscription-id]')) {
     row.classList.toggle('is-editing', row.dataset.subscriptionId === editingId);
   }
+  syncSubscriptionAddControl();
   syncSubscriptionEditControls();
 }
 
@@ -2684,7 +2718,10 @@ function syncSubscriptionEditControls() {
 function renderSubscriptionRows() {
   const listEl = els.subscriptionList;
   if (!listEl) return;
-  listEl.replaceChildren();
+  const editor = els.subscriptionAddDetails?.parentElement === listEl
+    ? els.subscriptionAddDetails
+    : null;
+  clearSubscriptionListChildren(listEl, editor);
   const list = subscriptionList();
   if (list.length === 0) {
     const empty = document.createElement('div');
@@ -2973,17 +3010,18 @@ function setSubscriptionError(message) {
   errorEl.classList.toggle('hidden', !message);
 }
 
-function setSubscriptionFormOpen(open) {
-  els.subscriptionAddToggle?.setAttribute('aria-expanded', open ? 'true' : 'false');
+function setSubscriptionFormOpen(open, formBase = null) {
   els.subscriptionAddDetails?.classList.toggle('hidden', !open);
-  els.subscriptionAddForm?.classList.toggle('expanded', open);
+  syncSubscriptionAddControl();
   if (typeof syncSubscriptionEditControls === 'function') syncSubscriptionEditControls();
   // What the form was filled from, held for as long as it stays open. A push
   // landing mid-edit replaces state.settings, and reading the version at save
   // time would claim to have seen a change the form was never shown — the save is
   // then accepted, taking another device's edit to the same record with it. Null
   // while closed, so the paths that save without a form say so.
-  state.subscriptionFormBase = open ? subscriptionSettingsVersion() : null;
+  state.subscriptionFormBase = open
+    ? (formBase || state.subscriptionFormBase || subscriptionSettingsVersion())
+    : null;
 }
 
 const SUBSCRIPTION_EDITOR_TRANSITION_MS = 250;
@@ -3000,6 +3038,10 @@ function cancelSubscriptionEditorClose() {
 function openSubscriptionEditor() {
   const details = els.subscriptionAddDetails;
   if (!details) return;
+  // Capture the concurrency context before the visual transition yields to the
+  // browser. A settings push can arrive before the next frame, but it must not
+  // make fields loaded from the previous list look like a newer edit.
+  const formBase = subscriptionSettingsVersion();
   cancelSubscriptionEditorClose();
   const transitionId = (state.subscriptionEditorTransitionId || 0) + 1;
   state.subscriptionEditorTransitionId = transitionId;
@@ -3010,7 +3052,7 @@ function openSubscriptionEditor() {
     : (callback) => setTimeout(callback, 0);
   schedule(() => {
     if (transitionId !== state.subscriptionEditorTransitionId) return;
-    setSubscriptionFormOpen(true);
+    setSubscriptionFormOpen(true, formBase);
   });
 }
 

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -3068,12 +3068,13 @@ function closeSubscriptionEditor({ onClosed } = {}) {
       .find((row) => row.dataset?.subscriptionId === editingId)
     : null;
   const editingButton = editingRow?.querySelector('.subscription-row-edit');
+  const returnFocusTarget = editingId ? editingButton : els.subscriptionAddToggle;
   // Keep the focus contract of a disclosure: when the editor closes, keyboard
-  // users return to the control that opened it. Do not steal focus from the Add
-  // mode switch or from a user who moved elsewhere while the close animation ran.
+  // users return to the control that opened it. Do not steal focus from a user
+  // who moved elsewhere while the close animation ran.
   const shouldRestoreFocus = Boolean(
-    editingId && activeElement && (
-      activeElement === editingButton
+    activeElement && (
+      activeElement === returnFocusTarget
       || activeElement === details
       || details?.contains?.(activeElement)
     )
@@ -3084,13 +3085,17 @@ function closeSubscriptionEditor({ onClosed } = {}) {
     const body = typeof document !== 'undefined' ? document.body : null;
     const stillInClosingContext = current === activeElement
       || current === body
-      || current === editingButton
+      || current === returnFocusTarget
       || current === details
       || details?.contains?.(current);
     if (!stillInClosingContext) return;
-    const row = [...(els.subscriptionList?.querySelectorAll?.('[data-subscription-id]') || [])]
-      .find((candidate) => candidate.dataset?.subscriptionId === editingId);
-    row?.querySelector('.subscription-row-edit')?.focus();
+    if (editingId) {
+      const row = [...(els.subscriptionList?.querySelectorAll?.('[data-subscription-id]') || [])]
+        .find((candidate) => candidate.dataset?.subscriptionId === editingId);
+      row?.querySelector('.subscription-row-edit')?.focus();
+      return;
+    }
+    returnFocusTarget?.focus();
   };
   const transitionId = (state.subscriptionEditorTransitionId || 0) + 1;
   state.subscriptionEditorTransitionId = transitionId;

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -3027,17 +3027,17 @@ function setSubscriptionFormOpen(open, formBase = null) {
 
 const SUBSCRIPTION_EDITOR_TRANSITION_MS = 250;
 let subscriptionEditorCloseCleanup = null;
-let subscriptionEditorCloseOnCancel = null;
+let subscriptionEditorCloseOnCanceled = null;
 
 function cancelSubscriptionEditorClose() {
-  const onCancel = subscriptionEditorCloseOnCancel;
-  subscriptionEditorCloseOnCancel = null;
+  const onCanceled = subscriptionEditorCloseOnCanceled;
+  subscriptionEditorCloseOnCanceled = null;
   subscriptionEditorCloseCleanup?.();
   subscriptionEditorCloseCleanup = null;
   // A successful write defers the full render until the collapse has settled so
   // the transition can paint. If a new mode cancels that collapse, settle the
   // deferred render here instead of silently dropping it with the old timer.
-  onCancel?.();
+  onCanceled?.();
 }
 
 // The class change has to happen in a later frame than the initial collapsed
@@ -3066,7 +3066,7 @@ function openSubscriptionEditor() {
 
 // Keep the editor in place until its collapse has finished. Moving it back to
 // the add form in the same task as hiding it cancels the transition entirely.
-function closeSubscriptionEditor({ onClosed } = {}) {
+function closeSubscriptionEditor({ onClosed, onCanceled } = {}) {
   cancelSubscriptionEditorClose();
   const details = els.subscriptionAddDetails;
   const editingId = String(state.subscriptionEditingId || '');
@@ -3118,7 +3118,7 @@ function closeSubscriptionEditor({ onClosed } = {}) {
   }
 
   setSubscriptionFormOpen(false);
-  subscriptionEditorCloseOnCancel = onClosed;
+  subscriptionEditorCloseOnCanceled = onCanceled;
   let finished = false;
   let timer = null;
   const onTransitionEnd = (event) => {
@@ -3129,7 +3129,7 @@ function closeSubscriptionEditor({ onClosed } = {}) {
     if (timer !== null) clearTimeout(timer);
     if (subscriptionEditorCloseCleanup === cleanup) {
       subscriptionEditorCloseCleanup = null;
-      subscriptionEditorCloseOnCancel = null;
+      subscriptionEditorCloseOnCanceled = null;
     }
   };
   const finish = () => {
@@ -3486,7 +3486,10 @@ async function submitSubscription() {
     ? list.map((entry) => (entry.id === editing.id ? next : entry))
     : [...list, next];
   if (!await saveSubscriptions(updated, state.subscriptionFormBase, { render: false })) return;
-  closeSubscriptionEditor({ onClosed: renderSubscriptionSettings });
+  closeSubscriptionEditor({
+    onClosed: renderSubscriptionSettings,
+    onCanceled: renderSubscriptionSettings
+  });
 }
 
 function configuredLimitProviderOrder() {

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -3026,10 +3026,17 @@ function setSubscriptionFormOpen(open, formBase = null) {
 
 const SUBSCRIPTION_EDITOR_TRANSITION_MS = 250;
 let subscriptionEditorCloseCleanup = null;
+let subscriptionEditorCloseOnCancel = null;
 
 function cancelSubscriptionEditorClose() {
+  const onCancel = subscriptionEditorCloseOnCancel;
+  subscriptionEditorCloseOnCancel = null;
   subscriptionEditorCloseCleanup?.();
   subscriptionEditorCloseCleanup = null;
+  // A successful write defers the full render until the collapse has settled so
+  // the transition can paint. If a new mode cancels that collapse, settle the
+  // deferred render here instead of silently dropping it with the old timer.
+  onCancel?.();
 }
 
 // The class change has to happen in a later frame than the initial collapsed
@@ -3110,6 +3117,7 @@ function closeSubscriptionEditor({ onClosed } = {}) {
   }
 
   setSubscriptionFormOpen(false);
+  subscriptionEditorCloseOnCancel = onClosed;
   let finished = false;
   let timer = null;
   const onTransitionEnd = (event) => {
@@ -3118,7 +3126,10 @@ function closeSubscriptionEditor({ onClosed } = {}) {
   const cleanup = () => {
     details.removeEventListener('transitionend', onTransitionEnd);
     if (timer !== null) clearTimeout(timer);
-    if (subscriptionEditorCloseCleanup === cleanup) subscriptionEditorCloseCleanup = null;
+    if (subscriptionEditorCloseCleanup === cleanup) {
+      subscriptionEditorCloseCleanup = null;
+      subscriptionEditorCloseOnCancel = null;
+    }
   };
   const finish = () => {
     if (finished) return;
@@ -3473,8 +3484,8 @@ async function submitSubscription() {
   const updated = editing
     ? list.map((entry) => (entry.id === editing.id ? next : entry))
     : [...list, next];
-  if (!await saveSubscriptions(updated, state.subscriptionFormBase)) return;
-  closeSubscriptionEditor();
+  if (!await saveSubscriptions(updated, state.subscriptionFormBase, { render: false })) return;
+  closeSubscriptionEditor({ onClosed: renderSubscriptionSettings });
 }
 
 function configuredLimitProviderOrder() {

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -287,7 +287,7 @@ function normalizeInitialViewValue(value, allowed, fallback) {
   return allowed.has(raw) ? raw : fallback;
 }
 
-const state = { period: normalizeInitialViewValue(initialViewState.period, viewPeriodValues, 'today'), appUpdate: null, breakdown: normalizeInitialViewValue(initialViewState.breakdown, viewBreakdownValues, 'home'), viewSwitcherOpen: false, viewSwitcherHasOpened: false, limitDetailTooltipHasOpened: false, limitDetailTooltipActive: false, limitDetailTooltipRenderPending: false, settings: null, stats: null, homeHistory: null, homeHistoryBusy: false, homeHistoryRequested: false, homeHistorySignature: '', homeHistoryRetries: 0, homeHistoryRetryTimer: null, homeActivityScrollLeft: null, homeActivityFollowEnd: true, homeActivityResizeObserver: null, serviceStatus: null, serviceStatusBusy: false, serviceProvidersExpanded: false, trendSettingsExpanded: false, trendsActivating: false, homeSettingsExpanded: false, homeLimitSettingsExpanded: false, limitProviderSettingsExpanded: '', subscriptionEditingId: '', subscriptionTopUps: [], subscriptionFormBase: null, serviceStatusTicker: null, refreshTimer: null, refreshBusy: false, refreshFeedbackTimer: null, currentTotal: 0, rowSignature: '', streamConnected: false, streamFailure: null, mode: 'idle', appInfo: null, tokscaleStatus: null, tokscaleCheck: null, tokscaleBusy: false, hubInfo: null, cursorAccount: { status: null, error: '' }, cursorAccountExpanded: false, codexAccountExpanded: false, codexAccountError: '', codexSignInBusy: false, codexSignInFlowId: '', codexLoginUrl: '', codexLoginStatus: '', codexLoginOutput: '', codexWorkspaceChoices: [], codexWorkspaceId: '', codexActiveAccount: null, codexPendingActiveAccount: null, codexPendingActiveAccountUntil: 0, codexPendingActiveAccountTimer: null, codexSystemSwitchingAccountId: '', codexSystemSwitchErrorAccountId: '', codexSystemSwitchError: '', codexSwitchPopoverHasOpened: false, codexSwitchPopoverActive: false, codexSwitchPopoverRenderPending: false, customPricingExpanded: false, claudeAccountExpanded: false, claudePendingCheckSince: 0, opencodeProfileCount: 0, opencodeCookieExpanded: false, openrouterProfileCount: 0, openrouterAccountExpanded: false, thirdPartyProfileCount: 0, thirdPartyAccountExpanded: false, deepseekAccountExpanded: false, deepseekPendingCheckSince: 0, minimaxAccountExpanded: false, minimaxPendingCheckSince: 0, zaiAccountExpanded: false, zaiPendingCheckSince: 0, zaiteamAccountExpanded: false, zaiteamPendingCheckSince: 0, volcengineAccountExpanded: false, volcenginePendingCheckSince: 0, qoderAccountExpanded: false, qoderPendingCheckSince: 0, kimiAccountExpanded: false, kimiPendingCheckSince: 0, ollamaAccountExpanded: false, ollamaPendingCheckSince: 0, mimoAccountExpanded: false, mimoAccountError: '', copilotAccountExpanded: false, copilotManualExpanded: false, copilotPendingCheckSince: 0, copilotSignInBusy: false, copilotSignInCancelable: false, copilotSignInFlowId: '', copilotAuthorizeMessage: '', copilotLoginStatus: '', copilotErrorMessage: '', floatingBubble: initialFloatingBubble, suppressInitialNumberAnimation: window.__TOKEN_MONITOR_SUPPRESS_INITIAL_NUMBER_ANIMATION__ === true, openSession: null, detailSort: 'time', recordingWindowShortcut: false, windowShortcutInvalid: false };
+const state = { period: normalizeInitialViewValue(initialViewState.period, viewPeriodValues, 'today'), appUpdate: null, breakdown: normalizeInitialViewValue(initialViewState.breakdown, viewBreakdownValues, 'home'), viewSwitcherOpen: false, viewSwitcherHasOpened: false, limitDetailTooltipHasOpened: false, limitDetailTooltipActive: false, limitDetailTooltipRenderPending: false, settings: null, stats: null, homeHistory: null, homeHistoryBusy: false, homeHistoryRequested: false, homeHistorySignature: '', homeHistoryRetries: 0, homeHistoryRetryTimer: null, homeActivityScrollLeft: null, homeActivityFollowEnd: true, homeActivityResizeObserver: null, serviceStatus: null, serviceStatusBusy: false, serviceProvidersExpanded: false, trendSettingsExpanded: false, trendsActivating: false, homeSettingsExpanded: false, homeLimitSettingsExpanded: false, limitProviderSettingsExpanded: '', subscriptionEditingId: '', subscriptionTopUps: [], subscriptionFormBase: null, subscriptionEditorTransitionId: 0, serviceStatusTicker: null, refreshTimer: null, refreshBusy: false, refreshFeedbackTimer: null, currentTotal: 0, rowSignature: '', streamConnected: false, streamFailure: null, mode: 'idle', appInfo: null, tokscaleStatus: null, tokscaleCheck: null, tokscaleBusy: false, hubInfo: null, cursorAccount: { status: null, error: '' }, cursorAccountExpanded: false, codexAccountExpanded: false, codexAccountError: '', codexSignInBusy: false, codexSignInFlowId: '', codexLoginUrl: '', codexLoginStatus: '', codexLoginOutput: '', codexWorkspaceChoices: [], codexWorkspaceId: '', codexActiveAccount: null, codexPendingActiveAccount: null, codexPendingActiveAccountUntil: 0, codexPendingActiveAccountTimer: null, codexSystemSwitchingAccountId: '', codexSystemSwitchErrorAccountId: '', codexSystemSwitchError: '', codexSwitchPopoverHasOpened: false, codexSwitchPopoverActive: false, codexSwitchPopoverRenderPending: false, customPricingExpanded: false, claudeAccountExpanded: false, claudePendingCheckSince: 0, opencodeProfileCount: 0, opencodeCookieExpanded: false, openrouterProfileCount: 0, openrouterAccountExpanded: false, thirdPartyProfileCount: 0, thirdPartyAccountExpanded: false, deepseekAccountExpanded: false, deepseekPendingCheckSince: 0, minimaxAccountExpanded: false, minimaxPendingCheckSince: 0, zaiAccountExpanded: false, zaiPendingCheckSince: 0, zaiteamAccountExpanded: false, zaiteamPendingCheckSince: 0, volcengineAccountExpanded: false, volcenginePendingCheckSince: 0, qoderAccountExpanded: false, qoderPendingCheckSince: 0, kimiAccountExpanded: false, kimiPendingCheckSince: 0, ollamaAccountExpanded: false, ollamaPendingCheckSince: 0, mimoAccountExpanded: false, mimoAccountError: '', copilotAccountExpanded: false, copilotManualExpanded: false, copilotPendingCheckSince: 0, copilotSignInBusy: false, copilotSignInCancelable: false, copilotSignInFlowId: '', copilotAuthorizeMessage: '', copilotLoginStatus: '', copilotErrorMessage: '', floatingBubble: initialFloatingBubble, suppressInitialNumberAnimation: window.__TOKEN_MONITOR_SUPPRESS_INITIAL_NUMBER_ANIMATION__ === true, openSession: null, detailSort: 'time', recordingWindowShortcut: false, windowShortcutInvalid: false };
 state.homeHistoryLoadedSignature = '';
 state.homeHistoryRetrySignature = '';
 state.homeReturnVisible = false;
@@ -2644,6 +2644,43 @@ function subscriptionRowMeta(subscription, account) {
   return parts.join(' · ');
 }
 
+function positionSubscriptionEditor() {
+  const listEl = els.subscriptionList;
+  const form = els.subscriptionAddForm;
+  const details = els.subscriptionAddDetails;
+  if (!listEl || !form || !details) return;
+
+  const editingId = String(state.subscriptionEditingId || '');
+  const editingRow = editingId
+    ? [...listEl.children].find((child) => child.dataset?.subscriptionId === editingId)
+    : null;
+  if (editingRow) editingRow.after(details);
+  else form.append(details);
+
+  for (const row of listEl.querySelectorAll('[data-subscription-id]')) {
+    row.classList.toggle('is-editing', row.dataset.subscriptionId === editingId);
+  }
+  syncSubscriptionEditControls();
+}
+
+function syncSubscriptionEditControls() {
+  const listEl = els.subscriptionList;
+  const details = els.subscriptionAddDetails;
+  if (!listEl) return;
+  const editingId = String(state.subscriptionEditingId || '');
+  const editorOpen = Boolean(details && !details.classList.contains('hidden'));
+  for (const row of listEl.querySelectorAll('[data-subscription-id]')) {
+    const edit = row.querySelector('.subscription-row-edit');
+    if (!edit) continue;
+    const editOpen = editorOpen && row.dataset.subscriptionId === editingId;
+    const editLabel = editOpen ? t('settings.subscriptions.cancelEdit') : t('settings.subscriptions.edit');
+    edit.textContent = editOpen ? '×' : '✎';
+    edit.title = editLabel;
+    edit.setAttribute('aria-label', editLabel);
+    edit.setAttribute('aria-expanded', editOpen ? 'true' : 'false');
+  }
+}
+
 function renderSubscriptionRows() {
   const listEl = els.subscriptionList;
   if (!listEl) return;
@@ -2654,6 +2691,7 @@ function renderSubscriptionRows() {
     empty.className = 'opencode-empty';
     empty.textContent = t('settings.subscriptions.emptyList');
     listEl.append(empty);
+    positionSubscriptionEditor();
     return;
   }
 
@@ -2661,7 +2699,8 @@ function renderSubscriptionRows() {
   for (const subscription of list) {
     const account = subscriptionApi.matchProviderAccount(subscription, providers);
     const row = document.createElement('div');
-    row.className = 'subscription-row';
+    row.className = `subscription-row${state.subscriptionEditingId === subscription.id ? ' is-editing' : ''}`;
+    row.dataset.subscriptionId = subscription.id;
 
     // The provider name is in the title too, but these rows are a dense stack of
     // near-identical text — four Codex accounts read as one block until the mark
@@ -2695,16 +2734,28 @@ function renderSubscriptionRows() {
       main.append(warn);
     }
 
-    // Glyph buttons, titled rather than labelled, matching the profile rows
-    // directly above them in this panel.
+    // Keep the edit control as a disclosure toggle: the active row gets an
+    // explicit cancel state, and the accessible state follows the editor.
     const actions = document.createElement('div');
     actions.className = 'subscription-row-actions';
     const edit = document.createElement('button');
     edit.type = 'button';
     edit.className = 'subscription-row-edit';
-    edit.textContent = '✎';
-    edit.title = t('settings.subscriptions.edit');
-    edit.addEventListener('click', () => beginSubscriptionEdit(subscription.id));
+    const editing = state.subscriptionEditingId === subscription.id;
+    const editOpen = editing && Boolean(els.subscriptionAddDetails && !els.subscriptionAddDetails.classList.contains('hidden'));
+    const editLabel = editOpen ? t('settings.subscriptions.cancelEdit') : t('settings.subscriptions.edit');
+    edit.textContent = editOpen ? '×' : '✎';
+    edit.title = editLabel;
+    edit.setAttribute('aria-label', editLabel);
+    edit.setAttribute('aria-expanded', editOpen ? 'true' : 'false');
+    edit.setAttribute('aria-controls', 'subscriptionAddDetails');
+    edit.addEventListener('click', () => {
+      if (state.subscriptionEditingId === subscription.id && els.subscriptionAddDetails && !els.subscriptionAddDetails.classList.contains('hidden')) {
+        closeSubscriptionEditor();
+        return;
+      }
+      beginSubscriptionEdit(subscription.id);
+    });
     const remove = document.createElement('button');
     remove.type = 'button';
     remove.className = 'subscription-row-delete';
@@ -2739,6 +2790,7 @@ function renderSubscriptionRows() {
     row.append(main, actions);
     listEl.append(row);
   }
+  positionSubscriptionEditor();
 }
 
 function renderSubscriptionPickers() {
@@ -2835,8 +2887,12 @@ function applySubscriptionSettings(settings) {
   // into the one they moved to — there is nothing here it could belong to, so it
   // stops being a form rather than becoming a form for the wrong list.
   if (state.subscriptionFormBase.hub !== current.hub) {
-    resetSubscriptionForm();
-    setSubscriptionFormOpen(false);
+    if (typeof closeSubscriptionEditor === 'function') {
+      closeSubscriptionEditor();
+    } else {
+      setSubscriptionFormOpen(false);
+      resetSubscriptionForm();
+    }
     return;
   }
   state.subscriptionFormBase = current;
@@ -2845,11 +2901,11 @@ function applySubscriptionSettings(settings) {
 // base is what the list being saved was built from — the open form's snapshot, or
 // what is on screen for a row action. Passed in rather than read here, because
 // those two stop being the same the moment a push lands.
-async function saveSubscriptions(list, base) {
+async function saveSubscriptions(list, base, { render = true } = {}) {
   try {
     applySubscriptionSettings(await window.tokenMonitor.saveSubscriptions(list, base));
     state.subscriptionSyncError = '';
-    renderSubscriptionSettings();
+    if (render) renderSubscriptionSettings();
     return true;
   } catch (error) {
     // Four different problems with four different answers: look at what changed,
@@ -2921,12 +2977,82 @@ function setSubscriptionFormOpen(open) {
   els.subscriptionAddToggle?.setAttribute('aria-expanded', open ? 'true' : 'false');
   els.subscriptionAddDetails?.classList.toggle('hidden', !open);
   els.subscriptionAddForm?.classList.toggle('expanded', open);
+  if (typeof syncSubscriptionEditControls === 'function') syncSubscriptionEditControls();
   // What the form was filled from, held for as long as it stays open. A push
   // landing mid-edit replaces state.settings, and reading the version at save
   // time would claim to have seen a change the form was never shown — the save is
   // then accepted, taking another device's edit to the same record with it. Null
   // while closed, so the paths that save without a form say so.
   state.subscriptionFormBase = open ? subscriptionSettingsVersion() : null;
+}
+
+const SUBSCRIPTION_EDITOR_TRANSITION_MS = 250;
+let subscriptionEditorCloseCleanup = null;
+
+function cancelSubscriptionEditorClose() {
+  subscriptionEditorCloseCleanup?.();
+  subscriptionEditorCloseCleanup = null;
+}
+
+// The class change has to happen in a later frame than the initial collapsed
+// layout. Otherwise Chromium batches both states into one paint and there is no
+// transition for the grid track to animate between.
+function openSubscriptionEditor() {
+  const details = els.subscriptionAddDetails;
+  if (!details) return;
+  cancelSubscriptionEditorClose();
+  const transitionId = (state.subscriptionEditorTransitionId || 0) + 1;
+  state.subscriptionEditorTransitionId = transitionId;
+  details.classList.add('hidden');
+  details.getBoundingClientRect();
+  const schedule = typeof requestAnimationFrame === 'function'
+    ? requestAnimationFrame
+    : (callback) => setTimeout(callback, 0);
+  schedule(() => {
+    if (transitionId !== state.subscriptionEditorTransitionId) return;
+    setSubscriptionFormOpen(true);
+  });
+}
+
+// Keep the editor in place until its collapse has finished. Moving it back to
+// the add form in the same task as hiding it cancels the transition entirely.
+function closeSubscriptionEditor({ onClosed } = {}) {
+  cancelSubscriptionEditorClose();
+  const details = els.subscriptionAddDetails;
+  const transitionId = (state.subscriptionEditorTransitionId || 0) + 1;
+  state.subscriptionEditorTransitionId = transitionId;
+
+  if (!details || details.classList.contains('hidden')) {
+    setSubscriptionFormOpen(false);
+    resetSubscriptionForm();
+    if (typeof renderSubscriptionRows === 'function') renderSubscriptionRows();
+    onClosed?.();
+    return;
+  }
+
+  setSubscriptionFormOpen(false);
+  let finished = false;
+  let timer = null;
+  const onTransitionEnd = (event) => {
+    if (event.target === details && event.propertyName === 'grid-template-rows') finish();
+  };
+  const cleanup = () => {
+    details.removeEventListener('transitionend', onTransitionEnd);
+    if (timer !== null) clearTimeout(timer);
+    if (subscriptionEditorCloseCleanup === cleanup) subscriptionEditorCloseCleanup = null;
+  };
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    cleanup();
+    if (transitionId !== state.subscriptionEditorTransitionId) return;
+    resetSubscriptionForm();
+    if (typeof renderSubscriptionRows === 'function') renderSubscriptionRows();
+    onClosed?.();
+  };
+  details.addEventListener('transitionend', onTransitionEnd);
+  subscriptionEditorCloseCleanup = cleanup;
+  timer = setTimeout(finish, SUBSCRIPTION_EDITOR_TRANSITION_MS + 50);
 }
 
 // Seeded on explicit picker changes and on opening the form — never from a
@@ -3128,12 +3254,29 @@ function resetSubscriptionForm() {
   els.subscriptionCancelEdit?.classList.add('hidden');
   setSubscriptionFormMode();
   syncSubscriptionDateBounds();
+  positionSubscriptionEditor();
   setSubscriptionError('');
+}
+
+function openSubscriptionAddEditor() {
+  renderSubscriptionPickers();
+  applySubscriptionAccountSelection();
+  openSubscriptionEditor();
+}
+
+function beginSubscriptionAdd() {
+  resetSubscriptionForm();
+  renderSubscriptionRows();
+  openSubscriptionAddEditor();
 }
 
 function beginSubscriptionEdit(id) {
   const subscription = subscriptionList().find((entry) => entry.id === id);
   if (!subscription) return;
+  if (state.subscriptionEditingId === id && els.subscriptionAddDetails && !els.subscriptionAddDetails.classList.contains('hidden')) {
+    closeSubscriptionEditor();
+    return;
+  }
   state.subscriptionEditingId = id;
 
   const account = subscriptionApi.matchProviderAccount(subscription, limitProvidersForSubscriptions());
@@ -3160,7 +3303,8 @@ function beginSubscriptionEdit(id) {
   els.subscriptionCancelEdit?.classList.remove('hidden');
   setSubscriptionFormMode();
   syncSubscriptionDateBounds();
-  setSubscriptionFormOpen(true);
+  positionSubscriptionEditor();
+  openSubscriptionEditor();
   setSubscriptionError('');
 }
 
@@ -3249,10 +3393,8 @@ async function submitSubscription() {
   const updated = editing
     ? list.map((entry) => (entry.id === editing.id ? next : entry))
     : [...list, next];
-  if (!await saveSubscriptions(updated, state.subscriptionFormBase)) return;
-  resetSubscriptionForm();
-  setSubscriptionFormOpen(false);
-  renderSubscriptionSettings();
+  if (!await saveSubscriptions(updated, state.subscriptionFormBase, { render: false })) return;
+  closeSubscriptionEditor({ onClosed: renderSubscriptionSettings });
 }
 
 function configuredLimitProviderOrder() {
@@ -9560,11 +9702,14 @@ els.maskLimitAccountEmailsInput.addEventListener('change', async () => {
 els.subscriptionAddToggle?.addEventListener('click', () => {
   const opening = els.subscriptionAddDetails?.classList.contains('hidden');
   if (opening) {
-    resetSubscriptionForm();
-    renderSubscriptionPickers();
-    applySubscriptionAccountSelection();
+    beginSubscriptionAdd();
+    return;
   }
-  setSubscriptionFormOpen(Boolean(opening));
+  if (state.subscriptionEditingId) {
+    closeSubscriptionEditor({ onClosed: openSubscriptionAddEditor });
+    return;
+  }
+  closeSubscriptionEditor();
 });
 els.subscriptionProviderInput?.addEventListener('change', () => {
   renderSubscriptionPickers();
@@ -9605,10 +9750,7 @@ for (const input of els.subscriptionKindInputs || []) {
 els.subscriptionCurrencyInput?.addEventListener('change', renderSubscriptionTopUpEntries);
 els.subscriptionTopUpAddButton?.addEventListener('click', addSubscriptionTopUpEntry);
 els.subscriptionSubmit?.addEventListener('click', submitSubscription);
-els.subscriptionCancelEdit?.addEventListener('click', () => {
-  resetSubscriptionForm();
-  setSubscriptionFormOpen(false);
-});
+els.subscriptionCancelEdit?.addEventListener('click', () => closeSubscriptionEditor());
 for (const input of els.showLimitUsedInputs || []) {
   input.addEventListener('change', async () => {
     if (input.checked) await saveSettings({ showLimitUsed: input.value === 'used' });

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -2818,10 +2818,11 @@ function renderSubscriptionRows() {
       const current = subscriptionList();
       if (!await saveSubscriptions(
         current.filter((entry) => entry.id !== subscription.id),
-        subscriptionSettingsVersion()
+        subscriptionSettingsVersion(),
+        { render: false }
       )) return;
       if (state.subscriptionEditingId === subscription.id) resetSubscriptionForm();
-      renderSubscriptionSettings();
+      preserveSettingsPanelScroll(renderSubscriptionSettings);
     });
     actions.append(edit, remove);
     row.append(main, actions);
@@ -10182,7 +10183,7 @@ window.tokenMonitor.onSettingsPush?.((next) => {
   const prevShowCompactTotalTokens = state.settings?.showCompactTotalTokens;
   state.settings = next;
   applyEffectiveCurrencyRates();
-  syncSettingsForm();
+  preserveSettingsPanelScroll(syncSettingsForm);
   maybeUpdateBarsIcon();
   if ((prevMetric || 'cost') !== (next.heatmapMetric || 'cost')) {
     render();

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -3080,6 +3080,14 @@ function closeSubscriptionEditor({ onClosed } = {}) {
   );
   const restoreFocus = () => {
     if (!shouldRestoreFocus) return;
+    const current = typeof document !== 'undefined' ? document.activeElement : null;
+    const body = typeof document !== 'undefined' ? document.body : null;
+    const stillInClosingContext = current === activeElement
+      || current === body
+      || current === editingButton
+      || current === details
+      || details?.contains?.(current);
+    if (!stillInClosingContext) return;
     const row = [...(els.subscriptionList?.querySelectorAll?.('[data-subscription-id]') || [])]
       .find((candidate) => candidate.dataset?.subscriptionId === editingId);
     row?.querySelector('.subscription-row-edit')?.focus();
@@ -3460,8 +3468,8 @@ async function submitSubscription() {
   const updated = editing
     ? list.map((entry) => (entry.id === editing.id ? next : entry))
     : [...list, next];
-  if (!await saveSubscriptions(updated, state.subscriptionFormBase, { render: false })) return;
-  closeSubscriptionEditor({ onClosed: renderSubscriptionSettings });
+  if (!await saveSubscriptions(updated, state.subscriptionFormBase)) return;
+  closeSubscriptionEditor();
 }
 
 function configuredLimitProviderOrder() {

--- a/src/electron/renderer/index.html
+++ b/src/electron/renderer/index.html
@@ -1263,6 +1263,7 @@
                     </div>
                     <p class="settings-note subscription-field-note" data-i18n="settings.subscriptions.topUpEntriesNote">Record every top-up. This month's total is what gets compared against this month's usage.</p>
                   </div>
+                  <p id="subscriptionErrorMessage" class="settings-note error subscription-form-error hidden" role="alert" aria-atomic="true"></p>
                   <div class="settings-actions">
                     <button id="subscriptionSubmit" data-i18n="settings.subscriptions.save">Save subscription</button>
                     <button id="subscriptionCancelEdit" class="hidden" data-i18n="settings.subscriptions.cancelEdit">Cancel</button>
@@ -1271,7 +1272,6 @@
               </div>
             </div>
             <div id="subscriptionTotalRow" class="subscription-total hidden"></div>
-            <div id="subscriptionErrorMessage" class="settings-note error hidden"></div>
           </div>
         </div>
 

--- a/src/electron/renderer/styles.css
+++ b/src/electron/renderer/styles.css
@@ -3904,6 +3904,15 @@ html.is-windows .limit-live-badge {
 .subscription-add-body .subscription-pair-row > select {
   flex: 1 1 0;
 }
+/* Amount, cadence, and dates are separate settings rows inside one field
+   wrapper. Give that wrapper its own rhythm; the outer add-form gap does not
+   reach these descendants, which previously made the rows touch. */
+.subscription-add-body .subscription-kind-fields {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 8px;
+}
 .subscription-field-note {
   margin-top: -2px;
 }
@@ -3920,7 +3929,6 @@ html.is-windows .limit-live-badge {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 6px;
 }
 .subscription-topup-heading {
   flex: 1 1 auto;
@@ -3982,9 +3990,6 @@ html.is-windows .limit-live-badge {
 }
 /* No label: the two fields are the entry, and the button says what happens to
    them. Dropping the label column also buys the date field the width it needs. */
-.subscription-topup-add-row {
-  margin-top: 6px;
-}
 .subscription-add-body .subscription-topup-add-row > input[type="date"] {
   flex: 1 1 0;
   min-width: 0;
@@ -4063,8 +4068,18 @@ html.is-windows .limit-live-badge {
   border-radius: 6px;
   background: rgba(var(--sunken-rgb), 0.36);
 }
+.subscription-row.is-editing {
+  border-color: rgba(var(--accent-rgb), 0.42);
+  background: rgba(var(--accent-rgb), 0.055);
+}
 .subscription-row + .subscription-row {
   margin-top: 6px;
+}
+/* The editor itself becomes a list child while editing. Its top margin is part
+   of the accordion transition, while the bottom margin preserves the row rhythm
+   for the subscriptions that follow it. */
+#subscriptionList > #subscriptionAddDetails {
+  margin: 6px 0;
 }
 /* The icon column only exists when there is an icon: a row without one keeps the
    two-column template, so the title still starts against the padding edge rather
@@ -4136,6 +4151,11 @@ html.is-windows .limit-live-badge {
 .subscription-row .subscription-row-actions button:focus-visible {
   opacity: 1;
   color: var(--text);
+}
+.subscription-row.is-editing .subscription-row-edit {
+  opacity: 1;
+  color: var(--accent);
+  background: rgba(var(--accent-rgb), 0.1);
 }
 .subscription-row .subscription-row-delete.is-armed {
   opacity: 1;

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -1968,6 +1968,93 @@ test('the add action switches directly from editing to a new editor', () => {
   assert.match(app, /if \(state\.subscriptionEditingId\) \{\s*closeSubscriptionEditor\(\{ onClosed: openSubscriptionAddEditor \}\);/);
 });
 
+test('subscription editor captures its version before the opening animation', () => {
+  const app = readRendererFile('app.js');
+  const open = functionBody(app, 'openSubscriptionEditor', 'closeSubscriptionEditor');
+  const frames = [];
+  const details = {
+    classList: { add() {} },
+    getBoundingClientRect() {}
+  };
+  const state = {
+    settings: { subscriptionsHub: 'hub-a', subscriptionsUpdatedAt: 'version-a' },
+    subscriptionEditorTransitionId: 0,
+    subscriptionFormBase: null
+  };
+  const els = { subscriptionAddDetails: details };
+  const subscriptionSettingsVersion = () => ({
+    hub: state.settings.subscriptionsHub,
+    updatedAt: state.settings.subscriptionsUpdatedAt
+  });
+
+  vm.runInNewContext(
+    `${open}\nopenSubscriptionEditor();`,
+    {
+      cancelSubscriptionEditorClose() {},
+      els,
+      requestAnimationFrame: (callback) => frames.push(callback),
+      setSubscriptionFormOpen(open, formBase) {
+        state.subscriptionFormBase = formBase;
+      },
+      state,
+      subscriptionSettingsVersion
+    }
+  );
+
+  state.settings.subscriptionsUpdatedAt = 'version-b';
+  frames[0]();
+  assert.deepEqual(state.subscriptionFormBase, { hub: 'hub-a', updatedAt: 'version-a' });
+});
+
+test('subscription row rerenders keep the live editor node attached', () => {
+  const app = readRendererFile('app.js');
+  const clear = functionBody(app, 'clearSubscriptionListChildren', 'positionSubscriptionEditor');
+  const editor = { removed: false, remove() { this.removed = true; } };
+  const row = { removed: false, remove() { this.removed = true; } };
+  const empty = { removed: false, remove() { this.removed = true; } };
+  const list = { children: [row, editor, empty] };
+
+  vm.runInNewContext(
+    `${clear}\nclearSubscriptionListChildren(list, editor);`,
+    { list, editor }
+  );
+
+  assert.equal(row.removed, true);
+  assert.equal(empty.removed, true);
+  assert.equal(editor.removed, false);
+});
+
+test('the add control is a disclosure only in add mode', () => {
+  const app = readRendererFile('app.js');
+  const control = functionBody(app, 'syncSubscriptionAddControl', 'clearSubscriptionListChildren');
+  const attrs = new Map();
+  const toggle = {
+    removeAttribute(name) { attrs.delete(name); },
+    setAttribute(name, value) { attrs.set(name, value); }
+  };
+  const form = {
+    classList: {
+      expanded: false,
+      remove(name) { if (name === 'expanded') this.expanded = false; },
+      toggle(name, value) { if (name === 'expanded') this.expanded = value; }
+    }
+  };
+  const details = { classList: { contains: () => false } };
+  const state = { subscriptionEditingId: 'subscription-1' };
+  const els = { subscriptionAddToggle: toggle, subscriptionAddForm: form, subscriptionAddDetails: details };
+
+  vm.runInNewContext(`${control}\nsyncSubscriptionAddControl();`, { els, state });
+  assert.equal(attrs.has('aria-expanded'), false);
+  assert.equal(attrs.has('aria-controls'), false);
+  assert.equal(form.classList.expanded, false);
+
+  state.subscriptionEditingId = '';
+  vm.runInNewContext(`${control}\nsyncSubscriptionAddControl();`, { els, state });
+  assert.equal(attrs.get('aria-expanded'), 'true');
+  assert.equal(attrs.get('aria-controls'), 'subscriptionAddDetails');
+  assert.equal(form.classList.expanded, true);
+});
+
 test('subscription rows carry the glyph actions the profile rows above them use', () => {
   const app = readRendererFile('app.js');
   const rows = functionBody(app, 'renderSubscriptionRows', 'renderSubscriptionPickers');
@@ -3562,6 +3649,7 @@ test('an edit is saved against the version its form was opened on', async () => 
       }
     },
     renderSubscriptionSettings: () => {},
+    syncSubscriptionAddControl: () => {},
     resetSubscriptionForm: () => { context.formReset = true; },
     Promise
   });

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -1941,12 +1941,66 @@ test('subscription form controls stay shrinkable so a long option cannot overflo
   assert.doesNotMatch(styles, /\.subscription-add-body > \.settings-row/);
 });
 
+test('subscription field groups keep their rows separated', () => {
+  const styles = readRendererFile('styles.css');
+  const fields = cssBlock(styles, '.subscription-add-body .subscription-kind-fields');
+  assert.match(fields, /display: flex;/);
+  assert.match(fields, /flex-direction: column;/);
+  assert.match(fields, /gap: 8px;/);
+  assert.doesNotMatch(cssBlock(styles, '.subscription-topup-heading-row'), /margin-bottom/);
+  assert.doesNotMatch(styles, /\.subscription-topup-add-row\s*\{\s*margin-top/);
+});
+
+test('subscription validation errors stay inside the active editor', () => {
+  const html = readRendererFile('index.html');
+  assert.match(html, /id="subscriptionErrorMessage" class="settings-note error subscription-form-error hidden" role="alert"/);
+  assert.match(html, /subscriptionErrorMessage[\s\S]*subscriptionSubmit/);
+  assert.doesNotMatch(html, /subscriptionTotalRow[\s\S]*subscriptionErrorMessage/);
+});
+
+test('the add action switches directly from editing to a new editor', () => {
+  const app = readRendererFile('app.js');
+  const beginAdd = functionBody(app, 'beginSubscriptionAdd', 'beginSubscriptionEdit');
+
+  assert.match(beginAdd, /resetSubscriptionForm\(\);/);
+  assert.match(beginAdd, /renderSubscriptionRows\(\);/);
+  assert.match(beginAdd, /openSubscriptionAddEditor\(\);/);
+  assert.match(app, /if \(state\.subscriptionEditingId\) \{\s*closeSubscriptionEditor\(\{ onClosed: openSubscriptionAddEditor \}\);/);
+});
+
 test('subscription rows carry the glyph actions the profile rows above them use', () => {
   const app = readRendererFile('app.js');
   const rows = functionBody(app, 'renderSubscriptionRows', 'renderSubscriptionPickers');
-  assert.match(rows, /edit\.textContent = '✎';/);
+  assert.match(rows, /edit\.textContent = editOpen \? '×' : '✎';/);
+  assert.match(rows, /edit\.setAttribute\('aria-expanded', editOpen \? 'true' : 'false'\);/);
   assert.match(rows, /remove\.textContent = '✕';/);
   assert.match(rows, /remove\.textContent = '✓';/);
+});
+
+test('editing a subscription moves only the editor beneath its row', () => {
+  const app = readRendererFile('app.js');
+  const styles = readRendererFile('styles.css');
+  const rows = functionBody(app, 'renderSubscriptionRows', 'renderSubscriptionPickers');
+  const beginEdit = functionBody(app, 'beginSubscriptionEdit', 'submitSubscription');
+  const submit = functionBody(app, 'submitSubscription', 'configuredLimitProviderOrder');
+  const reset = functionBody(app, 'resetSubscriptionForm', 'beginSubscriptionEdit');
+
+  assert.match(rows, /row\.dataset\.subscriptionId = subscription\.id;/);
+  assert.match(rows, /positionSubscriptionEditor\(\);/);
+  assert.match(beginEdit, /positionSubscriptionEditor\(\);\s*openSubscriptionEditor\(\);/);
+  assert.match(reset, /positionSubscriptionEditor\(\);/);
+  assert.match(app, /editingRow\.after\(details\);/);
+  assert.match(app, /else form\.append\(details\);/);
+  assert.doesNotMatch(app, /editingRow\.after\(form\)/);
+  assert.match(app, /details\.getBoundingClientRect\(\);/);
+  assert.match(app, /setSubscriptionFormOpen\(false\);[\s\S]*resetSubscriptionForm\(\);/);
+  assert.match(app, /state\.subscriptionEditingId === subscription\.id[\s\S]*closeSubscriptionEditor\(\);/);
+  assert.match(app, /els\.subscriptionCancelEdit\?\.addEventListener\('click', \(\) => closeSubscriptionEditor\(\)\);/);
+  assert.match(submit, /saveSubscriptions\(updated, state\.subscriptionFormBase, \{ render: false \}\)/);
+  assert.match(submit, /closeSubscriptionEditor\(\{ onClosed: renderSubscriptionSettings \}\);/);
+  assert.match(cssBlock(styles, '.subscription-row.is-editing'), /border-color/);
+  assert.match(styles, /\.subscription-row\.is-editing \.subscription-row-edit/);
+  assert.match(styles, /#subscriptionList > #subscriptionAddDetails/);
 });
 
 test('the plan-name seed never runs from a render, so it cannot wipe what is being typed', () => {
@@ -2552,7 +2606,7 @@ test('subscriptions are written through the hub-aware channel, never as a settin
   assert.match(preload, /saveSubscriptions: \(subscriptions, base\) => ipcRenderer\.invoke\('subscriptions:save', subscriptions, base\)/);
   // An edit says what it was made on, and that is what the form was opened with —
   // not whatever a push has left in state.settings since.
-  assert.match(submit, /saveSubscriptions\(updated, state\.subscriptionFormBase\)/);
+  assert.match(submit, /saveSubscriptions\(updated, state\.subscriptionFormBase(?:, \{ render: false \})?\)/);
   // A row action has no form, so it reads the list and what it was taken from
   // together at the click rather than reusing the list the row was drawn with.
   assert.doesNotMatch(rows, /saveSubscriptions\(list\.filter/);

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -2101,6 +2101,41 @@ test('closing the subscription editor does not steal focus moved to another cont
   assert.equal(finalEdit.focused, false);
 });
 
+test('closing a new subscription editor restores focus to the Add action', () => {
+  const app = readRendererFile('app.js');
+  const close = functionBody(app, 'closeSubscriptionEditor', 'setSubscriptionDateBound');
+  const input = {};
+  const addToggle = { focused: false, focus() { this.focused = true; } };
+  const documentState = { activeElement: input, body: {} };
+  const details = {
+    classList: { contains: () => false },
+    contains: (node) => node === input,
+    addEventListener: () => {},
+    removeEventListener: () => {}
+  };
+  const state = { subscriptionEditingId: '', subscriptionEditorTransitionId: 0 };
+  let finish;
+  const context = vm.createContext({
+    document: documentState,
+    els: { subscriptionAddDetails: details, subscriptionAddToggle: addToggle },
+    state,
+    cancelSubscriptionEditorClose() {},
+    setSubscriptionFormOpen() {},
+    resetSubscriptionForm() {},
+    renderSubscriptionRows() {},
+    clearTimeout() {},
+    setTimeout(callback) { finish = callback; return 1; }
+  });
+
+  vm.runInContext(
+    `const SUBSCRIPTION_EDITOR_TRANSITION_MS = 250;\nlet subscriptionEditorCloseCleanup = null;\n${close}\ncloseSubscriptionEditor();`,
+    context
+  );
+  finish();
+
+  assert.equal(addToggle.focused, true);
+});
+
 test('a successful subscription save renders before starting the close animation', async () => {
   const app = readRendererFile('app.js');
   const submit = functionBody(app, 'submitSubscription', 'configuredLimitProviderOrder');

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -2054,6 +2054,117 @@ test('closing the subscription editor restores focus to the rebuilt row action',
   assert.equal(finalEdit.focused, true);
 });
 
+test('closing the subscription editor does not steal focus moved to another control', () => {
+  const app = readRendererFile('app.js');
+  const close = functionBody(app, 'closeSubscriptionEditor', 'setSubscriptionDateBound');
+  const oldEdit = { focus() {} };
+  const otherControl = {};
+  const finalEdit = { focused: false, focus() { this.focused = true; } };
+  const rowFor = (edit) => ({
+    dataset: { subscriptionId: 'subscription-1' },
+    querySelector: (selector) => selector === '.subscription-row-edit' ? edit : null
+  });
+  const dom = { rows: [rowFor(oldEdit)] };
+  const documentState = { activeElement: oldEdit, body: {} };
+  let finish;
+  const list = { querySelectorAll: () => dom.rows };
+  const details = {
+    classList: { contains: () => false },
+    contains: () => false,
+    addEventListener: () => {},
+    removeEventListener: () => {}
+  };
+  const state = { subscriptionEditingId: 'subscription-1', subscriptionEditorTransitionId: 0 };
+  const context = vm.createContext({
+    document: documentState,
+    els: { subscriptionAddDetails: details, subscriptionList: list },
+    state,
+    dom,
+    rowFor,
+    finalEdit,
+    cancelSubscriptionEditorClose() {},
+    setSubscriptionFormOpen() {},
+    resetSubscriptionForm() { state.subscriptionEditingId = ''; },
+    renderSubscriptionRows() { dom.rows = [rowFor(finalEdit)]; },
+    clearTimeout() {},
+    setTimeout(callback) { finish = callback; return 1; }
+  });
+
+  vm.runInContext(
+    `const SUBSCRIPTION_EDITOR_TRANSITION_MS = 250;\nlet subscriptionEditorCloseCleanup = null;\n${close}\ncloseSubscriptionEditor();`,
+    context
+  );
+  documentState.activeElement = otherControl;
+  finish();
+
+  assert.equal(documentState.activeElement, otherControl);
+  assert.equal(finalEdit.focused, false);
+});
+
+test('a successful subscription save renders before starting the close animation', async () => {
+  const app = readRendererFile('app.js');
+  const submit = functionBody(app, 'submitSubscription', 'configuredLimitProviderOrder');
+  const account = { provider: 'codex', accountKey: 'acct-1', accountName: 'acct' };
+  const list = [{
+    id: 'subscription-1',
+    provider: 'codex',
+    binding: { accountKey: 'acct-1', accountEmail: 'acct@example.com' },
+    planName: 'Old plan',
+    amountMinor: 1000,
+    currency: 'USD',
+    interval: 'month',
+    intervalCount: 1,
+    startDate: '2026-01-01',
+    topUps: [],
+    autoRenew: true,
+    nextRenewalOverride: null,
+    endDate: null
+  }];
+  const els = {
+    subscriptionProviderInput: { value: 'codex' },
+    subscriptionAccountInput: { value: 'acct-1' },
+    subscriptionAmountInput: { value: '10' },
+    subscriptionStartDateInput: { value: '2026-01-01' },
+    subscriptionAutoRenewInput: { checked: true },
+    subscriptionNextRenewalInput: { value: '' },
+    subscriptionPlanNameInput: { value: 'Updated plan' },
+    subscriptionCurrencyInput: { value: 'USD' },
+    subscriptionIntervalInput: { value: 'month' },
+    subscriptionIntervalCountInput: { value: '1' }
+  };
+  const state = { subscriptionEditingId: 'subscription-1', subscriptionFormBase: { updatedAt: 'v1' } };
+  let fullRenderCompleted = false;
+  let closeArgs = null;
+  const context = vm.createContext({
+    els,
+    state,
+    subscriptionApi: {
+      todayString: () => '2026-02-01',
+      bindingFromAccount: () => ({ accountKey: 'acct-1' }),
+      normalizeSubscription: (value) => value
+    },
+    currencyApi: {},
+    subscriptionFormTopUps: () => [],
+    subscriptionFormIsTopUp: () => false,
+    subscriptionAccountChoices: () => [{ value: 'acct-1', provider: account }],
+    subscriptionList: () => list,
+    subscriptionForAccountValue: () => false,
+    saveSubscriptions: async (updated, base, options) => {
+      if (options?.render === false) return true;
+      fullRenderCompleted = true;
+      return true;
+    },
+    closeSubscriptionEditor: (...args) => { closeArgs = args; },
+    setSubscriptionError() {},
+    Promise
+  });
+
+  await vm.runInContext(`async ${submit}\nsubmitSubscription();`, context);
+
+  assert.equal(fullRenderCompleted, true);
+  assert.deepEqual(closeArgs, []);
+});
+
 test('subscription row rerenders keep the live editor node attached', () => {
   const app = readRendererFile('app.js');
   const clear = functionBody(app, 'clearSubscriptionListChildren', 'positionSubscriptionEditor');
@@ -2131,8 +2242,10 @@ test('editing a subscription moves only the editor beneath its row', () => {
   assert.match(app, /setSubscriptionFormOpen\(false\);[\s\S]*resetSubscriptionForm\(\);/);
   assert.match(app, /state\.subscriptionEditingId === subscription\.id[\s\S]*closeSubscriptionEditor\(\);/);
   assert.match(app, /els\.subscriptionCancelEdit\?\.addEventListener\('click', \(\) => closeSubscriptionEditor\(\)\);/);
-  assert.match(submit, /saveSubscriptions\(updated, state\.subscriptionFormBase, \{ render: false \}\)/);
-  assert.match(submit, /closeSubscriptionEditor\(\{ onClosed: renderSubscriptionSettings \}\);/);
+  assert.match(submit, /saveSubscriptions\(updated, state\.subscriptionFormBase\)/);
+  assert.doesNotMatch(submit, /render: false/);
+  assert.match(submit, /closeSubscriptionEditor\(\);/);
+  assert.doesNotMatch(submit, /onClosed: renderSubscriptionSettings/);
   assert.match(cssBlock(styles, '.subscription-row.is-editing'), /border-color/);
   assert.match(styles, /\.subscription-row\.is-editing \.subscription-row-edit/);
   assert.match(styles, /#subscriptionList > #subscriptionAddDetails/);

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -1971,6 +1971,7 @@ test('the add action switches directly from editing to a new editor', () => {
 test('subscription editor captures its version before the opening animation', () => {
   const app = readRendererFile('app.js');
   const open = functionBody(app, 'openSubscriptionEditor', 'closeSubscriptionEditor');
+  const setOpen = functionBody(app, 'setSubscriptionFormOpen', 'seedSubscriptionPlanName');
   const frames = [];
   const details = {
     classList: { add() {} },
@@ -2004,6 +2005,53 @@ test('subscription editor captures its version before the opening animation', ()
   state.settings.subscriptionsUpdatedAt = 'version-b';
   frames[0]();
   assert.deepEqual(state.subscriptionFormBase, { hub: 'hub-a', updatedAt: 'version-a' });
+  assert.doesNotMatch(setOpen, /formBase \|\| state\.subscriptionFormBase/);
+});
+
+test('closing the subscription editor restores focus to the rebuilt row action', () => {
+  const app = readRendererFile('app.js');
+  const close = functionBody(app, 'closeSubscriptionEditor', 'setSubscriptionDateBound');
+  const input = {};
+  const oldEdit = { focus() {} };
+  const newEdit = { focused: false, focus() { this.focused = true; } };
+  const finalEdit = { focused: false, focus() { this.focused = true; } };
+  const rowFor = (edit) => ({
+    dataset: { subscriptionId: 'subscription-1' },
+    querySelector: (selector) => selector === '.subscription-row-edit' ? edit : null
+  });
+  const dom = { rows: [rowFor(oldEdit)] };
+  let finish;
+  const list = { querySelectorAll: () => dom.rows };
+  const details = {
+    classList: { contains: () => false },
+    contains: (node) => node === input,
+    addEventListener: () => {},
+    removeEventListener: () => {}
+  };
+  const state = { subscriptionEditingId: 'subscription-1', subscriptionEditorTransitionId: 0 };
+  const context = vm.createContext({
+    document: { activeElement: oldEdit },
+    els: { subscriptionAddDetails: details, subscriptionList: list },
+    state,
+    dom,
+    rowFor,
+    finalEdit,
+    cancelSubscriptionEditorClose() {},
+    setSubscriptionFormOpen() {},
+    resetSubscriptionForm() { state.subscriptionEditingId = ''; },
+    renderSubscriptionRows() { dom.rows = [rowFor(newEdit)]; },
+    clearTimeout() {},
+    setTimeout(callback) { finish = callback; return 1; }
+  });
+
+  vm.runInContext(
+    `const SUBSCRIPTION_EDITOR_TRANSITION_MS = 250;\nlet subscriptionEditorCloseCleanup = null;\n${close}\ncloseSubscriptionEditor({ onClosed: () => { dom.rows = [rowFor(finalEdit)]; } });`,
+    context
+  );
+  finish();
+
+  assert.equal(newEdit.focused, false);
+  assert.equal(finalEdit.focused, true);
 });
 
 test('subscription row rerenders keep the live editor node attached', () => {

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -2048,6 +2048,7 @@ test('closing the subscription editor restores focus to the rebuilt row action',
     `const SUBSCRIPTION_EDITOR_TRANSITION_MS = 250;\nlet subscriptionEditorCloseCleanup = null;\n${close}\ncloseSubscriptionEditor({ onClosed: () => { dom.rows = [rowFor(finalEdit)]; } });`,
     context
   );
+  assert.equal(finalEdit.focused, false);
   finish();
 
   assert.equal(newEdit.focused, false);
@@ -2136,7 +2137,40 @@ test('closing a new subscription editor restores focus to the Add action', () =>
   assert.equal(addToggle.focused, true);
 });
 
-test('a successful subscription save renders before starting the close animation', async () => {
+test('canceling a close settles its deferred render exactly once', () => {
+  const app = readRendererFile('app.js');
+  const cancel = functionBody(app, 'cancelSubscriptionEditorClose', 'openSubscriptionEditor');
+  const close = functionBody(app, 'closeSubscriptionEditor', 'setSubscriptionDateBound');
+  const details = {
+    classList: { contains: () => false },
+    contains: () => false,
+    addEventListener: () => {},
+    removeEventListener: () => {}
+  };
+  const state = { subscriptionEditingId: '', subscriptionEditorTransitionId: 0 };
+  const context = vm.createContext({
+    document: { activeElement: null, body: {} },
+    els: { subscriptionAddDetails: details },
+    state,
+    setSubscriptionFormOpen() {},
+    resetSubscriptionForm() {},
+    renderSubscriptionRows() {},
+    clearTimeout() {},
+    setTimeout() { return 1; },
+    renderCount: 0
+  });
+
+  vm.runInContext(
+    `const SUBSCRIPTION_EDITOR_TRANSITION_MS = 250;\nlet subscriptionEditorCloseCleanup = null;\nlet subscriptionEditorCloseOnCancel = null;\n${cancel}\n${close}\ncloseSubscriptionEditor({ onClosed: () => { renderCount += 1; } });`,
+    context
+  );
+  assert.equal(context.renderCount, 0);
+  vm.runInContext('cancelSubscriptionEditorClose();', context);
+
+  assert.equal(context.renderCount, 1);
+});
+
+test('a successful subscription save defers the full render until close completes', async () => {
   const app = readRendererFile('app.js');
   const submit = functionBody(app, 'submitSubscription', 'configuredLimitProviderOrder');
   const account = { provider: 'codex', accountKey: 'acct-1', accountName: 'acct' };
@@ -2168,8 +2202,6 @@ test('a successful subscription save renders before starting the close animation
     subscriptionIntervalCountInput: { value: '1' }
   };
   const state = { subscriptionEditingId: 'subscription-1', subscriptionFormBase: { updatedAt: 'v1' } };
-  let fullRenderCompleted = false;
-  let closeArgs = null;
   const context = vm.createContext({
     els,
     state,
@@ -2184,20 +2216,31 @@ test('a successful subscription save renders before starting the close animation
     subscriptionAccountChoices: () => [{ value: 'acct-1', provider: account }],
     subscriptionList: () => list,
     subscriptionForAccountValue: () => false,
+    saveCompleted: false,
+    saveOptions: null,
+    closeOptions: null,
+    renderCount: 0,
     saveSubscriptions: async (updated, base, options) => {
-      if (options?.render === false) return true;
-      fullRenderCompleted = true;
+      context.saveOptions = options;
+      context.saveCompleted = true;
       return true;
     },
-    closeSubscriptionEditor: (...args) => { closeArgs = args; },
+    closeSubscriptionEditor: (options) => {
+      assert.equal(context.saveCompleted, true);
+      context.closeOptions = options;
+    },
+    renderSubscriptionSettings() { context.renderCount += 1; },
     setSubscriptionError() {},
     Promise
   });
 
   await vm.runInContext(`async ${submit}\nsubmitSubscription();`, context);
 
-  assert.equal(fullRenderCompleted, true);
-  assert.deepEqual(closeArgs, []);
+  assert.equal(context.saveOptions?.render, false);
+  assert.equal(context.renderCount, 0);
+  assert.equal(typeof context.closeOptions?.onClosed, 'function');
+  context.closeOptions.onClosed();
+  assert.equal(context.renderCount, 1);
 });
 
 test('subscription row rerenders keep the live editor node attached', () => {
@@ -2277,10 +2320,8 @@ test('editing a subscription moves only the editor beneath its row', () => {
   assert.match(app, /setSubscriptionFormOpen\(false\);[\s\S]*resetSubscriptionForm\(\);/);
   assert.match(app, /state\.subscriptionEditingId === subscription\.id[\s\S]*closeSubscriptionEditor\(\);/);
   assert.match(app, /els\.subscriptionCancelEdit\?\.addEventListener\('click', \(\) => closeSubscriptionEditor\(\)\);/);
-  assert.match(submit, /saveSubscriptions\(updated, state\.subscriptionFormBase\)/);
-  assert.doesNotMatch(submit, /render: false/);
-  assert.match(submit, /closeSubscriptionEditor\(\);/);
-  assert.doesNotMatch(submit, /onClosed: renderSubscriptionSettings/);
+  assert.match(submit, /saveSubscriptions\(updated, state\.subscriptionFormBase, \{ render: false \}\)/);
+  assert.match(submit, /closeSubscriptionEditor\(\{ onClosed: renderSubscriptionSettings \}\);/);
   assert.match(cssBlock(styles, '.subscription-row.is-editing'), /border-color/);
   assert.match(styles, /\.subscription-row\.is-editing \.subscription-row-edit/);
   assert.match(styles, /#subscriptionList > #subscriptionAddDetails/);

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -2301,6 +2301,41 @@ test('subscription rows carry the glyph actions the profile rows above them use'
   assert.match(rows, /remove\.textContent = '✓';/);
 });
 
+test('deleting a subscription preserves the settings scroll position and renders once', () => {
+  const app = readRendererFile('app.js');
+  const rows = functionBody(app, 'renderSubscriptionRows', 'renderSubscriptionPickers');
+  const settingsPush = app.match(/window\.tokenMonitor\.onSettingsPush\?\.\(\(next\) => \{[\s\S]*?\n\}\);/)?.[0] || '';
+  const preserve = functionBody(app, 'preserveSettingsPanelScroll', 'saveSettings');
+
+  assert.match(rows, /subscriptionSettingsVersion\(\),\s*\{ render: false \}\s*\)\)/);
+  assert.match(rows, /preserveSettingsPanelScroll\(renderSubscriptionSettings\);/);
+  assert.match(settingsPush, /preserveSettingsPanelScroll\(syncSettingsForm\);/);
+
+  const frames = [];
+  const panel = {
+    scrollTop: 240,
+    scrollLeft: 0,
+    classList: { contains: () => false }
+  };
+  const context = vm.createContext({
+    els: { settingsPanel: panel },
+    panel,
+    settingsScrollInteractionRevision: 0,
+    requestAnimationFrame(callback) {
+      frames.push(callback);
+    }
+  });
+
+  vm.runInContext(
+    `${preserve}\npreserveSettingsPanelScroll(() => { panel.scrollTop = 0; });`,
+    context
+  );
+  assert.equal(panel.scrollTop, 240);
+  panel.scrollTop = 0;
+  frames[0]();
+  assert.equal(panel.scrollTop, 240);
+});
+
 test('editing a subscription moves only the editor beneath its row', () => {
   const app = readRendererFile('app.js');
   const styles = readRendererFile('styles.css');

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -2161,13 +2161,139 @@ test('canceling a close settles its deferred render exactly once', () => {
   });
 
   vm.runInContext(
-    `const SUBSCRIPTION_EDITOR_TRANSITION_MS = 250;\nlet subscriptionEditorCloseCleanup = null;\nlet subscriptionEditorCloseOnCancel = null;\n${cancel}\n${close}\ncloseSubscriptionEditor({ onClosed: () => { renderCount += 1; } });`,
+    `const SUBSCRIPTION_EDITOR_TRANSITION_MS = 250;\nlet subscriptionEditorCloseCleanup = null;\nlet subscriptionEditorCloseOnCanceled = null;\n${cancel}\n${close}\ncloseSubscriptionEditor({ onCanceled: () => { renderCount += 1; } });`,
     context
   );
   assert.equal(context.renderCount, 0);
   vm.runInContext('cancelSubscriptionEditorClose();', context);
 
   assert.equal(context.renderCount, 1);
+});
+
+test('canceling an edit-to-add close does not run its stale onClosed callback', () => {
+  const app = readRendererFile('app.js');
+  const cancel = functionBody(app, 'cancelSubscriptionEditorClose', 'openSubscriptionEditor');
+  const close = functionBody(app, 'closeSubscriptionEditor', 'setSubscriptionDateBound');
+  const details = {
+    classList: { contains: () => false },
+    contains: () => false,
+    addEventListener: () => {},
+    removeEventListener: () => {}
+  };
+  const state = { subscriptionEditingId: 'subscription-a', subscriptionEditorTransitionId: 0 };
+  const context = vm.createContext({
+    document: { activeElement: null, body: {} },
+    els: { subscriptionAddDetails: details },
+    state,
+    cancelSubscriptionEditorClose() {},
+    setSubscriptionFormOpen() {},
+    resetSubscriptionForm() {},
+    renderSubscriptionRows() {},
+    clearTimeout() {},
+    setTimeout() { return 1; },
+    staleCallbackCalls: 0,
+    canceledCallbackCalls: 0
+  });
+
+  vm.runInContext(
+    `const SUBSCRIPTION_EDITOR_TRANSITION_MS = 250;\nlet subscriptionEditorCloseCleanup = null;\nlet subscriptionEditorCloseOnCanceled = null;\n${cancel}\n${close}\ncloseSubscriptionEditor({ onClosed: () => { staleCallbackCalls += 1; }, onCanceled: () => { canceledCallbackCalls += 1; } });`,
+    context
+  );
+  vm.runInContext('cancelSubscriptionEditorClose();', context);
+
+  assert.equal(context.staleCallbackCalls, 0);
+  assert.equal(context.canceledCallbackCalls, 1);
+});
+
+test('switching to another edit preserves its form values during a canceled close', () => {
+  const app = readRendererFile('app.js');
+  const cancel = functionBody(app, 'cancelSubscriptionEditorClose', 'openSubscriptionEditor');
+  const close = functionBody(app, 'closeSubscriptionEditor', 'setSubscriptionDateBound');
+  const beginEdit = functionBody(app, 'beginSubscriptionEdit', 'submitSubscription');
+  const details = {
+    classList: { contains: () => false },
+    contains: () => false,
+    addEventListener: () => {},
+    removeEventListener: () => {}
+  };
+  const fields = {
+    provider: { value: '' },
+    account: { value: '' },
+    kind: '',
+    plan: { value: '' },
+    amount: { value: '' },
+    currency: { value: '' },
+    intervalCount: { value: '' },
+    interval: { value: '' },
+    startDate: { value: '' },
+    nextRenewal: { value: '' },
+    autoRenew: { checked: false },
+    submit: { textContent: '' },
+    cancel: { classList: { add() {}, remove() {} } }
+  };
+  const kindInputs = [
+    { value: 'subscription', checked: false },
+    { value: 'topup', checked: false }
+  ];
+  const account = { provider: 'codex', accountKey: 'acct-b', accountName: 'B' };
+  const records = [
+    { id: 'subscription-a', provider: 'codex', kind: 'subscription', planName: 'A plan', amountMinor: 1000, currency: 'USD', intervalCount: 1, interval: 'month', startDate: '2026-01-01', autoRenew: true, nextRenewalOverride: '', endDate: null, topUps: [] },
+    { id: 'subscription-b', provider: 'codex', kind: 'topup', planName: 'B plan', amountMinor: 2000, currency: 'HKD', intervalCount: 1, interval: 'month', startDate: '2026-02-01', autoRenew: true, nextRenewalOverride: '2026-03-01', endDate: null, topUps: [{ id: 'topup-b', date: '2026-02-01', amountMinor: 2000 }] }
+  ];
+  const state = { subscriptionEditingId: 'subscription-a', subscriptionEditorTransitionId: 0, subscriptionTopUps: [] };
+  const context = vm.createContext({
+    document: { activeElement: null, body: {} },
+    els: {
+      subscriptionAddDetails: details,
+      subscriptionList: { querySelectorAll: () => [] },
+      subscriptionProviderInput: fields.provider,
+      subscriptionAccountInput: fields.account,
+      subscriptionPlanNameInput: fields.plan,
+      subscriptionAmountInput: fields.amount,
+      subscriptionCurrencyInput: fields.currency,
+      subscriptionIntervalCountInput: fields.intervalCount,
+      subscriptionIntervalInput: fields.interval,
+      subscriptionStartDateInput: fields.startDate,
+      subscriptionNextRenewalInput: fields.nextRenewal,
+      subscriptionAutoRenewInput: fields.autoRenew,
+      subscriptionSubmit: fields.submit,
+      subscriptionCancelEdit: fields.cancel,
+      subscriptionKindInputs: kindInputs
+    },
+    fields,
+    kindInputs,
+    state,
+    subscriptionList: () => records,
+    subscriptionApi: {
+      matchProviderAccount: () => account,
+      amountUnits: (subscription) => subscription.amountMinor / 100
+    },
+    limitProvidersForSubscriptions: () => [],
+    subscriptionAccountValue: () => 'acct-b',
+    renderSubscriptionPickers() {},
+    setSubscriptionFormMode: () => {},
+    syncSubscriptionDateBounds: () => {},
+    positionSubscriptionEditor: () => {},
+    setSubscriptionError: () => {},
+    t: () => 'Update subscription',
+    setSubscriptionFormOpen() {},
+    resetSubscriptionForm() {},
+    renderSubscriptionRows() {},
+    clearTimeout() {},
+    setTimeout() { return 1; },
+    staleCallbackCalls: 0
+  });
+
+  vm.runInContext(
+    `const SUBSCRIPTION_EDITOR_TRANSITION_MS = 250;\nlet subscriptionEditorCloseCleanup = null;\nlet subscriptionEditorCloseOnCanceled = null;\n${cancel}\n${close}\nfunction openSubscriptionEditor() { cancelSubscriptionEditorClose(); }\n${beginEdit}\ncloseSubscriptionEditor({ onClosed: () => { staleCallbackCalls += 1; fields.plan.value = 'Add default'; kindInputs[0].checked = true; kindInputs[1].checked = false; } });\nbeginSubscriptionEdit('subscription-b');`,
+    context
+  );
+
+  assert.equal(context.staleCallbackCalls, 0);
+  assert.equal(context.fields.plan.value, 'B plan');
+  assert.equal(context.kindInputs[0].checked, false);
+  assert.equal(context.kindInputs[1].checked, true);
+  assert.equal(context.fields.amount.value, '20');
 });
 
 test('a successful subscription save defers the full render until close completes', async () => {
@@ -2356,7 +2482,7 @@ test('editing a subscription moves only the editor beneath its row', () => {
   assert.match(app, /state\.subscriptionEditingId === subscription\.id[\s\S]*closeSubscriptionEditor\(\);/);
   assert.match(app, /els\.subscriptionCancelEdit\?\.addEventListener\('click', \(\) => closeSubscriptionEditor\(\)\);/);
   assert.match(submit, /saveSubscriptions\(updated, state\.subscriptionFormBase, \{ render: false \}\)/);
-  assert.match(submit, /closeSubscriptionEditor\(\{ onClosed: renderSubscriptionSettings \}\);/);
+  assert.match(submit, /closeSubscriptionEditor\(\{\s*onClosed: renderSubscriptionSettings,\s*onCanceled: renderSubscriptionSettings\s*\}\);/);
   assert.match(cssBlock(styles, '.subscription-row.is-editing'), /border-color/);
   assert.match(styles, /\.subscription-row\.is-editing \.subscription-row-edit/);
   assert.match(styles, /#subscriptionList > #subscriptionAddDetails/);


### PR DESCRIPTION
## Summary

- Keep the add button at the bottom of the subscription list.
- Move only the inline editor beneath the subscription being edited.
- Preserve expand and collapse animations for add, edit, cancel, and update flows.
- Switch from edit mode to add mode with a single click.
- Keep validation errors inside the active editor near the save actions.
- Fix spacing between amount, interval, and first-charge date fields.
- Capture the shared-list revision before the opening animation.
- Preserve the live editor node and input focus during settings refreshes.
- Keep Add action semantics separate from edit disclosure state.
- Restore focus to the edited row action after closing and rebuilding the editor.
- Restore focus to the Add action after closing a new subscription editor.
- Keep mode switches from stealing focus from the Add action.
- Render saved subscription state before starting the close animation.
- Avoid stealing focus if the user moves to another control during the close animation.
- Remove the unreachable intermediate form-base fallback.

## Validation

- `npm run verify`
- 2237 tests: 2236 passed, 1 skipped, 0 failed
- `git diff --check`

## UI Verification

Verified the add, edit, cancel, save, edit-to-add, and keyboard focus restoration flows.
