### PR TITLE
refactor(settings): extract the whole-row drag controller from the limits list

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -162,6 +162,7 @@ const customPricingFormApi = window.TokenMonitorCustomPricingForm;
 const viewDisplayPreferencesApi = window.TokenMonitorViewDisplayPreferences;
 const preferenceDragSortApi = window.TokenMonitorPreferenceDragSort;
 const verticalDragSortApi = window.TokenMonitorVerticalDragSort;
+const rowDragControllerApi = window.TokenMonitorRowDragController;
 const homeOverviewApi = window.TokenMonitorHomeOverview;
 const homeModulePreferencesApi = window.TokenMonitorHomeModulePreferences;
 const { limitFillPercent, limitModeSuffix } = window.TokenMonitorLimitDisplayMode;
@@ -7942,268 +7943,32 @@ function createPreferenceOrderHandle({ kind, id, label, count }) {
   return handle;
 }
 
-// The limit provider list drags from the whole row instead of a handle: the
-// pointer must travel this far vertically before the gesture counts as a drag
-// rather than a click. Same threshold the tray composer uses horizontally.
-const LIMIT_PROVIDER_DRAG_THRESHOLD = 4;
-let limitProviderDrag = null;
-
-// Rows are measured in the settings panel's content space (client Y plus its
-// scrollTop) so edge auto-scrolling never invalidates the snapshot: when the
-// panel scrolls the pointer's content Y advances on its own, with no
-// compensation term anywhere else.
-function limitProviderContentY(clientY) {
-  const panel = els.settingsPanel;
-  if (!panel) return clientY;
-  return clientY - panel.getBoundingClientRect().top + panel.scrollTop;
-}
-
-function limitProviderRowElements() {
-  return Array.from(els.limitProviderCheckboxes?.querySelectorAll('.limit-provider-row[data-provider]') || []);
-}
-
-function limitProviderContentTop(el) {
-  const panel = els.settingsPanel;
-  const panelTop = panel ? panel.getBoundingClientRect().top - panel.scrollTop : 0;
-  return el.getBoundingClientRect().top - panelTop;
-}
-
-function limitProviderDragRows() {
-  const panel = els.settingsPanel;
-  const panelTop = panel ? panel.getBoundingClientRect().top - panel.scrollTop : 0;
-  return limitProviderRowElements().map((el) => {
-    const rect = el.getBoundingClientRect();
-    return { el, id: el.dataset.provider, top: rect.top - panelTop, height: rect.height };
-  });
-}
-
+// The limit provider list drags from the whole row instead of a handle. The
+// gesture itself is generic and lives in `rowDragController.js`; what stays
+// here is the wiring to this list's DOM, ordering setting, and accordion.
+//
 // The checkbox, nested controls, and options panel own their clicks. The main
 // disclosure button is deliberately the drag surface too: below the threshold
 // it clicks, above it the drag suppresses that click.
 const LIMIT_PROVIDER_DRAG_EXCLUDED = 'button:not(.limit-provider-main), input, select, textarea, a, .accordion-animated-container';
 
