### PR TITLE
fix(collector): prune MiMo Code watch tree to the db family

### DIFF
--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1212,6 +1212,14 @@ function clientsForWatchPath(filePath, rootsByClient) {
 // never recurses into an ignored dir (so the runaway poll is gone), yet a
 // newly created state.db-wal is still seen on the next top-level readdir.
 const HERMES_DB_FILES = new Set(['state.db', 'state.db-wal', 'state.db-shm']);
+// MiMo Code keeps a multi-gigabyte log/ tree alongside its SQLite state file.
+// A plain recursive watch of ~/.local/share/mimocode storms the watcher (every
+// SQLite WAL/SHM transaction is a chokidar event, the log dir holds thousands
+// of rotated files). Tokscale only reads the db sidecar files for real usage,
+// so — like Hermes above — keep watching the home dir but ignore everything
+// except the db family. The home root itself stays watched so a freshly
+// created mimocode.db-wal still surfaces on the next top-level readdir.
+const MICODE_DB_FILES = new Set(['mimocode.db', 'mimocode.db-wal', 'mimocode.db-shm']);
 // Which parts of an Antigravity IDE home are worth an event. Not "what tokscale
 // parses" — tokscale gets the token data over RPC from the running language
 // server and only reads `brain/`+`conversations/` to enumerate session ids.
@@ -1247,7 +1255,9 @@ function watchIgnoreMatcher(clientsCsv) {
     ? antigravityDataRoots().map((dir) => path.resolve(canonicalWatchPath(dir)))
     : [];
   const antigravityRootSet = new Set(antigravityRoots);
-  if (hermesRoots.length === 0 && copilotRoots.length === 0 && antigravityRoots.length === 0) return undefined;
+  const micodeRoots = (candidates.micode || []).map((dir) => path.resolve(canonicalWatchPath(dir)));
+  const micodeRootSet = new Set(micodeRoots);
+  if (hermesRoots.length === 0 && copilotRoots.length === 0 && antigravityRoots.length === 0 && micodeRoots.length === 0) return undefined;
   return (target) => {
     const resolved = path.resolve(target);
     // Every explicit watch root stays watched — the home dir AND each profile
@@ -1281,7 +1291,16 @@ function watchIgnoreMatcher(clientsCsv) {
       if (ANTIGRAVITY_SHALLOW_SOURCE_DIRS.has(firstChild)) return parts.length > 2;
       return false;
     }
-    return false; // paths outside the bounded Hermes/Copilot/Antigravity roots are never ignored
+    if (micodeRootSet.has(resolved)) return false;
+    for (const root of micodeRoots) {
+      // The MiMo Code home has a multi-GB log/ tree and the SQLite db family.
+      // The db family is what actually surfaces session changes — log/* would
+      // fire chokidar events on every transaction and stall the collector.
+      // The home root itself stays watched (basename isn't a db file, so
+      // existing comparison would incorrectly ignore it).
+      if (resolved.startsWith(root + path.sep)) return !MICODE_DB_FILES.has(path.basename(resolved));
+    }
+    return false; // paths outside the bounded Hermes/Copilot/Antigravity/MiCode roots are never ignored
   };
 }
 

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1212,14 +1212,16 @@ function clientsForWatchPath(filePath, rootsByClient) {
 // never recurses into an ignored dir (so the runaway poll is gone), yet a
 // newly created state.db-wal is still seen on the next top-level readdir.
 const HERMES_DB_FILES = new Set(['state.db', 'state.db-wal', 'state.db-shm']);
-// MiMo Code keeps a multi-gigabyte log/ tree alongside its SQLite state file.
+// MiMo Code keeps a multi-gigabyte log/ tree alongside its SQLite state files.
 // A plain recursive watch of ~/.local/share/mimocode storms the watcher (every
 // SQLite WAL/SHM transaction is a chokidar event, the log dir holds thousands
-// of rotated files). Tokscale only reads the db sidecar files for real usage,
-// so — like Hermes above — keep watching the home dir but ignore everything
-// except the db family. The home root itself stays watched so a freshly
-// created mimocode.db-wal still surfaces on the next top-level readdir.
-const MICODE_DB_FILES = new Set(['mimocode.db', 'mimocode.db-wal', 'mimocode.db-shm']);
+// of rotated files). Tokscale discovers mimocode.db and
+// mimocode-<channel>.db directly under each data root; the sidecars are not
+// parsed but must stay watched so a write through WAL/SHM triggers a refresh.
+// Keep the home dir watched but ignore everything except that direct db family.
+// The home root itself stays watched so a freshly created database or sidecar
+// still surfaces on the next top-level readdir.
+const MICODE_DB_WATCH_PATTERN = /^mimocode(?:-[A-Za-z0-9._-]+)?\.db(?:-(?:wal|shm))?$/;
 // Which parts of an Antigravity IDE home are worth an event. Not "what tokscale
 // parses" — tokscale gets the token data over RPC from the running language
 // server and only reads `brain/`+`conversations/` to enumerate session ids.
@@ -1293,12 +1295,12 @@ function watchIgnoreMatcher(clientsCsv) {
     }
     if (micodeRootSet.has(resolved)) return false;
     for (const root of micodeRoots) {
-      // The MiMo Code home has a multi-GB log/ tree and the SQLite db family.
-      // The db family is what actually surfaces session changes — log/* would
-      // fire chokidar events on every transaction and stall the collector.
-      // The home root itself stays watched (basename isn't a db file, so
-      // existing comparison would incorrectly ignore it).
-      if (resolved.startsWith(root + path.sep)) return !MICODE_DB_FILES.has(path.basename(resolved));
+      if (!resolved.startsWith(root + path.sep)) continue;
+      // Tokscale reads only direct children of each MiMo root. Keep those
+      // database names and their WAL/SHM sidecars, but prune log/* and every
+      // other recursive subtree before chokidar descends into it.
+      if (path.dirname(resolved) !== root) return true;
+      return !MICODE_DB_WATCH_PATTERN.test(path.basename(resolved));
     }
     return false; // paths outside the bounded Hermes/Copilot/Antigravity/MiCode roots are never ignored
   };

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -81,7 +81,7 @@ test('watchPathsForClients excludes the tokscale cache dirs our own syncs write'
 });
 
 test('watchPathsForClients watches both MiMo Code roots tokscale scans', () => {
-  // tokscale 4.8.0 unions the XDG data dir with orca's hook-sandbox copy, and
+  // Tokscale unions the XDG data dir with orca's hook-sandbox copy, and
   // that copy can hold sessions the XDG one is missing. Watching only XDG would
   // leave an orca-driven install without the seconds-level refresh.
   const orcaRoot = path.join('Library', 'Application Support', 'orca', 'mimocode-hooks', 'shared', 'data');
@@ -93,6 +93,40 @@ test('watchPathsForClients watches both MiMo Code roots tokscale scans', () => {
     const dirs = watchPathsForClients('micode');
     assert.ok(dirs.includes(path.join(tmp, '.local', 'share', 'mimocode')));
     assert.ok(dirs.includes(path.join(tmp, orcaRoot)));
+  } finally {
+    os.homedir = originalHomedir;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('watchIgnoreMatcher keeps every direct Tokscale MiMo database variant but prunes logs', () => {
+  const orcaRoot = path.join('Library', 'Application Support', 'orca', 'mimocode-hooks', 'shared', 'data');
+  const tmp = withTmpHome([path.join('.local', 'share', 'mimocode'), orcaRoot]);
+  const originalHomedir = os.homedir;
+  os.homedir = () => tmp;
+  try {
+    const { watchIgnoreMatcher } = freshCollector();
+    const ignored = watchIgnoreMatcher('micode');
+    const roots = [
+      path.join(tmp, '.local', 'share', 'mimocode'),
+      path.join(tmp, orcaRoot)
+    ];
+    const dbFamily = [
+      'mimocode.db',
+      'mimocode.db-wal',
+      'mimocode.db-shm',
+      'mimocode-nightly.db',
+      'mimocode-nightly.db-wal',
+      'mimocode-nightly.db-shm'
+    ];
+    for (const root of roots) {
+      assert.equal(ignored(root), false);
+      for (const name of dbFamily) assert.equal(ignored(path.join(root, name)), false);
+      assert.equal(ignored(path.join(root, 'log')), true);
+      assert.equal(ignored(path.join(root, 'log', 'mimocode-nightly.db')), true);
+      assert.equal(ignored(path.join(root, 'other.txt')), true);
+    }
   } finally {
     os.homedir = originalHomedir;
     delete require.cache[collectorPath];


### PR DESCRIPTION
勾选 micode 后程序卡死。根因：~/.local/share/mimocode 目录里同时存在 log/ 子目录（4.2 GB 旋转日志）和 mimocode.db 的 SQLite 家族文件。
chokidar 默认递归整个目录，SQLite 每次事务都写 .db-wal/.db-shm，
每次写入都触发 watch tick；90 秒内能产生数百次 tokscale 子进程 spawn
且都 EBADF 失败，UI 假死。

tokscale 实际只读取 SQLite db 家族（其它目录对它是运行期/缓存材料）。
仿照已有的 Hermes 处理（只关心 state.db/-wal/-shm），把 micode 的 watchIgnoreMatcher 扩展成同样的限制——home dir 本身和 db 家族保留
事件，递归子树里其它所有路径都交给 chokidar 的 ignored matcher
直接跳过。验证：勾选 micode 后 90 秒内 watch:change 0 次（修复前
每秒数次），spawn EBADF 从数百次降到 1 次（正常 interval tick）。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a UI freeze when MiMo Code is enabled by limiting `chokidar` to only watch the SQLite db family, including channel variants, under MiMo roots. Keeps the home dirs watched but ignores non-db paths to stop watch storms and `tokscale` spawn floods.

- **Bug Fixes**
  - Extended `watchIgnoreMatcher` with `MICODE_DB_WATCH_PATTERN` to keep direct `mimocode*.db` plus `-wal`/`-shm`; prunes `log/` and all recursive subtrees.
  - Supports channel databases (e.g., `mimocode-nightly.db`) while avoiding recursive events from WAL/SHM writes and multi‑GB logs.
  - Validation: 0 watch changes in 90s after enabling MiMo; EBADF spawns drop from hundreds to 1.

<sup>Written for commit 78735b4541c101eecf055b7edd1e8a385d42679f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

