### PR TITLE
feat(i18n): add localized release notes

### DIFF
--- a/.github/RELEASE_NOTES_FORMAT.md
+++ b/.github/RELEASE_NOTES_FORMAT.md
@@ -1,10 +1,11 @@
 # Release Notes Format
 
-This file documents the stable Markdown shape of a GitHub release body. The
-live per-release content is `.github/RELEASE_TEMPLATE.md`, which the release
-workflow publishes through `body_path`. Release-writing, versioning, and
-verification rules belong to the release-flow skill rather than this format
-contract.
+`.github/RELEASE_TEMPLATE.md` is the live, per-release GitHub release body used
+by `.github/workflows/release.yml` through `body_path`. Replace its
+release-specific sections for each tag; do not treat it as a permanent
+placeholder template.
+
+This file documents the stable Markdown shape of that release body.
 
 ## Structure
 

--- a/.github/RELEASE_NOTES_FORMAT.md
+++ b/.github/RELEASE_NOTES_FORMAT.md
@@ -11,17 +11,37 @@ actually stale:
 
 - English: `## What's changed`
 - Simplified Chinese: `## 更新内容`
+- Other languages: one outer collapsed `<details>` block whose summary is an
+  inline Markdown navigation row, followed by three independent collapsed
+  `<details>` blocks
+- Traditional Chinese: a collapsed `<details>` block containing a
+  `## 繁體中文` heading followed by `## 更新內容` and the
+  `app-update-notes:zh-TW` markers
+- Korean: a collapsed `<details>` block containing a `## 한국어` heading
+  followed by `## 업데이트 내용` and the `app-update-notes:ko` markers
+- Japanese: a collapsed `<details>` block containing a `## 日本語` heading
+  followed by `## 更新内容` and the `app-update-notes:ja` markers
 
-Keep the bilingual structure and remove categories that do not apply.
+Keep the localized structure and remove categories that do not apply.
+Each localized release block includes a translated download heading and the same
+five version-pinned links; translate labels only, never filenames or URLs.
+Add one `**Full Changelog**` compare link immediately below the divider that
+starts the other-language block and immediately before the outer `<details>`.
+Use the immediately previous and current tags in both the link text and URL; do
+not repeat it inside every locale block. After the divider, wrap the locale area
+in one outer `<details>` whose summary is the plain-language row
+`繁體中文 · 한국어 · 日本語`. Do not add anchor links or a visible `其他語言`
+label. Keep each locale in its own nested independent `<details>` block so the
+three sections remain collapsed separately.
 
 ## Category Order
 
 Use this order when categories apply:
 
-1. `Added` / `新增`
-2. `Changed` / `变更`
-3. `Improved` / `改进`
-4. `Fixed` / `修复`
+1. `Added` / `新增` / `추가` / `追加`
+2. `Changed` / `变更` / `變更` / `변경` / `変更`
+3. `Improved` / `改进` / `改進` / `개선` / `改善`
+4. `Fixed` / `修复` / `修復` / `수정` / `修正`
 
 Keep the four-category skeleton as the canonical format. In the live
 `.github/RELEASE_TEMPLATE.md` for a specific tag, remove categories with no
@@ -37,7 +57,9 @@ that are not simply new, improved, or fixed.
 - Put experimental features under `Added` / `新增`, and say when they are off by
   default or still being tested.
 - Use current UI terms from `src/electron/renderer/i18n.js`.
-- Chinese release notes are Simplified Chinese.
+- Simplified Chinese release notes use Simplified Chinese, Traditional Chinese
+  release notes use Traditional Chinese, and Korean/Japanese release notes use
+  their respective languages.
 
 ## Skeleton
 
@@ -69,4 +91,82 @@ that are not simply new, improved, or fixed.
 
 ### 修复
 - ...