-function startLimitProviderRowDrag(event, id) {
-  if (event.button !== 0) return;
-  const rowEl = event.currentTarget;
-  // Scoped to the row on purpose: `closest` keeps walking past it, and the
-  // whole settings section is itself an `.accordion-animated-container`, so an
-  // unscoped match excludes every row and no drag ever starts.
-  const excluded = event.target?.closest?.(LIMIT_PROVIDER_DRAG_EXCLUDED);
-  if (excluded && rowEl.contains(excluded)) return;
-  if (limitProviderDrag) finishLimitProviderDrag(false);
-  if (limitProviderRowElements().length <= 1) return;
-  const pressY = limitProviderContentY(event.clientY);
-  limitProviderDrag = {
-    id,
-    pointerId: event.pointerId,
-    // Where in the row the pointer landed. The origin is rebuilt from this once
-    // the rows are measured, so a collapse between press and measurement cannot
-    // leave the row hanging off the cursor.
-    grabOffset: pressY - limitProviderContentTop(rowEl),
-    pressY,
-    lastClientY: event.clientY,
-    started: false,
-    changed: false,
-    expandedBefore: state.limitProviderSettingsExpanded,
-    captureEl: rowEl,
-    rows: [],
-    snapshot: null,
-    order: null,
-    scrollFrame: 0,
-    renderPending: false
-  };
-  setLimitProviderDragListeners(true);
-}
-
-function setLimitProviderDragListeners(active) {
-  const method = active ? 'addEventListener' : 'removeEventListener';
-  window[method]('pointermove', onLimitProviderPointerMove, true);
-  window[method]('pointerup', onLimitProviderPointerUp, true);
-  window[method]('pointercancel', onLimitProviderDragAbort, true);
-  window[method]('keydown', onLimitProviderDragKeydown, true);
-  // Deliberately not capture. `blur` does not bubble, so a capture listener on
-  // `window` is the standard way to observe *every* element's blur — including
-  // the one the press itself causes when focus leaves whatever the user last
-  // clicked. That cancelled the drag before it could start. Without capture only
-  // the window's own blur arrives, which is the case worth aborting on.
-  window[method]('blur', onLimitProviderDragAbort);
-}
-
-// Order matters: freeze the accordion, collapse, and only then measure. With
-// the transition disabled the collapse lands synchronously, so the snapshot
-// sees settled geometry instead of a mid-animation height.
-function beginLimitProviderDrag() {
-  const drag = limitProviderDrag;
-  const list = els.limitProviderCheckboxes;
-  drag.started = true;
-  list?.classList.add('is-reordering');
-  if (drag.expandedBefore) setLimitProviderSettingsExpanded('');
-  drag.rows = limitProviderDragRows();
-  drag.snapshot = verticalDragSortApi.createVerticalDragSnapshot(
-    drag.rows.map(({ id, top, height }) => ({ id, top, height })),
-    drag.id,
-    drag.grabOffset
-  );
-  if (drag.snapshot.sourceIndex < 0) {
-    finishLimitProviderDrag(false);
-    return false;
-  }
-  drag.rows[drag.snapshot.sourceIndex].el.classList.add('dragging');
-  list?.classList.add('drag-active');
-  startLimitProviderDragScroll();
-  return true;
-}
-
-function updateLimitProviderDragPositions() {
-  const drag = limitProviderDrag;
-  if (!drag?.started) return;
-  const offsetY = limitProviderContentY(drag.lastClientY) - drag.snapshot.originY;
-  const resolved = verticalDragSortApi.resolveVerticalDrag(drag.snapshot, offsetY);
-  drag.order = resolved.order;
-  drag.changed = resolved.targetIndex !== drag.snapshot.sourceIndex;
-  for (const [index, { el }] of drag.rows.entries()) {
-    if (index === drag.snapshot.sourceIndex) el.style.setProperty('--drag-y', `${offsetY}px`);
-    else el.style.setProperty('--drag-shift', `${resolved.shifts[index]}px`);
-  }
-}
-
-function startLimitProviderDragScroll() {
-  const step = () => {
-    const drag = limitProviderDrag;
-    const panel = els.settingsPanel;
-    if (!drag?.started || !panel) return;
-    const rect = panel.getBoundingClientRect();
-    const delta = verticalDragSortApi.edgeScrollDelta({
-      pointerY: drag.lastClientY,
-      top: rect.top,
-      bottom: rect.bottom
-    });
-    if (delta) {
-      panel.scrollTop += delta;
-      updateLimitProviderDragPositions();
-    }
-    drag.scrollFrame = requestAnimationFrame(step);
-  };
-  limitProviderDrag.scrollFrame = requestAnimationFrame(step);
-}
-
-function onLimitProviderPointerMove(event) {
-  const drag = limitProviderDrag;
-  if (!drag || drag.pointerId !== event.pointerId) return;
-  drag.lastClientY = event.clientY;
-  if (!drag.started) {
-    if (Math.abs(limitProviderContentY(event.clientY) - drag.pressY) < LIMIT_PROVIDER_DRAG_THRESHOLD) return;
-    // Capture only after the gesture crosses the drag threshold. Capturing on
-    // pointerdown retargets the eventual click from the nested disclosure
-    // button to the outer row, so an ordinary press can no longer expand it.
-    // Once dragging, capture still guarantees that an outside-window release
-    // reaches cleanup instead of leaving the repaint gate stuck.
-    drag.captureEl?.addEventListener('lostpointercapture', onLimitProviderDragAbort);
-    try { drag.captureEl?.setPointerCapture?.(event.pointerId); } catch (_) {}
-    if (!beginLimitProviderDrag()) return;
-  }
-  event.preventDefault();
-  updateLimitProviderDragPositions();
-}
-
-function onLimitProviderPointerUp(event) {
-  const drag = limitProviderDrag;
-  if (!drag || drag.pointerId !== event.pointerId) return;
-  const { started, changed, order } = drag;
-  if (!started || !changed || !order?.length) {
-    finishLimitProviderDrag(true);
-    return;
-  }
-  // Mirror the new order locally before anything can repaint. A stats update
-  // held back during the drag is flushed on drop, and every repaint sorts from
-  // `state.settings` — which the deferred save has not written yet, so without
-  // this the list rebuilds into the old order and flips again a frame later.
-  const value = order.join(',');
-  state.settings = { ...state.settings, limitProviderOrder: value };
-  finishLimitProviderDrag(true);
-  // The drop itself is already in the DOM. Persisting re-renders the whole
-  // settings form, which on a populated install is a long task — run it only
-  // once the browser has painted the landed row, or that paint gets swallowed
-  // and the drop reads as a freeze. rAF fires before paint, so the timeout
-  // inside it is what lands after. Saved directly rather than through
-  // `onPreferenceOrderCommit`, whose no-op guard compares against the value we
-  // just mirrored and would drop the write.
-  requestAnimationFrame(() => {
-    setTimeout(() => void saveSettings({ limitProviderOrder: value }), 0);
-  });
-}
-
-function onLimitProviderDragAbort(event) {
-  if (!limitProviderDrag) return;
-  if (event?.pointerId != null && event.pointerId !== limitProviderDrag.pointerId) return;
-  finishLimitProviderDrag(false);
-}
-
-function onLimitProviderDragKeydown(event) {
-  if (event.key !== 'Escape' || !limitProviderDrag) return;
-  event.preventDefault();
-  finishLimitProviderDrag(false);
-}
-
-function releaseLimitProviderLandingStyleAfterPaint(list) {
-  requestAnimationFrame(() => {
-    setTimeout(() => list?.classList.remove('is-landing'), 0);
-  });
-}
-
-// The final DOM positions and the drag transforms both encode the same move.
-// Keep transform transitions disabled through the first landed paint so rows
-// do not briefly apply both offsets and animate back from a double displacement.
-function finishLimitProviderDrag(commit) {
-  const drag = limitProviderDrag;
-  if (!drag) return;
-  // The DOM reorder itself runs before the asynchronous settings save. Moving
-  // the focused row (and every sibling via appendChild) can trigger browser
-  // scroll anchoring immediately, so the save-time scroll guard is already too
-  // late. Preserve the panel around the whole landing transaction, including a
-  // deferred repaint that was held while dragging.
-  preserveSettingsPanelScroll(() => {
-    if (drag.scrollFrame) cancelAnimationFrame(drag.scrollFrame);
-    setLimitProviderDragListeners(false);
-    // Released before the reorder moves the node: relocating a captured element
-    // fires `lostpointercapture`, which would re-enter this as an abort.
-    const captureEl = drag.captureEl;
-    captureEl?.removeEventListener('lostpointercapture', onLimitProviderDragAbort);
-    try {
-      if (captureEl?.hasPointerCapture?.(drag.pointerId)) captureEl.releasePointerCapture(drag.pointerId);
-    } catch (_) {}
-    const list = els.limitProviderCheckboxes;
-    if (drag.started) {
-      const landing = Boolean(commit && drag.changed && drag.order?.length);
-      if (landing) list?.classList.add('is-landing');
-      if (landing) applyPreferenceOrder('provider', drag.order);
-      for (const { el } of drag.rows) {
-        el.style.removeProperty('--drag-y');
-        el.style.removeProperty('--drag-shift');
-        el.classList.remove('dragging');
-      }
-      list?.classList.remove('drag-active');
-      list?.classList.remove('is-reordering');
-      if (drag.expandedBefore) setLimitProviderSettingsExpanded(drag.expandedBefore);
-      suppressNextLimitProviderClick();
-      if (landing) releaseLimitProviderLandingStyleAfterPaint(list);
-    }
-    const renderPending = drag.renderPending;
-    limitProviderDrag = null;
-    if (renderPending) renderLimitProviderCheckboxes();
-  });
-}
-
-// The same main-row button owns click-to-expand and drag-to-reorder. Cancelling
-// its click after a completed drag prevents the drop from also toggling details.
-function suppressNextLimitProviderClick() {
-  const swallow = (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-  };
-  window.addEventListener('click', swallow, true);
-  setTimeout(() => window.removeEventListener('click', swallow, true), 0);
-}
+const limitProviderRowDrag = rowDragControllerApi.createRowDragController({
+  dragSort: verticalDragSortApi,
+  getList: () => els.limitProviderCheckboxes,
+  getScrollPanel: () => els.settingsPanel,
+  rowSelector: '.limit-provider-row[data-provider]',
+  idKey: 'provider',
+  dragExcluded: LIMIT_PROVIDER_DRAG_EXCLUDED,
+  getExpanded: () => state.limitProviderSettingsExpanded,
+  setExpanded: setLimitProviderSettingsExpanded,
+  applyOrder: (order) => applyPreferenceOrder('provider', order),
+  preserveScroll: preserveSettingsPanelScroll,
+  mirrorOrder: (value) => { state.settings = { ...state.settings, limitProviderOrder: value }; },
+  // Saved directly rather than through `onPreferenceOrderCommit`, whose no-op
+  // guard compares against the value `mirrorOrder` just wrote and would drop it.
+  persistOrder: (value) => void saveSettings({ limitProviderOrder: value }),
+  requestRender: () => renderLimitProviderCheckboxes()
+});
 
 function renderViewPreferences() {
   if (!els.viewDisplayList) return;
@@ -9012,10 +8777,7 @@ function renderLimitProviderCheckboxes() {
   if (!els.limitProviderCheckboxes) return;
   // A stats update mid-drag would replace the rows under the pointer and kill
   // the gesture silently. Defer the repaint until the drop.
-  if (limitProviderDrag) {
-    limitProviderDrag.renderPending = true;
-    return;
-  }
+  if (limitProviderRowDrag.deferRender()) return;
   return preserveSettingsPanelScroll(renderLimitProviderCheckboxesNow);
 }
 
@@ -9141,7 +8903,7 @@ function renderLimitProviderCheckboxesNow() {
     } else {
       row.append(wrap, copy, actions);
     }
-    row.addEventListener('pointerdown', (event) => startLimitProviderRowDrag(event, id));
+    row.addEventListener('pointerdown', (event) => limitProviderRowDrag.startRowDrag(event, id));
     // Kept inside the row rather than as a sibling: reordering moves only
     // `.limit-provider-row` nodes, so a sibling panel would be stranded when the
     // list is dragged.

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -7963,10 +7963,10 @@ const limitProviderRowDrag = rowDragControllerApi.createRowDragController({
   setExpanded: setLimitProviderSettingsExpanded,
   applyOrder: (order) => applyPreferenceOrder('provider', order),
   preserveScroll: preserveSettingsPanelScroll,
-  mirrorOrder: (value) => { state.settings = { ...state.settings, limitProviderOrder: value }; },
+  mirrorOrder: (order) => { state.settings = { ...state.settings, limitProviderOrder: order.join(',') }; },
   // Saved directly rather than through `onPreferenceOrderCommit`, whose no-op
   // guard compares against the value `mirrorOrder` just wrote and would drop it.
-  persistOrder: (value) => void saveSettings({ limitProviderOrder: value }),
+  persistOrder: (order) => void saveSettings({ limitProviderOrder: order.join(',') }),
   requestRender: () => renderLimitProviderCheckboxes()
 });
 

--- a/src/electron/renderer/index.html
+++ b/src/electron/renderer/index.html
@@ -1410,6 +1410,7 @@
     <script src="homeModulePreferences.js"></script>
     <script src="preferenceDragSort.js"></script>
     <script src="verticalDragSort.js"></script>
+    <script src="rowDragController.js"></script>
     <script src="i18n.js"></script>
     <script src="sessionRows.js"></script>
     <script src="breakdownRenderPolicy.js"></script>

--- a/src/electron/renderer/rowDragController.js
+++ b/src/electron/renderer/rowDragController.js
@@ -195,10 +195,10 @@
       }
       // Mirror the new order locally before anything can repaint. A stats update
       // held back during the drag is flushed on drop, and every repaint sorts from
