### PR TITLE
fix(trends): preserve live totals across date rollover

### DIFF
--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -658,6 +658,7 @@ async function collectHistoryOnce(options) {
     try {
       const retainedGraph = retainDailyHistory(rawGraphs, {
         ...(options.dailyHistoryArchiveOptions || {}),
+        archive: options.dailyHistoryArchive,
         todayKey,
         capDays,
         writeEnabled: options.dailyHistoryArchiveWriteEnabled
@@ -728,6 +729,7 @@ async function collectUsageOnce(options) {
   let today = emptyPeriod();
   let month = emptyPeriod();
   let allTime = emptyPeriod();
+  let dailyHistoryArchive;
   let todayPartitions = null;
   const anchor = options.todayOnlyAnchor;
   const anchorUsed = Boolean(
@@ -907,7 +909,7 @@ async function collectUsageOnce(options) {
   // revealing a smaller graph-only observation from the previous day.
   if (options.historyEnabled !== false && options.dailyHistoryArchiveEnabled && !anchorUsed) {
     try {
-      retainLiveDailyHistory(today, {
+      dailyHistoryArchive = retainLiveDailyHistory(today, {
         ...(options.dailyHistoryArchiveOptions || {}),
         todayKey: localTodayKey(collectedAt),
         writeEnabled: options.dailyHistoryArchiveWriteEnabled
@@ -986,6 +988,7 @@ async function collectUsageOnce(options) {
       dailyHistoryArchiveEnabled: options.dailyHistoryArchiveEnabled,
       dailyHistoryArchiveWriteEnabled: options.dailyHistoryArchiveWriteEnabled,
       dailyHistoryArchiveOptions: options.dailyHistoryArchiveOptions,
+      dailyHistoryArchive,
       onHistoryStatus: options.onHistoryStatus,
       logger: options.logger
     });

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -658,7 +658,7 @@ async function collectHistoryOnce(options) {
     try {
       const retainedGraph = retainDailyHistory(rawGraphs, {
         ...(options.dailyHistoryArchiveOptions || {}),
-        archive: options.dailyHistoryArchive,
+        liveDays: options.dailyHistoryLiveDays,
         todayKey,
         capDays,
         writeEnabled: options.dailyHistoryArchiveWriteEnabled
@@ -729,7 +729,7 @@ async function collectUsageOnce(options) {
   let today = emptyPeriod();
   let month = emptyPeriod();
   let allTime = emptyPeriod();
-  let dailyHistoryArchive;
+  let dailyHistoryLiveDays = options.dailyHistoryLiveDays;
   let todayPartitions = null;
   const anchor = options.todayOnlyAnchor;
   const anchorUsed = Boolean(
@@ -904,16 +904,22 @@ async function collectUsageOnce(options) {
   allTime = mergePeriods(windowsPeriods.allTime, wslBundle.allTime);
 
   // The renderer intentionally uses the live today period while a day is in
-  // progress. Persist the largest complete live snapshot on full ticks so the
-  // following day's graph/history refresh can hand that value over instead of
-  // revealing a smaller graph-only observation from the previous day.
-  if (options.historyEnabled !== false && options.dailyHistoryArchiveEnabled && !anchorUsed) {
+  // progress. Callers that do not defer capture persist the largest complete
+  // live snapshot here; startCollector defers it until after transformUsage so
+  // the saved value matches the period delivered to the renderer.
+  if (
+    options.historyEnabled !== false
+    && options.dailyHistoryArchiveEnabled
+    && options.deferLiveHistoryCapture !== true
+  ) {
     try {
-      dailyHistoryArchive = retainLiveDailyHistory(today, {
+      const retainedLive = retainLiveDailyHistory(today, {
         ...(options.dailyHistoryArchiveOptions || {}),
+        liveDays: dailyHistoryLiveDays,
         todayKey: localTodayKey(collectedAt),
         writeEnabled: options.dailyHistoryArchiveWriteEnabled
       });
+      dailyHistoryLiveDays = retainedLive.liveDays || {};
     } catch (error) {
       if (typeof options.logger === 'function') options.logger(`daily live history archive failed: ${error.message}`);
     }
@@ -988,7 +994,7 @@ async function collectUsageOnce(options) {
       dailyHistoryArchiveEnabled: options.dailyHistoryArchiveEnabled,
       dailyHistoryArchiveWriteEnabled: options.dailyHistoryArchiveWriteEnabled,
       dailyHistoryArchiveOptions: options.dailyHistoryArchiveOptions,
-      dailyHistoryArchive,
+      dailyHistoryLiveDays,
       onHistoryStatus: options.onHistoryStatus,
       logger: options.logger
     });
@@ -1762,6 +1768,10 @@ function startCollector(options) {
   // rather than kept as a second copy, so the two cannot drift; a restart simply
   // relearns them from the first tick, which always includes history.
   let activityDaysAnchor = {};
+  // Keep the highest complete live day in this collector even when another
+  // process owns the shared archive. A watch tick can then hand its value to a
+  // later full/history tick instead of losing it at the tick boundary.
+  let liveDailyHistoryDays = {};
   let lastFullScanAt = 0;
   let pendingWaiters = [];
   let debounceTimer = null;
@@ -1918,6 +1928,11 @@ function startCollector(options) {
         agentRuntime,
         osInfo: deviceOsInfo,
         includeHistory,
+        // Capture after the runtime's transformUsage hook so the archive uses
+        // the same today period that the user actually sees. The process-local
+        // liveDays overlay is passed into any graph scan that happens first.
+        deferLiveHistoryCapture: true,
+        dailyHistoryLiveDays: liveDailyHistoryDays,
         onHistoryStatus: includeHistory ? (status) => {
           lastHistoryAttemptAt = Date.parse(status.attemptedAt) || lastHistoryAttemptAt;
           const successAt = Date.parse(status.successAt);
@@ -2021,7 +2036,35 @@ function startCollector(options) {
           wslStatusAnchor = captured.wslStatus || null;
         }
       }
-      await onUpdate?.(summary, reason);
+      const transformedSummary = await onUpdate?.(summary, reason);
+      const visibleSummary = transformedSummary && typeof transformedSummary === 'object'
+        ? transformedSummary
+        : summary;
+      if (historyEnabled !== false && options.dailyHistoryArchiveEnabled) {
+        try {
+          const visibleAt = visibleSummary.updatedAt || summary.updatedAt;
+          const visibleDate = visibleAt ? new Date(visibleAt) : new Date();
+          const visibleDateKey = Number.isFinite(visibleDate.getTime())
+            ? localTodayKey(visibleDate)
+            : todayKey;
+          const retainedLive = retainLiveDailyHistory(visibleSummary.today, {
+            ...(options.dailyHistoryArchiveOptions || {}),
+            liveDays: liveDailyHistoryDays,
+            todayKey: visibleDateKey,
+            // Watch ticks update the in-memory maximum on every refresh, but
+            // only full/history ticks write it. This avoids a disk write for
+            // every few-second watch event without dropping the value before
+            // the next tick or local-day rollover.
+            writeEnabled: !anchored || includeHistory
+              || anchor?.dateKey !== visibleDateKey
+              ? options.dailyHistoryArchiveWriteEnabled
+              : false
+          });
+          liveDailyHistoryDays = retainedLive.liveDays || {};
+        } catch (error) {
+          log(`daily live history archive failed: ${error.message}`);
+        }
+      }
       const tickFinishedAt = Date.now();
       lastTickSuccessAt = tickFinishedAt;
       lastTickDurationMs = Math.max(0, tickFinishedAt - tickStartedAt);

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -28,7 +28,7 @@ const {
 const { collectWslUsage: collectWslUsageImpl, emptyWslBundle, probeWslState: probeWslStateImpl } = require('./wslUsage');
 const { hermesProfileWatchDirs, resolveHermesHome } = require('./hermesProfiles');
 const { mergeHistories, parseGraphResult, normalizeHistory } = require('./history');
-const { retainDailyHistory } = require('./dailyHistoryArchive');
+const { retainDailyHistory, retainLiveDailyHistory } = require('./dailyHistoryArchive');
 const cursorAuth = require('./cursorAuth');
 const { findSessionFiles, codexSessionFile } = require('./sessionFiles');
 const opencodeSession = require('./opencodeSession');
@@ -900,6 +900,22 @@ async function collectUsageOnce(options) {
   today = mergePeriods(windowsPeriods.today, wslBundle.today);
   month = mergePeriods(windowsPeriods.month, wslBundle.month);
   allTime = mergePeriods(windowsPeriods.allTime, wslBundle.allTime);
+
+  // The renderer intentionally uses the live today period while a day is in
+  // progress. Persist the largest complete live snapshot on full ticks so the
+  // following day's graph/history refresh can hand that value over instead of
+  // revealing a smaller graph-only observation from the previous day.
+  if (options.historyEnabled !== false && options.dailyHistoryArchiveEnabled && !anchorUsed) {
+    try {
+      retainLiveDailyHistory(today, {
+        ...(options.dailyHistoryArchiveOptions || {}),
+        todayKey: localTodayKey(collectedAt),
+        writeEnabled: options.dailyHistoryArchiveWriteEnabled
+      });
+    } catch (error) {
+      if (typeof options.logger === 'function') options.logger(`daily live history archive failed: ${error.message}`);
+    }
+  }
 
   // WSL attribution (Windows only; null elsewhere). detected = markers found,
   // withData = clients whose WSL scan or local parser returned tokens. The gap

--- a/src/shared/dailyHistoryArchive.js
+++ b/src/shared/dailyHistoryArchive.js
@@ -160,7 +160,24 @@ function captureDailyHistoryArchive(existingArchive, graphs, options = {}) {
 
 function periodLiveDay(period, date) {
   if (!period || typeof period !== 'object' || !DAY_KEY_RE.test(date)) return null;
-  const observations = [];
+  const observations = new Map();
+  const addObservation = (client, modelId, tokens, cost) => {
+    const observation = {
+      client,
+      modelId,
+      tokens: Math.max(0, Math.round(num(tokens))),
+      cost: Math.max(0, num(cost)),
+      messages: 0
+    };
+    const key = observationKey(observation);
+    const previous = observations.get(key);
+    if (!previous) {
+      observations.set(key, observation);
+      return;
+    }
+    previous.tokens += observation.tokens;
+    previous.cost += observation.cost;
+  };
   const clientModels = period.clientModels && typeof period.clientModels === 'object'
     ? period.clientModels
     : {};
@@ -176,42 +193,39 @@ function periodLiveDay(period, date) {
       ? clientModels[client]
       : {};
     const modelIds = Object.keys(models);
-    if (modelIds.length > 0) {
-      for (const modelId of modelIds) {
-        observations.push({
-          client,
-          modelId,
-          tokens: models[modelId],
-          cost: clientModelCosts[client]?.[modelId] || 0,
-          messages: 0
-        });
-      }
-      continue;
+    let modeledTokens = 0;
+    let modeledCost = 0;
+    for (const modelId of modelIds) {
+      const modelTokens = Math.max(0, Math.round(num(models[modelId])));
+      const modelCost = Math.max(0, num(clientModelCosts[client]?.[modelId]));
+      addObservation(client, modelId, modelTokens, modelCost);
+      modeledTokens += modelTokens;
+      modeledCost += modelCost;
     }
-    observations.push({
-      client,
-      modelId: 'unknown',
-      tokens: clients[client] || 0,
-      cost: clientCosts[client] || 0,
-      messages: 0
-    });
+    const clientTokens = Math.max(0, Math.round(num(clients[client])));
+    const clientCost = Math.max(0, num(clientCosts[client]));
+    const remainderTokens = Math.max(0, clientTokens - modeledTokens);
+    const remainderCost = Math.max(0, clientCost - modeledCost);
+    if (modelIds.length === 0 || remainderTokens > 0 || remainderCost > 0) {
+      addObservation(client, 'unknown', remainderTokens, remainderCost);
+    }
   }
 
   const totalTokens = Math.max(0, Math.round(num(period.totalTokens)));
   const totalCost = Math.max(0, num(period.costUsd));
-  const observedTokens = observations.reduce((sum, observation) => sum + Math.max(0, Math.round(num(observation.tokens))), 0);
-  const observedCost = observations.reduce((sum, observation) => sum + Math.max(0, num(observation.cost)), 0);
+  const observed = [...observations.values()];
+  const observedTokens = observed.reduce((sum, observation) => sum + observation.tokens, 0);
+  const observedCost = observed.reduce((sum, observation) => sum + observation.cost, 0);
   if (totalTokens > observedTokens || totalCost > observedCost) {
-    observations.push({
-      client: 'unknown',
-      modelId: 'unknown',
-      tokens: Math.max(0, totalTokens - observedTokens),
-      cost: Math.max(0, totalCost - observedCost),
-      messages: 0
-    });
+    addObservation(
+      'unknown',
+      'unknown',
+      Math.max(0, totalTokens - observedTokens),
+      Math.max(0, totalCost - observedCost)
+    );
   }
 
-  const day = normalizeDay({ date, activeTimeMs: 0, observations }, date);
+  const day = normalizeDay({ date, activeTimeMs: 0, observations: [...observations.values()] }, date);
   return day && Object.keys(day.observations).length > 0 ? day : null;
 }
 
@@ -352,7 +366,9 @@ function clearDailyHistoryArchive(options = {}) {
 }
 
 function retainDailyHistory(graphs, options = {}) {
-  const previous = readDailyHistoryArchive(options);
+  const previous = options.archive === undefined
+    ? readDailyHistoryArchive(options)
+    : normalizeDailyHistoryArchive(options.archive);
   const next = captureDailyHistoryArchive(previous, graphs, options);
   // Ownership can change while a graph scan is running (for example, a
   // headless agent starts after Electron's collector tick begins). Resolve a

--- a/src/shared/dailyHistoryArchive.js
+++ b/src/shared/dailyHistoryArchive.js
@@ -65,6 +65,13 @@ function normalizeDailyHistoryArchive(value) {
     const day = normalizeDay(rawDay, date);
     if (day) normalized.days[day.date] = day;
   }
+  const liveSource = value?.liveDays && typeof value.liveDays === 'object' ? value.liveDays : {};
+  const liveDays = {};
+  for (const [date, rawDay] of Object.entries(liveSource)) {
+    const day = normalizeDay(rawDay, date);
+    if (day) liveDays[day.date] = day;
+  }
+  if (Object.keys(liveDays).length > 0) normalized.liveDays = liveDays;
   return normalized;
 }
 
@@ -151,6 +158,115 @@ function captureDailyHistoryArchive(existingArchive, graphs, options = {}) {
   return archive;
 }
 
+function periodLiveDay(period, date) {
+  if (!period || typeof period !== 'object' || !DAY_KEY_RE.test(date)) return null;
+  const observations = [];
+  const clientModels = period.clientModels && typeof period.clientModels === 'object'
+    ? period.clientModels
+    : {};
+  const clientModelCosts = period.clientModelCosts && typeof period.clientModelCosts === 'object'
+    ? period.clientModelCosts
+    : {};
+  const clients = period.clients && typeof period.clients === 'object' ? period.clients : {};
+  const clientCosts = period.clientCosts && typeof period.clientCosts === 'object' ? period.clientCosts : {};
+  const clientIds = new Set([...Object.keys(clientModels), ...Object.keys(clients), ...Object.keys(clientCosts)]);
+
+  for (const client of clientIds) {
+    const models = clientModels[client] && typeof clientModels[client] === 'object'
+      ? clientModels[client]
+      : {};
+    const modelIds = Object.keys(models);
+    if (modelIds.length > 0) {
+      for (const modelId of modelIds) {
+        observations.push({
+          client,
+          modelId,
+          tokens: models[modelId],
+          cost: clientModelCosts[client]?.[modelId] || 0,
+          messages: 0
+        });
+      }
+      continue;
+    }
+    observations.push({
+      client,
+      modelId: 'unknown',
+      tokens: clients[client] || 0,
+      cost: clientCosts[client] || 0,
+      messages: 0
+    });
+  }
+
+  const totalTokens = Math.max(0, Math.round(num(period.totalTokens)));
+  const totalCost = Math.max(0, num(period.costUsd));
+  const observedTokens = observations.reduce((sum, observation) => sum + Math.max(0, Math.round(num(observation.tokens))), 0);
+  const observedCost = observations.reduce((sum, observation) => sum + Math.max(0, num(observation.cost)), 0);
+  if (totalTokens > observedTokens || totalCost > observedCost) {
+    observations.push({
+      client: 'unknown',
+      modelId: 'unknown',
+      tokens: Math.max(0, totalTokens - observedTokens),
+      cost: Math.max(0, totalCost - observedCost),
+      messages: 0
+    });
+  }
+
+  const day = normalizeDay({ date, activeTimeMs: 0, observations }, date);
+  return day && Object.keys(day.observations).length > 0 ? day : null;
+}
+
+function dayTokens(day) {
+  return Object.values(day?.observations || {}).reduce((sum, observation) => sum + num(observation.tokens), 0);
+}
+
+function dayCost(day) {
+  return Object.values(day?.observations || {}).reduce((sum, observation) => sum + num(observation.cost), 0);
+}
+
+function liveDayIsGreater(incoming, previous) {
+  const incomingTokens = dayTokens(incoming);
+  const previousTokens = dayTokens(previous);
+  if (incomingTokens !== previousTokens) return incomingTokens > previousTokens;
+  return dayCost(incoming) > dayCost(previous);
+}
+
+function mergeLiveDayMetadata(liveDay, previousDay) {
+  if (!previousDay) return liveDay;
+  const observations = Object.fromEntries(Object.entries(liveDay.observations).map(([key, observation]) => {
+    const previous = previousDay.observations[key];
+    if (!previous) return [key, observation];
+    return [key, {
+      ...observation,
+      messages: Math.max(observation.messages, previous.messages),
+      ...(Math.max(num(observation.reasoningTokens), num(previous.reasoningTokens)) > 0
+        ? { reasoningTokens: Math.max(num(observation.reasoningTokens), num(previous.reasoningTokens)) }
+        : {})
+    }];
+  }));
+  return {
+    ...liveDay,
+    activeTimeMs: Math.max(liveDay.activeTimeMs, previousDay.activeTimeMs),
+    observations
+  };
+}
+
+function captureLiveDailyHistory(existingArchive, period, options = {}) {
+  const archive = normalizeDailyHistoryArchive(existingArchive);
+  const date = String(options.todayKey || '').slice(0, 10);
+  const incoming = periodLiveDay(period, date);
+  if (!incoming) return archive;
+  const previous = archive.liveDays?.[date];
+  if (!previous || liveDayIsGreater(incoming, previous)) {
+    archive.liveDays = { ...(archive.liveDays || {}), [date]: incoming };
+  }
+  if (DAY_KEY_RE.test(date) && archive.liveDays) {
+    for (const liveDate of Object.keys(archive.liveDays)) {
+      if (liveDate > date) delete archive.liveDays[liveDate];
+    }
+  }
+  return archive;
+}
+
 function graphTimeMetrics(graphs, activeTimeMs) {
   const source = graphsArray(graphs)
     .map((graph) => graph.timeMetrics ?? graph.time_metrics)
@@ -174,6 +290,13 @@ function graphFromDailyHistoryArchive(graphs, archive, options = {}) {
   for (const [date, day] of Object.entries(normalizedArchive.days)) {
     if (hasTodayKey && date > todayKey) continue;
     currentDays.set(date, day);
+  }
+  for (const [date, liveDay] of Object.entries(normalizedArchive.liveDays || {})) {
+    if (hasTodayKey && date > todayKey) continue;
+    const previous = currentDays.get(date);
+    if (!previous || liveDayIsGreater(liveDay, previous)) {
+      currentDays.set(date, mergeLiveDayMetadata(liveDay, previous));
+    }
   }
 
   const contributions = [...currentDays.values()]
@@ -243,15 +366,29 @@ function retainDailyHistory(graphs, options = {}) {
   return graphFromDailyHistoryArchive(graphs, next, options);
 }
 
+function retainLiveDailyHistory(period, options = {}) {
+  const previous = readDailyHistoryArchive(options);
+  const next = captureLiveDailyHistory(previous, period, options);
+  const writeEnabled = typeof options.writeEnabled === 'function'
+    ? options.writeEnabled() !== false
+    : options.writeEnabled !== false;
+  if (writeEnabled && !isDeepStrictEqual(previous, next)) {
+    writeDailyHistoryArchive(next, options);
+  }
+  return next;
+}
+
 module.exports = {
   captureDailyHistoryArchive,
   clearDailyHistoryArchive,
   dailyHistoryArchivePath,
   graphFromDailyHistoryArchive,
+  captureLiveDailyHistory,
   normalizeDailyHistoryArchive,
   observationKey,
   readDailyHistoryArchive,
   retainDailyHistory,
+  retainLiveDailyHistory,
   shouldReplaceObservation,
   writeDailyHistoryArchive
 };

--- a/src/shared/dailyHistoryArchive.js
+++ b/src/shared/dailyHistoryArchive.js
@@ -267,16 +267,16 @@ function mergeLiveDayMetadata(liveDay, previousDay) {
 function captureLiveDailyHistory(existingArchive, period, options = {}) {
   const archive = normalizeDailyHistoryArchive(existingArchive);
   const date = String(options.todayKey || '').slice(0, 10);
+  if (DAY_KEY_RE.test(date) && archive.liveDays) {
+    for (const liveDate of Object.keys(archive.liveDays)) {
+      if (liveDate > date) delete archive.liveDays[liveDate];
+    }
+  }
   const incoming = periodLiveDay(period, date);
   if (!incoming) return archive;
   const previous = archive.liveDays?.[date];
   if (!previous || liveDayIsGreater(incoming, previous)) {
     archive.liveDays = { ...(archive.liveDays || {}), [date]: incoming };
-  }
-  if (DAY_KEY_RE.test(date) && archive.liveDays) {
-    for (const liveDate of Object.keys(archive.liveDays)) {
-      if (liveDate > date) delete archive.liveDays[liveDate];
-    }
   }
   return archive;
 }
@@ -365,31 +365,62 @@ function clearDailyHistoryArchive(options = {}) {
   }
 }
 
+function mergeLiveDaysIntoArchive(existingArchive, liveDays) {
+  const archive = normalizeDailyHistoryArchive(existingArchive);
+  const incoming = normalizeDailyHistoryArchive({ liveDays }).liveDays || {};
+  for (const [date, liveDay] of Object.entries(incoming)) {
+    const previous = archive.liveDays?.[date];
+    if (!previous || liveDayIsGreater(liveDay, previous)) {
+      archive.liveDays = { ...(archive.liveDays || {}), [date]: liveDay };
+    }
+  }
+  return archive;
+}
+
+function archiveWriteEnabled(options = {}) {
+  return typeof options.writeEnabled === 'function'
+    ? options.writeEnabled() !== false
+    : options.writeEnabled !== false;
+}
+
 function retainDailyHistory(graphs, options = {}) {
-  const previous = options.archive === undefined
-    ? readDailyHistoryArchive(options)
-    : normalizeDailyHistoryArchive(options.archive);
-  const next = captureDailyHistoryArchive(previous, graphs, options);
+  const previous = readDailyHistoryArchive(options);
+  const capture = (archive) => captureDailyHistoryArchive(
+    mergeLiveDaysIntoArchive(archive, options.liveDays),
+    graphs,
+    options
+  );
+  let next = capture(previous);
   // Ownership can change while a graph scan is running (for example, a
   // headless agent starts after Electron's collector tick begins). Resolve a
   // lazy guard immediately before the write instead of freezing it at startup.
-  const writeEnabled = typeof options.writeEnabled === 'function'
-    ? options.writeEnabled() !== false
-    : options.writeEnabled !== false;
-  if (writeEnabled && !isDeepStrictEqual(previous, next)) {
-    writeDailyHistoryArchive(next, options);
+  if (archiveWriteEnabled(options) && !isDeepStrictEqual(previous, next)) {
+    // The graph scan can take long enough for the other collector to update the
+    // shared archive. Rebase on the latest file immediately before writing so
+    // this scan cannot put that newer observation back on disk.
+    const latest = readDailyHistoryArchive(options);
+    next = capture(latest);
+    if (archiveWriteEnabled(options) && !isDeepStrictEqual(latest, next)) {
+      writeDailyHistoryArchive(next, options);
+    }
   }
   return graphFromDailyHistoryArchive(graphs, next, options);
 }
 
 function retainLiveDailyHistory(period, options = {}) {
   const previous = readDailyHistoryArchive(options);
-  const next = captureLiveDailyHistory(previous, period, options);
-  const writeEnabled = typeof options.writeEnabled === 'function'
-    ? options.writeEnabled() !== false
-    : options.writeEnabled !== false;
-  if (writeEnabled && !isDeepStrictEqual(previous, next)) {
-    writeDailyHistoryArchive(next, options);
+  const capture = (archive) => captureLiveDailyHistory(
+    mergeLiveDaysIntoArchive(archive, options.liveDays),
+    period,
+    options
+  );
+  let next = capture(previous);
+  if (archiveWriteEnabled(options) && !isDeepStrictEqual(previous, next)) {
+    const latest = readDailyHistoryArchive(options);
+    next = capture(latest);
+    if (archiveWriteEnabled(options) && !isDeepStrictEqual(latest, next)) {
+      writeDailyHistoryArchive(next, options);
+    }
   }
   return next;
 }

--- a/src/shared/deviceRuntime.js
+++ b/src/shared/deviceRuntime.js
@@ -60,6 +60,7 @@ function createDeviceRuntime(options = {}, deps = {}) {
         ? options.transformUsage(summary, reason, { preview: false })
         : summary;
       deviceState.updateUsage(transformed, reason, { epoch, preview: false });
+      return transformed;
     },
     onDiagnosticEvent(event) {
       if (!active) return;

--- a/tests/electron/usageCharts.test.js
+++ b/tests/electron/usageCharts.test.js
@@ -378,6 +378,25 @@ test('patchTodayBar keeps earlier values while replacing an existing today row',
   assert.equal(points[1].tokens, 2);          // original not mutated
 });
 
+test('cross-day live bar keeps the current date and hover title on the same slot', () => {
+  const points = patchTodayBar([
+    { date: '2026-08-04', tokens: 500 },
+    { date: '2026-08-05', tokens: 507_800_000 }
+  ], 11_751_310, '2026-08-06');
+  const model = sparklinePreview(points, { width: 300, height: 120, gap: 0.3, metric: 'tokens' });
+  const titles = points.map((point) => `${point.date} · ${point.tokens}`);
+  const svg = sparklineSvg(model, { titles });
+
+  assert.deepEqual(points.slice(-2), [
+    { date: '2026-08-05', tokens: 507_800_000 },
+    { date: '2026-08-06', tokens: 11_751_310 }
+  ]);
+  assert.deepEqual([...svg.matchAll(/<title>([^<]+)/g)].map((match) => match[1]).slice(-2), [
+    '2026-08-05 · 507800000',
+    '2026-08-06 · 11751310'
+  ]);
+});
+
 test('sparklineSvg renders one rect per bar and marks the last', () => {
   const model = sparklinePreview([{ tokens: 1 }, { tokens: 2 }], { width: 20, height: 10, gap: 0, metric: 'tokens' });
   const svg = sparklineSvg(model);

--- a/tests/shared/collectorHistory.test.js
+++ b/tests/shared/collectorHistory.test.js
@@ -244,6 +244,60 @@ test('collectUsageOnce uses the live history snapshot while archive ownership is
   assert.equal(fs.existsSync(archivePath), false);
 });
 
+test('startCollector retains a transformed watch total until the next history tick', async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-monitor-live-history-ticks-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const archivePath = path.join(dir, 'daily-history.json');
+  const todayKey = localTodayKey();
+  const updates = [];
+  const runtime = startCollector({
+    clients: 'claude',
+    allTimeSince: '2026-01-01',
+    deviceId: 'live-history-ticks',
+    intervalMs: 60 * 60 * 1000,
+    historyIntervalMs: 15 * 60 * 1000,
+    watchEnabled: false,
+    watchTriggersCollection: false,
+    historyEnabled: true,
+    dailyHistoryArchiveEnabled: true,
+    dailyHistoryArchiveWriteEnabled: true,
+    dailyHistoryArchiveOptions: { path: archivePath },
+    projectsEnabled: false,
+    limitsEnabled: false,
+    wslScanEnabled: false,
+    anchorPersistenceEnabled: false,
+    runTokscale: async () => usageSnapshot(100),
+    runGraph: async () => ({ contributions: [{ date: todayKey, clients: [
+      { client: 'claude', modelId: 'opus', tokens: { input: 90 }, cost: 0, messages: 1 }
+    ] }] }),
+    onUpdate: (summary, reason) => {
+      const visibleTotal = reason === 'watch' ? 300 : 200;
+      const visible = {
+        ...summary,
+        today: { ...summary.today, totalTokens: visibleTotal }
+      };
+      updates.push({ reason, summary: visible });
+      return visible;
+    }
+  });
+
+  try {
+    await waitForCondition(() => updates.length >= 1);
+    await runtime.tick('watch', { todayOnly: true });
+    await runtime.tick('manual', { forceHistory: true });
+
+    const latest = updates.at(-1).summary;
+    assert.equal(latest.history.daily.find((day) => day.date === todayKey).tokens, 300);
+    const stored = JSON.parse(fs.readFileSync(archivePath, 'utf8'));
+    assert.equal(
+      Object.values(stored.liveDays[todayKey].observations).reduce((sum, item) => sum + item.tokens, 0),
+      300
+    );
+  } finally {
+    runtime.stop();
+  }
+});
+
 test('collectHistoryOnce falls back to the current graph when archive persistence fails', async () => {
   const messages = [];
   const history = await collectHistoryOnce({

--- a/tests/shared/collectorHistory.test.js
+++ b/tests/shared/collectorHistory.test.js
@@ -39,6 +39,18 @@ const SAMPLE_GRAPH = {
   ]
 };
 
+function usageSnapshot(totalTokens) {
+  return {
+    entries: [{
+      client: 'claude',
+      modelId: 'opus',
+      input: totalTokens,
+      cost: 0,
+      messages: 1
+    }]
+  };
+}
+
 test('collectHistoryOnce normalizes injected graph JSON into a History', async () => {
   const statuses = [];
   const history = await collectHistoryOnce({
@@ -166,6 +178,43 @@ test('collectHistoryOnce stores older days locally while capping daily output', 
   assert.deepEqual(history.daily.map((day) => day.date), ['2026-07-17']);
   assert.deepEqual(history.monthly.map((month) => month.month), ['2025-06', '2026-07']);
   assert.equal(history.summary.totalTokens, 125);
+});
+
+test('collectUsageOnce hands the live day total to history across local rollover', async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-monitor-live-history-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const archivePath = path.join(dir, 'daily-history.json');
+  const common = {
+    clients: 'claude',
+    allTimeSince: '2026-01-01',
+    deviceId: 'live-handoff',
+    includeHistory: true,
+    historyEnabled: true,
+    dailyHistoryArchiveEnabled: true,
+    dailyHistoryArchiveWriteEnabled: true,
+    dailyHistoryArchiveOptions: { path: archivePath },
+    projectsEnabled: false,
+    limitsEnabled: false,
+    wslScanEnabled: false,
+    runGraph: async () => ({ contributions: [{ date: '2026-08-05', clients: [
+      { client: 'claude', modelId: 'opus', tokens: { input: 507_800_000 }, cost: 0, messages: 1 }
+    ] }] })
+  };
+  const collect = (now, todayTotal) => collectUsageOnce({
+    ...common,
+    now,
+    runTokscale: async () => usageSnapshot(todayTotal)
+  });
+
+  const beforeRollover = await collect('2026-08-05T23:55:00+08:00', 645_957_554);
+  assert.equal(beforeRollover.today.totalTokens, 645_957_554);
+  assert.equal(beforeRollover.history.daily[0].tokens, 645_957_554);
+
+  const afterRollover = await collect('2026-08-06T00:05:00+08:00', 11_751_310);
+  const previousDay = afterRollover.history.daily.find((day) => day.date === '2026-08-05');
+  const currentDay = afterRollover.history.daily.find((day) => day.date === '2026-08-06');
+  assert.equal(previousDay.tokens, 645_957_554);
+  assert.equal(currentDay.tokens, 11_751_310);
 });
 
 test('collectHistoryOnce falls back to the current graph when archive persistence fails', async () => {

--- a/tests/shared/collectorHistory.test.js
+++ b/tests/shared/collectorHistory.test.js
@@ -206,15 +206,42 @@ test('collectUsageOnce hands the live day total to history across local rollover
     runTokscale: async () => usageSnapshot(todayTotal)
   });
 
-  const beforeRollover = await collect('2026-08-05T23:55:00+08:00', 645_957_554);
+  const beforeRollover = await collect(new Date(2026, 7, 5, 23, 55), 645_957_554);
   assert.equal(beforeRollover.today.totalTokens, 645_957_554);
   assert.equal(beforeRollover.history.daily[0].tokens, 645_957_554);
 
-  const afterRollover = await collect('2026-08-06T00:05:00+08:00', 11_751_310);
+  const afterRollover = await collect(new Date(2026, 7, 6, 0, 5), 11_751_310);
   const previousDay = afterRollover.history.daily.find((day) => day.date === '2026-08-05');
   const currentDay = afterRollover.history.daily.find((day) => day.date === '2026-08-06');
   assert.equal(previousDay.tokens, 645_957_554);
   assert.equal(currentDay.tokens, 11_751_310);
+});
+
+test('collectUsageOnce uses the live history snapshot while archive ownership is read-only', async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-monitor-read-only-live-history-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const archivePath = path.join(dir, 'daily-history.json');
+  const result = await collectUsageOnce({
+    clients: 'claude',
+    allTimeSince: '2026-01-01',
+    deviceId: 'read-only-live-history',
+    now: new Date(2026, 7, 5, 12),
+    includeHistory: true,
+    historyEnabled: true,
+    dailyHistoryArchiveEnabled: true,
+    dailyHistoryArchiveWriteEnabled: false,
+    dailyHistoryArchiveOptions: { path: archivePath },
+    projectsEnabled: false,
+    limitsEnabled: false,
+    wslScanEnabled: false,
+    runTokscale: async () => usageSnapshot(645_957_554),
+    runGraph: async () => ({ contributions: [{ date: '2026-08-05', clients: [
+      { client: 'claude', modelId: 'opus', tokens: { input: 507_800_000 }, cost: 0, messages: 1 }
+    ] }] })
+  });
+
+  assert.equal(result.history.daily[0].tokens, 645_957_554);
+  assert.equal(fs.existsSync(archivePath), false);
 });
 
 test('collectHistoryOnce falls back to the current graph when archive persistence fails', async () => {

--- a/tests/shared/dailyHistoryArchive.test.js
+++ b/tests/shared/dailyHistoryArchive.test.js
@@ -5,10 +5,12 @@ const test = require('node:test');
 
 const {
   captureDailyHistoryArchive,
+  captureLiveDailyHistory,
   clearDailyHistoryArchive,
   graphFromDailyHistoryArchive,
   normalizeDailyHistoryArchive,
-  retainDailyHistory
+  retainDailyHistory,
+  retainLiveDailyHistory
 } = require('../../src/shared/dailyHistoryArchive');
 const { normalizeHistory, parseGraphResult } = require('../../src/shared/history');
 
@@ -32,6 +34,19 @@ function client(clientId, modelId, tokens, cost, messages, extra = {}) {
 
 function historyFrom(graphValue, todayKey = '2026-07-18') {
   return normalizeHistory(parseGraphResult(graphValue), { todayKey, capDays: 370 });
+}
+
+function livePeriod(totalTokens, costUsd = 0) {
+  return {
+    totalTokens,
+    costUsd,
+    clients: { claude: totalTokens },
+    clientCosts: { claude: costUsd },
+    models: { opus: totalTokens },
+    modelCosts: { opus: costUsd },
+    clientModels: { claude: { opus: totalTokens } },
+    clientModelCosts: { claude: { opus: costUsd } }
+  };
 }
 
 test('normalizeDailyHistoryArchive rejects malformed days and observations', () => {
@@ -81,6 +96,45 @@ test('capture replaces the whole observation when usage grows and refreshes equa
   ]), { todayKey: '2026-07-18' });
   const [stored] = Object.values(repriced.days['2026-07-17'].observations);
   assert.deepEqual(stored, { client: 'claude', modelId: 'opus', tokens: 120, cost: 5.2, messages: 6 });
+});
+
+test('live today snapshot wins over a smaller graph value after date rollover', () => {
+  const archive = captureLiveDailyHistory({}, livePeriod(645_957_554, 62.42), {
+    todayKey: '2026-08-05'
+  });
+  const lowerGraph = graph('2026-08-05', [client('claude', 'opus', 507_800_000, 40, 5)]);
+  const restored = historyFrom(graphFromDailyHistoryArchive(lowerGraph, archive, {
+    todayKey: '2026-08-06'
+  }), '2026-08-06');
+
+  assert.equal(restored.daily[0].date, '2026-08-05');
+  assert.equal(restored.daily[0].tokens, 645_957_554);
+  assert.equal(restored.daily[0].perClient.claude.tokens, 645_957_554);
+
+  const lowerLive = captureLiveDailyHistory(archive, livePeriod(507_800_000, 40), {
+    todayKey: '2026-08-05'
+  });
+  assert.equal(dayObservation(lowerLive, '2026-08-05').tokens, 645_957_554);
+});
+
+function dayObservation(archive, date) {
+  return Object.values(archive.liveDays[date].observations)[0];
+}
+
+test('retainLiveDailyHistory persists only a higher live snapshot', () => {
+  let stored = {};
+  let writes = 0;
+  const options = {
+    todayKey: '2026-08-05',
+    readJson: () => stored,
+    writeJsonAtomic: (_path, value) => { stored = value; writes += 1; }
+  };
+
+  retainLiveDailyHistory(livePeriod(645_957_554), options);
+  retainLiveDailyHistory(livePeriod(507_800_000), options);
+
+  assert.equal(writes, 1);
+  assert.equal(dayObservation(stored, '2026-08-05').tokens, 645_957_554);
 });
 
 test('capture keeps all observed past days beyond the presentation window', () => {

--- a/tests/shared/dailyHistoryArchive.test.js
+++ b/tests/shared/dailyHistoryArchive.test.js
@@ -199,6 +199,37 @@ test('retainDailyHistory persists only changes and can serve the archive when a 
   assert.equal(restored.daily[0].tokens, 100);
 });
 
+test('retainDailyHistory rebases on archive changes made during the graph scan', () => {
+  const initial = captureDailyHistoryArchive({}, graph('2026-07-17', [
+    client('claude', 'opus', 100, 4, 5)
+  ]), { todayKey: '2026-07-18' });
+  const handedOff = captureDailyHistoryArchive(initial, graph('2026-07-17', [
+    client('codex', 'gpt', 50, 2, 3)
+  ]), { todayKey: '2026-07-18' });
+  let reads = 0;
+  let stored;
+  const retained = retainDailyHistory(graph('2026-07-17', [
+    client('claude', 'opus', 120, 4.8, 6)
+  ]), {
+    todayKey: '2026-07-18',
+    readJson: () => (++reads === 1 ? initial : handedOff),
+    writeJsonAtomic: (_path, value) => { stored = value; }
+  });
+
+  assert.equal(reads, 2);
+  assert.deepEqual(
+    Object.values(stored.days['2026-07-17'].observations).map((item) => item.client).sort(),
+    ['claude', 'codex']
+  );
+  assert.equal(historyFrom(retained).daily[0].tokens, 170);
+});
+
+test('captureLiveDailyHistory prunes future snapshots even when today has no usage', () => {
+  const future = captureLiveDailyHistory({}, livePeriod(100), { todayKey: '2026-08-06' });
+  const pruned = captureLiveDailyHistory(future, { totalTokens: 0 }, { todayKey: '2026-08-05' });
+  assert.equal(pruned.liveDays?.['2026-08-06'], undefined);
+});
+
 test('widget stays read-only while a headless agent owns the shared archive', () => {
   let stored = {};
   let writes = 0;

--- a/tests/shared/dailyHistoryArchive.test.js
+++ b/tests/shared/dailyHistoryArchive.test.js
@@ -117,6 +117,31 @@ test('live today snapshot wins over a smaller graph value after date rollover', 
   assert.equal(dayObservation(lowerLive, '2026-08-05').tokens, 645_957_554);
 });
 
+test('live snapshot keeps model-less remainder under its original client', () => {
+  const archive = captureLiveDailyHistory({}, {
+    totalTokens: 150,
+    costUsd: 15,
+    clients: { claude: 150 },
+    clientCosts: { claude: 15 },
+    clientModels: { claude: { opus: 100 } },
+    clientModelCosts: { claude: { opus: 10 } }
+  }, { todayKey: '2026-08-05' });
+  const restored = historyFrom(graphFromDailyHistoryArchive([], archive, {
+    todayKey: '2026-08-05'
+  }), '2026-08-05');
+
+  assert.equal(restored.daily[0].tokens, 150);
+  assert.equal(restored.daily[0].perClient.claude.tokens, 150);
+  assert.equal(restored.daily[0].perModel.opus.tokens, 100);
+  assert.equal(restored.daily[0].perModel.unknown.tokens, 50);
+  assert.equal(dayObservation(archive, '2026-08-05').tokens, 100);
+  assert.equal(
+    Object.values(archive.liveDays['2026-08-05'].observations)
+      .find((observation) => observation.modelId === 'unknown').tokens,
+    50
+  );
+});
+
 function dayObservation(archive, date) {
   return Object.values(archive.liveDays[date].observations)[0];
 }

--- a/tests/shared/deviceRuntime.test.js
+++ b/tests/shared/deviceRuntime.test.js
@@ -79,10 +79,11 @@ test('usage transforms run only for usage events, not limits-only publishes', ()
       return { ...summary, transformed: true };
     }
   });
-  usageOptions.onUpdate({ updatedAt: 'usage-time', today: { totalTokens: 4 } }, 'startup');
+  const visible = usageOptions.onUpdate({ updatedAt: 'usage-time', today: { totalTokens: 4 } }, 'startup');
   limitsDeps.onUpdate({ updatedAt: 'limits-time', refreshMs: 300000, providers: [] });
 
   assert.deepEqual(transformed, [{ reason: 'startup', preview: false }]);
+  assert.equal(visible.transformed, true);
   assert.equal(records.length, 2);
   assert.equal(records[1].record.transformed, true);
 });


### PR DESCRIPTION
## Summary

- Persist the highest complete live snapshot for the current local day.
- Reconcile live snapshots with graph history when rebuilding daily history.
- Prevent a completed day's trend value from silently decreasing after date rollover.
- Add regression coverage for the 8/5 → 8/6 bar and hover-title mapping.

The current-day bar remains live. Historical reconstruction compares the graph value and the persisted live snapshot for the same date, then keeps the higher complete observation without adding both values together.

Closes #336

## Verification

- `npm run lint`
- `node --test tests/electron/usageCharts.test.js`
- `node --test tests/shared/dailyHistoryArchive.test.js tests/shared/collectorHistory.test.js`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves live totals across date rollover and collector handoff so completed days never drop or regress. Keeps same-tick live snapshots in history when the archive is read-only and rebases writes to avoid overwriting newer data.

- **Bug Fixes**
  - Persist the highest complete live snapshot for today via `retainLiveDailyHistory`; prune future snapshots.
  - Merge `liveDays` into history rebuild and prefer higher totals; keep model-less remainder under its owning client; no double counting.
  - Share in-memory `liveDays` across watch and history ticks and write only on full/history ticks; archive the transformed total the user sees.
  - Rebase archive writes on the latest file to handle collector handoff and prevent clobbering newer observations.
  - Use same-tick live snapshots when writes are disabled so history reflects current values; add timezone-independent rollover and cross-day hover-title tests. Addresses Linear issue #336.

<sup>Written for commit 330b4dd09f52b590069f00cd05719f88468b921b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

