### PR TITLE
feat(diagnostics): expose self-sync failure details

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -239,6 +239,8 @@ Current agents and widgets include `osName` and, when known, `osVersion` so devi
         },
         "collection": {
           "state": "failed",
+          "syncFailureStage": "timeout",
+          "syncDetailCode": "network-timeout",
           "lastAttemptAt": "2026-08-04T09:12:00.000Z",
           "lastSuccessAt": "2026-08-04T08:40:00.000Z"
         },
@@ -258,6 +260,8 @@ Every tracked client sends the same fixed core — `source.state`, `source.detec
 A client installed only inside a running WSL distro has no host directory, and its usage is merged into the same periods before either derivation runs. Its WSL marker is therefore a source that exists, reported as the `wsl-home` check — without it the same snapshot would count the client's tokens and call its source missing.
 
 `source.checks[].id` is a stable identifier for a *kind* of source root, never a filesystem path: one id can stand for several platform variants (a VS Code workspace-storage root has one per platform), and an absolute path contains the user's home directory. Ids outside the recognized set are dropped on ingest. A failed self-sync likewise reports a stable code in `diagnostics` (`sync-failed`, `sync-timeout`, `sync-spawn-failed`, `sync-exit-error`) and never the subprocess's stderr. The other diagnostic codes are `source-missing`, `no-usage-observed`, and `wsl-detected-no-data`; the last one states that a WSL marker was found and the scan returned nothing, which can equally mean the tool is installed in that distro and unused.
+
+For a failed self-sync, `collection.syncFailureStage` is an optional bounded stage: `spawn`, `timeout`, `process-exit`, or `unknown`. `collection.syncDetailCode` is a conservative classification of the failure: `language-server-not-found`, `rpc-failed`, `permission-denied`, `cache-write-failed`, `invalid-response`, `network-timeout`, `network-failed`, `authentication-failed`, or `unknown`. A non-negative `collection.syncExitCode` is included only when the subprocess reported a numeric exit code. These fields add process-level evidence without exposing stderr, paths, or provider output; an exit code is not interpreted as a universal root cause.
 
 `diagnostics` entries are objects carrying a `code`, not bare strings, even though `code` is the only field today: the extension point belongs inside the entry, matching how LSP, ESLint, SARIF, and RFC 9457 all shape a diagnostic. Adding a field to the object stays backward compatible; turning `string[]` into `object[]` would not. Severity is deliberately **not** on the wire — the same code means different things on different clients, so it is a renderer decision rather than something a collector can know. Observation time is likewise recorded once, as `clientHealth.observedAt`, rather than per diagnostic: every entry comes from the same scan. It is its own field because a limits-only ingest carries health forward while the record's `updatedAt` moves on, so `updatedAt` cannot be read as the time the diagnosis was made.
 

--- a/src/shared/clientHealth.js
+++ b/src/shared/clientHealth.js
@@ -70,6 +70,7 @@ const CLIENT_SYNC_DETAIL_CODES = Object.freeze([
   'unknown'
 ]);
 const CLIENT_SYNC_DETAIL_CODE_SET = new Set(CLIENT_SYNC_DETAIL_CODES);
+const MAX_SYNC_DETAIL_INPUT_LENGTH = 8 * 1024;
 
 function normalizeClientSyncFailureStage(value) {
   const stage = String(value ?? '').trim().toLowerCase();
@@ -91,14 +92,27 @@ function normalizeClientSyncDetailCode(value) {
   return CLIENT_SYNC_DETAIL_CODE_SET.has(code) ? code : 'unknown';
 }
 
+function boundedSyncDetailText(value) {
+  const raw = String(value ?? '');
+  if (raw.length <= MAX_SYNC_DETAIL_INPUT_LENGTH) return raw;
+  let bounded = '';
+  let codePoints = 0;
+  for (const character of raw) {
+    if (codePoints >= MAX_SYNC_DETAIL_INPUT_LENGTH) break;
+    bounded += character;
+    codePoints += 1;
+  }
+  return bounded;
+}
+
 // Classify only high-confidence, stable substrings from the local sync error.
 // The input is used inside the process and the return value is the only part
 // that may cross the client-health or diagnostic boundaries.
 function classifyClientSyncDetailCode({ client = '', text = '' } = {}) {
-  const message = String(text ?? '').trim().toLowerCase();
+  const message = boundedSyncDetailText(text).trim().toLowerCase();
   if (!message) return null;
 
-  if (/permission denied|access is denied|operation not permitted|\beacces\b/.test(message)) {
+  if (/permission denied|access is denied|operation not permitted|\beacces\b|\beperm\b/.test(message)) {
     return 'permission-denied';
   }
   if (
@@ -440,6 +454,7 @@ module.exports = {
   CLIENT_COLLECTION_STATES,
   CLIENT_SYNC_DETAIL_CODES,
   CLIENT_SYNC_FAILURE_STAGES,
+  MAX_SYNC_DETAIL_INPUT_LENGTH,
   CLIENT_SOURCE_CHECK_IDS,
   CLIENT_SOURCE_STATES,
   MAX_CHECKS_PER_CLIENT,

--- a/src/shared/clientHealth.js
+++ b/src/shared/clientHealth.js
@@ -125,7 +125,7 @@ function classifyClientSyncDetailCode({ client = '', text = '' } = {}) {
   if (/session (?:token )?(?:expired|invalid)|invalid (?:api )?token|not authenticated|re-authenticate|unauthorized|forbidden|status\s+(?:401|403)\b/.test(message)) {
     return 'authentication-failed';
   }
-  const hasNetworkTimeoutTerm = /\b(?:etimedout|network|http|request|connect(?:ion)?|socket|tcp|tls|dns)\b/.test(message);
+  const hasNetworkTimeoutTerm = /\b(?:etimedout|network|https?|request|connect(?:ion)?|socket|tcp|tls|dns)\b/.test(message);
   const hasTimeoutTerm = /\b(?:etimedout|timed out|timeout|deadline exceeded|deadline has elapsed)\b/.test(message);
   if (hasNetworkTimeoutTerm && hasTimeoutTerm) {
     return 'network-timeout';

--- a/src/shared/clientHealth.js
+++ b/src/shared/clientHealth.js
@@ -52,6 +52,89 @@ const CLIENT_COLLECTION_STATES = Object.freeze([
   'direct', 'idle', 'pending', 'ok', 'failed', 'unknown'
 ]);
 
+// Additional evidence for a failed self-sync. These values describe the stage
+// that failed, not the subprocess's message; the latter may contain paths and
+// is never allowed onto the device record.
+const CLIENT_SYNC_FAILURE_STAGES = Object.freeze(['spawn', 'timeout', 'process-exit', 'unknown']);
+const CLIENT_SYNC_FAILURE_STAGE_SET = new Set(CLIENT_SYNC_FAILURE_STAGES);
+const MAX_SYNC_EXIT_CODE = 2 ** 31 - 1;
+const CLIENT_SYNC_DETAIL_CODES = Object.freeze([
+  'language-server-not-found',
+  'rpc-failed',
+  'permission-denied',
+  'cache-write-failed',
+  'invalid-response',
+  'network-timeout',
+  'network-failed',
+  'authentication-failed',
+  'unknown'
+]);
+const CLIENT_SYNC_DETAIL_CODE_SET = new Set(CLIENT_SYNC_DETAIL_CODES);
+
+function normalizeClientSyncFailureStage(value) {
+  const stage = String(value ?? '').trim().toLowerCase();
+  if (!stage) return null;
+  return CLIENT_SYNC_FAILURE_STAGE_SET.has(stage) ? stage : 'unknown';
+}
+
+function normalizeClientSyncExitCode(value) {
+  if (typeof value !== 'number' && typeof value !== 'string') return null;
+  const raw = String(value).trim();
+  if (!/^\d+$/.test(raw)) return null;
+  const code = Number(raw);
+  return Number.isSafeInteger(code) && code >= 0 && code <= MAX_SYNC_EXIT_CODE ? code : null;
+}
+
+function normalizeClientSyncDetailCode(value) {
+  const code = String(value ?? '').trim().toLowerCase();
+  if (!code) return null;
+  return CLIENT_SYNC_DETAIL_CODE_SET.has(code) ? code : 'unknown';
+}
+
+// Classify only high-confidence, stable substrings from the local sync error.
+// The input is used inside the process and the return value is the only part
+// that may cross the client-health or diagnostic boundaries.
+function classifyClientSyncDetailCode({ client = '', text = '' } = {}) {
+  const message = String(text ?? '').trim().toLowerCase();
+  if (!message) return null;
+
+  if (/permission denied|access is denied|operation not permitted|\beacces\b/.test(message)) {
+    return 'permission-denied';
+  }
+  if (
+    /no space left on device|read-only file system/.test(message)
+    || /failed to (?:create|persist|write|save).*(?:cache|artifact|manifest)/.test(message)
+    || /(?:cache|artifact|manifest).*(?:write|persist|save).*(?:failed|error)/.test(message)
+  ) {
+    return 'cache-write-failed';
+  }
+  if (/session (?:token )?(?:expired|invalid)|invalid (?:api )?token|not authenticated|re-authenticate|unauthorized|forbidden|status\s+(?:401|403)\b/.test(message)) {
+    return 'authentication-failed';
+  }
+  if (/timed out|timeout|deadline has elapsed|operation timed out/.test(message)) {
+    return 'network-timeout';
+  }
+  if (/malformed.*response|invalid response|expected csv format|failed to parse response|invalid json/.test(message)) {
+    return 'invalid-response';
+  }
+  if (
+    client === 'antigravity'
+    && /cannot discover .*language servers?|language server.*(?:not found|unavailable)|no .*language servers?/.test(message)
+  ) {
+    return 'language-server-not-found';
+  }
+  if (
+    client === 'antigravity'
+    && (/\brpc\b.*(?:fail|error)|(?:fail|error).*\brpc\b|failed to connect to antigravity rpc/.test(message))
+  ) {
+    return 'rpc-failed';
+  }
+  if (/failed to connect|connection refused|connection reset|could not resolve|\bdns\b|\bnetwork\b/.test(message)) {
+    return 'network-failed';
+  }
+  return null;
+}
+
 // Stable ids for the source roots the collector probes. One id can stand for
 // several paths of the same kind — Copilot's workspaceStorage has a variant per
 // platform, Kiro's IDE globalStorage has four — because "the VS Code workspace
@@ -282,6 +365,14 @@ function normalizeClientHealthEntry(value) {
   if (lastAttemptAt) entry.collection.lastAttemptAt = lastAttemptAt;
   const lastSuccessAt = normalizeTimestamp(value?.collection?.lastSuccessAt);
   if (lastSuccessAt) entry.collection.lastSuccessAt = lastSuccessAt;
+  if (entry.collection.state === 'failed') {
+    const syncFailureStage = normalizeClientSyncFailureStage(value?.collection?.syncFailureStage);
+    if (syncFailureStage) entry.collection.syncFailureStage = syncFailureStage;
+    const syncExitCode = normalizeClientSyncExitCode(value?.collection?.syncExitCode);
+    if (syncExitCode !== null) entry.collection.syncExitCode = syncExitCode;
+    const syncDetailCode = normalizeClientSyncDetailCode(value?.collection?.syncDetailCode);
+    if (syncDetailCode) entry.collection.syncDetailCode = syncDetailCode;
+  }
   const lastActivityDay = normalizeDay(value?.data?.lastActivityDay);
   if (lastActivityDay) entry.data.lastActivityDay = lastActivityDay;
   const diagnostics = normalizeDiagnostics(value?.diagnostics, entry);
@@ -347,6 +438,8 @@ module.exports = {
   CLIENT_HEALTH_OVERALL_STATES,
   CLIENT_HEALTH_VERSION,
   CLIENT_COLLECTION_STATES,
+  CLIENT_SYNC_DETAIL_CODES,
+  CLIENT_SYNC_FAILURE_STAGES,
   CLIENT_SOURCE_CHECK_IDS,
   CLIENT_SOURCE_STATES,
   MAX_CHECKS_PER_CLIENT,
@@ -355,5 +448,9 @@ module.exports = {
   countOverall,
   deriveClientOverall,
   deriveLegacyClientStatus,
-  normalizeClientHealth
+  normalizeClientHealth,
+  normalizeClientSyncDetailCode,
+  normalizeClientSyncExitCode,
+  normalizeClientSyncFailureStage,
+  classifyClientSyncDetailCode
 };

--- a/src/shared/clientHealth.js
+++ b/src/shared/clientHealth.js
@@ -125,7 +125,9 @@ function classifyClientSyncDetailCode({ client = '', text = '' } = {}) {
   if (/session (?:token )?(?:expired|invalid)|invalid (?:api )?token|not authenticated|re-authenticate|unauthorized|forbidden|status\s+(?:401|403)\b/.test(message)) {
     return 'authentication-failed';
   }
-  if (/timed out|timeout|deadline has elapsed|operation timed out/.test(message)) {
+  const hasNetworkTimeoutTerm = /\b(?:etimedout|network|http|request|connect(?:ion)?|socket|tcp|tls|dns)\b/.test(message);
+  const hasTimeoutTerm = /\b(?:etimedout|timed out|timeout|deadline exceeded|deadline has elapsed)\b/.test(message);
+  if (hasNetworkTimeoutTerm && hasTimeoutTerm) {
     return 'network-timeout';
   }
   if (/malformed.*response|invalid response|expected csv format|failed to parse response|invalid json/.test(message)) {

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -12,6 +12,7 @@ const { normalizeClientsCsv } = require('./clientTracking');
 const {
   CLIENT_HEALTH_VERSION,
   MAX_DIAGNOSTICS_PER_CLIENT,
+  classifyClientSyncDetailCode,
   deriveClientOverall
 } = require('./clientHealth');
 const { tokscalePackageNameForPlatform, tokscalePlatformKey } = require('./tokscalePlatform');
@@ -532,7 +533,11 @@ async function maybeSyncCursor(clientsCsv, logger, options = {}) {
     selfSyncThrottle.completeAttempt('cursor', attempt, false);
   } catch (err) {
     if (typeof logger === 'function') logger(`cursor sync failed: ${err.message}`);
-    selfSyncThrottle.completeAttempt('cursor', attempt, true);
+    selfSyncThrottle.completeAttempt('cursor', attempt, true, '', {
+      failureStage: err?.syncFailureStage,
+      detailCode: err?.syncDetailCode || classifyClientSyncDetailCode({ client: 'cursor', text: err?.message }),
+      exitCode: err?.syncExitCode
+    });
     options.onFailure?.('cursor');
   }
 }
@@ -561,7 +566,11 @@ async function maybeSyncAntigravity(clientsCsv, logger, home = os.homedir(), opt
       selfSyncThrottle.completeAttempt('antigravity', attempt, false);
     } catch (err) {
       if (typeof logger === 'function') logger(`antigravity sync failed: ${err.message}`);
-      selfSyncThrottle.completeAttempt('antigravity', attempt, true);
+      selfSyncThrottle.completeAttempt('antigravity', attempt, true, '', {
+        failureStage: err?.syncFailureStage,
+        detailCode: err?.syncDetailCode || classifyClientSyncDetailCode({ client: 'antigravity', text: err?.message }),
+        exitCode: err?.syncExitCode
+      });
       options.onFailure?.('antigravity');
     }
     return;
@@ -586,22 +595,34 @@ async function maybeSyncAntigravity(clientsCsv, logger, home = os.homedir(), opt
     // The failure code reaches the health record; stderr only ever reaches the
     // local log, since it is neither translatable nor reliably free of the
     // user's paths.
-    const settle = (failed, code = '') => {
+    const settle = (failed, code = '', details = {}) => {
       if (settled) return;
       settled = true;
       if (timer) clearTimeout(timer);
-      selfSyncThrottle.completeAttempt('antigravity', attempt, failed, code);
+      selfSyncThrottle.completeAttempt('antigravity', attempt, failed, code, details);
       if (failed) options.onFailure?.('antigravity');
       resolve();
     };
-    timer = setTimeout(() => { child.kill('SIGTERM'); settle(true, 'sync-timeout'); }, 30000);
+    timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      settle(true, 'sync-timeout', { failureStage: 'timeout' });
+    }, 30000);
     child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
-    child.on('error', () => settle(true, 'sync-spawn-failed'));
+    child.on('error', (err) => settle(true, 'sync-spawn-failed', {
+      failureStage: 'spawn',
+      detailCode: classifyClientSyncDetailCode({ client: 'antigravity', text: err?.message })
+    }));
     child.on('close', (code) => {
       if (code !== 0 && !settled && typeof logger === 'function') {
         logger(`antigravity sync exited ${code}: ${stderr.trim().slice(0, 200)}`);
       }
-      settle(code !== 0, 'sync-exit-error');
+      settle(code !== 0, 'sync-exit-error', {
+        failureStage: code !== 0 ? 'process-exit' : null,
+        detailCode: code !== 0
+          ? classifyClientSyncDetailCode({ client: 'antigravity', text: stderr })
+          : null,
+        exitCode: code
+      });
     });
     child.stdin?.end();
   });
@@ -1550,6 +1571,11 @@ function deriveClientHealth(clientsCsv, allTimePeriod, options = {}) {
     // is the answer to "why is today still 0", not a fault report.
     if (sync?.lastAttemptAt) entry.collection.lastAttemptAt = new Date(sync.lastAttemptAt).toISOString();
     if (sync?.lastSuccessAt) entry.collection.lastSuccessAt = new Date(sync.lastSuccessAt).toISOString();
+    if (sync?.state === 'failed') {
+      if (sync.failureStage) entry.collection.syncFailureStage = sync.failureStage;
+      if (sync.detailCode) entry.collection.syncDetailCode = sync.detailCode;
+      if (sync.exitCode !== null && sync.exitCode !== undefined) entry.collection.syncExitCode = sync.exitCode;
+    }
     const activityDay = activityDays[client];
     if (activityDay) entry.data.lastActivityDay = activityDay;
     const overall = deriveClientOverall(entry);

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -11,6 +11,7 @@ const { appVersion } = require('./appVersion');
 const { normalizeClientsCsv } = require('./clientTracking');
 const {
   CLIENT_HEALTH_VERSION,
+  MAX_SYNC_DETAIL_INPUT_LENGTH,
   MAX_DIAGNOSTICS_PER_CLIENT,
   classifyClientSyncDetailCode,
   deriveClientOverall
@@ -607,7 +608,11 @@ async function maybeSyncAntigravity(clientsCsv, logger, home = os.homedir(), opt
       child.kill('SIGTERM');
       settle(true, 'sync-timeout', { failureStage: 'timeout' });
     }, 30000);
-    child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+    child.stderr.on('data', (chunk) => {
+      if (stderr.length >= MAX_SYNC_DETAIL_INPUT_LENGTH) return;
+      const remaining = MAX_SYNC_DETAIL_INPUT_LENGTH - stderr.length;
+      stderr += chunk.toString().slice(0, remaining);
+    });
     child.on('error', (err) => settle(true, 'sync-spawn-failed', {
       failureStage: 'spawn',
       detailCode: classifyClientSyncDetailCode({ client: 'antigravity', text: err?.message })

--- a/src/shared/cursorAuth.js
+++ b/src/shared/cursorAuth.js
@@ -5,6 +5,19 @@ const os = require('node:os');
 const path = require('node:path');
 const crypto = require('node:crypto');
 const { spawn } = require('node:child_process');
+const { classifyClientSyncDetailCode } = require('./clientHealth');
+
+const MAX_SYNC_EXIT_CODE = 2 ** 31 - 1;
+
+function annotateSyncError(error, failureStage, exitCode = null) {
+  const target = error instanceof Error ? error : new Error(String(error || 'Cursor sync failed'));
+  target.syncFailureStage = failureStage;
+  target.syncDetailCode = classifyClientSyncDetailCode({ client: 'cursor', text: target.message });
+  if (Number.isSafeInteger(exitCode) && exitCode >= 0 && exitCode <= MAX_SYNC_EXIT_CODE) {
+    target.syncExitCode = exitCode;
+  }
+  return target;
+}
 
 function credentialsPath(home = os.homedir()) {
   return path.join(home, '.config', 'tokscale', 'cursor-credentials.json');
@@ -85,15 +98,19 @@ function runTokscaleSubcommand(args, { stdin = null, timeoutMs = 30000 } = {}) {
     let stderr = '';
     const timer = setTimeout(() => {
       child.kill('SIGTERM');
-      reject(new Error(`tokscale cursor ${args[0]} timed out after ${timeoutMs}ms`));
+      reject(annotateSyncError(new Error(`tokscale cursor ${args[0]} timed out after ${timeoutMs}ms`), 'timeout'));
     }, timeoutMs);
     child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
     child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
-    child.on('error', (err) => { clearTimeout(timer); reject(err); });
+    child.on('error', (err) => { clearTimeout(timer); reject(annotateSyncError(err, 'spawn')); });
     child.on('close', (code) => {
       clearTimeout(timer);
       if (code !== 0) {
-        return reject(new Error(`tokscale cursor ${args[0]} exited ${code}: ${(stderr || stdout).trim()}`));
+        return reject(annotateSyncError(
+          new Error(`tokscale cursor ${args[0]} exited ${code}: ${(stderr || stdout).trim()}`),
+          'process-exit',
+          code
+        ));
       }
       resolve(stdout);
     });

--- a/src/shared/diagnosticReport.js
+++ b/src/shared/diagnosticReport.js
@@ -1,6 +1,12 @@
 'use strict';
 
 const { staleAfterMsForSyncUpload } = require('./syncUploadInterval');
+const { SELF_SYNC_FAILURE_CODES } = require('./selfSyncThrottle');
+const {
+  normalizeClientSyncDetailCode,
+  normalizeClientSyncExitCode,
+  normalizeClientSyncFailureStage
+} = require('./clientHealth');
 
 const DIAGNOSTIC_SCHEMA_VERSION = 1;
 const DIAGNOSTIC_REDACTION_VERSION = 1;
@@ -18,6 +24,7 @@ const SOURCE_STATES = new Set(['detected', 'missing', 'unknown']);
 const FINDING_CODES = new Set([
   'collector-failed',
   'collector-stale',
+  'client-sync-failed',
   'external-agent-stale',
   'limits-provider-failed',
   'storage-archive-write-failed',
@@ -122,6 +129,15 @@ function projectClientHealth(health, device = {}) {
       checkedCount: integer(source.checkedCount, 0),
       sourceChecks: checks,
       collectionState: safeCollectionState(collection.state),
+      syncFailureStage: safeCollectionState(collection.state) === 'failed'
+        ? normalizeClientSyncFailureStage(collection.syncFailureStage)
+        : null,
+      syncDetailCode: safeCollectionState(collection.state) === 'failed'
+        ? (normalizeClientSyncDetailCode(collection.syncDetailCode) || 'unknown')
+        : null,
+      syncExitCode: safeCollectionState(collection.state) === 'failed'
+        ? normalizeClientSyncExitCode(collection.syncExitCode)
+        : null,
       lastAttemptAt: isoTimestamp(collection.lastAttemptAt),
       lastSuccessAt: isoTimestamp(collection.lastSuccessAt),
       lastActivityDay: text(data.lastActivityDay, 'unknown', 16),
@@ -413,6 +429,7 @@ function sanitizeClient(client = {}) {
   const diagnosticCodes = Array.isArray(client.diagnosticCodes)
     ? client.diagnosticCodes.map((code) => identifier(code, '')).filter(Boolean).slice(0, 4)
     : [];
+  const collectionState = safeCollectionState(client.collectionState);
   return {
     client: identifier(client.client),
     healthEntryAvailable: client.healthEntryAvailable === true,
@@ -421,7 +438,12 @@ function sanitizeClient(client = {}) {
     detectedCount: boundedCount(client.detectedCount),
     checkedCount: boundedCount(client.checkedCount),
     sourceChecks,
-    collectionState: safeCollectionState(client.collectionState),
+    collectionState,
+    syncFailureStage: collectionState === 'failed' ? normalizeClientSyncFailureStage(client.syncFailureStage) : null,
+    syncDetailCode: collectionState === 'failed'
+      ? (normalizeClientSyncDetailCode(client.syncDetailCode) || 'unknown')
+      : null,
+    syncExitCode: collectionState === 'failed' ? normalizeClientSyncExitCode(client.syncExitCode) : null,
     lastAttemptAt: isoTimestamp(client.lastAttemptAt),
     lastSuccessAt: isoTimestamp(client.lastSuccessAt),
     lastActivityDay: text(client.lastActivityDay, 'unknown', 16),
@@ -601,6 +623,13 @@ function deriveDiagnosticFindings(snapshot, nowMs = Date.now()) {
   if (usage.usageOwner === 'external-agent' && usage.usageObservationAgeSeconds !== null && usage.usageObservationAgeSeconds > usageStaleAfterSeconds) {
     add({ code: 'external-agent-stale' });
   }
+  for (const client of snapshot.clients?.clients || []) {
+    if (client?.collectionState !== 'failed') continue;
+    const detailCode = (Array.isArray(client.diagnosticCodes) ? client.diagnosticCodes : [])
+      .map((code) => String(code || '').trim().toLowerCase())
+      .find((code) => SELF_SYNC_FAILURE_CODES.has(code));
+    if (detailCode) add({ code: 'client-sync-failed', client: client.client, detailCode });
+  }
   for (const provider of limits.providers || []) {
     const failureCode = provider.failureCode || provider.lastFailureCode;
     if (!isNoFailureCode(failureCode) && !isNotConfiguredFailure(failureCode)) {
@@ -760,6 +789,15 @@ function formatClient(client) {
     line('detectedCount', client.detectedCount, '    '),
     line('checkedCount', client.checkedCount, '    '),
     line('collectionState', client.collectionState, '    '),
+    ...(client.collectionState === 'failed' && client.syncFailureStage
+      ? [line('syncFailureStage', client.syncFailureStage, '    ')]
+      : []),
+    ...(client.collectionState === 'failed' && client.syncDetailCode
+      ? [line('syncDetailCode', client.syncDetailCode, '    ')]
+      : []),
+    ...(client.collectionState === 'failed' && client.syncExitCode !== null && client.syncExitCode !== undefined
+      ? [line('syncExitCode', client.syncExitCode, '    ')]
+      : []),
     line('lastAttemptAt', client.lastAttemptAt, '    '),
     line('lastSuccessAt', client.lastSuccessAt, '    '),
     line('lastActivityDay', client.lastActivityDay, '    '),

--- a/src/shared/selfSyncThrottle.js
+++ b/src/shared/selfSyncThrottle.js
@@ -19,6 +19,11 @@
 // be wrong about the other.
 
 const SELF_SYNC_KINDS = ['cursor', 'antigravity'];
+const {
+  normalizeClientSyncDetailCode,
+  normalizeClientSyncExitCode,
+  normalizeClientSyncFailureStage
+} = require('./clientHealth');
 
 // Re-running these syncs on every ordinary tick is pure overhead, so they keep
 // their own slow cadence rather than the collector's.
@@ -40,6 +45,18 @@ const SYNC_SOURCE_EVENT_MIN_INTERVAL_MS = 10 * 1000;
 // UI, and tokscale's stderr is neither translatable nor guaranteed free of the
 // user's paths. Anything unrecognised collapses to the generic code.
 const SELF_SYNC_FAILURE_CODES = new Set(['sync-failed', 'sync-timeout', 'sync-spawn-failed', 'sync-exit-error']);
+const FAILURE_STAGE_BY_CODE = Object.freeze({
+  'sync-failed': 'unknown',
+  'sync-timeout': 'timeout',
+  'sync-spawn-failed': 'spawn',
+  'sync-exit-error': 'process-exit'
+});
+const FAILURE_CODE_BY_STAGE = Object.freeze({
+  unknown: 'sync-failed',
+  timeout: 'sync-timeout',
+  spawn: 'sync-spawn-failed',
+  'process-exit': 'sync-exit-error'
+});
 
 // setTimeout stores its delay in a 32-bit signed int and silently rewrites
 // anything larger — or non-finite — to 1ms, turning a "wait a while" into a
@@ -104,6 +121,9 @@ function createSelfSyncThrottle(options = {}) {
   const lastAttemptAt = {};
   const lastSuccessAt = {};
   const lastFailureCode = {};
+  const lastFailureStage = {};
+  const lastDetailCode = {};
+  const lastExitCode = {};
   const completedSeq = {};
   for (const kind of SELF_SYNC_KINDS) {
     lastSyncAt[kind] = 0;
@@ -112,6 +132,9 @@ function createSelfSyncThrottle(options = {}) {
     lastAttemptAt[kind] = 0;
     lastSuccessAt[kind] = 0;
     lastFailureCode[kind] = '';
+    lastFailureStage[kind] = '';
+    lastDetailCode[kind] = '';
+    lastExitCode[kind] = null;
     completedSeq[kind] = 0;
   }
 
@@ -149,16 +172,26 @@ function createSelfSyncThrottle(options = {}) {
     return attemptSeq[kind];
   }
 
-  function completeAttempt(kind, attempt, failed, code = '') {
+  function completeAttempt(kind, attempt, failed, code = '', details = {}) {
     if (attempt !== attemptSeq[kind]) return;
     completedSeq[kind] = attempt;
     lastSyncFailed[kind] = failed;
     if (!failed) {
       lastSuccessAt[kind] = now();
       lastFailureCode[kind] = '';
+      lastFailureStage[kind] = '';
+      lastDetailCode[kind] = '';
+      lastExitCode[kind] = null;
       return;
     }
-    lastFailureCode[kind] = SELF_SYNC_FAILURE_CODES.has(code) ? code : 'sync-failed';
+    const requestedStage = normalizeClientSyncFailureStage(details?.failureStage);
+    const failureStage = requestedStage || FAILURE_STAGE_BY_CODE[code] || 'unknown';
+    lastFailureCode[kind] = SELF_SYNC_FAILURE_CODES.has(code)
+      ? code
+      : (FAILURE_CODE_BY_STAGE[failureStage] || 'sync-failed');
+    lastFailureStage[kind] = failureStage;
+    lastDetailCode[kind] = normalizeClientSyncDetailCode(details?.detailCode) || 'unknown';
+    lastExitCode[kind] = normalizeClientSyncExitCode(details?.exitCode);
   }
 
   // A read-only view for diagnostics. `pending` is reachable rather than
@@ -176,7 +209,10 @@ function createSelfSyncThrottle(options = {}) {
       state,
       lastAttemptAt: lastAttemptAt[kind] || 0,
       lastSuccessAt: lastSuccessAt[kind] || 0,
-      failureCode: lastFailureCode[kind] || ''
+      failureCode: lastFailureCode[kind] || '',
+      failureStage: lastFailureStage[kind] || '',
+      detailCode: lastDetailCode[kind] || '',
+      exitCode: lastExitCode[kind]
     };
   }
 

--- a/tests/shared/clientHealth.test.js
+++ b/tests/shared/clientHealth.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 
 const {
+  CLIENT_SYNC_DETAIL_CODES,
   CLIENT_HEALTH_OVERALL_STATES,
   CLIENT_HEALTH_VERSION,
   CLIENT_SOURCE_CHECK_IDS,
@@ -13,6 +14,7 @@ const {
   countOverall,
   deriveClientOverall,
   deriveLegacyClientStatus,
+  classifyClientSyncDetailCode,
   normalizeClientHealth
 } = require('../../src/shared/clientHealth');
 const {
@@ -456,6 +458,9 @@ test('deriveClientHealth carries the self-sync lane into the record', () => {
   throttle.completeAttempt('cursor', attempt, true, 'sync-timeout');
   const failed = deriveClientHealth('cursor', { clients: { cursor: 500 } }, options).clients.cursor;
   assert.equal(failed.collection.state, 'failed');
+  assert.equal(failed.collection.syncFailureStage, 'timeout');
+  assert.equal(failed.collection.syncDetailCode, 'unknown');
+  assert.equal(Object.hasOwn(failed.collection, 'syncExitCode'), false);
   assert.equal(failed.overall, 'attention');
   assert.deepEqual(failed.diagnostics, [{ code: 'sync-timeout' }]);
 
@@ -465,6 +470,9 @@ test('deriveClientHealth carries the self-sync lane into the record', () => {
   const ok = deriveClientHealth('cursor', { clients: { cursor: 500 } }, options).clients.cursor;
   assert.equal(ok.collection.state, 'ok');
   assert.equal(ok.collection.lastSuccessAt, new Date(clock.now).toISOString());
+  assert.equal(Object.hasOwn(ok.collection, 'syncFailureStage'), false);
+  assert.equal(Object.hasOwn(ok.collection, 'syncDetailCode'), false);
+  assert.equal(Object.hasOwn(ok.collection, 'syncExitCode'), false);
   assert.equal(ok.overall, 'healthy');
   // A healthy client keeps its sync stamps: "last synced two minutes ago" is the
   // answer to "why is today still 0", not a fault report.
@@ -479,6 +487,79 @@ test('a self-sync failure reports a code and never its stderr', () => {
   const later = throttle.beginAttempt('antigravity');
   throttle.completeAttempt('antigravity', later, true, 'sync-exit-error');
   assert.equal(throttle.syncStatus('antigravity').failureCode, 'sync-exit-error');
+});
+
+test('client health preserves safe process-exit evidence and drops unsafe metadata', () => {
+  const valid = normalizeClientHealth({
+    clients: {
+      antigravity: {
+        ...core({
+          collection: {
+            state: 'failed',
+            syncFailureStage: 'process-exit',
+            syncDetailCode: 'rpc-failed',
+            syncExitCode: 17
+          }
+        }),
+        diagnostics: [{ code: 'sync-exit-error' }]
+      }
+    }
+  });
+  assert.equal(valid.clients.antigravity.collection.syncFailureStage, 'process-exit');
+  assert.equal(valid.clients.antigravity.collection.syncDetailCode, 'rpc-failed');
+  assert.equal(valid.clients.antigravity.collection.syncExitCode, 17);
+
+  const unsafe = normalizeClientHealth({
+    clients: {
+      antigravity: {
+        ...core({
+          collection: {
+            state: 'failed',
+            syncFailureStage: '/Users/alice/private',
+            syncDetailCode: '/Users/alice/private',
+            syncExitCode: '17; rm -rf'
+          }
+        }),
+        diagnostics: [{ code: 'sync-exit-error' }]
+      }
+    }
+  });
+  assert.equal(unsafe.clients.antigravity.collection.syncFailureStage, 'unknown');
+  assert.equal(unsafe.clients.antigravity.collection.syncDetailCode, 'unknown');
+  assert.equal(Object.hasOwn(unsafe.clients.antigravity.collection, 'syncExitCode'), false);
+});
+
+test('sync detail classification is conservative and emits only closed codes', () => {
+  assert.deepEqual([...CLIENT_SYNC_DETAIL_CODES].sort(), [
+    'authentication-failed',
+    'cache-write-failed',
+    'invalid-response',
+    'language-server-not-found',
+    'network-failed',
+    'network-timeout',
+    'permission-denied',
+    'rpc-failed',
+    'unknown'
+  ].sort());
+  assert.equal(
+    classifyClientSyncDetailCode({
+      client: 'antigravity',
+      text: 'Failed to connect to Antigravity RPC on port 12345'
+    }),
+    'rpc-failed'
+  );
+  assert.equal(
+    classifyClientSyncDetailCode({
+      client: 'antigravity',
+      text: 'Windows process discovery returned no data; cannot discover Antigravity language servers'
+    }),
+    'language-server-not-found'
+  );
+  assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'Cursor API returned status 401' }), 'authentication-failed');
+  assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'Invalid response from Cursor API - expected CSV format' }), 'invalid-response');
+  assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'Failed to persist file: Permission denied /Users/alice' }), 'permission-denied');
+  assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'The request timed out' }), 'network-timeout');
+  assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'new upstream wording with no known meaning' }), null);
 });
 
 // lastSyncAt is the rate-limit anchor that claim() moves; a completion never

--- a/tests/shared/clientHealth.test.js
+++ b/tests/shared/clientHealth.test.js
@@ -8,6 +8,7 @@ const {
   CLIENT_HEALTH_OVERALL_STATES,
   CLIENT_HEALTH_VERSION,
   CLIENT_SOURCE_CHECK_IDS,
+  MAX_SYNC_DETAIL_INPUT_LENGTH,
   MAX_CHECKS_PER_CLIENT,
   MAX_DIAGNOSTICS_PER_CLIENT,
   MAX_TRACKED_CLIENTS,
@@ -558,8 +559,18 @@ test('sync detail classification is conservative and emits only closed codes', (
   assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'Cursor API returned status 401' }), 'authentication-failed');
   assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'Invalid response from Cursor API - expected CSV format' }), 'invalid-response');
   assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'Failed to persist file: Permission denied /Users/alice' }), 'permission-denied');
+  assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'spawn EPERM' }), 'permission-denied');
+  assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'Failed to write to cache manifest' }), 'cache-write-failed');
+  assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'Connection refused by Cursor API' }), 'network-failed');
   assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'The request timed out' }), 'network-timeout');
   assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'new upstream wording with no known meaning' }), null);
+  assert.equal(
+    classifyClientSyncDetailCode({
+      client: 'cursor',
+      text: `${'x'.repeat(MAX_SYNC_DETAIL_INPUT_LENGTH + 1)}connection refused`
+    }),
+    null
+  );
 });
 
 // lastSyncAt is the rate-limit anchor that claim() moves; a completion never

--- a/tests/shared/clientHealth.test.js
+++ b/tests/shared/clientHealth.test.js
@@ -563,6 +563,7 @@ test('sync detail classification is conservative and emits only closed codes', (
   assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'Failed to write to cache manifest' }), 'cache-write-failed');
   assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'Connection refused by Cursor API' }), 'network-failed');
   assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'The request timed out' }), 'network-timeout');
+  assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'HTTPS request timed out' }), 'network-timeout');
   assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'tokscale cursor sync timed out after 30000ms' }), null);
   assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'ETIMEDOUT while connecting to Cursor API' }), 'network-timeout');
   assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'new upstream wording with no known meaning' }), null);

--- a/tests/shared/clientHealth.test.js
+++ b/tests/shared/clientHealth.test.js
@@ -563,6 +563,8 @@ test('sync detail classification is conservative and emits only closed codes', (
   assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'Failed to write to cache manifest' }), 'cache-write-failed');
   assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'Connection refused by Cursor API' }), 'network-failed');
   assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'The request timed out' }), 'network-timeout');
+  assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'tokscale cursor sync timed out after 30000ms' }), null);
+  assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'ETIMEDOUT while connecting to Cursor API' }), 'network-timeout');
   assert.equal(classifyClientSyncDetailCode({ client: 'cursor', text: 'new upstream wording with no known meaning' }), null);
   assert.equal(
     classifyClientSyncDetailCode({

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -1622,6 +1622,46 @@ test('cursor sync runs at most once per throttle window across ticks', async () 
   }
 });
 
+test('cursor sync failure metadata reaches client health without stderr or paths', async () => {
+  const childProcess = require('node:child_process');
+  const originalSpawn = childProcess.spawn;
+  childProcess.spawn = recordingSpawn([]);
+  const cursorAuth = require('../../src/shared/cursorAuth');
+  const originalReadActiveAccount = cursorAuth.readActiveAccount;
+  const originalRunCursorSync = cursorAuth.runCursorSync;
+  cursorAuth.readActiveAccount = () => ({ accessToken: 'token' });
+  cursorAuth.runCursorSync = async () => {
+    const error = new Error('tokscale cursor sync exited 17: /Users/alice/.config/tokscale/private');
+    error.syncFailureStage = 'process-exit';
+    error.syncDetailCode = 'authentication-failed';
+    error.syncExitCode = 17;
+    throw error;
+  };
+  try {
+    const { collectUsageOnce } = freshCollector();
+    const summary = await collectUsageOnce({
+      clients: 'cursor',
+      allTimeSince: '2024-01-01',
+      commandTimeoutMs: 1000,
+      deviceId: 'test-device',
+      agentVersion: 'test',
+      forceSelfSync: true,
+      limitsEnabled: false
+    });
+    const entry = summary.clientHealth.clients.cursor;
+    assert.equal(entry.collection.state, 'failed');
+    assert.equal(entry.collection.syncFailureStage, 'process-exit');
+    assert.equal(entry.collection.syncDetailCode, 'authentication-failed');
+    assert.equal(entry.collection.syncExitCode, 17);
+    assert.equal(JSON.stringify(summary).includes('/Users/alice'), false);
+  } finally {
+    childProcess.spawn = originalSpawn;
+    cursorAuth.readActiveAccount = originalReadActiveAccount;
+    cursorAuth.runCursorSync = originalRunCursorSync;
+    delete require.cache[collectorPath];
+  }
+});
+
 test('a targeted tick does not sync an unrelated self-synced client', async () => {
   const childProcess = require('node:child_process');
   const originalSpawn = childProcess.spawn;

--- a/tests/shared/diagnosticReport.test.js
+++ b/tests/shared/diagnosticReport.test.js
@@ -188,6 +188,69 @@ test('findings mark a collector stale after the effective interval threshold', (
   assert.deepEqual(findings, [{ code: 'collector-stale' }]);
 });
 
+test('client sync failures become findings for Cursor and Antigravity', () => {
+  const now = Date.parse('2026-08-05T10:00:00.000Z');
+  const findings = deriveDiagnosticFindings(baseSnapshot({
+    clients: {
+      clients: [
+        {
+          client: 'cursor',
+          collectionState: 'failed',
+          diagnosticCodes: ['sync-timeout']
+        },
+        {
+          client: 'antigravity',
+          collectionState: 'failed',
+          diagnosticCodes: ['sync-exit-error']
+        }
+      ],
+      counts: { attention: 2 }
+    }
+  }), now);
+
+  assert.deepEqual(findings, [
+    { code: 'client-sync-failed', client: 'cursor', detailCode: 'sync-timeout' },
+    { code: 'client-sync-failed', client: 'antigravity', detailCode: 'sync-exit-error' }
+  ]);
+});
+
+test('client findings require a recognized sync failure code', () => {
+  const now = Date.parse('2026-08-05T10:00:00.000Z');
+  const findings = deriveDiagnosticFindings(baseSnapshot({
+    clients: {
+      clients: [{
+        client: 'antigravity',
+        collectionState: 'failed',
+        diagnosticCodes: ['source-missing']
+      }],
+      counts: { attention: 1 }
+    }
+  }), now);
+
+  assert.deepEqual(findings, []);
+});
+
+test('client report includes bounded sync stage and exit evidence', () => {
+  const report = formatDiagnosticReport(baseSnapshot({
+    clients: {
+      clients: [{
+        client: 'antigravity',
+        collectionState: 'failed',
+        syncFailureStage: 'process-exit',
+        syncDetailCode: 'rpc-failed',
+        syncExitCode: 17,
+        diagnosticCodes: ['sync-exit-error']
+      }],
+      counts: { attention: 1 }
+    }
+  }));
+
+  assert.match(report.text, /syncFailureStage: process-exit/);
+  assert.match(report.text, /syncDetailCode: rpc-failed/);
+  assert.match(report.text, /syncExitCode: 17/);
+  assert.equal(report.text.includes('/Users/'), false);
+});
+
 test('diagnostic values preserve large token totals and archive sizes', () => {
   const report = formatDiagnosticReport(baseSnapshot({
     environment: {

--- a/tests/shared/selfSyncThrottle.test.js
+++ b/tests/shared/selfSyncThrottle.test.js
@@ -120,6 +120,36 @@ test('a failure drops the source floor to the idle cadence until one succeeds', 
   assert.equal(throttle.sourceFloorMs('antigravity'), SYNC_SOURCE_EVENT_MIN_INTERVAL_MS);
 });
 
+test('a failed sync keeps bounded stage and exit metadata without retaining stderr', () => {
+  const throttle = createSelfSyncThrottle({ now: () => 1 });
+  const attempt = throttle.beginAttempt('antigravity');
+  throttle.completeAttempt('antigravity', attempt, true, 'sync-exit-error', {
+    failureStage: 'process-exit',
+    exitCode: 17,
+    stderr: 'ENOENT: /Users/alice/.gemini/private'
+  });
+
+  assert.deepEqual(throttle.syncStatus('antigravity'), {
+    state: 'failed',
+    lastAttemptAt: 1,
+    lastSuccessAt: 0,
+    failureCode: 'sync-exit-error',
+    failureStage: 'process-exit',
+    detailCode: 'unknown',
+    exitCode: 17
+  });
+  assert.equal(JSON.stringify(throttle.syncStatus('antigravity')).includes('alice'), false);
+});
+
+test('failure stage infers the stable code when a producer supplies only stage metadata', () => {
+  const throttle = createSelfSyncThrottle({ now: () => 1 });
+  const attempt = throttle.beginAttempt('cursor');
+  throttle.completeAttempt('cursor', attempt, true, '', { failureStage: 'timeout' });
+  assert.equal(throttle.syncStatus('cursor').failureCode, 'sync-timeout');
+  assert.equal(throttle.syncStatus('cursor').failureStage, 'timeout');
+  assert.equal(throttle.syncStatus('cursor').detailCode, 'unknown');
+});
+
 test('a superseded attempt cannot rewrite the current backoff', () => {
   // stop() cannot cancel a sync already in flight, so a collector rebuilt by a
   // settings change can have the previous one's attempt land after its own.

--- a/worker/src/shared/clientHealth.js
+++ b/worker/src/shared/clientHealth.js
@@ -128,7 +128,9 @@ function classifyClientSyncDetailCode({ client = '', text = '' } = {}) {
   if (/session (?:token )?(?:expired|invalid)|invalid (?:api )?token|not authenticated|re-authenticate|unauthorized|forbidden|status\s+(?:401|403)\b/.test(message)) {
     return 'authentication-failed';
   }
-  if (/timed out|timeout|deadline has elapsed|operation timed out/.test(message)) {
+  const hasNetworkTimeoutTerm = /\b(?:etimedout|network|http|request|connect(?:ion)?|socket|tcp|tls|dns)\b/.test(message);
+  const hasTimeoutTerm = /\b(?:etimedout|timed out|timeout|deadline exceeded|deadline has elapsed)\b/.test(message);
+  if (hasNetworkTimeoutTerm && hasTimeoutTerm) {
     return 'network-timeout';
   }
   if (/malformed.*response|invalid response|expected csv format|failed to parse response|invalid json/.test(message)) {

--- a/worker/src/shared/clientHealth.js
+++ b/worker/src/shared/clientHealth.js
@@ -55,6 +55,89 @@ const CLIENT_COLLECTION_STATES = Object.freeze([
   'direct', 'idle', 'pending', 'ok', 'failed', 'unknown'
 ]);
 
+// Additional evidence for a failed self-sync. These values describe the stage
+// that failed, not the subprocess's message; the latter may contain paths and
+// is never allowed onto the device record.
+const CLIENT_SYNC_FAILURE_STAGES = Object.freeze(['spawn', 'timeout', 'process-exit', 'unknown']);
+const CLIENT_SYNC_FAILURE_STAGE_SET = new Set(CLIENT_SYNC_FAILURE_STAGES);
+const MAX_SYNC_EXIT_CODE = 2 ** 31 - 1;
+const CLIENT_SYNC_DETAIL_CODES = Object.freeze([
+  'language-server-not-found',
+  'rpc-failed',
+  'permission-denied',
+  'cache-write-failed',
+  'invalid-response',
+  'network-timeout',
+  'network-failed',
+  'authentication-failed',
+  'unknown'
+]);
+const CLIENT_SYNC_DETAIL_CODE_SET = new Set(CLIENT_SYNC_DETAIL_CODES);
+
+function normalizeClientSyncFailureStage(value) {
+  const stage = String(value ?? '').trim().toLowerCase();
+  if (!stage) return null;
+  return CLIENT_SYNC_FAILURE_STAGE_SET.has(stage) ? stage : 'unknown';
+}
+
+function normalizeClientSyncExitCode(value) {
+  if (typeof value !== 'number' && typeof value !== 'string') return null;
+  const raw = String(value).trim();
+  if (!/^\d+$/.test(raw)) return null;
+  const code = Number(raw);
+  return Number.isSafeInteger(code) && code >= 0 && code <= MAX_SYNC_EXIT_CODE ? code : null;
+}
+
+function normalizeClientSyncDetailCode(value) {
+  const code = String(value ?? '').trim().toLowerCase();
+  if (!code) return null;
+  return CLIENT_SYNC_DETAIL_CODE_SET.has(code) ? code : 'unknown';
+}
+
+// Classify only high-confidence, stable substrings from the local sync error.
+// The input is used inside the process and the return value is the only part
+// that may cross the client-health or diagnostic boundaries.
+function classifyClientSyncDetailCode({ client = '', text = '' } = {}) {
+  const message = String(text ?? '').trim().toLowerCase();
+  if (!message) return null;
+
+  if (/permission denied|access is denied|operation not permitted|\beacces\b/.test(message)) {
+    return 'permission-denied';
+  }
+  if (
+    /no space left on device|read-only file system/.test(message)
+    || /failed to (?:create|persist|write|save).*(?:cache|artifact|manifest)/.test(message)
+    || /(?:cache|artifact|manifest).*(?:write|persist|save).*(?:failed|error)/.test(message)
+  ) {
+    return 'cache-write-failed';
+  }
+  if (/session (?:token )?(?:expired|invalid)|invalid (?:api )?token|not authenticated|re-authenticate|unauthorized|forbidden/.test(message)) {
+    return 'authentication-failed';
+  }
+  if (/timed out|timeout|deadline has elapsed|operation timed out/.test(message)) {
+    return 'network-timeout';
+  }
+  if (/malformed.*response|invalid response|expected csv format|failed to parse response|invalid json/.test(message)) {
+    return 'invalid-response';
+  }
+  if (
+    client === 'antigravity'
+    && /cannot discover .*language servers?|language server.*(?:not found|unavailable)|no .*language servers?/.test(message)
+  ) {
+    return 'language-server-not-found';
+  }
+  if (
+    client === 'antigravity'
+    && (/\brpc\b.*(?:fail|error)|(?:fail|error).*\brpc\b|failed to connect to antigravity rpc/.test(message))
+  ) {
+    return 'rpc-failed';
+  }
+  if (/failed to connect|connection refused|connection reset|could not resolve|\bdns\b|\bnetwork\b/.test(message)) {
+    return 'network-failed';
+  }
+  return null;
+}
+
 // Stable ids for the source roots the collector probes. One id can stand for
 // several paths of the same kind — Copilot's workspaceStorage has a variant per
 // platform, Kiro's IDE globalStorage has four — because "the VS Code workspace
@@ -285,6 +368,14 @@ function normalizeClientHealthEntry(value) {
   if (lastAttemptAt) entry.collection.lastAttemptAt = lastAttemptAt;
   const lastSuccessAt = normalizeTimestamp(value?.collection?.lastSuccessAt);
   if (lastSuccessAt) entry.collection.lastSuccessAt = lastSuccessAt;
+  if (entry.collection.state === 'failed') {
+    const syncFailureStage = normalizeClientSyncFailureStage(value?.collection?.syncFailureStage);
+    if (syncFailureStage) entry.collection.syncFailureStage = syncFailureStage;
+    const syncExitCode = normalizeClientSyncExitCode(value?.collection?.syncExitCode);
+    if (syncExitCode !== null) entry.collection.syncExitCode = syncExitCode;
+    const syncDetailCode = normalizeClientSyncDetailCode(value?.collection?.syncDetailCode);
+    if (syncDetailCode) entry.collection.syncDetailCode = syncDetailCode;
+  }
   const lastActivityDay = normalizeDay(value?.data?.lastActivityDay);
   if (lastActivityDay) entry.data.lastActivityDay = lastActivityDay;
   const diagnostics = normalizeDiagnostics(value?.diagnostics, entry);
@@ -350,6 +441,8 @@ module.exports = {
   CLIENT_HEALTH_OVERALL_STATES,
   CLIENT_HEALTH_VERSION,
   CLIENT_COLLECTION_STATES,
+  CLIENT_SYNC_DETAIL_CODES,
+  CLIENT_SYNC_FAILURE_STAGES,
   CLIENT_SOURCE_CHECK_IDS,
   CLIENT_SOURCE_STATES,
   MAX_CHECKS_PER_CLIENT,
@@ -358,5 +451,9 @@ module.exports = {
   countOverall,
   deriveClientOverall,
   deriveLegacyClientStatus,
-  normalizeClientHealth
+  normalizeClientHealth,
+  normalizeClientSyncDetailCode,
+  normalizeClientSyncExitCode,
+  normalizeClientSyncFailureStage,
+  classifyClientSyncDetailCode
 };

--- a/worker/src/shared/clientHealth.js
+++ b/worker/src/shared/clientHealth.js
@@ -73,6 +73,7 @@ const CLIENT_SYNC_DETAIL_CODES = Object.freeze([
   'unknown'
 ]);
 const CLIENT_SYNC_DETAIL_CODE_SET = new Set(CLIENT_SYNC_DETAIL_CODES);
+const MAX_SYNC_DETAIL_INPUT_LENGTH = 8 * 1024;
 
 function normalizeClientSyncFailureStage(value) {
   const stage = String(value ?? '').trim().toLowerCase();
@@ -94,14 +95,27 @@ function normalizeClientSyncDetailCode(value) {
   return CLIENT_SYNC_DETAIL_CODE_SET.has(code) ? code : 'unknown';
 }
 
+function boundedSyncDetailText(value) {
+  const raw = String(value ?? '');
+  if (raw.length <= MAX_SYNC_DETAIL_INPUT_LENGTH) return raw;
+  let bounded = '';
+  let codePoints = 0;
+  for (const character of raw) {
+    if (codePoints >= MAX_SYNC_DETAIL_INPUT_LENGTH) break;
+    bounded += character;
+    codePoints += 1;
+  }
+  return bounded;
+}
+
 // Classify only high-confidence, stable substrings from the local sync error.
 // The input is used inside the process and the return value is the only part
 // that may cross the client-health or diagnostic boundaries.
 function classifyClientSyncDetailCode({ client = '', text = '' } = {}) {
-  const message = String(text ?? '').trim().toLowerCase();
+  const message = boundedSyncDetailText(text).trim().toLowerCase();
   if (!message) return null;
 
-  if (/permission denied|access is denied|operation not permitted|\beacces\b/.test(message)) {
+  if (/permission denied|access is denied|operation not permitted|\beacces\b|\beperm\b/.test(message)) {
     return 'permission-denied';
   }
   if (
@@ -111,7 +125,7 @@ function classifyClientSyncDetailCode({ client = '', text = '' } = {}) {
   ) {
     return 'cache-write-failed';
   }
-  if (/session (?:token )?(?:expired|invalid)|invalid (?:api )?token|not authenticated|re-authenticate|unauthorized|forbidden/.test(message)) {
+  if (/session (?:token )?(?:expired|invalid)|invalid (?:api )?token|not authenticated|re-authenticate|unauthorized|forbidden|status\s+(?:401|403)\b/.test(message)) {
     return 'authentication-failed';
   }
   if (/timed out|timeout|deadline has elapsed|operation timed out/.test(message)) {
@@ -443,6 +457,7 @@ module.exports = {
   CLIENT_COLLECTION_STATES,
   CLIENT_SYNC_DETAIL_CODES,
   CLIENT_SYNC_FAILURE_STAGES,
+  MAX_SYNC_DETAIL_INPUT_LENGTH,
   CLIENT_SOURCE_CHECK_IDS,
   CLIENT_SOURCE_STATES,
   MAX_CHECKS_PER_CLIENT,

--- a/worker/src/shared/clientHealth.js
+++ b/worker/src/shared/clientHealth.js
@@ -128,7 +128,7 @@ function classifyClientSyncDetailCode({ client = '', text = '' } = {}) {
   if (/session (?:token )?(?:expired|invalid)|invalid (?:api )?token|not authenticated|re-authenticate|unauthorized|forbidden|status\s+(?:401|403)\b/.test(message)) {
     return 'authentication-failed';
   }
-  const hasNetworkTimeoutTerm = /\b(?:etimedout|network|http|request|connect(?:ion)?|socket|tcp|tls|dns)\b/.test(message);
+  const hasNetworkTimeoutTerm = /\b(?:etimedout|network|https?|request|connect(?:ion)?|socket|tcp|tls|dns)\b/.test(message);
   const hasTimeoutTerm = /\b(?:etimedout|timed out|timeout|deadline exceeded|deadline has elapsed)\b/.test(message);
   if (hasNetworkTimeoutTerm && hasTimeoutTerm) {
     return 'network-timeout';


### PR DESCRIPTION
## Summary

Extend the on-demand diagnostic report with bounded failure metadata for Cursor and Antigravity self-sync operations.

- Record the failed sync stage: `spawn`, `timeout`, `process-exit`, or `unknown`.
- Preserve the numeric Tokscale exit code when available.
- Add conservative detail classifications such as `rpc-failed`, `network-timeout`, `permission-denied`, `invalid-response`, and `cache-write-failed`.
- Carry the metadata through client health, diagnostic reports, the API documentation, and the generated Worker schema.
- Keep raw stderr, paths, credentials, and provider output out of the wire record and diagnostic report.

## Why

The existing diagnostic report could show that a self-sync failed, but it could not distinguish a process-exit failure caused by RPC, networking, permissions, authentication, or an invalid response.

The new fields provide stable evidence for reproducing and investigating the same failure case without exposing the original subprocess output.

## Privacy and performance

Only allowlisted codes and bounded numeric values cross the client-health and diagnostic boundaries. Unrecognized failures are reported as `unknown`.

This change does not add background polling, timers, scans, subprocesses, network requests, or archive reads. Existing Cursor and Antigravity sync attempts are only annotated when they already complete or fail.

## Validation

- `npm run verify` — 2470 passed, 1 skipped
- Focused diagnostics and self-sync tests — 131 passed
- `npm run sync:worker`
- `git diff --check`

Refs #316

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose bounded self-sync failure details for Cursor and Antigravity in client health and diagnostic reports, and harden classification to avoid leaking stderr or paths. Distinguishes generic watchdog timeouts from true network timeouts, now including HTTPS timeout evidence. Addresses Linear #316.

- **New Features**
  - Client health includes `collection.syncFailureStage`, `collection.syncDetailCode`, and `collection.syncExitCode` on sync failure, with strict normalization.
  - Conservative detail codes from bounded (8KB) high-confidence text only; preserves permission failures (e.g., EPERM). Codes: `rpc-failed`, `network-timeout`, `network-failed`, `permission-denied`, `authentication-failed`, `invalid-response`, `cache-write-failed`, `language-server-not-found`.
  - Diagnostics add `client-sync-failed` for recognized sync failure codes; reports bounded stage/detail/exit evidence.
  - Self-sync throttle tracks `failureStage`, `detailCode`, and `exitCode`; infers stable codes from stage when needed; never retains stderr.
  - Collector and `cursorAuth` propagate and classify failure metadata from subprocesses; Worker schema and `docs/API.md` updated.

- **Bug Fixes**
  - Distinguish local watchdog timeouts from network timeouts: only emit `network-timeout` when the error shows both network and timeout terms; generic timeouts keep `syncFailureStage: timeout` with `syncDetailCode: unknown`.
  - Recognize HTTPS timeout messages as `network-timeout` under the same conservative rule.

<sup>Written for commit e8da1a9af6feab5cd82d9ded9275107ad5d88bd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