-      // `state.settings` — which the deferred save has not written yet, so without
-      // this the list rebuilds into the old order and flips again a frame later.
-      const value = order.join(',');
-      mirrorOrder(value);
+      // the caller's settings — which the deferred save has not written yet, so
+      // without this the list rebuilds into the old order and flips a frame later.
+      // The order is handed over as ids; how a list serializes them is its own.
+      mirrorOrder(order);
       finishRowDrag(true);
       // The drop itself is already in the DOM. Persisting re-renders the whole
       // settings form, which on a populated install is a long task — run it only
@@ -206,7 +206,7 @@
       // and the drop reads as a freeze. rAF fires before paint, so the timeout
       // inside it is what lands after.
       requestAnimationFrame(() => {
-        setTimeout(() => persistOrder(value), 0);
+        setTimeout(() => persistOrder(order), 0);
       });
     }
 

--- a/src/electron/renderer/rowDragController.js
+++ b/src/electron/renderer/rowDragController.js
@@ -1,0 +1,298 @@
+'use strict';
+
+// Whole-row drag-to-reorder for a settings list, factored out of the limit
+// provider list so a second list can adopt the same gesture without a second
+// copy of it. The pure geometry lives in `verticalDragSort.js`; what is here is
+// the pointer/DOM choreography around it, every step of which exists because of
+// a specific failure noted inline.
+(function exposeRowDragController(root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  if (root) root.TokenMonitorRowDragController = api;
+})(typeof window !== 'undefined' ? window : null, function createRowDragControllerApi() {
+  // The list drags from the whole row instead of a handle: the pointer must
+  // travel this far vertically before the gesture counts as a drag rather than
+  // a click. Same threshold the tray composer uses horizontally.
+  const DEFAULT_DRAG_THRESHOLD = 4;
+
+  function createRowDragController(config = {}) {
+    const {
+      dragSort,
+      getList,
+      getScrollPanel,
+      rowSelector,
+      idKey,
+      dragExcluded,
+      threshold = DEFAULT_DRAG_THRESHOLD,
+      getExpanded = () => '',
+      setExpanded = () => {},
+      applyOrder = () => {},
+      preserveScroll = (callback) => callback(),
+      mirrorOrder = () => {},
+      persistOrder = () => {},
+      requestRender = () => {}
+    } = config;
+
+    let drag = null;
+
+    // Rows are measured in the scroll panel's content space (client Y plus its
+    // scrollTop) so edge auto-scrolling never invalidates the snapshot: when the
+    // panel scrolls the pointer's content Y advances on its own, with no
+    // compensation term anywhere else.
+    function contentY(clientY) {
+      const panel = getScrollPanel();
+      if (!panel) return clientY;
+      return clientY - panel.getBoundingClientRect().top + panel.scrollTop;
+    }
+
+    function rowElements() {
+      return Array.from(getList()?.querySelectorAll(rowSelector) || []);
+    }
+
+    function panelContentTop() {
+      const panel = getScrollPanel();
+      return panel ? panel.getBoundingClientRect().top - panel.scrollTop : 0;
+    }
+
+    function contentTop(el) {
+      return el.getBoundingClientRect().top - panelContentTop();
+    }
+
+    function measureRows() {
+      const panelTop = panelContentTop();
+      return rowElements().map((el) => {
+        const rect = el.getBoundingClientRect();
+        return { el, id: el.dataset[idKey], top: rect.top - panelTop, height: rect.height };
+      });
+    }
+
+    function setDragListeners(active) {
+      const method = active ? 'addEventListener' : 'removeEventListener';
+      window[method]('pointermove', onPointerMove, true);
+      window[method]('pointerup', onPointerUp, true);
+      window[method]('pointercancel', onDragAbort, true);
+      window[method]('keydown', onDragKeydown, true);
+      // Deliberately not capture. `blur` does not bubble, so a capture listener on
+      // `window` is the standard way to observe *every* element's blur — including
+      // the one the press itself causes when focus leaves whatever the user last
+      // clicked. That cancelled the drag before it could start. Without capture only
+      // the window's own blur arrives, which is the case worth aborting on.
+      window[method]('blur', onDragAbort);
+    }
+
+    function startRowDrag(event, id) {
+      if (event.button !== 0) return;
+      const rowEl = event.currentTarget;
+      // Scoped to the row on purpose: `closest` keeps walking past it, and the
+      // whole settings section is itself an `.accordion-animated-container`, so an
+      // unscoped match excludes every row and no drag ever starts.
+      const excluded = event.target?.closest?.(dragExcluded);
+      if (excluded && rowEl.contains(excluded)) return;
+      if (drag) finishRowDrag(false);
+      if (rowElements().length <= 1) return;
+      const pressY = contentY(event.clientY);
+      drag = {
+        id,
+        pointerId: event.pointerId,
+        // Where in the row the pointer landed. The origin is rebuilt from this once
+        // the rows are measured, so a collapse between press and measurement cannot
+        // leave the row hanging off the cursor.
+        grabOffset: pressY - contentTop(rowEl),
+        pressY,
+        lastClientY: event.clientY,
+        started: false,
+        changed: false,
+        expandedBefore: getExpanded(),
+        captureEl: rowEl,
+        rows: [],
+        snapshot: null,
+        order: null,
+        scrollFrame: 0,
+        renderPending: false
+      };
+      setDragListeners(true);
+    }
+
+    // Order matters: freeze the accordion, collapse, and only then measure. With
+    // the transition disabled the collapse lands synchronously, so the snapshot
+    // sees settled geometry instead of a mid-animation height.
+    function beginRowDrag() {
+      const list = getList();
+      drag.started = true;
+      list?.classList.add('is-reordering');
+      if (drag.expandedBefore) setExpanded('');
+      drag.rows = measureRows();
+      drag.snapshot = dragSort.createVerticalDragSnapshot(
+        drag.rows.map(({ id, top, height }) => ({ id, top, height })),
+        drag.id,
+        drag.grabOffset
+      );
+      if (drag.snapshot.sourceIndex < 0) {
+        finishRowDrag(false);
+        return false;
+      }
+      drag.rows[drag.snapshot.sourceIndex].el.classList.add('dragging');
+      list?.classList.add('drag-active');
+      startDragScroll();
+      return true;
+    }
+
+    function updateDragPositions() {
+      if (!drag?.started) return;
+      const offsetY = contentY(drag.lastClientY) - drag.snapshot.originY;
+      const resolved = dragSort.resolveVerticalDrag(drag.snapshot, offsetY);
+      drag.order = resolved.order;
+      drag.changed = resolved.targetIndex !== drag.snapshot.sourceIndex;
+      for (const [index, { el }] of drag.rows.entries()) {
+        if (index === drag.snapshot.sourceIndex) el.style.setProperty('--drag-y', `${offsetY}px`);
+        else el.style.setProperty('--drag-shift', `${resolved.shifts[index]}px`);
+      }
+    }
+
+    function startDragScroll() {
+      const step = () => {
+        const panel = getScrollPanel();
+        if (!drag?.started || !panel) return;
+        const rect = panel.getBoundingClientRect();
+        const delta = dragSort.edgeScrollDelta({
+          pointerY: drag.lastClientY,
+          top: rect.top,
+          bottom: rect.bottom
+        });
+        if (delta) {
+          panel.scrollTop += delta;
+          updateDragPositions();
+        }
+        drag.scrollFrame = requestAnimationFrame(step);
+      };
+      drag.scrollFrame = requestAnimationFrame(step);
+    }
+
+    function onPointerMove(event) {
+      if (!drag || drag.pointerId !== event.pointerId) return;
+      drag.lastClientY = event.clientY;
+      if (!drag.started) {
+        if (Math.abs(contentY(event.clientY) - drag.pressY) < threshold) return;
+        // Capture only after the gesture crosses the drag threshold. Capturing on
+        // pointerdown retargets the eventual click from the nested disclosure
+        // button to the outer row, so an ordinary press can no longer expand it.
+        // Once dragging, capture still guarantees that an outside-window release
+        // reaches cleanup instead of leaving the repaint gate stuck.
+        drag.captureEl?.addEventListener('lostpointercapture', onDragAbort);
+        try { drag.captureEl?.setPointerCapture?.(event.pointerId); } catch (_) {}
+        if (!beginRowDrag()) return;
+      }
+      event.preventDefault();
+      updateDragPositions();
+    }
+
+    function onPointerUp(event) {
+      if (!drag || drag.pointerId !== event.pointerId) return;
+      const { started, changed, order } = drag;
+      if (!started || !changed || !order?.length) {
+        finishRowDrag(true);
+        return;
+      }
+      // Mirror the new order locally before anything can repaint. A stats update
+      // held back during the drag is flushed on drop, and every repaint sorts from
+      // `state.settings` — which the deferred save has not written yet, so without
+      // this the list rebuilds into the old order and flips again a frame later.
+      const value = order.join(',');
+      mirrorOrder(value);
+      finishRowDrag(true);
+      // The drop itself is already in the DOM. Persisting re-renders the whole
+      // settings form, which on a populated install is a long task — run it only
+      // once the browser has painted the landed row, or that paint gets swallowed
+      // and the drop reads as a freeze. rAF fires before paint, so the timeout
+      // inside it is what lands after.
+      requestAnimationFrame(() => {
+        setTimeout(() => persistOrder(value), 0);
+      });
+    }
+
+    function onDragAbort(event) {
+      if (!drag) return;
+      if (event?.pointerId != null && event.pointerId !== drag.pointerId) return;
+      finishRowDrag(false);
+    }
+
+    function onDragKeydown(event) {
+      if (event.key !== 'Escape' || !drag) return;
+      event.preventDefault();
+      finishRowDrag(false);
+    }
+
+    function releaseLandingStyleAfterPaint(list) {
+      requestAnimationFrame(() => {
+        setTimeout(() => list?.classList.remove('is-landing'), 0);
+      });
+    }
+
+    // The final DOM positions and the drag transforms both encode the same move.
+    // Keep transform transitions disabled through the first landed paint so rows
+    // do not briefly apply both offsets and animate back from a double displacement.
+    function finishRowDrag(commit) {
+      const current = drag;
+      if (!current) return;
+      // The DOM reorder itself runs before the asynchronous settings save. Moving
+      // the focused row (and every sibling via appendChild) can trigger browser
+      // scroll anchoring immediately, so the save-time scroll guard is already too
+      // late. Preserve the panel around the whole landing transaction, including a
+      // deferred repaint that was held while dragging.
+      preserveScroll(() => {
+        if (current.scrollFrame) cancelAnimationFrame(current.scrollFrame);
+        setDragListeners(false);
+        // Released before the reorder moves the node: relocating a captured element
+        // fires `lostpointercapture`, which would re-enter this as an abort.
+        const captureEl = current.captureEl;
+        captureEl?.removeEventListener('lostpointercapture', onDragAbort);
+        try {
+          if (captureEl?.hasPointerCapture?.(current.pointerId)) captureEl.releasePointerCapture(current.pointerId);
+        } catch (_) {}
+        const list = getList();
+        if (current.started) {
+          const landing = Boolean(commit && current.changed && current.order?.length);
+          if (landing) list?.classList.add('is-landing');
+          if (landing) applyOrder(current.order);
+          for (const { el } of current.rows) {
+            el.style.removeProperty('--drag-y');
+            el.style.removeProperty('--drag-shift');
+            el.classList.remove('dragging');
+          }
+          list?.classList.remove('drag-active');
+          list?.classList.remove('is-reordering');
+          if (current.expandedBefore) setExpanded(current.expandedBefore);
+          suppressNextClick();
+          if (landing) releaseLandingStyleAfterPaint(list);
+        }
+        const renderPending = current.renderPending;
+        drag = null;
+        if (renderPending) requestRender();
+      });
+    }
+
+    // The same main-row button owns click-to-expand and drag-to-reorder. Cancelling
+    // its click after a completed drag prevents the drop from also toggling details.
+    function suppressNextClick() {
+      const swallow = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      };
+      window.addEventListener('click', swallow, true);
+      setTimeout(() => window.removeEventListener('click', swallow, true), 0);
+    }
+
+    // A repaint mid-drag would replace the rows under the pointer and kill the
+    // gesture silently. The caller skips its repaint when this answers true, and
+    // the held repaint is flushed from `finishRowDrag`.
+    function deferRender() {
+      if (!drag) return false;
+      drag.renderPending = true;
+      return true;
+    }
+
+    return { startRowDrag, deferRender, isDragging: () => Boolean(drag) };
+  }
+
+  return { createRowDragController, DEFAULT_DRAG_THRESHOLD };
+});