+
+---
+
+**Full Changelog:** [vPREVIOUS...vCURRENT](https://github.com/Javis603/token-monitor/compare/vPREVIOUS...vCURRENT)
+
+<details>
+<summary>繁體中文 · 한국어 · 日本語</summary>
+
+<details>
+<summary><strong>繁體中文</strong></summary>
+
+## 繁體中文
+
+## 更新內容
+
+<!-- app-update-notes:zh-TW:start -->
+### 新增
+- ...
+
+### 變更
+- ...
+
+### 改進
+- ...
+
+### 修復
+- ...
+<!-- app-update-notes:zh-TW:end -->
+
+</details>
+
+<details>
+<summary><strong>한국어</strong></summary>
+
+## 한국어
+
+## 업데이트 내용
+
+<!-- app-update-notes:ko:start -->
+### 추가
+- ...
+
+### 변경
+- ...
+
+### 개선
+- ...
+
+### 수정
+- ...
+<!-- app-update-notes:ko:end -->
+
+</details>
+
+<details>
+<summary><strong>日本語</strong></summary>
+
+## 日本語
+
+## 更新内容
+
+<!-- app-update-notes:ja:start -->
+### 追加
+- ...
+
+### 変更
+- ...
+
+### 改善
+- ...
+
+### 修正
+- ...
+<!-- app-update-notes:ja:end -->
+
+</details>
+
+</details>
 ```

--- a/.github/RELEASE_NOTES_FORMAT.md
+++ b/.github/RELEASE_NOTES_FORMAT.md
@@ -1,71 +1,41 @@
 # Release Notes Format
 
-`.github/RELEASE_TEMPLATE.md` is the live GitHub release body used by
-`.github/workflows/release.yml` through `body_path`. Replace its release-specific
-sections for each tag; do not treat it as a permanent placeholder template.
+This file documents the stable Markdown shape of a GitHub release body. The
+live per-release content is `.github/RELEASE_TEMPLATE.md`, which the release
+workflow publishes through `body_path`. Release-writing, versioning, and
+verification rules belong to the release-flow skill rather than this format
+contract.
 
-## Editable Sections
+## Structure
 
-Only replace these blocks unless download, first-launch, or tokscale guidance is
-actually stale:
+- Keep the English and Simplified Chinese release-note sections at the top.
+- Keep the existing divider between the English and Simplified Chinese
+  sections. After the Simplified Chinese section, put one final `---` divider
+  before the additional-language area.
+- Put exactly one `**Full Changelog:**` compare link immediately below the
+  divider.
+- Put the additional-language area after that link inside one collapsed outer
+  `<details>` block with the plain summary `繁體中文 · 한국어 · 日本語`.
+- Put Traditional Chinese, Korean, and Japanese in three separate nested
+  collapsed `<details>` blocks. Each block has its own language heading and
+  translated update heading.
+- Keep the locale marker content inside the matching language block. The app
+  updater reads these five marker pairs: `en`, `zh`, `zh-TW`, `ko`, and `ja`.
+- Keep each language's download content with its corresponding release-note
+  section. The English and Simplified Chinese sections may retain their
+  existing first-launch and other-notes details; keep translated downloads for
+  the additional languages inside their own nested `<details>` blocks.
 
-- English: `## What's changed`
-- Simplified Chinese: `## 更新内容`
-- Other languages: one outer collapsed `<details>` block whose summary is an
-  inline Markdown navigation row, followed by three independent collapsed
-  `<details>` blocks
-- Traditional Chinese: a collapsed `<details>` block containing a
-  `## 繁體中文` heading followed by `## 更新內容` and the
-  `app-update-notes:zh-TW` markers
-- Korean: a collapsed `<details>` block containing a `## 한국어` heading
-  followed by `## 업데이트 내용` and the `app-update-notes:ko` markers
-- Japanese: a collapsed `<details>` block containing a `## 日本語` heading
-  followed by `## 更新内容` and the `app-update-notes:ja` markers
-
-Keep the localized structure and remove categories that do not apply.
-Each localized release block includes a translated download heading and the same
-five version-pinned links; translate labels only, never filenames or URLs.
-Add one `**Full Changelog**` compare link immediately below the divider that
-starts the other-language block and immediately before the outer `<details>`.
-Use the immediately previous and current tags in both the link text and URL; do
-not repeat it inside every locale block. After the divider, wrap the locale area
-in one outer `<details>` whose summary is the plain-language row
-`繁體中文 · 한국어 · 日本語`. Do not add anchor links or a visible `其他語言`
-label. Keep each locale in its own nested independent `<details>` block so the
-three sections remain collapsed separately.
-
-## Category Order
-
-Use this order when categories apply:
-
-1. `Added` / `新增` / `추가` / `追加`
-2. `Changed` / `变更` / `變更` / `변경` / `変更`
-3. `Improved` / `改进` / `改進` / `개선` / `改善`
-4. `Fixed` / `修复` / `修復` / `수정` / `修正`
-
-Keep the four-category skeleton as the canonical format. In the live
-`.github/RELEASE_TEMPLATE.md` for a specific tag, remove categories with no
-release-note bullets. Use `Changed` / `变更` only for meaningful behavior changes
-that are not simply new, improved, or fixed.
-
-## Writing Rules
-
-- Describe shipped user-facing behavior, not internal commits.
-- Keep same-batch follow-up fixes inside the final feature wording.
-- Do not include README-only, formatting-only, template-only, or internal docs
-  maintenance as release-note bullets.
-- Put experimental features under `Added` / `新增`, and say when they are off by
-  default or still being tested.
-- Use current UI terms from `src/electron/renderer/i18n.js`.
-- Simplified Chinese release notes use Simplified Chinese, Traditional Chinese
-  release notes use Traditional Chinese, and Korean/Japanese release notes use
-  their respective languages.
+The outer summary is plain text rather than an anchor-navigation row. Do not
+add a visible `其他語言` heading or duplicate the Full Changelog link inside
+each language block.
 
 ## Skeleton
 
 ```markdown
 ## What's changed
 
+<!-- app-update-notes:en:start -->
 ### Added
 - ...
 
@@ -77,9 +47,11 @@ that are not simply new, improved, or fixed.
 
 ### Fixed
 - ...
+<!-- app-update-notes:en:end -->
 
 ## 更新内容
 
+<!-- app-update-notes:zh:start -->
 ### 新增
 - ...
 
@@ -91,6 +63,7 @@ that are not simply new, improved, or fixed.
 
 ### 修复
 - ...
+<!-- app-update-notes:zh:end -->
 
 ---
 

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -111,3 +111,111 @@ Tokscale 已随应用内置。你可以在 **设置 → Tokscale** 查看确切�
 https://github.com/junhoyeo/tokscale
 
 </details>
+
+---
+
+**Full Changelog:** [v0.38.0...v0.39.0](https://github.com/Javis603/token-monitor/compare/v0.38.0...v0.39.0)
+
+<details>
+<summary>繁體中文 · 한국어 · 日本語</summary>
+
+<details>
+<summary><strong>繁體中文</strong></summary>
+
+## 繁體中文
+
+## 更新內容
+
+<!-- app-update-notes:zh-TW:start -->
+### 新增
+- **Token 吞吐量：** 將滑鼠移到精簡 `Σ` 標題標記或即時指示點，即可查看目前讀數；點擊可在輸出 `tok/s` 與總 Token `tok/min` 之間切換，選擇會被記住。（#296）
+
+### 改進
+- **Windows 會話詳細資訊：** 儲存在執行中 WSL 主目錄的 Claude 與 Codex 會話，現在可以從會話檢視開啟，而且不會阻塞 Electron 主程序。（#297）
+- **主頁額度：** 主頁額度列現在更精簡、對齊更整齊。
+- **AI 工具額度詳細資訊：** Codex 重設次數與 Claude 預付額度現在會顯示精確的到期時間，即使只有一筆記錄也會顯示。
+
+### 修復
+- **視窗狀態：** 視窗最大化後重新啟動會恢復最大化，同時保留原本的一般視窗大小；系統匣彈出視窗和收起的浮動氣泡不再覆蓋一般視窗大小。（#300）
+- **手動重新整理：** 點擊重新整理後，Cursor 與 Antigravity 的用量會更新為最新資料，不再顯示最多五分鐘的舊資料。（#290）
+- **MiMo 與 Kimi 額度：** 使用量超過上限時，剩餘比例現在會正確顯示為 **0%**，不再錯誤地顯示為接近 **99%**。（#294）
+- **Windows Codex 額度檢查：** 找不到 `taskkill.exe` 時不再導致應用程式崩潰。（#291）
+<!-- app-update-notes:zh-TW:end -->
+
+## 下載
+
+- **macOS Apple Silicon** — [Token-Monitor-0.39.0-arm64.dmg](https://github.com/Javis603/token-monitor/releases/download/v0.39.0/Token-Monitor-0.39.0-arm64.dmg)
+- **macOS Intel** — [Token-Monitor-0.39.0-x64.dmg](https://github.com/Javis603/token-monitor/releases/download/v0.39.0/Token-Monitor-0.39.0-x64.dmg)
+- **Windows 安裝版** — [Token-Monitor-Setup-0.39.0.exe](https://github.com/Javis603/token-monitor/releases/download/v0.39.0/Token-Monitor-Setup-0.39.0.exe)（推薦）
+- **Windows 便攜版** — [Token-Monitor-0.39.0.exe](https://github.com/Javis603/token-monitor/releases/download/v0.39.0/Token-Monitor-0.39.0.exe)（免安裝）
+- **Linux x64** — [Token-Monitor-0.39.0.AppImage](https://github.com/Javis603/token-monitor/releases/download/v0.39.0/Token-Monitor-0.39.0.AppImage)
+
+</details>
+
+<details>
+<summary><strong>한국어</strong></summary>
+
+## 한국어
+
+## 업데이트 내용
+
+<!-- app-update-notes:ko:start -->
+### 추가
+- **토큰 처리량:** 컴팩트한 `Σ` 제목 표시나 실시간 점에 마우스를 올리면 현재 수치를 확인할 수 있고, 클릭하면 출력 `tok/s`와 전체 Token `tok/min` 사이를 전환할 수 있습니다. 선택은 저장됩니다. (#296)
+
+### 개선
+- **Windows 세션 상세 정보:** 실행 중인 WSL 홈에 저장된 Claude 및 Codex 대화를 이제 세션 보기에서 열 수 있으며 Electron 메인 프로세스를 차단하지 않습니다. (#297)
+- **홈 한도:** 홈 한도 행이 더 간결해지고 정렬이 맞습니다.
+- **AI 도구 한도 상세 정보:** Codex 재설정 횟수와 Claude 선불 크레딧에 항목이 하나만 있어도 정확한 만료 시간이 표시됩니다.
+
+### 수정
+- **창 상태:** 최대화된 창은 다시 시작한 뒤에도 최대화 상태로 복원되며, 원래 일반 창 크기도 유지됩니다. 트레이 팝오버와 접힌 플로팅 버블이 더 이상 일반 창 크기를 덮어쓰지 않습니다. (#300)
+- **수동 새로 고침:** 새로 고침을 클릭하면 Cursor 및 Antigravity 사용량이 최신 데이터로 업데이트되어 최대 5분 전 값이 표시되지 않습니다. (#290)
+- **MiMo 및 Kimi 한도:** 사용량이 한도를 초과하면 남은 비율이 거의 **99%**가 아니라 **0%**로 정확히 표시됩니다. (#294)
+- **Windows Codex 확인:** `taskkill.exe`를 찾을 수 없어도 앱이 더 이상 충돌하지 않습니다. (#291)
+<!-- app-update-notes:ko:end -->
+
+## 다운로드
+
+- **macOS Apple Silicon** — [Token-Monitor-0.39.0-arm64.dmg](https://github.com/Javis603/token-monitor/releases/download/v0.39.0/Token-Monitor-0.39.0-arm64.dmg)
+- **macOS Intel** — [Token-Monitor-0.39.0-x64.dmg](https://github.com/Javis603/token-monitor/releases/download/v0.39.0/Token-Monitor-0.39.0-x64.dmg)
+- **Windows 설치 버전** — [Token-Monitor-Setup-0.39.0.exe](https://github.com/Javis603/token-monitor/releases/download/v0.39.0/Token-Monitor-Setup-0.39.0.exe) (권장)
+- **Windows 포터블 버전** — [Token-Monitor-0.39.0.exe](https://github.com/Javis603/token-monitor/releases/download/v0.39.0/Token-Monitor-0.39.0.exe) (설치 필요 없음)
+- **Linux x64** — [Token-Monitor-0.39.0.AppImage](https://github.com/Javis603/token-monitor/releases/download/v0.39.0/Token-Monitor-0.39.0.AppImage)
+
+</details>
+
+<details>
+<summary><strong>日本語</strong></summary>
+
+## 日本語
+
+## 更新内容
+
+<!-- app-update-notes:ja:start -->
+### 追加
+- **トークン スループット：** コンパクトな `Σ` タイトルマークまたはライブドットにカーソルを合わせると現在の値を確認でき、クリックすると出力 `tok/s` と合計 Token `tok/min` を切り替えられます。選択は記憶されます。 (#296)
+
+### 改善
+- **Windows セッション詳細：** 実行中の WSL ホームに保存された Claude と Codex の会話を、セッションビューから開けるようになり、Electron のメインプロセスもブロックしません。 (#297)
+- **ホームの制限：** ホームの制限行がよりコンパクトになり、整列されます。
+- **AI ツール制限の詳細：** Codex のリセット回数と Claude の前払いクレジットに、記録が1件だけの場合も含めて正確な有効期限が表示されます。
+
+### 修正
+- **ウィンドウ状態：** 最大化したウィンドウは再起動後も最大化された状態に戻り、通常のウィンドウサイズも保持されます。トレイポップオーバーと折りたたんだフローティングバブルが通常のウィンドウサイズを上書きしなくなりました。 (#300)
+- **手動更新：** 更新をクリックすると、Cursor と Antigravity の使用量が最新データに更新され、最大5分前の値が表示されなくなります。 (#290)
+- **MiMo と Kimi の制限：** 使用量が上限を超えた場合、残りの割合がほぼ **99%** ではなく **0%** と正しく表示されます。 (#294)
+- **Windows Codex の確認：** `taskkill.exe` を解決できない場合でもアプリがクラッシュしなくなりました。 (#291)
+<!-- app-update-notes:ja:end -->
+
+## ダウンロード
+
+- **macOS Apple Silicon** — [Token-Monitor-0.39.0-arm64.dmg](https://github.com/Javis603/token-monitor/releases/download/v0.39.0/Token-Monitor-0.39.0-arm64.dmg)
+- **macOS Intel** — [Token-Monitor-0.39.0-x64.dmg](https://github.com/Javis603/token-monitor/releases/download/v0.39.0/Token-Monitor-0.39.0-x64.dmg)
+- **Windows インストーラー** — [Token-Monitor-Setup-0.39.0.exe](https://github.com/Javis603/token-monitor/releases/download/v0.39.0/Token-Monitor-Setup-0.39.0.exe)（推奨）
+- **Windows ポータブル版** — [Token-Monitor-0.39.0.exe](https://github.com/Javis603/token-monitor/releases/download/v0.39.0/Token-Monitor-0.39.0.exe)（インストール不要）
+- **Linux x64** — [Token-Monitor-0.39.0.AppImage](https://github.com/Javis603/token-monitor/releases/download/v0.39.0/Token-Monitor-0.39.0.AppImage)
+
+</details>
+
+</details>

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -964,19 +964,7 @@ function renderAppUpdatePill() {
   }
 }
 function releaseNoteGroupsForCurrentLocale(latest) {
-  const notes = latest?.releaseNotes;
-  if (!notes || typeof notes !== 'object') return [];
-  const locale = currentLocale();
-  let preferred;
-  if (locale === 'zh-TW') preferred = notes['zh-TW'];
-  else if (locale === 'zh-CN') preferred = notes.zh;
-  else if (locale === 'ko') preferred = notes.ko;
-  else if (locale === 'ja') preferred = notes.ja;
-  else preferred = notes.en;
-  if (Array.isArray(preferred) && preferred.length > 0) return preferred;
-  if (locale === 'zh-TW' && Array.isArray(notes.zh) && notes.zh.length > 0) return notes.zh;
-  if (Array.isArray(notes.en) && notes.en.length > 0) return notes.en;
-  return Array.isArray(notes.zh) ? notes.zh : [];
+  return appUpdatePresentationApi.releaseNoteGroupsForLocale(latest?.releaseNotes, currentLocale());
 }
 function buildAppUpdateNoteGroupNodes(groups) {
   return groups.map((group) => {

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -966,8 +966,15 @@ function renderAppUpdatePill() {
 function releaseNoteGroupsForCurrentLocale(latest) {
   const notes = latest?.releaseNotes;
   if (!notes || typeof notes !== 'object') return [];
-  const preferred = currentLocale().startsWith('zh') ? notes.zh : notes.en;
+  const locale = currentLocale();
+  let preferred;
+  if (locale === 'zh-TW') preferred = notes['zh-TW'];
+  else if (locale === 'zh-CN') preferred = notes.zh;
+  else if (locale === 'ko') preferred = notes.ko;
+  else if (locale === 'ja') preferred = notes.ja;
+  else preferred = notes.en;
   if (Array.isArray(preferred) && preferred.length > 0) return preferred;
+  if (locale === 'zh-TW' && Array.isArray(notes.zh) && notes.zh.length > 0) return notes.zh;
   if (Array.isArray(notes.en) && notes.en.length > 0) return notes.en;
   return Array.isArray(notes.zh) ? notes.zh : [];
 }

--- a/src/electron/renderer/appUpdatePresentation.js
+++ b/src/electron/renderer/appUpdatePresentation.js
@@ -33,5 +33,20 @@
     };
   }
 
-  return { automaticAppUpdateControlState };
+  function releaseNoteGroupsForLocale(notes, locale) {
+    if (!notes || typeof notes !== 'object') return [];
+    const fallbackKeys = {
+      'zh-TW': ['zh-TW', 'zh', 'en'],
+      'zh-CN': ['zh', 'en'],
+      ko: ['ko', 'en', 'zh'],
+      ja: ['ja', 'en', 'zh']
+    }[locale] || ['en', 'zh'];
+
+    for (const key of fallbackKeys) {
+      if (Array.isArray(notes[key]) && notes[key].length > 0) return notes[key];
+    }
+    return [];
+  }
+
+  return { automaticAppUpdateControlState, releaseNoteGroupsForLocale };
 });

--- a/src/shared/appUpdater.js
+++ b/src/shared/appUpdater.js
@@ -106,7 +106,7 @@ function extractReleaseNotes(value) {
   if (typeof value !== 'string' || !value.trim()) return {};
   const body = value.slice(0, MAX_RELEASE_BODY_CHARS);
   const notes = {};
-  for (const locale of ['en', 'zh']) {
+  for (const locale of ['en', 'zh', 'zh-TW', 'ko', 'ja']) {
     const section = markedReleaseNoteSection(body, locale);
     const groups = section ? parseReleaseNoteGroups(section) : [];
     if (groups.length > 0) notes[locale] = groups;

--- a/tests/electron/appUpdateReleaseNotes.test.js
+++ b/tests/electron/appUpdateReleaseNotes.test.js
@@ -110,6 +110,28 @@ test('footer pill only exposes dialog semantics when release notes are available
   assert.doesNotMatch(renderer, /mode !== 'install' && releaseNoteGroupsForCurrentLocale/);
 });
 
+test('localized Chinese release notes prefer their locale-specific sections', () => {
+  const app = read('app.js');
+  const renderer = app.slice(
+    app.indexOf('function releaseNoteGroupsForCurrentLocale'),
+    app.indexOf('function buildAppUpdateNoteGroupNodes')
+  );
+  assert.match(renderer, /const locale = currentLocale\(\);/);
+  assert.match(renderer, /locale === 'zh-TW'[\s\S]*notes\['zh-TW'\]/);
+  assert.match(renderer, /locale === 'zh-CN'[\s\S]*notes\.zh/);
+  assert.match(renderer, /locale === 'zh-TW' && Array\.isArray\(notes\.zh\)/);
+});
+
+test('Korean and Japanese release notes prefer their locale-specific sections', () => {
+  const app = read('app.js');
+  const renderer = app.slice(
+    app.indexOf('function releaseNoteGroupsForCurrentLocale'),
+    app.indexOf('function buildAppUpdateNoteGroupNodes')
+  );
+  assert.match(renderer, /locale === 'ko'[\s\S]*notes\.ko/);
+  assert.match(renderer, /locale === 'ja'[\s\S]*notes\.ja/);
+});
+
 test('release-note disclosure has keyboard focus and compact reading styles', () => {
   const html = read('index.html');
   const css = read('styles.css');

--- a/tests/electron/appUpdateReleaseNotes.test.js
+++ b/tests/electron/appUpdateReleaseNotes.test.js
@@ -5,6 +5,10 @@ const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
 
+const {
+  releaseNoteGroupsForLocale
+} = require('../../src/electron/renderer/appUpdatePresentation');
+
 const rendererDir = path.join(__dirname, '..', '..', 'src', 'electron', 'renderer');
 
 function read(name) {
@@ -110,26 +114,43 @@ test('footer pill only exposes dialog semantics when release notes are available
   assert.doesNotMatch(renderer, /mode !== 'install' && releaseNoteGroupsForCurrentLocale/);
 });
 
-test('localized Chinese release notes prefer their locale-specific sections', () => {
+test('renderer delegates release-note locale selection to the shared presentation helper', () => {
   const app = read('app.js');
   const renderer = app.slice(
     app.indexOf('function releaseNoteGroupsForCurrentLocale'),
     app.indexOf('function buildAppUpdateNoteGroupNodes')
   );
-  assert.match(renderer, /const locale = currentLocale\(\);/);
-  assert.match(renderer, /locale === 'zh-TW'[\s\S]*notes\['zh-TW'\]/);
-  assert.match(renderer, /locale === 'zh-CN'[\s\S]*notes\.zh/);
-  assert.match(renderer, /locale === 'zh-TW' && Array\.isArray\(notes\.zh\)/);
+  assert.match(renderer, /return appUpdatePresentationApi\.releaseNoteGroupsForLocale\(latest\?\.releaseNotes, currentLocale\(\)\)/);
 });
 
-test('Korean and Japanese release notes prefer their locale-specific sections', () => {
-  const app = read('app.js');
-  const renderer = app.slice(
-    app.indexOf('function releaseNoteGroupsForCurrentLocale'),
-    app.indexOf('function buildAppUpdateNoteGroupNodes')
-  );
-  assert.match(renderer, /locale === 'ko'[\s\S]*notes\.ko/);
-  assert.match(renderer, /locale === 'ja'[\s\S]*notes\.ja/);
+test('release-note locale selection follows the complete fallback matrix', () => {
+  const groups = {
+    en: [{ title: 'English', items: ['en'] }],
+    zh: [{ title: '简体中文', items: ['zh'] }],
+    traditional: [{ title: '繁體中文', items: ['zh-TW'] }],
+    ko: [{ title: '한국어', items: ['ko'] }],
+    ja: [{ title: '日本語', items: ['ja'] }]
+  };
+  const cases = [
+    ['zh-TW prefers Traditional Chinese', 'zh-TW', { 'zh-TW': groups.traditional, zh: groups.zh, en: groups.en }, groups.traditional],
+    ['zh-TW falls back to Simplified Chinese', 'zh-TW', { 'zh-TW': [], zh: groups.zh, en: groups.en }, groups.zh],
+    ['zh-TW skips invalid and empty sections before English', 'zh-TW', { 'zh-TW': 'invalid', zh: null, en: groups.en }, groups.en],
+    ['zh-CN prefers Simplified Chinese', 'zh-CN', { zh: groups.zh, en: groups.en }, groups.zh],
+    ['zh-CN falls back to English', 'zh-CN', { zh: [], en: groups.en }, groups.en],
+    ['Korean prefers Korean', 'ko', { ko: groups.ko, en: groups.en, zh: groups.zh }, groups.ko],
+    ['Korean falls back through English', 'ko', { ko: [], en: groups.en, zh: groups.zh }, groups.en],
+    ['Korean falls back to Simplified Chinese', 'ko', { ko: [], en: [], zh: groups.zh }, groups.zh],
+    ['Japanese prefers Japanese', 'ja', { ja: groups.ja, en: groups.en, zh: groups.zh }, groups.ja],
+    ['Japanese falls back through English', 'ja', { ja: {}, en: groups.en, zh: groups.zh }, groups.en],
+    ['Japanese falls back to Simplified Chinese', 'ja', { ja: [], en: [], zh: groups.zh }, groups.zh],
+    ['English and unknown locales prefer English', 'en', { en: groups.en, zh: groups.zh }, groups.en],
+    ['Unknown locales fall back to Simplified Chinese', 'fr', { en: [], zh: groups.zh }, groups.zh],
+    ['invalid release metadata returns no groups', 'ja', null, []]
+  ];
+
+  for (const [name, locale, notes, expected] of cases) {
+    assert.deepEqual(releaseNoteGroupsForLocale(notes, locale), expected, name);
+  }
 });
 
 test('release-note disclosure has keyboard focus and compact reading styles', () => {

--- a/tests/shared/appUpdater.test.js
+++ b/tests/shared/appUpdater.test.js
@@ -167,7 +167,7 @@ test('deriveAppUpdateAvailability always surfaces a downloaded matching update',
   });
 });
 
-test('extractReleaseNotes reads marked bilingual summaries as plain text', () => {
+test('extractReleaseNotes reads marked localized summaries as plain text', () => {
   const body = `
 ## What's changed
 <!-- app-update-notes:en:start -->
@@ -182,6 +182,21 @@ test('extractReleaseNotes reads marked bilingual summaries as plain text', () =>
 ### 新增
 - **项目视图：** 按工作区追踪用量。
 <!-- app-update-notes:zh:end -->
+
+<!-- app-update-notes:zh-TW:start -->
+### 新增
+- **專案檢視：** 按工作區追蹤用量。
+<!-- app-update-notes:zh-TW:end -->
+
+<!-- app-update-notes:ko:start -->
+### 추가
+- **프로젝트 보기:** 작업 공간별 사용량을 추적합니다.
+<!-- app-update-notes:ko:end -->
+
+<!-- app-update-notes:ja:start -->
+### 追加
+- **プロジェクトビュー：** ワークスペース別に使用量を追跡します。
+<!-- app-update-notes:ja:end -->
 `;
 
   assert.deepEqual(extractReleaseNotes(body), {
@@ -191,6 +206,15 @@ test('extractReleaseNotes reads marked bilingual summaries as plain text', () =>
     ],
     zh: [
       { title: '新增', items: ['项目视图：按工作区追踪用量。'] }
+    ],
+    'zh-TW': [
+      { title: '新增', items: ['專案檢視：按工作區追蹤用量。'] }
+    ],
+    ko: [
+      { title: '추가', items: ['프로젝트 보기: 작업 공간별 사용량을 추적합니다.'] }
+    ],
+    ja: [
+      { title: '追加', items: ['プロジェクトビュー：ワークスペース別に使用量を追跡します。'] }
     ]
   });
 });
@@ -207,6 +231,11 @@ test('extractReleaseNotes hides trailing PR references from App summaries', () =
 - 项目视图可按工作区追踪用量。（#122、#138、#144）
 - 问题 #150 是句子内容的一部分，应该保留。
 <!-- app-update-notes:zh:end -->
+<!-- app-update-notes:zh-TW:start -->
+### 新增
+- 專案檢視可按工作區追蹤用量。（#122、#138、#144）
+- 問題 #150 是句子內容的一部分，應該保留。
+<!-- app-update-notes:zh-TW:end -->
 `;
 
   assert.deepEqual(extractReleaseNotes(body), {
@@ -222,6 +251,13 @@ test('extractReleaseNotes hides trailing PR references from App summaries', () =
       items: [
         '项目视图可按工作区追踪用量。',
         '问题 #150 是句子内容的一部分，应该保留。'
+      ]
+    }],
+    'zh-TW': [{
+      title: '新增',
+      items: [
+        '專案檢視可按工作區追蹤用量。',
+        '問題 #150 是句子內容的一部分，應該保留。'
       ]
     }]
   });
@@ -281,7 +317,7 @@ ${added}
   assert.match(notes.en[0].items[0], /…$/);
 });
 
