### PR TITLE
chore(deps): update tokscale to 4.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "koffi": "^3.1.2",
         "semver": "^7.8.5",
         "tar": "^7.5.21",
-        "tokscale": "^4.9.0",
+        "tokscale": "^4.10.0",
         "undici": "^7.28.0"
       },
       "devDependencies": {
@@ -1028,29 +1028,29 @@
       }
     },
     "node_modules/@tokscale/cli": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli/-/cli-4.9.0.tgz",
-      "integrity": "sha512-Qslv7aaLWjHKoZD7n3W/aLR7SOPAPDE+2n8/b99RKDRBNMzVAbdUPT65pTY1kJ06M7xmgU/jANmR1mBd3P6gPw==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli/-/cli-4.10.0.tgz",
+      "integrity": "sha512-+fd+rlu7e0dP+nAtW6C53WH/9NbhE+HUbiYNzWqaQcYmzuUqH45WYMcVshGmvnx5da4p60FcEqQ5IzAipSuwLA==",
       "license": "MIT",
       "bin": {
         "tokscale": "bin.js"
       },
       "optionalDependencies": {
-        "@tokscale/cli-android-arm64": "4.9.0",
-        "@tokscale/cli-darwin-arm64": "4.9.0",
-        "@tokscale/cli-darwin-x64": "4.9.0",
-        "@tokscale/cli-linux-arm64-gnu": "4.9.0",
-        "@tokscale/cli-linux-arm64-musl": "4.9.0",
-        "@tokscale/cli-linux-x64-gnu": "4.9.0",
-        "@tokscale/cli-linux-x64-musl": "4.9.0",
-        "@tokscale/cli-win32-arm64-msvc": "4.9.0",
-        "@tokscale/cli-win32-x64-msvc": "4.9.0"
+        "@tokscale/cli-android-arm64": "4.10.0",
+        "@tokscale/cli-darwin-arm64": "4.10.0",
+        "@tokscale/cli-darwin-x64": "4.10.0",
+        "@tokscale/cli-linux-arm64-gnu": "4.10.0",
+        "@tokscale/cli-linux-arm64-musl": "4.10.0",
+        "@tokscale/cli-linux-x64-gnu": "4.10.0",
+        "@tokscale/cli-linux-x64-musl": "4.10.0",
+        "@tokscale/cli-win32-arm64-msvc": "4.10.0",
+        "@tokscale/cli-win32-x64-msvc": "4.10.0"
       }
     },
     "node_modules/@tokscale/cli-android-arm64": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-android-arm64/-/cli-android-arm64-4.9.0.tgz",
-      "integrity": "sha512-9LscZlRUby1QfRWc+Y5prJeTr0vcnvkZaHwwccF1mlE9/2rf/hwynySBRy3HDbhqMeAEozF/L8todCSYX2zbEA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-android-arm64/-/cli-android-arm64-4.10.0.tgz",
+      "integrity": "sha512-kgmcTBokE1TFh7NBS4JKB8VmBGip0DhRnKnTLtWgxYJ1vcCPHFRXPPcdiuPzydDoUuuy3FaQ5X3RPfbqHHj9mw==",
       "cpu": [
         "arm64"
       ],
@@ -1061,9 +1061,9 @@
       ]
     },
     "node_modules/@tokscale/cli-darwin-arm64": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-arm64/-/cli-darwin-arm64-4.9.0.tgz",
-      "integrity": "sha512-ZtcGOhJXJBaLtQK5l51MHgfhHX/cmPncrUoCiSoW8T8aLVpH9j8kXDz8q1xaSaOrTTEoQIr11/gnBFMkakTBZg==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-arm64/-/cli-darwin-arm64-4.10.0.tgz",
+      "integrity": "sha512-UNWnDTbpJpBRr3vyIiUdYMA57Y0eYziqDfhYnjXUQCRertEcFoCfl5c4DRzJc83rJn+SclIHBgF0yhHagt72oQ==",
       "cpu": [
         "arm64"
       ],
@@ -1074,9 +1074,9 @@
       ]
     },
     "node_modules/@tokscale/cli-darwin-x64": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-x64/-/cli-darwin-x64-4.9.0.tgz",
-      "integrity": "sha512-fsigPahgyXMJfyDoFh59JNPxTNUYpyAJkjNnPQT4txlKLfbtpHStDU7ikM4uvVa9NOwEzDso1POPOWFyJKQueA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-x64/-/cli-darwin-x64-4.10.0.tgz",
+      "integrity": "sha512-BlqA06Shiw+8BxTVfo8EP7cZyHp5QKvpTbxQf7XGD6lHgROA66qLbP5ms02vPRp7U6WeqkURNMnRNb/XbaQxhw==",
       "cpu": [
         "x64"
       ],
@@ -1087,9 +1087,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-arm64-gnu": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-4.9.0.tgz",
-      "integrity": "sha512-hYfZkXFjmOsWefECsvbELr/0/PwMHXPMgUIH9QngnPjHSkdKpUaVfHbM7lSzZtD1sXeX5eH2R2Si7/kTzFz5Pw==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-4.10.0.tgz",
+      "integrity": "sha512-9LYNxBZbmojrZFMWwx8J0W7kD7hc6Mkpz0rPG3KXem56m8WvWAb6G/qjAkJlWPMjo28jEaZheachlNkNpbl3wQ==",
       "cpu": [
         "arm64"
       ],