--- a/tests/electron/limitProviderDrag.test.js
+++ b/tests/electron/limitProviderDrag.test.js
@@ -49,22 +49,45 @@ function createDragHarness(config = {}) {
     setTimeout: (callback) => timers.push(callback)
   });
 
-  const makeRow = (id, top) => ({
-    dataset: { provider: id },
-    style: { setProperty() {}, removeProperty() {} },
-    classList: { add() {}, remove() {} },
-    getBoundingClientRect: () => ({ top, height: 40, bottom: top + 40 }),
-    contains: () => true,
-    addEventListener() {},
-    removeEventListener() {},
-    setPointerCapture() {},
-    hasPointerCapture: () => false,
-    releasePointerCapture() {}
-  });
+  // Pointer capture is stateful so the release path in finishRowDrag is actually
+  // reached: a fake whose hasPointerCapture always answers false skips it.
+  const captured = new Set();
+  const makeRow = (id, top) => {
+    const classes = new Set();
+    const styles = new Map();
+    const rowListeners = [];
+    return {
+      dataset: { provider: id },
+      classes,
+      styles,
+      rowListeners,
+      style: {
+        setProperty: (key, value) => styles.set(key, value),
+        removeProperty: (key) => styles.delete(key)
+      },
+      classList: { add: (value) => classes.add(value), remove: (value) => classes.delete(value) },
+      getBoundingClientRect: () => ({ top, height: 40, bottom: top + 40 }),
+      contains: () => true,
+      addEventListener: (type) => rowListeners.push(type),
+      removeEventListener: (type) => {
+        const index = rowListeners.indexOf(type);
+        if (index >= 0) rowListeners.splice(index, 1);
+      },
+      setPointerCapture: (pointerId) => captured.add(pointerId),
+      hasPointerCapture: (pointerId) => captured.has(pointerId),
+      releasePointerCapture: (pointerId) => captured.delete(pointerId)
+    };
+  };
   const rows = [makeRow('a', 0), makeRow('b', 40), makeRow('c', 80)];
   const panel = { scrollTop: 0, getBoundingClientRect: () => ({ top: 0, bottom: 500 }) };
-  const list = { classList: { add() {}, remove() {} }, querySelectorAll: () => rows };
+  const listClasses = new Set();
+  const list = {
+    classes: listClasses,
+    classList: { add: (value) => listClasses.add(value), remove: (value) => listClasses.delete(value) },
+    querySelectorAll: () => rows
+  };
 
