### PR TITLE
fix(dashboard): preserve fractional cost precision

### DIFF
--- a/src/shared/compactMoney.js
+++ b/src/shared/compactMoney.js
@@ -21,7 +21,7 @@
     }
 
     const symbol = currencyApi.CURRENCY_RATES[code]?.symbol || `${code} `;
-    return `${symbol}${compactTokenApi.formatCompactTokens(amount, unitSystem, locale)}`;
+    return `${symbol}${compactTokenApi.formatCompactValue(amount, unitSystem, locale)}`;
   }
 
   return { formatCompactCurrencyFromUsd };

--- a/src/shared/compactTokens.js
+++ b/src/shared/compactTokens.js
@@ -55,10 +55,10 @@
     return 1;
   }
 
-  function formatCompactTokens(value, unitSystem = 'western', locale = 'en', options = {}) {
+  function formatCompactValue(value, unitSystem = 'western', locale = 'en', options = {}) {
     const requested = normalizeCompactTokenUnits(unitSystem);
     const effective = effectiveCompactTokenUnits(requested, locale);
-    const num = Math.round(Number(value || 0));
+    const num = Number(value || 0);
     const abs = Math.abs(num);
     const units = unitsFor(effective, locale);
     let unitIndex = -1;
@@ -87,6 +87,10 @@
     return `${display}${units[unitIndex].suffix}`;
   }
 
+  function formatCompactTokens(value, unitSystem = 'western', locale = 'en', options = {}) {
+    return formatCompactValue(Math.round(Number(value || 0)), unitSystem, locale, options);
+  }
+
   function compactTokenUnitThreshold(unitSystem, locale) {
     return effectiveCompactTokenUnits(unitSystem, locale) === 'localized' ? 1e4 : 1e3;
   }
@@ -95,6 +99,7 @@
     compactTokenUnitThreshold,
     effectiveCompactTokenUnits,
     formatCompactTokens,
+    formatCompactValue,
     normalizeCompactTokenUnits,
     supportsLocalizedCompactTokenUnits
   };

--- a/tests/shared/compactMoney.test.js
+++ b/tests/shared/compactMoney.test.js
@@ -34,3 +34,13 @@ test('compact currency preserves exact currency precision below the unit thresho
   assert.equal(formatCompactCurrencyFromUsd(999.5, 'USD', 'western', 'en'), '$999.50');
   assert.equal(formatCompactCurrencyFromUsd(9_999.5, 'USD', 'localized', 'zh-TW'), '$9999.50');
 });
+
+test('compact currency preserves fractional precision after crossing a unit threshold', () => {
+  assert.equal(formatCompactCurrencyFromUsd(1_249.5, 'USD', 'western', 'en'), '$1.2K');
+  assert.equal(formatCompactCurrencyFromUsd(1_250, 'USD', 'western', 'en'), '$1.3K');
+  assert.equal(formatCompactCurrencyFromUsd(999_949.5, 'USD', 'western', 'en'), '$999.9K');
+  assert.equal(formatCompactCurrencyFromUsd(999_950, 'USD', 'western', 'en'), '$1M');
+  assert.equal(formatCompactCurrencyFromUsd(12_449.5, 'USD', 'localized', 'zh-TW'), '$1.24萬');
+  assert.equal(formatCompactCurrencyFromUsd(99_999_499.5, 'USD', 'localized', 'zh-TW'), '$9999.9萬');
+  assert.equal(formatCompactCurrencyFromUsd(99_999_500, 'USD', 'localized', 'zh-TW'), '$1億');
+});

--- a/tests/shared/compactTokens.test.js
+++ b/tests/shared/compactTokens.test.js
@@ -33,6 +33,13 @@ test('compact token formatter uses western units and promotes rounded values', (
   assert.equal(compactTokens.formatCompactTokens(999_950_000), '1B');
 });
 
+test('compact value core preserves fractional input while token formatting stays integer-based', () => {
+  assert.equal(compactTokens.formatCompactValue(1_249.5), '1.2K');
+  assert.equal(compactTokens.formatCompactValue(1_250), '1.3K');
+  assert.equal(compactTokens.formatCompactValue(999_949.5), '999.9K');
+  assert.equal(compactTokens.formatCompactValue(999_950), '1M');
+});
+
 test('compact token formatter uses locale-specific East Asian units', () => {
   assert.equal(compactTokens.formatCompactTokens(9_999, 'localized', 'zh-TW'), '9999');
   assert.equal(compactTokens.formatCompactTokens(15_000, 'localized', 'zh-TW'), '1.5萬');
@@ -40,6 +47,12 @@ test('compact token formatter uses locale-specific East Asian units', () => {
   assert.equal(compactTokens.formatCompactTokens(295_116_445, 'localized', 'ja'), '2.95億');
   assert.equal(compactTokens.formatCompactTokens(295_116_445, 'localized', 'ko'), '2.95억');
   assert.equal(compactTokens.formatCompactTokens(99_999_500, 'localized', 'zh-TW'), '1億');
+});
+
+test('compact value core preserves localized fractional boundaries', () => {
+  assert.equal(compactTokens.formatCompactValue(12_449.5, 'localized', 'zh-TW'), '1.24萬');
+  assert.equal(compactTokens.formatCompactValue(99_999_499.5, 'localized', 'zh-TW'), '9999.9萬');
+  assert.equal(compactTokens.formatCompactValue(99_999_500, 'localized', 'zh-TW'), '1億');
 });
 
 test('tray formatting keeps its existing western precision while sharing localized units', () => {


### PR DESCRIPTION
## Summary

- Preserve fractional converted amounts through the shared compact formatter core.
- Keep token formatting integer-based while preventing double rounding for monetary values.
- Cover western and localized threshold and promotion boundaries.

## Validation

- `npm run verify` — 2232 passed, 0 failed, 1 skipped
- `npm run sync:worker` — passed with no Worker drift

## Scope

This follow-up only affects compact Dashboard cost presentation. Token counts and raw cost data are unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix compact currency formatting to preserve fractional precision across unit thresholds and prevent double rounding. Dashboard costs now show accurate fractions (e.g., $1.2K) while token formatting stays integer-based.

- **Bug Fixes**
  - `compactMoney` now uses shared `formatCompactValue` to retain fractional precision for western and localized units (`zh-TW`).
  - `formatCompactTokens` remains integer-based to avoid double rounding in monetary displays.
  - Added tests for threshold boundaries and localized promotions; token counts and raw cost data are unchanged.

<sup>Written for commit cbfc1660e1c1e73a2f8adf89915a0d35721730fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