@@ -1100,9 +1100,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-arm64-musl": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-musl/-/cli-linux-arm64-musl-4.9.0.tgz",
-      "integrity": "sha512-nsP9/k3tlISATQ0Fj5qin1Sre6pcpAO48QOJJYtRB5tPGDJnMWec+ZPYNQRySXX6hae+S8X2a6pKIIA0xHk2LA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-musl/-/cli-linux-arm64-musl-4.10.0.tgz",
+      "integrity": "sha512-plw3/gngDAArhCqgvY+v4TxdaQ0nNcD5TKk+xGVAN7ZNN8gBpmz92TE4KeYW4lnEqB6gS2XcVQ193IqiJPFrzg==",
       "cpu": [
         "arm64"
       ],
@@ -1113,9 +1113,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-x64-gnu": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-gnu/-/cli-linux-x64-gnu-4.9.0.tgz",
-      "integrity": "sha512-5KLot6uivxrlEF/g3MwS7TCHux4M8WHUwFUnAramO/iHbySIsNkW9ODDwn00vuqNViDxcQYJNRVXM+bZV2ahjQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-gnu/-/cli-linux-x64-gnu-4.10.0.tgz",
+      "integrity": "sha512-8EPrn4auy4CyGKwajUKpl36dBY39nZncVr6KIQpaxtMGwGUxrh+wMscT+L8pbxjuVXi+MiIUyjxXGJZnz17boQ==",
       "cpu": [
         "x64"
       ],
@@ -1126,9 +1126,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-x64-musl": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-musl/-/cli-linux-x64-musl-4.9.0.tgz",
-      "integrity": "sha512-xA9I1UqwEr2lBM9W1LGTtwVnF2TSJLCOAqKlxn0a5Uk2SPB7FchgJ14EA0B5sI3bTQdWrvm8wgaB2kizEhq1ZA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-musl/-/cli-linux-x64-musl-4.10.0.tgz",
+      "integrity": "sha512-Cxe3Gi8BaF3y/pSN75NrkJJP4sITx8bJKcrR6bY43CIRRP733YHx2eWCGVZUmLTJXewTX67jzO0D2iDMeIDNaw==",
       "cpu": [
         "x64"
       ],
@@ -1139,9 +1139,9 @@
       ]
     },
     "node_modules/@tokscale/cli-win32-arm64-msvc": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-4.9.0.tgz",
-      "integrity": "sha512-kXyTyztnDoofmbtK09SV0xDkUqE63of9ErW3UwBPg1pO2J+EMcY8e6X3tQJatBHkhK44ZyZsHpm/4ARJ92VQvg==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-4.10.0.tgz",
+      "integrity": "sha512-FC7CZTsC+zeB+T9luefcf6vBY16N0QeQ6FDGj5X8lQSGNLiJPODQr3ei6yDagPIYKGAcQc0j6YvA2mYLz0yjMA==",
       "cpu": [
         "arm64"
       ],
@@ -1152,9 +1152,9 @@
       ]
     },
     "node_modules/@tokscale/cli-win32-x64-msvc": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-x64-msvc/-/cli-win32-x64-msvc-4.9.0.tgz",
-      "integrity": "sha512-s/jZA2SFQzVGA3FY5abOOsSNiuMEiA+0na2V3Ye9BVV6CX/RYx5pQ1pIRJSWv3qrLjDaK9osFYyBwgO3BaeCOw==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-x64-msvc/-/cli-win32-x64-msvc-4.10.0.tgz",
+      "integrity": "sha512-HVIKnSCeNg+Hx2pLuLUm452l2DFOIw1rC/d1dDzSvCXR+juxcv5IVJh6wW0zO+/QUdb7IR7OsHAvy9osY/PNjw==",
       "cpu": [
         "x64"
       ],
@@ -4676,12 +4676,12 @@
       }
     },
     "node_modules/tokscale": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/tokscale/-/tokscale-4.9.0.tgz",
-      "integrity": "sha512-ELBKpL6E8pv1XtfJDNdt8X+q+5R3wGe4D3en5qLPZxd/go1Yt1DUeAX16EWoqZFTtbIqkOYzp4O6LlHgofx6FQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tokscale/-/tokscale-4.10.0.tgz",
+      "integrity": "sha512-Mp5fwNi8APy2G6ht/jhHv19sIv1QfcrjOv4xUqEdWVoLTil3OIlgpdrt+1Z3HlvtXhKzm/dHwczAO0Kevev0+w==",
       "license": "MIT",
       "dependencies": {
-        "@tokscale/cli": "4.9.0"
+        "@tokscale/cli": "4.10.0"
       },
       "bin": {
         "tokscale": "bin.js"

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "koffi": "^3.1.2",
     "semver": "^7.8.5",
     "tar": "^7.5.21",
-    "tokscale": "^4.9.0",
+    "tokscale": "^4.10.0",
     "undici": "^7.28.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Update `tokscale` from 4.9.0 to 4.10.0.
- Pick up Tokscale's Grok Build parser support for authoritative usage records in `updates.jsonl`.
- Preserve Token Monitor's existing `--json --client ... --group-by client,session,model` integration.

Tokscale 4.10.0 recognizes Grok's `params.update.usage` and `modelUsage` fields, including input, output, cached-read, and reasoning tokens. This fixes the case where Grok session files contain usage data but Tokscale 4.9.0 returns zero or an incomplete breakdown.

## Verification

- `npm run verify` (2370 passed, 1 skipped)
- Tokscale `--version` and `--help`
- Sanitized Grok fixture: 4.9.0 returned zero entries, while 4.10.0 returned the expected populated usage entry and token breakdown
- `git diff --check`

Fixes #324


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `tokscale` from 4.9.0 to 4.10.0 to correctly parse Grok usage in updates.jsonl and return full token breakdowns. Keeps existing Token Monitor flags/output unchanged and fixes #324.

<sup>Written for commit 524a1f1cfa4ff9be3b04130b46d1732663fa2dc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

