### PR TITLE
fix(trends): preserve empty local calendar days

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -5346,7 +5346,7 @@ function renderTrends() {
 
   const model = charts.sparklinePreview(finalPoints, { width: 300, height: 120, gap: 0.3, metric });
   const titles = finalPoints.map((p) => `${trendShortLabel(p[labelKey], labelKey)} · ${formatCompact(p[metric])}`);
-  const svg = charts.sparklineSvg(model, { titles });
+  const svg = charts.sparklineSvg(model, { titles, showZeroMarkers: state.period === 'today' });
 
   const summary = preview.summary || {};
   const rangeLabel = state.period === 'allTime' ? t('trends.range.year')

--- a/src/electron/renderer/styles.css
+++ b/src/electron/renderer/styles.css
@@ -5002,6 +5002,14 @@ html.is-windows .limit-live-badge {
   transform-origin: bottom center;
 }
 .trends-spark .spark-bar--last { opacity: 1; }
+.trends-spark .spark-zero-marker {
+  stroke: #6ab4f0;
+  stroke-width: 1;
+  opacity: 0.24;
+  pointer-events: stroke;
+  vector-effect: non-scaling-stroke;
+}
+.trends-spark .spark-zero-marker--last { opacity: 0.32; }
 .trends-axis { flex: none; display: flex; justify-content: space-between; padding: 0 4px; font-size: 10px; opacity: 0.45; font-variant-numeric: tabular-nums; }
 .trends-stats { flex: none; display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
 .trends-stat { display: flex; flex-direction: column; gap: 2px; padding: 8px 10px; border-radius: 8px; background: rgba(var(--overlay-rgb), 0.04); }

--- a/src/electron/renderer/usageCharts.js
+++ b/src/electron/renderer/usageCharts.js
@@ -337,11 +337,27 @@
     return { points: daily.slice(-7), metric: 'tokens', labelKey: 'date' }; // 'today' -> last 7 days
   }
 
-  function patchTodayBar(points, todayTotal) {
+  // History omits zero-usage days. Build the rolling preview from seven local
+  // calendar dates so sparse history cannot shift today's value onto an older
+  // row or make the empty days disappear from the chart.
+  const TREND_WINDOW_DAYS = 7;
+  function patchTodayBar(points, todayTotal, todayDate = localDayKey()) {
     if (!Array.isArray(points) || points.length === 0) return Array.isArray(points) ? points : [];
-    const copy = points.slice();
-    copy[copy.length - 1] = Object.assign({}, copy[copy.length - 1], { tokens: n(todayTotal) });
-    return copy;
+    const date = String(todayDate || localDayKey()).slice(0, 10);
+    const byDate = new Map();
+    for (const point of points) {
+      const key = String(point?.date || '').slice(0, 10);
+      if (/^\d{4}-\d{2}-\d{2}$/.test(key)) byDate.set(key, point);
+    }
+    const result = [];
+    for (let offset = -(TREND_WINDOW_DAYS - 1); offset <= 0; offset += 1) {
+      const key = addDaysUTC(date, offset);
+      const point = byDate.get(key);
+      result.push(point
+        ? Object.assign({}, point, { tokens: key === date ? n(todayTotal) : n(point.tokens) })
+        : { date: key, tokens: key === date ? n(todayTotal) : 0 });
+    }
+    return result;
   }
 
   const clientColors = {
@@ -399,13 +415,23 @@
   }
 
   function sparklineSvg(model, options) {
-    const o = Object.assign({ radius: 1, titles: null }, options || {});
+    const o = Object.assign({ radius: 1, titles: null, showZeroMarkers: false }, options || {});
     const titles = Array.isArray(o.titles) ? o.titles : null;
-    const rects = (model.bars || []).map((b, i) => {
-      const tip = titles && titles[i] ? `<title>${escapeXml(titles[i])}</title>` : '';
-      return `<rect x="${svgRound(b.x)}" y="${svgRound(b.y)}" width="${svgRound(b.width)}" height="${svgRound(Math.max(0, b.height))}" rx="${o.radius}" class="spark-bar${b.last ? ' spark-bar--last' : ''}">${tip}</rect>`;
+    const bars = Array.isArray(model?.bars) ? model.bars : [];
+    const titleOf = (index) => titles && titles[index] ? `<title>${escapeXml(titles[index])}</title>` : '';
+    const zeroMarkers = o.showZeroMarkers
+      ? bars.map((b, i) => {
+        if (b.value !== 0) return '';
+        const y = Math.max(0, model.height - 0.5);
+        return `<line x1="${svgRound(b.x)}" y1="${svgRound(y)}" x2="${svgRound(b.x + b.width)}" y2="${svgRound(y)}" class="spark-zero-marker${b.last ? ' spark-zero-marker--last' : ''}">${titleOf(i)}</line>`;
+      }).join('')
+      : '';
+    const rects = bars.map((b, i) => {
+      const tip = o.showZeroMarkers && b.value === 0 ? '' : titleOf(i);
+      const zeroClass = b.value === 0 ? ' spark-bar--zero' : '';
+      return `<rect x="${svgRound(b.x)}" y="${svgRound(b.y)}" width="${svgRound(b.width)}" height="${svgRound(Math.max(0, b.height))}" rx="${o.radius}" class="spark-bar${zeroClass}${b.last ? ' spark-bar--last' : ''}">${tip}</rect>`;
     }).join('');
-    return `<svg class="sparkline" viewBox="0 0 ${model.width} ${model.height}" preserveAspectRatio="none" width="100%" height="${model.height}" aria-hidden="true">${rects}</svg>`;
+    return `<svg class="sparkline" viewBox="0 0 ${model.width} ${model.height}" preserveAspectRatio="none" width="100%" height="${model.height}" aria-hidden="true">${zeroMarkers}${rects}</svg>`;
   }
 
   function areaLineSvg(model) {

--- a/src/electron/renderer/usageCharts.js
+++ b/src/electron/renderer/usageCharts.js
@@ -428,8 +428,7 @@
       : '';
     const rects = bars.map((b, i) => {
       const tip = o.showZeroMarkers && b.value === 0 ? '' : titleOf(i);
-      const zeroClass = b.value === 0 ? ' spark-bar--zero' : '';
-      return `<rect x="${svgRound(b.x)}" y="${svgRound(b.y)}" width="${svgRound(b.width)}" height="${svgRound(Math.max(0, b.height))}" rx="${o.radius}" class="spark-bar${zeroClass}${b.last ? ' spark-bar--last' : ''}">${tip}</rect>`;
+      return `<rect x="${svgRound(b.x)}" y="${svgRound(b.y)}" width="${svgRound(b.width)}" height="${svgRound(Math.max(0, b.height))}" rx="${o.radius}" class="spark-bar${b.last ? ' spark-bar--last' : ''}">${tip}</rect>`;
     }).join('');
     return `<svg class="sparkline" viewBox="0 0 ${model.width} ${model.height}" preserveAspectRatio="none" width="100%" height="${model.height}" aria-hidden="true">${zeroMarkers}${rects}</svg>`;
   }

--- a/src/electron/renderer/usageCharts.js
+++ b/src/electron/renderer/usageCharts.js
@@ -342,7 +342,9 @@
   // row or make the empty days disappear from the chart.
   const TREND_WINDOW_DAYS = 7;
   function patchTodayBar(points, todayTotal, todayDate = localDayKey()) {
-    if (!Array.isArray(points) || points.length === 0) return Array.isArray(points) ? points : [];
+    if (!Array.isArray(points)) return [];
+    const liveTotal = n(todayTotal);
+    if (points.length === 0 && liveTotal === 0) return [];
     const date = String(todayDate || localDayKey()).slice(0, 10);
     const byDate = new Map();
     for (const point of points) {
@@ -354,8 +356,8 @@
       const key = addDaysUTC(date, offset);
       const point = byDate.get(key);
       result.push(point
-        ? Object.assign({}, point, { tokens: key === date ? n(todayTotal) : n(point.tokens) })
-        : { date: key, tokens: key === date ? n(todayTotal) : 0 });
+        ? Object.assign({}, point, { tokens: key === date ? liveTotal : n(point.tokens) })
+        : { date: key, tokens: key === date ? liveTotal : 0 });
     }
     return result;
   }

--- a/tests/electron/usageCharts.test.js
+++ b/tests/electron/usageCharts.test.js
@@ -243,6 +243,16 @@ test('sparklinePreview builds scaled mini bars and flags the last one', () => {
   assert.equal(s.bars[2].last, true);
 });
 
+test('sparklinePreview keeps zero values at true zero height', () => {
+  const s = sparklinePreview([{ tokens: 0 }, { tokens: 10 }, { tokens: 0 }], {
+    width: 30, height: 10, gap: 0, metric: 'tokens'
+  });
+
+  assert.deepEqual(s.bars.map((bar) => [bar.value, bar.y, bar.height]), [
+    [0, 10, 0], [10, 0, 10], [0, 10, 0]
+  ]);
+});
+
 test('sparklinePreview tolerates empty input', () => {
   const s = sparklinePreview([], {});
   assert.deepEqual(s.bars, []);
@@ -325,12 +335,35 @@ test('selectPreviewSeries maps period to the right points', () => {
   assert.deepEqual(total.points.map((p) => p.month), ['2026-05', '2026-06']);
 });
 
-test('patchTodayBar overwrites the last point tokens with the live total', () => {
-  const points = [{ date: 'a', tokens: 1 }, { date: 'b', tokens: 2 }];
-  const out = patchTodayBar(points, 99);
-  assert.deepEqual(out[1], { date: 'b', tokens: 99 });
+test('patchTodayBar updates the local today row without mutating history', () => {
+  const points = [{ date: '2026-06-07', tokens: 1 }, { date: '2026-06-08', tokens: 2 }];
+  const out = patchTodayBar(points, 99, '2026-06-08');
+  assert.deepEqual(out.map((point) => point.date), [
+    '2026-06-02', '2026-06-03', '2026-06-04', '2026-06-05', '2026-06-06', '2026-06-07', '2026-06-08'
+  ]);
+  assert.deepEqual(out[6], { date: '2026-06-08', tokens: 99 });
   assert.equal(points[1].tokens, 2);          // original not mutated
   assert.deepEqual(patchTodayBar([], 99), []); // empty safe
+});
+
+test('patchTodayBar fills missing calendar days in a sparse history', () => {
+  const points = [{ date: '2026-08-01', tokens: 21000 }];
+  const out = patchTodayBar(points, 0, '2026-08-05');
+
+  assert.deepEqual(out.map((point) => point.date), [
+    '2026-07-30', '2026-07-31', '2026-08-01', '2026-08-02', '2026-08-03', '2026-08-04', '2026-08-05'
+  ]);
+  assert.deepEqual(out.map((point) => point.tokens), [0, 0, 21000, 0, 0, 0, 0]);
+  assert.deepEqual(points, [{ date: '2026-08-01', tokens: 21000 }]); // original not mutated
+});
+
+test('patchTodayBar keeps earlier values while replacing an existing today row', () => {
+  const points = [{ date: '2026-08-01', tokens: 21000 }, { date: '2026-08-05', tokens: 2 }];
+  const out = patchTodayBar(points, 0, '2026-08-05');
+
+  assert.equal(out.find((point) => point.date === '2026-08-05').tokens, 0);
+  assert.equal(out.find((point) => point.date === '2026-08-01').tokens, 21000);
+  assert.equal(points[1].tokens, 2);          // original not mutated
 });
 
 test('sparklineSvg renders one rect per bar and marks the last', () => {
@@ -341,6 +374,17 @@ test('sparklineSvg renders one rect per bar and marks the last', () => {
   assert.equal((svg.match(/<rect /g) || []).length, 2);
   assert.match(svg, /spark-bar--last/);
   assert.doesNotMatch(svg, /<title>/); // no titles unless provided
+});
+
+test('sparklineSvg can mark zero-value trend dates without changing bar height', () => {
+  const model = sparklinePreview([{ tokens: 0 }, { tokens: 2 }], {
+    width: 20, height: 10, gap: 0, metric: 'tokens'
+  });
+  const svg = sparklineSvg(model, { titles: ['zero', 'two'], showZeroMarkers: true });
+  assert.match(svg, /class="spark-zero-marker"/);
+  assert.match(svg, /<title>zero<\/title>/);
+  assert.match(svg, /class="spark-bar spark-bar--last"/);
+  assert.doesNotMatch(svg, /spark-zero-marker--last/);
 });
 
 test('sparklineSvg embeds per-bar hover titles when supplied and escapes them', () => {

--- a/tests/electron/usageCharts.test.js
+++ b/tests/electron/usageCharts.test.js
@@ -387,6 +387,17 @@ test('sparklineSvg can mark zero-value trend dates without changing bar height',
   assert.doesNotMatch(svg, /spark-zero-marker--last/);
 });
 
+test('sparklineSvg marks a trailing zero-value date as the last marker', () => {
+  const model = sparklinePreview([{ tokens: 2 }, { tokens: 0 }], {
+    width: 20, height: 10, gap: 0, metric: 'tokens'
+  });
+  const svg = sparklineSvg(model, { titles: ['two', 'zero'], showZeroMarkers: true });
+
+  assert.equal(model.bars[1].height, 0);
+  assert.match(svg, /class="spark-zero-marker spark-zero-marker--last"/);
+  assert.match(svg, /<title>zero<\/title>/);
+});
+
 test('sparklineSvg embeds per-bar hover titles when supplied and escapes them', () => {
   const model = sparklinePreview([{ tokens: 1 }, { tokens: 2 }], { width: 20, height: 10, gap: 0, metric: 'tokens' });
   const svg = sparklineSvg(model, { titles: ['6/7 · 1', 'a<b&c'] });

--- a/tests/electron/usageCharts.test.js
+++ b/tests/electron/usageCharts.test.js
@@ -343,7 +343,19 @@ test('patchTodayBar updates the local today row without mutating history', () =>
   ]);
   assert.deepEqual(out[6], { date: '2026-06-08', tokens: 99 });
   assert.equal(points[1].tokens, 2);          // original not mutated
-  assert.deepEqual(patchTodayBar([], 99), []); // empty safe
+});
+
+test('patchTodayBar builds a calendar window from empty history when live usage exists', () => {
+  const out = patchTodayBar([], 99, '2026-06-08');
+
+  assert.deepEqual(out.map((point) => point.date), [
+    '2026-06-02', '2026-06-03', '2026-06-04', '2026-06-05', '2026-06-06', '2026-06-07', '2026-06-08'
+  ]);
+  assert.deepEqual(out.map((point) => point.tokens), [0, 0, 0, 0, 0, 0, 99]);
+});
+
+test('patchTodayBar keeps empty state when history and live usage are both empty', () => {
+  assert.deepEqual(patchTodayBar([], 0, '2026-06-08'), []);
 });
 
 test('patchTodayBar fills missing calendar days in a sparse history', () => {


### PR DESCRIPTION
## Summary

- Build the DAY trends preview from the latest seven local calendar dates, including zero-usage days.
- Keep zero values at true zero height and show a subtle baseline marker only in DAY view.
- Preserve proportional rendering in MONTH and TOTAL views.

This PR fixes the confirmed trend-chart issue from #332 only. The separate Total Tokens discrepancy is not addressed by this PR and remains open for follow-up.

## Verification

- `node --test tests/electron/usageCharts.test.js tests/electron/rendererMotion.test.js` (44 passed)
- `npm run verify` (2377 passed, 1 skipped, 0 failed)

Refs #332