+  let expanded = config.initialExpanded || '';
   const controller = api.createRowDragController({
     dragSort: verticalDragSort,
     getList: () => list,
@@ -72,6 +95,8 @@ function createDragHarness(config = {}) {
     rowSelector: '.row',
     idKey: 'provider',
     dragExcluded: '.excluded',
+    getExpanded: () => expanded,
+    setExpanded: (value) => { expanded = value; },
     ...config
   });
 
@@ -79,6 +104,10 @@ function createDragHarness(config = {}) {
     controller,
     frames,
     timers,
+    rows,
+    list,
+    captured,
+    expandedNow: () => expanded,
     press: (clientY) => controller.startRowDrag({
       button: 0,
       pointerId: 1,
@@ -86,9 +115,9 @@ function createDragHarness(config = {}) {
       currentTarget: rows[0],
       target: { closest: () => null }
     }, 'a'),
-    dispatch: (type, clientY) => {
-      const event = { pointerId: 1, clientY, preventDefault() {} };
-      for (const listener of [...(listeners.get(type) || [])]) listener(event);
+    dispatch: (type, event = {}) => {
+      const payload = { pointerId: 1, preventDefault() {}, ...event };
+      for (const listener of [...(listeners.get(type) || [])]) listener(payload);
     }
   };
 }
@@ -201,9 +230,9 @@ test('the drop mirrors the new order locally before anything can repaint', () =>
   const end = controller.indexOf('function onDragAbort(', start);
   assert.ok(start !== -1 && end > start);
   const body = controller.slice(start, end);
-  const mirror = body.indexOf('mirrorOrder(value)');
+  const mirror = body.indexOf('mirrorOrder(order)');
   const finish = body.indexOf('finishRowDrag(true);', mirror);
-  const persist = body.indexOf('persistOrder(value)', finish);
+  const persist = body.indexOf('persistOrder(order)', finish);
   assert.ok(mirror !== -1, 'the new order should be mirrored before the drag finishes');
   assert.ok(finish > mirror, 'the mirror must land before the drag is finished and repaints flush');
   assert.ok(persist > finish, 'persisting happens after the landed row has painted');
@@ -213,9 +242,13 @@ test('the drop mirrors the new order locally before anything can repaint', () =>
   // would treat the write as a no-op.
   const app = readRendererFile('app.js');
   const wiring = app.slice(app.indexOf('const limitProviderRowDrag = '), app.indexOf('function renderViewPreferences('));
-  assert.match(wiring, /mirrorOrder: \(value\) => \{ state\.settings = \{ \.\.\.state\.settings, limitProviderOrder: value \}; \}/);
-  assert.match(wiring, /persistOrder: \(value\) => void saveSettings\(\{ limitProviderOrder: value \}\)/);
+  // The controller hands over ids; the comma-joined setting is this list's own
+  // storage format and stays in the wiring.
+  assert.match(wiring, /mirrorOrder: \(order\) => \{ state\.settings = \{ \.\.\.state\.settings, limitProviderOrder: order\.join\(','\) \}; \}/);
+  assert.match(wiring, /persistOrder: \(order\) => void saveSettings\(\{ limitProviderOrder: order\.join\(','\) \}\)/);
   assert.doesNotMatch(wiring, /onPreferenceOrderCommit\(/);
+  const controllerSource = readRendererFile('rowDragController.js');
+  assert.doesNotMatch(controllerSource, /join\(','\)/, 'serialization belongs to the caller');
 });
 
 // Below the 4px threshold a press is a click; above it the drag swallows the
@@ -377,29 +410,77 @@ test('the controller reorders on a drag and stays a click under the threshold', 
     persistOrder: (value) => persisted.push(value)
   });
 
-  // A 2px press stays under the 4px threshold: no drag, no write.
+  // A 2px press stays under the 4px threshold: no drag, no capture, no write.
   harness.press(10);
   assert.equal(harness.controller.isDragging(), true, 'the press arms the gesture');
-  harness.dispatch('pointermove', 12);
-  harness.dispatch('pointerup', 12);
+  harness.dispatch('pointermove', { clientY: 12 });
+  assert.equal(harness.captured.size, 0, 'a press under the threshold never captures');
+  harness.dispatch('pointerup', { clientY: 12 });
   assert.deepEqual(applied, []);
   assert.deepEqual(mirrored, []);
   assert.equal(harness.controller.isDragging(), false);
 
   // Dragging the first row past the last one commits the new order.
   harness.press(10);
-  harness.dispatch('pointermove', 100);
-  harness.dispatch('pointerup', 100);
+  harness.dispatch('pointermove', { clientY: 100 });
+  assert.equal(harness.captured.size, 1, 'crossing the threshold captures the pointer');
+  harness.dispatch('pointerup', { clientY: 100 });
+  assert.equal(harness.captured.size, 0, 'the drop releases the capture');
   // Joined rather than compared as arrays: the order is built inside the vm
   // realm, so its Array prototype is not this realm's.
   assert.deepEqual(applied.map((order) => order.join(',')), ['b,c,a']);
-  assert.deepEqual(mirrored, ['b,c,a']);
+  assert.deepEqual(mirrored.map((order) => order.join(',')), ['b,c,a']);
   // Persisting waits for the landed paint: one rAF, then one timeout.
   assert.deepEqual(persisted, []);
   harness.frames.at(-1)();
   harness.timers.at(-1)();
-  assert.deepEqual(persisted, ['b,c,a']);
+  assert.deepEqual(persisted.map((order) => order.join(',')), ['b,c,a']);
+  // The row is handed ids, not a serialized setting: joining is the list's call.
+  assert.ok(Array.isArray(mirrored[0]) && Array.isArray(persisted[0]));
 });
+
+// Cleanup is the part an extraction is most likely to drop, and every abort
+// route lands in the same teardown: Escape, pointercancel, a window blur, and
+// the lostpointercapture that a reparented row fires.
+for (const abort of ['keydown', 'pointercancel', 'blur']) {
+  test(`a drag cancelled by ${abort} restores the row and writes nothing`, () => {
+    const applied = [];
+    const mirrored = [];
+    const persisted = [];
+    const renders = [];
+    const harness = createDragHarness({
+      initialExpanded: 'c',
+      applyOrder: (order) => applied.push(order),
+      mirrorOrder: (order) => mirrored.push(order),
+      persistOrder: (order) => persisted.push(order),
+      requestRender: () => renders.push('render')
+    });
+
+    harness.press(10);
+    harness.dispatch('pointermove', { clientY: 100 });
+    assert.equal(harness.expandedNow(), '', 'the accordion collapses for the drag');
+    assert.equal(harness.list.classes.has('drag-active'), true);
+    assert.ok(harness.rows[0].styles.has('--drag-y'), 'the dragged row is offset');
+    assert.equal(harness.controller.deferRender(), true);
+
+    harness.dispatch(abort, abort === 'keydown' ? { key: 'Escape' } : {});
+
+    assert.deepEqual(applied, [], 'a cancelled drag never reorders');
+    assert.deepEqual(mirrored, []);
+    assert.deepEqual(persisted, []);
+    assert.equal(harness.expandedNow(), 'c', 'the expanded row comes back');
+    assert.equal(harness.captured.size, 0, 'the capture is released');
+    assert.equal(harness.list.classes.has('drag-active'), false);
+    assert.equal(harness.list.classes.has('is-reordering'), false);
+    for (const row of harness.rows) {
+      assert.equal(row.styles.size, 0, 'drag offsets are cleared');
+      assert.equal(row.classes.has('dragging'), false);
+      assert.deepEqual(row.rowListeners, [], 'the lostpointercapture listener is removed');
+    }
+    assert.deepEqual(renders, ['render'], 'the held repaint still flushes exactly once');
+    assert.equal(harness.controller.isDragging(), false);
+  });
+}
 
 test('a repaint requested mid-drag is deferred and flushed once on drop', () => {
   const renders = [];
@@ -409,11 +490,11 @@ test('a repaint requested mid-drag is deferred and flushed once on drop', () => 
   assert.equal(harness.controller.deferRender(), false);
 
   harness.press(10);
-  harness.dispatch('pointermove', 100);
+  harness.dispatch('pointermove', { clientY: 100 });
   assert.equal(harness.controller.deferRender(), true, 'a repaint mid-drag is held back');
   assert.equal(harness.controller.deferRender(), true);
   assert.deepEqual(renders, [], 'nothing repaints while the pointer is down');
 
-  harness.dispatch('pointerup', 100);
+  harness.dispatch('pointerup', { clientY: 100 });
   assert.deepEqual(renders, ['render'], 'the held repaint flushes exactly once on drop');
 });

--- a/tests/electron/limitProviderDrag.test.js
+++ b/tests/electron/limitProviderDrag.test.js
@@ -68,9 +68,9 @@ function createDragHarness(config = {}) {
       classList: { add: (value) => classes.add(value), remove: (value) => classes.delete(value) },
       getBoundingClientRect: () => ({ top, height: 40, bottom: top + 40 }),
       contains: () => true,
-      addEventListener: (type) => rowListeners.push(type),
-      removeEventListener: (type) => {
-        const index = rowListeners.indexOf(type);
+      addEventListener: (type, listener) => rowListeners.push({ type, listener }),
+      removeEventListener: (type, listener) => {
+        const index = rowListeners.findIndex((entry) => entry.type === type && entry.listener === listener);
         if (index >= 0) rowListeners.splice(index, 1);
       },
       setPointerCapture: (pointerId) => captured.add(pointerId),
@@ -115,9 +115,20 @@ function createDragHarness(config = {}) {
       currentTarget: rows[0],
       target: { closest: () => null }
     }, 'a'),
+    // Only pointer events carry an id. A window blur has none, and that is
+    // exactly what the abort guard's `pointerId != null` branch exists for, so
+    // handing blur a synthetic id would test the wrong branch.
     dispatch: (type, event = {}) => {
-      const payload = { pointerId: 1, preventDefault() {}, ...event };
+      const payload = { preventDefault() {}, ...event };
+      if (/pointer/.test(type) && payload.pointerId == null) payload.pointerId = 1;
       for (const listener of [...(listeners.get(type) || [])]) listener(payload);
+    },
+    // `lostpointercapture` is registered on the row, not the window.
+    dispatchRow: (type, event = {}) => {
+      const payload = { pointerId: 1, preventDefault() {}, ...event };
+      for (const entry of [...rows[0].rowListeners]) {
+        if (entry.type === type) entry.listener(payload);
+      }
     }
   };
 }
@@ -440,10 +451,17 @@ test('the controller reorders on a drag and stays a click under the threshold', 
 });
 
 // Cleanup is the part an extraction is most likely to drop, and every abort
