### PR TITLE
fix(site): match activity heatmap hover with app

### DIFF
--- a/site/scripts/islands.jsx
+++ b/site/scripts/islands.jsx
@@ -6,6 +6,7 @@
  */
 import { useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
+import { createPortal } from "react-dom";
 import { Mesh, Program, Renderer, Triangle } from "ogl";
 import DarkVeil from "./darkVeil.jsx";
 
@@ -258,8 +259,25 @@ function heroHeatLevel(index) {
   return 1 + Math.min(3, Math.floor(strength * (1.3 + (column / 31) * 2.7)));
 }
 
-var HERO_HEAT_LEVELS = Array.from({ length: 224 }, function heatCell(_, index) {
-  return heroHeatLevel(index);
+var HERO_HEAT_CELL_COUNT = 224;
+var HERO_HEAT_END_DATE = Date.UTC(2026, 6, 31);
+var HERO_HEAT_TOKEN_BASES = [0, 12000000, 52000000, 142000000, 275700000];
+
+function heroHeatDate(index) {
+  return new Date(HERO_HEAT_END_DATE - (HERO_HEAT_CELL_COUNT - 1 - index) * 86400000)
+    .toISOString()
+    .slice(0, 10);
+}
+
+function heroHeatTokens(index, level) {
+  if (!level) return 0;
+  var variance = ((index * 17 + level * 23) % 15 - 7) / 100;
+  return Math.round((HERO_HEAT_TOKEN_BASES[level] * (1 + variance)) / 100000) * 100000;
+}
+
+var HERO_HEAT_CELLS = Array.from({ length: HERO_HEAT_CELL_COUNT }, function heatCell(_, index) {
+  var level = heroHeatLevel(index);
+  return { date: heroHeatDate(index), level: level, tokens: heroHeatTokens(index, level) };
 });
 
 function prefersReducedMotion() {
@@ -416,6 +434,12 @@ function HeroViewSwitcher() {
 function HeroDashboard() {
   var [period, setPeriod] = useState("day");
   var [liveTick, setLiveTick] = useState(0);
+  var [hoveredHeat, setHoveredHeat] = useState(null);
+  var [focusedHeatIndex, setFocusedHeatIndex] = useState(0);
+  var dashboardRef = useRef(null);
+  var heatmapRef = useRef(null);
+  var heatCellRefs = useRef([]);
+  var heatTooltipRef = useRef(null);
   var periodData = HERO_PERIODS[period];
   var periodIndex = HERO_PERIOD_IDS.indexOf(period);
   var liveTotal = periodData.total + liveTick * HERO_LIVE_STEP;
@@ -435,8 +459,85 @@ function HeroDashboard() {
     if (HERO_PERIODS[id]) setPeriod(id);
   }
 
+  function updateHeatTooltip(index, target) {
+    var dashboard = dashboardRef.current;
+    var tooltip = heatTooltipRef.current;
+    if (!dashboard || !target || !tooltip) return;
+    var dashboardRect = dashboard.getBoundingClientRect();
+    var cellRect = target.getBoundingClientRect();
+    var tooltipRect = tooltip.getBoundingClientRect();
+    var gap = 9;
+    var pad = 6;
+    var desiredX = cellRect.left + cellRect.width / 2;
+    var minCenterX = dashboardRect.left + pad + tooltipRect.width / 2;
+    var maxCenterX = dashboardRect.right - pad - tooltipRect.width / 2;
+    var left = Math.max(
+      minCenterX,
+      Math.min(maxCenterX, desiredX),
+    );
+    var aboveTop = cellRect.top - tooltipRect.height - gap;
+    var belowTop = cellRect.bottom + gap;
+    var minTop = dashboardRect.top + pad;
+    var maxTop = dashboardRect.bottom - pad - tooltipRect.height;
+    var aboveFits = aboveTop >= minTop;
+    var belowFits = belowTop <= maxTop;
+    var top = aboveFits
+      ? aboveTop
+      : belowFits
+        ? belowTop
+        : Math.max(minTop, Math.min(maxTop, aboveTop));
+    var placement = aboveFits ? "above" : "below";
+    setHoveredHeat(function keepStablePosition(current) {
+      if (current && current.index === index
+        && Math.abs(current.left - left) < 0.5
+        && Math.abs(current.top - top) < 0.5
+        && current.placement === placement) return current;
+      return { index: index, left: left, top: top, placement: placement };
+    });
+  }
+
+  function hideHeatTooltip() {
+    setHoveredHeat(null);
+  }
+
+  function handleHeatmapLeave() {
+    if (!heatmapRef.current || !heatmapRef.current.contains(document.activeElement)) hideHeatTooltip();
+  }
+
+  function moveHeatFocus(index, event) {
+    var row = index % 7;
+    var column = Math.floor(index / 7);
+    var next = index;
+    if (event.key === "ArrowUp") next = row === 0 ? index + 6 : index - 1;
+    else if (event.key === "ArrowDown") next = row === 6 ? index - 6 : index + 1;
+    else if (event.key === "ArrowLeft") next = column === 0 ? 31 * 7 + row : index - 7;
+    else if (event.key === "ArrowRight") next = column === 31 ? row : index + 7;
+    else if (event.key === "Home") next = row;
+    else if (event.key === "End") next = 31 * 7 + row;
+    else return;
+    event.preventDefault();
+    setFocusedHeatIndex(next);
+    var target = heatCellRefs.current[next];
+    if (target) target.focus();
+  }
+
+  useEffect(function keepHeatTooltipAnchored() {
+    if (!hoveredHeat) return undefined;
+    function refreshPosition() {
+      var target = heatCellRefs.current[hoveredHeat.index];
+      if (target) updateHeatTooltip(hoveredHeat.index, target);
+    }
+    refreshPosition();
+    window.addEventListener("resize", refreshPosition, { passive: true });
+    window.addEventListener("scroll", refreshPosition, { passive: true });
+    return function cleanup() {
+      window.removeEventListener("resize", refreshPosition);
+      window.removeEventListener("scroll", refreshPosition);
+    };
+  }, [hoveredHeat ? hoveredHeat.index : -1, liveTick]);
+
   return (
-    <div className="hero-dashboard" aria-label="Interactive Token Monitor Home dashboard">
+    <div className="hero-dashboard" ref={dashboardRef} aria-label="Interactive Token Monitor Home dashboard">
       <header className="hero-dashboard-titlebar">
         <div className="hero-dashboard-mark" aria-label="Token Monitor">
           <span aria-hidden="true">Σ</span>
@@ -560,9 +661,37 @@ function HeroDashboard() {
         </div>
         <div className="hero-dashboard-activity-scroll">
           <div className="hero-dashboard-activity-canvas">
-            <div className="hero-dashboard-heatmap" aria-hidden="true">
-              {HERO_HEAT_LEVELS.map(function renderHeat(level, index) {
-                return <i className={`level-${level}`} key={index}></i>;
+            <div
+              className="hero-dashboard-heatmap"
+              ref={heatmapRef}
+              role="group"
+              aria-label="Token activity by day"
+              onPointerLeave={handleHeatmapLeave}
+            >
+              {HERO_HEAT_CELLS.map(function renderHeat(cell, index) {
+                var tooltipActive = hoveredHeat && hoveredHeat.index === index;
+                var cellLabel = `${cell.date}: ${formatHeroCompact(cell.tokens)} tokens`;
+                return (
+                  <button
+                    className={`hero-dashboard-heat-cell level-${cell.level}`}
+                    key={cell.date}
+                    ref={function keepHeatCellRef(node) { heatCellRefs.current[index] = node; }}
+                    type="button"
+                    tabIndex={focusedHeatIndex === index ? 0 : -1}
+                    aria-label={cellLabel}
+                    aria-describedby={tooltipActive ? "hero-activity-tooltip" : undefined}
+                    onPointerEnter={function showHeatOnPointerEnter(event) { updateHeatTooltip(index, event.currentTarget); }}
+                    onPointerMove={function moveHeatWithPointer(event) { updateHeatTooltip(index, event.currentTarget); }}
+                    onFocus={function showHeatOnFocus(event) {
+                      setFocusedHeatIndex(index);
+                      updateHeatTooltip(index, event.currentTarget);
+                    }}
+                    onBlur={function hideHeatOnBlur(event) {
+                      if (!heatmapRef.current || !heatmapRef.current.contains(event.relatedTarget)) hideHeatTooltip();
+                    }}
+                    onKeyDown={function moveHeatWithKeyboard(event) { moveHeatFocus(index, event); }}
+                  ></button>
+                );
               })}
             </div>
             <div className="hero-dashboard-months" aria-hidden="true">
@@ -606,6 +735,26 @@ function HeroDashboard() {
           </svg>
         </button>
       </footer>
+      {typeof document !== "undefined" ? createPortal(
+        <div
+          id="hero-activity-tooltip"
+          ref={heatTooltipRef}
+          className={`hero-dashboard-heat-tooltip is-${hoveredHeat ? hoveredHeat.placement : "hidden"}`}
+          data-visible={hoveredHeat ? "true" : "false"}
+          aria-hidden={hoveredHeat ? "false" : "true"}
+          role="tooltip"
+          style={hoveredHeat ? { left: `${hoveredHeat.left}px`, top: `${hoveredHeat.top}px` } : undefined}
+        >
+          <span className="hero-dashboard-heat-tooltip-row">
+            <strong>{formatHeroCompact(HERO_HEAT_CELLS[hoveredHeat ? hoveredHeat.index : 0].tokens)}</strong>
+            <span>tokens</span>
+          </span>
+          <span className="hero-dashboard-heat-tooltip-date">
+            {HERO_HEAT_CELLS[hoveredHeat ? hoveredHeat.index : 0].date}
+          </span>
+        </div>,
+        document.body,
+      ) : null}
     </div>
   );
 }

--- a/site/styles/sections.css
+++ b/site/styles/sections.css
@@ -418,6 +418,7 @@ html[data-platform="linux"] [data-platform-option="linux"] { display: none; }
 }
 .hero-dashboard {
   --hero-dashboard-total-size: clamp(30px, 10.5vw, 42px);
+  position: relative;
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -743,16 +744,80 @@ html[data-platform="linux"] [data-platform-option="linux"] { display: none; }
   width: 381px;
   height: 81px;
 }
-.hero-dashboard-heatmap i {
+.hero-dashboard-heatmap .hero-dashboard-heat-cell {
+  position: relative;
   display: block;
+  width: 9px;
+  height: 9px;
+  padding: 0;
   min-width: 0;
+  border: 0;
   border-radius: 2px;
   background: rgba(255, 255, 255, 0.035);
+  cursor: pointer;
+  transition: transform 130ms cubic-bezier(.16, 1, .3, 1), outline-color 130ms ease;
+}
+.hero-dashboard-heatmap .hero-dashboard-heat-cell:hover,
+.hero-dashboard-heatmap .hero-dashboard-heat-cell:focus-visible {
+  z-index: 2;
+  outline: 1px solid rgba(224, 242, 255, 0.86);
+  outline-offset: 0;
+  transform: scale(1.28);
 }
 .hero-dashboard-heatmap .level-1 { background: rgba(90, 170, 255, 0.18); }
 .hero-dashboard-heatmap .level-2 { background: rgba(120, 190, 255, 0.45); }
 .hero-dashboard-heatmap .level-3 { background: rgba(150, 210, 255, 0.8); }
 .hero-dashboard-heatmap .level-4 { background: #b4e6ff; box-shadow: 0 0 6px rgba(142, 211, 255, 0.32); }
+.hero-dashboard-heat-tooltip {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  min-width: 72px;
+  padding: 6px 9px;
+  border: 1px solid rgba(226, 239, 253, 0.16);
+  border-radius: 8px;
+  background: rgba(10, 17, 27, 0.97);
+  color: #f4f8ff;
+  font-size: 10px;
+  line-height: 1.1;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-9999px, -9999px);
+  transition: opacity 130ms ease;
+  white-space: nowrap;
+  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.32);
+}
+.hero-dashboard-heat-tooltip[data-visible="true"] {
+  opacity: 1;
+  transform: translateX(-50%);
+}
+.hero-dashboard-heat-tooltip-row {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  font-weight: 700;
+}
+.hero-dashboard-heat-tooltip strong {
+  font-variant-numeric: tabular-nums;
+}
+.hero-dashboard-heat-tooltip-row > span,
+.hero-dashboard-heat-tooltip-date {
+  color: rgba(212, 225, 239, 0.62);
+  font-weight: 500;
+}
+.hero-dashboard-heat-tooltip-date {
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-dashboard-heatmap .hero-dashboard-heat-cell { transition: none; }
+}
 .hero-dashboard-months {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary

- Add hover, focus, and keyboard interaction to the Hero activity heatmap.
- Show token/date tooltips through a body-level portal and keep them inside the dashboard surface.
- Match the Electron app's compact active-cell scale and remove the browser-native title tooltip.

## Preview

Verified in the local preview at http://127.0.0.1:4173/?lang=zh-TW. The heatmap tooltip stays inside the dashboard and the active-cell frame matches the Electron app.

## Verification

- `npm run build --prefix site`
- `npm run verify`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the site's Hero activity heatmap with the Electron app. Adds accessible hover, focus, and keyboard navigation, and replaces native titles with clamped, portal-based tooltips.

- **New Features**
  - Interactive cells: buttons with ARIA labels; arrow keys and Home/End move focus with wraparound.
  - Tooltips: show tokens and date, follow pointer/focus, and stay within the dashboard via a body-level portal; native title tooltip removed.
  - Visual parity: compact hover/focus scale and outline match the app.

<sup>Written for commit 8035a290028db33dbb7d0b6d3ee44edb265a4064. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

