### PR TITLE
fix(updater): reuse successful automatic update checks

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -100,6 +100,7 @@ const {
   latestFromUpdaterInfo,
   mergeLatestReleaseMetadata,
   providerUpdateCheckAvailability,
+  resolveProviderUpdateCheck,
   resolveAppUpdateCheckError,
   shouldDownloadAutomaticAppUpdate,
   shouldSkipAppUpdateCheck
@@ -4231,6 +4232,7 @@ async function checkAppUpdateProvider() {
     newer: availability.newer,
     latest: availability.latest,
     clearLatest: availability.clearLatest,
+    providerReady: true,
     error: null,
     errorKind: null,
     checkedAt
@@ -4300,7 +4302,7 @@ async function runAppUpdateCheck({ force = false, bypassCooldown = false } = {})
       }
       sendAppUpdatePush();
     }
-    return maybeDownloadAutomaticAppUpdate(deriveAppUpdateState());
+    return maybeDownloadAutomaticAppUpdate(deriveAppUpdateState(), activeResult);
   }
   const block = settings?.appUpdate || {};
   if (!bypassCooldown && shouldSkipAppUpdateCheck({
@@ -4350,20 +4352,21 @@ async function runAppUpdateCheck({ force = false, bypassCooldown = false } = {})
     return result;
   })();
   appUpdateCheckPromise = checkTask;
+  let completedCheck;
   try {
-    await checkTask;
+    completedCheck = await checkTask;
   } finally {
     if (appUpdateCheckPromise === checkTask) appUpdateCheckPromise = null;
   }
-  return maybeDownloadAutomaticAppUpdate(deriveAppUpdateState());
+  return maybeDownloadAutomaticAppUpdate(deriveAppUpdateState(), completedCheck);
 }
 