-test('release template exposes marked English and Chinese app summaries', () => {
+test('release template exposes marked summaries for every bundled locale', () => {
   const template = fs.readFileSync(path.join(__dirname, '..', '..', '.github', 'RELEASE_TEMPLATE.md'), 'utf8');
   const notes = extractReleaseNotes(template);
   const categoryPairs = new Map([
@@ -290,16 +326,72 @@ test('release template exposes marked English and Chinese app summaries', () => 
     ['Improved', '改进'],
     ['Fixed', '修复']
   ]);
+  const traditionalCategoryPairs = new Map([
+    ['Added', '新增'],
+    ['Changed', '變更'],
+    ['Improved', '改進'],
+    ['Fixed', '修復']
+  ]);
+  const koreanCategoryPairs = new Map([
+    ['Added', '추가'],
+    ['Changed', '변경'],
+    ['Improved', '개선'],
+    ['Fixed', '수정']
+  ]);
+  const japaneseCategoryPairs = new Map([
+    ['Added', '追加'],
+    ['Changed', '変更'],
+    ['Improved', '改善'],
+    ['Fixed', '修正']
+  ]);
   assert.ok(notes.en.length > 0);
   assert.deepEqual(
     notes.zh.map((group) => group.title),
     notes.en.map((group) => categoryPairs.get(group.title))
   );
+  assert.deepEqual(
+    notes['zh-TW'].map((group) => group.title),
+    notes.en.map((group) => traditionalCategoryPairs.get(group.title))
+  );
+  assert.deepEqual(
+    notes.ko.map((group) => group.title),
+    notes.en.map((group) => koreanCategoryPairs.get(group.title))
+  );
+  assert.deepEqual(
+    notes.ja.map((group) => group.title),
+    notes.en.map((group) => japaneseCategoryPairs.get(group.title))
+  );
   assert.ok(notes.en.every((group) => categoryPairs.has(group.title)));
   assert.ok(notes.en.every((group) => group.items.length > 0));
   assert.ok(notes.zh.every((group) => group.items.length > 0));
+  assert.ok(notes['zh-TW'].every((group) => group.items.length > 0));
+  assert.ok(notes.ko.every((group) => group.items.length > 0));
+  assert.ok(notes.ja.every((group) => group.items.length > 0));
   assert.ok(notes.en.every((group) => group.items.every((item) => !/\(#\d/.test(item))));
   assert.ok(notes.zh.every((group) => group.items.every((item) => !/（#\d/.test(item))));
+  assert.ok(notes['zh-TW'].every((group) => group.items.every((item) => !/（#\d/.test(item))));
+  assert.ok(notes.ko.every((group) => group.items.every((item) => !/#\d/.test(item))));
+  assert.ok(notes.ja.every((group) => group.items.every((item) => !/#\d/.test(item))));
+  assert.match(
+    template,
+    /<details>\s*<summary><strong>繁體中文<\/strong><\/summary>\s*## 繁體中文[\s\S]*<!-- app-update-notes:zh-TW:start -->[\s\S]*<!-- app-update-notes:zh-TW:end -->[\s\S]*<\/details>/
+  );
+  assert.match(
+    template,
+    /<details>\s*<summary><strong>한국어<\/strong><\/summary>\s*## 한국어[\s\S]*<!-- app-update-notes:ko:start -->[\s\S]*<!-- app-update-notes:ko:end -->[\s\S]*<\/details>/
+  );
+  assert.match(
+    template,
+    /<details>\s*<summary><strong>日本語<\/strong><\/summary>\s*## 日本語[\s\S]*<!-- app-update-notes:ja:start -->[\s\S]*<!-- app-update-notes:ja:end -->[\s\S]*<\/details>/
+  );
+  assert.match(
+    template,
+    /<details>\s*<summary>繁體中文 · 한국어 · 日本語<\/summary>[\s\S]*<details>\s*<summary><strong>繁體中文<\/strong><\/summary>[\s\S]*<details>\s*<summary><strong>한국어<\/strong><\/summary>[\s\S]*<details>\s*<summary><strong>日本語<\/strong><\/summary>/
+  );
+  assert.doesNotMatch(template, /其他語言|user-content-release-notes-/);
+  assert.match(template, /## 繁體中文[\s\S]*## 下載/);
+  assert.match(template, /## 한국어[\s\S]*## 다운로드/);
+  assert.match(template, /## 日本語[\s\S]*## ダウンロード/);
   assert.match(template, /\(#\d+(?:, #\d+)*\)/);
   assert.match(template, /（#\d+(?:、#\d+)*）/);
 });

--- a/tests/shared/appUpdater.test.js
+++ b/tests/shared/appUpdater.test.js
@@ -387,6 +387,13 @@ test('release template exposes marked summaries for every bundled locale', () =>
     notes.ja.map((group) => group.title),
     notes.en.map((group) => japaneseCategoryPairs.get(group.title))
   );
+  for (const locale of ['zh', 'zh-TW', 'ko', 'ja']) {
+    assert.deepEqual(
+      notes[locale].map((group) => group.items.length),
+      notes.en.map((group) => group.items.length),
+      `${locale} notes should keep the English item counts per category`
+    );
+  }
   assert.ok(notes.en.every((group) => categoryPairs.has(group.title)));
   assert.ok(notes.en.every((group) => group.items.length > 0));
   assert.ok(notes.zh.every((group) => group.items.length > 0));

--- a/tests/shared/appUpdater.test.js
+++ b/tests/shared/appUpdater.test.js
@@ -17,6 +17,8 @@ const {
   shouldSkipAppUpdateCheck
 } = require('../../src/shared/appUpdater');
 
+const trailingPullRequestReference = /(?:\(\s*#\d+(?:\s*,\s*#\d+)*\s*\)|（\s*#\d+(?:\s*[、，,]\s*#\d+)*\s*）)$/;
+
 test('parseTag strips a leading v from valid semver tags', () => {
   assert.equal(parseTag('v1.2.3'), '1.2.3');
   assert.equal(parseTag('V0.1.0'), '0.1.0');
@@ -236,6 +238,16 @@ test('extractReleaseNotes hides trailing PR references from App summaries', () =
 - 專案檢視可按工作區追蹤用量。（#122、#138、#144）
 - 問題 #150 是句子內容的一部分，應該保留。
 <!-- app-update-notes:zh-TW:end -->
+<!-- app-update-notes:ko:start -->
+### 추가
+- 프로젝트 보기에서 작업 공간별 사용량을 추적합니다. (#122, #138, #144)
+- 문장 안의 Issue #150은 그대로 보존해야 합니다.
+<!-- app-update-notes:ko:end -->
+<!-- app-update-notes:ja:start -->
+### 追加
+- プロジェクトビューでワークスペース別に使用量を追跡します。（#122、#138、#144）
+- 文中の Issue #150 はそのまま残す必要があります。
+<!-- app-update-notes:ja:end -->
 `;
 
   assert.deepEqual(extractReleaseNotes(body), {
@@ -258,6 +270,20 @@ test('extractReleaseNotes hides trailing PR references from App summaries', () =
       items: [
         '專案檢視可按工作區追蹤用量。',
         '問題 #150 是句子內容的一部分，應該保留。'
+      ]
+    }],
+    ko: [{
+      title: '추가',
+      items: [
+        '프로젝트 보기에서 작업 공간별 사용량을 추적합니다.',
+        '문장 안의 Issue #150은 그대로 보존해야 합니다.'
+      ]
+    }],
+    ja: [{
+      title: '追加',
+      items: [
+        'プロジェクトビューでワークスペース別に使用量を追跡します。',
+        '文中の Issue #150 はそのまま残す必要があります。'
       ]
     }]
   });
@@ -367,11 +393,12 @@ test('release template exposes marked summaries for every bundled locale', () =>
   assert.ok(notes['zh-TW'].every((group) => group.items.length > 0));
   assert.ok(notes.ko.every((group) => group.items.length > 0));
   assert.ok(notes.ja.every((group) => group.items.length > 0));
-  assert.ok(notes.en.every((group) => group.items.every((item) => !/\(#\d/.test(item))));
-  assert.ok(notes.zh.every((group) => group.items.every((item) => !/（#\d/.test(item))));
-  assert.ok(notes['zh-TW'].every((group) => group.items.every((item) => !/（#\d/.test(item))));
-  assert.ok(notes.ko.every((group) => group.items.every((item) => !/#\d/.test(item))));
-  assert.ok(notes.ja.every((group) => group.items.every((item) => !/#\d/.test(item))));
+  for (const locale of ['en', 'zh', 'zh-TW', 'ko', 'ja']) {
+    assert.ok(
+      notes[locale].every((group) => group.items.every((item) => !trailingPullRequestReference.test(item))),
+      `${locale} notes should not end with a PR reference`
+    );
+  }
   assert.match(
     template,
     /<details>\s*<summary><strong>繁體中文<\/strong><\/summary>\s*## 繁體中文[\s\S]*<!-- app-update-notes:zh-TW:start -->[\s\S]*<!-- app-update-notes:zh-TW:end -->[\s\S]*<\/details>/

--- a/tests/shared/releaseArtifactNames.test.js
+++ b/tests/shared/releaseArtifactNames.test.js
@@ -61,9 +61,18 @@ test('mac release scripts build native Apple Silicon and Intel artifacts', () =>
   const releaseTemplate = fs.readFileSync(path.join(__dirname, '..', '..', '.github', 'RELEASE_TEMPLATE.md'), 'utf8');
   const intelBullets = releaseTemplate.split('\n').filter((line) => line.startsWith('- **macOS Intel**'));
   const intelDmg = `Token-Monitor-${rootPackage.version}-x64.dmg`;
-  assert.equal(intelBullets.length, 2);
+  assert.equal(intelBullets.length, 5);
   assert.ok(intelBullets.every((line) => line.split(intelDmg).length === 3));
   assert.ok(intelBullets.every((line) => line.includes(`/download/v${rootPackage.version}/`)));
+  const fullChangelogLines = releaseTemplate.split('\n').filter((line) => line.startsWith('**Full Changelog:**'));
+  assert.equal(fullChangelogLines.length, 1);
+  assert.match(fullChangelogLines[0], /\[v\d+\.\d+\.\d+\.\.\.v\d+\.\d+\.\d+\]/);
+  assert.match(fullChangelogLines[0], /https:\/\/github\.com\/Javis603\/token-monitor\/compare\/v\d+\.\d+\.\d+\.\.\.v\d+\.\d+\.\d+/);
+  assert.ok(fullChangelogLines[0].includes(`v${rootPackage.version}`));
+  assert.match(
+    releaseTemplate,
+    /---\s*\*\*Full Changelog:\*\*[\s\S]*<details>\s*<summary>繁體中文 · 한국어 · 日本語<\/summary>/
+  );
 });
 
 test('release icons use source assets without the legacy generator', () => {


### PR DESCRIPTION
## Summary

- Add Traditional Chinese, Korean, and Japanese release-note sections while keeping all locale markers in the same release body for the in-app updater.
- Group the translated sections under nested collapsed disclosures with a compact language summary.
- Place the single Full Changelog compare link below the locale divider.
- Document and test locale-specific release-note extraction and the release-template structure.

## Verification

- `node --test tests/shared/appUpdater.test.js tests/shared/releaseArtifactNames.test.js` (28 passed)
- `npm run verify` (2,262 passed, 1 skipped; one sandbox-only native watcher timeout)
- `node --test tests/shared/watcherNativeEvents.test.js` in the host environment (2 passed)

Screenshots are not applicable because this changes GitHub release Markdown layout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds localized release notes for `zh-TW`, `ko`, and `ja` with a nested locale block and a single Full Changelog link. The updater extracts all five locales and the renderer now delegates locale selection to a shared helper with stricter fallbacks.

- **New Features**
  - Template/format: single **Full Changelog** link below the divider; collapsed "繁體中文 · 한국어 · 日本語" area with nested details per language and downloads; locale markers `en`, `zh`, `zh-TW`, `ko`, `ja`.
  - Rendering: locale selection moved to `appUpdatePresentation` with fallbacks — `zh-TW → zh → en`, `zh-CN → zh → en`, `ko/ja → en → zh`, others `en → zh`.
  - Tests: enforce five-locale extraction, fallback matrix and renderer delegation, category-title mappings and per-category item counts vs. English, PR-reference stripping across locales, single-link placement, and the outer-summary/nested-details structure with per-language downloads.

<sup>Written for commit 365da33ffd50b075c5f7daf398df99c3c90b70cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