-// route lands in the same teardown: Escape, pointercancel, a window blur, and
-// the lostpointercapture that a reparented row fires.
-for (const abort of ['keydown', 'pointercancel', 'blur']) {
-  test(`a drag cancelled by ${abort} restores the row and writes nothing`, () => {
+// route lands in the same teardown.
+const ABORT_ROUTES = [
+  { name: 'Escape', abort: (harness) => harness.dispatch('keydown', { key: 'Escape' }) },
+  { name: 'pointercancel', abort: (harness) => harness.dispatch('pointercancel') },
+  // No pointerId, like the real event.
+  { name: 'a window blur', abort: (harness) => harness.dispatch('blur') },
+  { name: 'lostpointercapture', abort: (harness) => harness.dispatchRow('lostpointercapture') }
+];
+
+for (const route of ABORT_ROUTES) {
+  test(`a drag cancelled by ${route.name} restores the row and writes nothing`, () => {
     const applied = [];
     const mirrored = [];
     const persisted = [];
@@ -463,7 +481,7 @@ for (const abort of ['keydown', 'pointercancel', 'blur']) {
     assert.ok(harness.rows[0].styles.has('--drag-y'), 'the dragged row is offset');
     assert.equal(harness.controller.deferRender(), true);
 
-    harness.dispatch(abort, abort === 'keydown' ? { key: 'Escape' } : {});
+    route.abort(harness);
 
     assert.deepEqual(applied, [], 'a cancelled drag never reorders');
     assert.deepEqual(mirrored, []);
@@ -475,7 +493,7 @@ for (const abort of ['keydown', 'pointercancel', 'blur']) {
     for (const row of harness.rows) {
       assert.equal(row.styles.size, 0, 'drag offsets are cleared');
       assert.equal(row.classes.has('dragging'), false);
-      assert.deepEqual(row.rowListeners, [], 'the lostpointercapture listener is removed');
+      assert.deepEqual(row.rowListeners.map((entry) => entry.type), [], 'the lostpointercapture listener is removed');
     }
     assert.deepEqual(renders, ['render'], 'the held repaint still flushes exactly once');
     assert.equal(harness.controller.isDragging(), false);

--- a/tests/electron/limitProviderDrag.test.js
+++ b/tests/electron/limitProviderDrag.test.js
@@ -7,6 +7,7 @@ const test = require('node:test');
 const vm = require('node:vm');
 
 const rendererDir = path.join(__dirname, '..', '..', 'src', 'electron', 'renderer');
+const verticalDragSort = require('../../src/electron/renderer/verticalDragSort.js');
 
 function readRendererFile(name) {
   return fs.readFileSync(path.join(rendererDir, name), 'utf8');
@@ -16,6 +17,80 @@ function cssRule(source, selector) {
   const match = new RegExp(`${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\{([^}]+)\\}`).exec(source);
   assert.ok(match, `${selector} rule should exist`);
   return match[1];
+}
+
+// The controller is loaded through a fake `window` rather than `require`, so the
+// same UMD path the renderer uses is what these tests exercise.
+function loadController(context) {
+  vm.runInNewContext(readRendererFile('rowDragController.js'), context);
+  return context.window.TokenMonitorRowDragController;
+}
+
+// A three-row list in a 500px panel anchored at viewport top, so a client Y and
+// the controller's content-space Y are the same number.
+function createDragHarness(config = {}) {
+  const listeners = new Map();
+  const frames = [];
+  const timers = [];
+  const window = {
+    addEventListener(type, listener) {
+      const entries = listeners.get(type) || [];
+      entries.push(listener);
+      listeners.set(type, entries);
+    },
+    removeEventListener(type, listener) {
+      listeners.set(type, (listeners.get(type) || []).filter((entry) => entry !== listener));
+    }
+  };
+  const api = loadController({
+    window,
+    requestAnimationFrame: (callback) => frames.push(callback),
+    cancelAnimationFrame: () => {},
+    setTimeout: (callback) => timers.push(callback)
+  });
+
+  const makeRow = (id, top) => ({
+    dataset: { provider: id },
+    style: { setProperty() {}, removeProperty() {} },
+    classList: { add() {}, remove() {} },
+    getBoundingClientRect: () => ({ top, height: 40, bottom: top + 40 }),
+    contains: () => true,
+    addEventListener() {},
+    removeEventListener() {},
+    setPointerCapture() {},
+    hasPointerCapture: () => false,
+    releasePointerCapture() {}
+  });
+  const rows = [makeRow('a', 0), makeRow('b', 40), makeRow('c', 80)];
+  const panel = { scrollTop: 0, getBoundingClientRect: () => ({ top: 0, bottom: 500 }) };
+  const list = { classList: { add() {}, remove() {} }, querySelectorAll: () => rows };
+
+  const controller = api.createRowDragController({
+    dragSort: verticalDragSort,
+    getList: () => list,
+    getScrollPanel: () => panel,
+    rowSelector: '.row',
+    idKey: 'provider',
+    dragExcluded: '.excluded',
+    ...config
+  });
+
+  return {
+    controller,
+    frames,
+    timers,
+    press: (clientY) => controller.startRowDrag({
+      button: 0,
+      pointerId: 1,
+      clientY,
+      currentTarget: rows[0],
+      target: { closest: () => null }
+    }, 'a'),
+    dispatch: (type, clientY) => {
+      const event = { pointerId: 1, clientY, preventDefault() {} };
+      for (const listener of [...(listeners.get(type) || [])]) listener(event);
+    }
+  };
 }
 
 test('limit provider expansion goes through one shared helper', () => {
@@ -78,11 +153,17 @@ test('the limits section tells the user rows can be dragged', () => {
   assert.equal((i18n.match(/'settings\.limits\.reorderNote':/g) || []).length, 5, 'one entry per bundled locale');
 });
 
-test('the renderer loads the vertical drag module', () => {
+test('the renderer loads the drag modules', () => {
   const html = readRendererFile('index.html');
   assert.match(html, /<script src="verticalDragSort\.js"><\/script>/);
+  // The controller consumes the geometry module, so it must load after it.
+  assert.ok(
+    html.indexOf('<script src="verticalDragSort.js">') < html.indexOf('<script src="rowDragController.js">'),
+    'rowDragController.js should load after verticalDragSort.js'
+  );
   const app = readRendererFile('app.js');
   assert.match(app, /const verticalDragSortApi = window\.TokenMonitorVerticalDragSort;/);
+  assert.match(app, /const rowDragControllerApi = window\.TokenMonitorRowDragController;/);
 });
 
 test('limit provider rows drag from the row itself, not a handle', () => {
@@ -92,7 +173,7 @@ test('limit provider rows drag from the row itself, not a handle', () => {
   assert.ok(start !== -1 && end > start, 'renderLimitProviderCheckboxes should precede the helper');
   const body = app.slice(start, end);
   assert.doesNotMatch(body, /createPreferenceOrderHandle/);
-  assert.match(body, /row\.addEventListener\('pointerdown', \(event\) => startLimitProviderRowDrag\(event, id\)\);/);
+  assert.match(body, /row\.addEventListener\('pointerdown', \(event\) => limitProviderRowDrag\.startRowDrag\(event, id\)\);/);
   // The keyboard reorder entry point moves onto the checkbox, keys unchanged.
   assert.match(body, /cb\.setAttribute\('aria-keyshortcuts', 'ArrowUp ArrowDown Home End'\);/);
   assert.match(body, /cb\.addEventListener\('keydown', \(event\) => onPreferenceOrderKeydown\(event, 'provider', id\)\);/);
@@ -107,25 +188,34 @@ test('the other five preference lists keep the drag handle', () => {
 
 test('a stats repaint mid-drag is deferred instead of replacing the rows', () => {
   const app = readRendererFile('app.js');
-  assert.match(app, /if \(limitProviderDrag\) \{\s*limitProviderDrag\.renderPending = true;\s*return;\s*\}/);
+  assert.match(app, /if \(limitProviderRowDrag\.deferRender\(\)\) return;/);
+  const controller = readRendererFile('rowDragController.js');
+  assert.match(controller, /function deferRender\(\) \{\s*if \(!drag\) return false;\s*drag\.renderPending = true;\s*return true;\s*\}/);
 });
 
 // A repaint held back during the drag is flushed on drop, and it sorts from
 // state.settings — which the deferred save has not written yet.
 test('the drop mirrors the new order locally before anything can repaint', () => {
-  const app = readRendererFile('app.js');
-  const start = app.indexOf('function onLimitProviderPointerUp(');
-  const end = app.indexOf('function onLimitProviderDragAbort(', start);
+  const controller = readRendererFile('rowDragController.js');
+  const start = controller.indexOf('function onPointerUp(');
+  const end = controller.indexOf('function onDragAbort(', start);
   assert.ok(start !== -1 && end > start);
-  const body = app.slice(start, end);
-  const mirror = body.indexOf('state.settings = { ...state.settings, limitProviderOrder: value }');
-  const finish = body.indexOf('finishLimitProviderDrag(true);', mirror);
-  assert.ok(mirror !== -1, 'the new order should be mirrored into state.settings');
+  const body = controller.slice(start, end);
+  const mirror = body.indexOf('mirrorOrder(value)');
+  const finish = body.indexOf('finishRowDrag(true);', mirror);
+  const persist = body.indexOf('persistOrder(value)', finish);
+  assert.ok(mirror !== -1, 'the new order should be mirrored before the drag finishes');
   assert.ok(finish > mirror, 'the mirror must land before the drag is finished and repaints flush');
+  assert.ok(persist > finish, 'persisting happens after the landed row has painted');
+
+  // The limits list mirrors into state.settings and saves directly:
   // onPreferenceOrderCommit compares against the value just mirrored, so it
   // would treat the write as a no-op.
-  assert.match(body, /saveSettings\(\{ limitProviderOrder: value \}\)/);
-  assert.doesNotMatch(body, /onPreferenceOrderCommit\(/);
+  const app = readRendererFile('app.js');
+  const wiring = app.slice(app.indexOf('const limitProviderRowDrag = '), app.indexOf('function renderViewPreferences('));
+  assert.match(wiring, /mirrorOrder: \(value\) => \{ state\.settings = \{ \.\.\.state\.settings, limitProviderOrder: value \}; \}/);
+  assert.match(wiring, /persistOrder: \(value\) => void saveSettings\(\{ limitProviderOrder: value \}\)/);
+  assert.doesNotMatch(wiring, /onPreferenceOrderCommit\(/);
 });
 
 // Below the 4px threshold a press is a click; above it the drag swallows the
@@ -134,10 +224,12 @@ test('the drop mirrors the new order locally before anything can repaint', () =>
 test('a press on the row own controls never arms a drag', () => {
   const app = readRendererFile('app.js');
   assert.match(app, /const LIMIT_PROVIDER_DRAG_EXCLUDED = 'button:not\(\.limit-provider-main\), input, select, textarea, a, \.accordion-animated-container';/);
-  const start = app.indexOf('function startLimitProviderRowDrag(');
-  const body = app.slice(start, app.indexOf('function setLimitProviderDragListeners(', start));
-  const guard = body.indexOf('LIMIT_PROVIDER_DRAG_EXCLUDED');
-  const arm = body.indexOf('limitProviderDrag = {');
+  assert.match(app, /dragExcluded: LIMIT_PROVIDER_DRAG_EXCLUDED,/);
+  const controller = readRendererFile('rowDragController.js');
+  const start = controller.indexOf('function startRowDrag(');
+  const body = controller.slice(start, controller.indexOf('function beginRowDrag(', start));
+  const guard = body.indexOf('dragExcluded');
+  const arm = body.indexOf('drag = {');
   assert.ok(guard !== -1 && arm > guard, 'the guard must run before the drag state is built');
   // `closest` walks past the row, and setupSettingsSections makes the whole
   // section an `.accordion-animated-container` — the same class the per-row
@@ -166,51 +258,58 @@ test('the provider main row is one accessible disclosure beside the checkbox', (
 });
 
 test('pointer capture starts only after the row crosses the drag threshold', () => {
-  const app = readRendererFile('app.js');
-  const armStart = app.indexOf('function startLimitProviderRowDrag(');
-  const armBody = app.slice(armStart, app.indexOf('function setLimitProviderDragListeners(', armStart));
+  const controller = readRendererFile('rowDragController.js');
+  const armStart = controller.indexOf('function startRowDrag(');
+  const armBody = controller.slice(armStart, controller.indexOf('function beginRowDrag(', armStart));
   assert.doesNotMatch(armBody, /setPointerCapture|lostpointercapture/);
 
-  const moveStart = app.indexOf('function onLimitProviderPointerMove(');
-  const moveBody = app.slice(moveStart, app.indexOf('function onLimitProviderPointerUp(', moveStart));
-  const threshold = moveBody.indexOf('LIMIT_PROVIDER_DRAG_THRESHOLD');
+  const moveStart = controller.indexOf('function onPointerMove(');
+  const moveBody = controller.slice(moveStart, controller.indexOf('function onPointerUp(', moveStart));
+  const threshold = moveBody.indexOf('< threshold');
   const capture = moveBody.indexOf('setPointerCapture');
-  const begin = moveBody.indexOf('beginLimitProviderDrag()');
+  const begin = moveBody.indexOf('beginRowDrag()');
   assert.ok(threshold !== -1 && capture > threshold, 'capture should wait until the drag threshold is crossed');
   assert.ok(begin > capture, 'capture should be active before the drag starts moving rows');
-  assert.match(moveBody, /addEventListener\('lostpointercapture', onLimitProviderDragAbort\)/);
+  assert.match(moveBody, /addEventListener\('lostpointercapture', onDragAbort\)/);
 });
 
 test('the drag releases pointer capture before the reorder', () => {
-  const app = readRendererFile('app.js');
-  const start = app.indexOf('function finishLimitProviderDrag(');
-  const body = app.slice(start, app.indexOf('function suppressNextLimitProviderClick(', start));
+  const controller = readRendererFile('rowDragController.js');
+  const start = controller.indexOf('function finishRowDrag(');
+  const body = controller.slice(start, controller.indexOf('function suppressNextClick(', start));
   const release = body.indexOf('releasePointerCapture');
-  const reorder = body.indexOf("applyPreferenceOrder('provider'");
+  const reorder = body.indexOf('applyOrder(current.order)');
   assert.ok(release !== -1 && reorder > release, 'capture is released before the node moves');
-  assert.match(body, /removeEventListener\('lostpointercapture', onLimitProviderDragAbort\)/);
+  assert.match(body, /removeEventListener\('lostpointercapture', onDragAbort\)/);
 });
 
 test('the drop preserves settings scroll across the DOM reorder and deferred repaint', () => {
-  const app = readRendererFile('app.js');
-  const start = app.indexOf('function finishLimitProviderDrag(');
-  const body = app.slice(start, app.indexOf('function suppressNextLimitProviderClick(', start));
-  const preserve = body.indexOf('preserveSettingsPanelScroll(() => {');
-  const reorder = body.indexOf("applyPreferenceOrder('provider'");
-  const pendingRender = body.indexOf('if (renderPending) renderLimitProviderCheckboxes();');
+  const controller = readRendererFile('rowDragController.js');
+  const start = controller.indexOf('function finishRowDrag(');
+  const body = controller.slice(start, controller.indexOf('function suppressNextClick(', start));
+  const preserve = body.indexOf('preserveScroll(() => {');
+  const reorder = body.indexOf('applyOrder(current.order)');
+  const pendingRender = body.indexOf('if (renderPending) requestRender();');
 
   assert.ok(preserve !== -1, 'drop should snapshot the scroll position before landing');
   assert.ok(reorder > preserve, 'the DOM reorder should happen inside the scroll-preserved transaction');
   assert.ok(pendingRender > reorder, 'a deferred repaint should be covered by the same transaction');
+
+  // The limits list supplies the settings panel guard.
+  const app = readRendererFile('app.js');
+  const wiring = app.slice(app.indexOf('const limitProviderRowDrag = '), app.indexOf('function renderViewPreferences('));
+  assert.match(wiring, /preserveScroll: preserveSettingsPanelScroll,/);
+  assert.match(wiring, /applyOrder: \(order\) => applyPreferenceOrder\('provider', order\),/);
+  assert.match(wiring, /requestRender: \(\) => renderLimitProviderCheckboxes\(\)/);
 });
 
 test('a committed drop suppresses transform settling through the first landed paint', () => {
-  const app = readRendererFile('app.js');
+  const controller = readRendererFile('rowDragController.js');
   const css = readRendererFile('styles.css');
-  const helperStart = app.indexOf('function releaseLimitProviderLandingStyleAfterPaint(');
-  const finishStart = app.indexOf('function finishLimitProviderDrag(', helperStart);
-  const helper = app.slice(helperStart, finishStart);
-  const finishBody = app.slice(finishStart, app.indexOf('function suppressNextLimitProviderClick(', finishStart));
+  const helperStart = controller.indexOf('function releaseLandingStyleAfterPaint(');
+  const finishStart = controller.indexOf('function finishRowDrag(', helperStart);
+  const helper = controller.slice(helperStart, finishStart);
+  const finishBody = controller.slice(finishStart, controller.indexOf('function suppressNextClick(', finishStart));
   const landingRule = cssRule(css, '.settings-panel .limit-provider-list.is-landing .limit-provider-row');
   const frames = [];
   const timers = [];
@@ -222,7 +321,7 @@ test('a committed drop suppresses transform settling through the first landed pa
   };
 
   vm.runInNewContext(
-    `${helper}\nreleaseLimitProviderLandingStyleAfterPaint(list);`,
+    `${helper}\nreleaseLandingStyleAfterPaint(list);`,
     {
       list,
       requestAnimationFrame: (callback) => frames.push(callback),
@@ -239,9 +338,9 @@ test('a committed drop suppresses transform settling through the first landed pa
   assert.deepEqual(removed, ['is-landing']);
 
   const suppress = finishBody.indexOf("list?.classList.add('is-landing')");
-  const reorder = finishBody.indexOf("applyPreferenceOrder('provider'");
+  const reorder = finishBody.indexOf('applyOrder(current.order)');
   const clearShift = finishBody.indexOf("el.style.removeProperty('--drag-shift')");
-  const release = finishBody.indexOf('releaseLimitProviderLandingStyleAfterPaint(list)');
+  const release = finishBody.indexOf('releaseLandingStyleAfterPaint(list)');
   assert.ok(suppress !== -1 && reorder > suppress, 'transition suppression should precede the DOM reorder');
   assert.ok(clearShift > reorder, 'drag offsets should clear only after the final order is in the DOM');
   assert.ok(release > clearShift, 'transition suppression should survive until the landing is complete');
@@ -254,13 +353,67 @@ test('a committed drop suppresses transform settling through the first landed pa
 // it began: the first drag after opening settings or collapsing the section
 // always failed, then every later one worked because focus sat on the body.
 test('only the window own blur aborts the drag', () => {
-  const app = readRendererFile('app.js');
-  assert.match(app, /window\[method\]\('blur', onLimitProviderDragAbort\);/);
-  assert.doesNotMatch(app, /'blur', onLimitProviderDragAbort, true/);
+  const controller = readRendererFile('rowDragController.js');
+  assert.match(controller, /window\[method\]\('blur', onDragAbort\);/);
+  assert.doesNotMatch(controller, /'blur', onDragAbort, true/);
 });
 
 test('the drag suppresses the click that would otherwise toggle provider details', () => {
-  const app = readRendererFile('app.js');
-  assert.match(app, /function suppressNextLimitProviderClick\(\)/);
-  assert.match(app, /window\.addEventListener\('click', swallow, true\);/);
+  const controller = readRendererFile('rowDragController.js');
+  assert.match(controller, /function suppressNextClick\(\)/);
+  assert.match(controller, /window\.addEventListener\('click', swallow, true\);/);
+});
+
+// The gesture itself, driven end to end. The source-shape assertions above lock
+// the ordering constraints; this one proves the extracted controller still
+// reorders, and that a press under the threshold stays a click.
+test('the controller reorders on a drag and stays a click under the threshold', () => {
+  const applied = [];
+  const mirrored = [];
+  const persisted = [];
+  const harness = createDragHarness({
+    applyOrder: (order) => applied.push(order),
+    mirrorOrder: (value) => mirrored.push(value),
+    persistOrder: (value) => persisted.push(value)
+  });
+
+  // A 2px press stays under the 4px threshold: no drag, no write.
+  harness.press(10);
+  assert.equal(harness.controller.isDragging(), true, 'the press arms the gesture');
+  harness.dispatch('pointermove', 12);
+  harness.dispatch('pointerup', 12);
+  assert.deepEqual(applied, []);
+  assert.deepEqual(mirrored, []);
+  assert.equal(harness.controller.isDragging(), false);
+
+  // Dragging the first row past the last one commits the new order.
+  harness.press(10);
+  harness.dispatch('pointermove', 100);
+  harness.dispatch('pointerup', 100);
+  // Joined rather than compared as arrays: the order is built inside the vm
+  // realm, so its Array prototype is not this realm's.
+  assert.deepEqual(applied.map((order) => order.join(',')), ['b,c,a']);
+  assert.deepEqual(mirrored, ['b,c,a']);
+  // Persisting waits for the landed paint: one rAF, then one timeout.
+  assert.deepEqual(persisted, []);
+  harness.frames.at(-1)();
+  harness.timers.at(-1)();
+  assert.deepEqual(persisted, ['b,c,a']);
+});
+
+test('a repaint requested mid-drag is deferred and flushed once on drop', () => {
+  const renders = [];
+  const harness = createDragHarness({ requestRender: () => renders.push('render') });
+
+  // Idle: the caller repaints normally.
+  assert.equal(harness.controller.deferRender(), false);
+
+  harness.press(10);
+  harness.dispatch('pointermove', 100);
+  assert.equal(harness.controller.deferRender(), true, 'a repaint mid-drag is held back');
+  assert.equal(harness.controller.deferRender(), true);
+  assert.deepEqual(renders, [], 'nothing repaints while the pointer is down');
+
+  harness.dispatch('pointerup', 100);
+  assert.deepEqual(renders, ['render'], 'the held repaint flushes exactly once on drop');
 });

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -1396,7 +1396,7 @@ test('background provider rerenders preserve settings scroll without a focused c
     {
       cancelAnimationFrame: () => {},
       els,
-      limitProviderDrag: null,
+      limitProviderRowDrag: { deferRender: () => false },
       renderLimitProviderCheckboxesNow,
       requestAnimationFrame: (callback) => frames.push(callback)
     }
@@ -1454,7 +1454,7 @@ renderLimitProviderCheckboxes();`,
       cancelAnimationFrame: () => {},
       document: { querySelectorAll: () => [] },
       els,
-      limitProviderDrag: null,
+      limitProviderRowDrag: { deferRender: () => false },
       renderLimitProviderCheckboxesNow,
       requestAnimationFrame: (callback) => frames.push(callback)
     }


### PR DESCRIPTION
## What

The limit provider list is the only settings list that drags from the row itself rather than a handle. Its gesture controller had grown to 262 lines in `app.js`, wired directly to `els.limitProviderCheckboxes`, `state.limitProviderSettingsExpanded` and the `limitProviderOrder` setting — so giving a second list the same interaction would have meant a second copy of it.

This extracts that controller into `src/electron/renderer/rowDragController.js` and leaves the limits list as a 26-line config object. **No behaviour change.**

```js
createRowDragController({
  dragSort, getList, getScrollPanel, rowSelector, idKey, dragExcluded,
  threshold,                    // defaults to 4px
  getExpanded, setExpanded,     // freeze/restore the accordion across the drag
  applyOrder, preserveScroll,
  mirrorOrder, persistOrder,    // mirror on drop, persist after the landed paint
  requestRender                 // flush a repaint held back during the drag
})
// → { startRowDrag(event, id), deferRender(), isDragging() }
```

The layering stays as it was: `verticalDragSort.js` keeps the pure geometry, the new module owns the pointer/DOM choreography around it.

`app.js`: −262 / +24.

## Why now

Follow-up work needs click-to-expand rows in the tracked-tools list, which still uses the older handle drag plus `replaceChildren()` on every stats tick — a repaint cadence that destroys any live DOM inside an expanded row. Adopting this controller there is the next step, and it should not start by duplicating 262 lines of gesture code.

## Tests

The drag suite asserted `app.js` source shape, so the ordering invariants it locks now read the module instead — capture only after the threshold, release before the reorder, scroll preserved across the entire landing transaction, landing style held through the first painted frame, and the deliberately non-capturing `blur` listener.

Behavioural tests are added on top, where the file previously had none:

- a press under the 4px threshold stays a click and never captures the pointer, while a completed drag captures, commits the new order, releases, and persists only after the landed paint (one rAF, then one timeout);
- a repaint requested mid-drag is held back and flushed exactly once on drop;
- each abort route — Escape, `pointercancel`, a window blur, and the `lostpointercapture` a reparented row fires — runs the shared teardown: nothing is written, the expanded row returns, capture and the row listener are released, transforms and classes are cleared, and a held repaint still flushes exactly once.

The controller hands `mirrorOrder`/`persistOrder` the ids rather than a joined string, so the comma-separated `limitProviderOrder` stays the limits list's own storage format — the interface the next list to adopt this needs.

`npm run verify` — lint clean, 2325 passing / 0 failing.

## Not in this PR

The tracked-tools list is untouched and still uses the handle drag. Migrating it (append-then-remove rendering, `moveBefore()` for live nodes, `.tool-preference-list` drag CSS) is the next PR, before any expand UI lands on top.