-async function maybeDownloadAutomaticAppUpdate(updateState) {
+async function maybeDownloadAutomaticAppUpdate(updateState, completedCheck = null) {
   if (!shouldDownloadAutomaticAppUpdate({
     automaticAppUpdates: settings?.automaticAppUpdates,
     updateState
   })) return updateState;
-  return downloadAndPrepareAppUpdate();
+  return downloadAndPrepareAppUpdate({ completedCheck });
 }
 
 function maybeRunBackgroundUpdateCheck() {
@@ -4387,7 +4390,7 @@ function dismissAppUpdateVersion(version) {
   return deriveAppUpdateState();
 }
 
-async function downloadAndPrepareAppUpdate() {
+async function downloadAndPrepareAppUpdate({ completedCheck = null } = {}) {
   const support = appUpdateInstallSupport({ isPackaged: app.isPackaged, platform: process.platform, env: process.env });
   if (!support.supported) {
     setNativeAppUpdateState({ phase: 'error', error: support.reason || 'unsupported-platform', progress: null });
@@ -4405,15 +4408,20 @@ async function downloadAndPrepareAppUpdate() {
   appUpdateNativeBusy = true;
   setNativeAppUpdateState({ phase: 'checking', progress: null, error: null });
   try {
-    const result = await autoUpdater.checkForUpdates();
-    const availability = providerUpdateCheckAvailability(result, app.getVersion());
+    const providerCheck = await resolveProviderUpdateCheck({
+      completedCheck,
+      currentVersion: app.getVersion(),
+      checkForUpdates: () => autoUpdater.checkForUpdates()
+    });
+    const { availability } = providerCheck;
     if (!availability.valid) throw new Error('Update metadata missing or invalid');
-    const checkedAt = new Date().toISOString();
-    const latestFromCheck = rememberSuccessfulAppUpdateCheck(
-      availability.latest,
-      checkedAt,
-      { clearLatest: availability.clearLatest }
-    );
+    const latestFromCheck = providerCheck.reused
+      ? settings?.appUpdate?.lastKnownLatest || availability.latest
+      : rememberSuccessfulAppUpdateCheck(
+        availability.latest,
+        new Date().toISOString(),
+        { clearLatest: availability.clearLatest }
+      );
     const version = latestFromCheck?.version || null;
     if (!availability.newer || !version) {
       appUpdateNativeBusy = false;

--- a/src/shared/appUpdater.js
+++ b/src/shared/appUpdater.js
@@ -415,6 +415,30 @@ function providerUpdateCheckAvailability(result, currentVersion) {
   };
 }
 
+async function resolveProviderUpdateCheck({
+  completedCheck = null,
+  currentVersion,
+  checkForUpdates
+} = {}) {
+  if (completedCheck?.ok && completedCheck.providerReady) {
+    return {
+      reused: true,
+      availability: {
+        valid: true,
+        newer: Boolean(completedCheck.newer),
+        latest: completedCheck.latest || null,
+        clearLatest: Boolean(completedCheck.clearLatest)
+      }
+    };
+  }
+  if (typeof checkForUpdates !== 'function') throw new TypeError('checkForUpdates must be a function');
+  const result = await checkForUpdates();
+  return {
+    reused: false,
+    availability: providerUpdateCheckAvailability(result, currentVersion)
+  };
+}
+
 function errorDetails(error) {
   const details = [];
   const seen = new Set();
@@ -576,6 +600,7 @@ module.exports = {
   parseLatestReleasePayload,
   latestFromUpdaterInfo,
   providerUpdateCheckAvailability,
+  resolveProviderUpdateCheck,
   classifyAppUpdateError,
   resolveAppUpdateCheckError,
   shouldSkipAppUpdateCheck,

--- a/tests/electron/appUpdateState.test.js
+++ b/tests/electron/appUpdateState.test.js
@@ -58,7 +58,8 @@ test('update state separates the last successful check from the latest attempt e
 test('starting a user-requested download restores its dismissed notification', () => {
   const download = sourceBetween('async function downloadAndPrepareAppUpdate', 'function installDownloadedAppUpdate');
   assert.match(download, /if \(appUpdateCheckPromise\) await appUpdateCheckPromise/);
-  assert.match(download, /providerUpdateCheckAvailability\(result, app\.getVersion\(\)\)/);
+  assert.match(download, /resolveProviderUpdateCheck\(\{\s*completedCheck,\s*currentVersion: app\.getVersion\(\)/);
+  assert.match(download, /checkForUpdates: \(\) => autoUpdater\.checkForUpdates\(\)/);
   assert.match(download, /if \(!availability\.newer \|\| !version\)/);
   assert.match(download, /restoreDismissedAppUpdate\(version\)/);
   assert.match(download, /await autoUpdater\.downloadUpdate\(\)/);
@@ -74,16 +75,18 @@ test('successful checks share one state transition that clears stale errors', ()
   assert.match(success, /appUpdateLastAttemptAt = checkedAt/);
   assert.match(success, /appUpdateLastError = null/);
   assert.match(check, /rememberSuccessfulAppUpdateCheck\(result\.latest, result\.checkedAt, \{ clearLatest: result\.clearLatest \}\)/);
-  assert.match(download, /const checkedAt = new Date\(\)\.toISOString\(\)/);
-  assert.match(download, /rememberSuccessfulAppUpdateCheck\(\s*availability\.latest,\s*checkedAt,\s*\{ clearLatest: availability\.clearLatest \}\s*\)/);
+  assert.match(download, /providerCheck\.reused[\s\S]*rememberSuccessfulAppUpdateCheck\(\s*availability\.latest,\s*new Date\(\)\.toISOString\(\),\s*\{ clearLatest: availability\.clearLatest \}\s*\)/);
 });
 
 test('automatic updates are opt-in and download without installing', () => {
   const defaults = sourceBetween('function defaultSettings', 'function normalizeCollectionMode');
+  const check = sourceBetween('async function runAppUpdateCheck', 'function maybeRunBackgroundUpdateCheck');
   const automaticDownload = sourceBetween('async function maybeDownloadAutomaticAppUpdate', 'function maybeRunBackgroundUpdateCheck');
   assert.match(defaults, /automaticAppUpdates: false/);
+  assert.match(check, /completedCheck = await checkTask/);
+  assert.match(check, /maybeDownloadAutomaticAppUpdate\(deriveAppUpdateState\(\), completedCheck\)/);
   assert.match(automaticDownload, /shouldDownloadAutomaticAppUpdate\(\{\s*automaticAppUpdates: settings\?\.automaticAppUpdates,\s*updateState\s*\}\)/);
-  assert.match(automaticDownload, /return downloadAndPrepareAppUpdate\(\)/);
+  assert.match(automaticDownload, /return downloadAndPrepareAppUpdate\(\{ completedCheck \}\)/);
   assert.doesNotMatch(automaticDownload, /installDownloadedAppUpdate/);
 });
 

--- a/tests/shared/appUpdater.test.js
+++ b/tests/shared/appUpdater.test.js
@@ -19,6 +19,7 @@ const {
   parseTag,
   providerUpdateCheckAvailability,
   RELEASES_LATEST_URL,
+  resolveProviderUpdateCheck,
   resolveAppUpdateCheckError,
   shouldDownloadAutomaticAppUpdate,
   shouldSkipAppUpdateCheck
@@ -718,6 +719,51 @@ test('providerUpdateCheckAvailability accepts eligible updates and current metad
   assert.equal(current.clearLatest, false);
 });
 
+test('resolveProviderUpdateCheck reuses a completed packaged check without another request', async () => {
+  let calls = 0;
+  const latest = { version: '0.40.0', tag: 'v0.40.0' };
+  const result = await resolveProviderUpdateCheck({
+    completedCheck: {
+      ok: true,
+      providerReady: true,
+      newer: true,
+      latest,
+      clearLatest: false
+    },
+    currentVersion: '0.39.0',
+    checkForUpdates: async () => {
+      calls += 1;
+      throw new Error('should not run');
+    }
+  });
+
+  assert.equal(calls, 0);
+  assert.deepEqual(result, {
+    reused: true,
+    availability: { valid: true, newer: true, latest, clearLatest: false }
+  });
+});
+
+test('resolveProviderUpdateCheck refreshes cached download attempts', async () => {
+  let calls = 0;
+  const result = await resolveProviderUpdateCheck({
+    currentVersion: '0.39.0',
+    checkForUpdates: async () => {
+      calls += 1;
+      return {
+        isUpdateAvailable: true,
+        updateInfo: { version: '0.40.0' }
+      };
+    }
+  });
+
+  assert.equal(calls, 1);
+  assert.equal(result.reused, false);
+  assert.equal(result.availability.valid, true);
+  assert.equal(result.availability.newer, true);
+  assert.equal(result.availability.latest.version, '0.40.0');
+});
+
 test('classifyAppUpdateError separates actionable failures including nested causes', () => {
   assert.equal(classifyAppUpdateError(Object.assign(new Error('rate limit exceeded'), { status: 429 })).kind, 'rateLimited');
   assert.equal(classifyAppUpdateError(Object.assign(new Error('aborted'), { name: 'AbortError' })).kind, 'timeout');
@@ -745,6 +791,7 @@ test('background update failures preserve a visible manual error until a success
     errorKind: 'timeout'
   };
 
+  assert.equal(resolveAppUpdateCheckError(null, backgroundFailure, { force: false }), null);
   let visibleError = resolveAppUpdateCheckError(null, manualFailure, { force: true });
   assert.deepEqual(visibleError, { kind: 'network', message: 'Unable to connect' });
   visibleError = resolveAppUpdateCheckError(visibleError, backgroundFailure, { force: false });


### PR DESCRIPTION
## Summary

- reuse the completed `electron-updater` provider check when an automatic download starts immediately after discovering an eligible update
- keep the fresh provider preflight for user-triggered downloads that may start later from cached update state
- lock the intentional silent-background-failure behavior and both provider-check paths with executable regression tests

## Before and after

| Before | After |
|---|---|
| Automatic updates checked provider metadata once to discover an update and immediately checked it again before downloading | Automatic updates reuse the provider result that was just validated |
| User-triggered downloads refreshed provider metadata before downloading | User-triggered downloads continue to refresh version and eligibility before downloading |

## Testing

- `npm run sync:worker`
- `node --test tests/shared/appUpdater.test.js tests/electron/appUpdatePresentation.test.js tests/electron/appUpdateState.test.js`
- `npm run verify` (`2289` passed, `1` skipped)

Follow-up to #312.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuse the completed `electron-updater` provider check for automatic updates to avoid a second request and start downloads faster. User-triggered downloads still re-validate provider metadata.

- **Bug Fixes**
  - Automatic downloads reuse the just-validated provider result; manual downloads refresh metadata before downloading.
  - Introduced `resolveProviderUpdateCheck()` and added tests that cover reuse vs. fresh checks and preserve silent background failure behavior.

<sup>Written for commit 3b907b58e2e174dce01b8999f0b0c3160e18bc2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

