### PR TITLE
fix(limits): align Kimi quota display with the web console

### DIFF
--- a/src/shared/kimiLimits.js
+++ b/src/shared/kimiLimits.js
@@ -239,6 +239,35 @@ function parseKimiUsage(rawBody) {
   const body = rawBody?.data && typeof rawBody.data === 'object' ? rawBody.data : rawBody;
   const windows = [];
   const seenKinds = new Set();
+
+  // The FEATURE_CODING detail on top-level `usage` is the authoritative weekly
+  // quota on both endpoints — the number the console shows. Add it before the
+  // limits[] entries so a compatible proxy that also reports a 7-day window
+  // cannot displace it: limits[] only backfills kinds the detail does not cover.
+  const usage = body?.usage;
+  if (usage && typeof usage === 'object') {
+    const usedPercent = usedPercentFromDetail(usage);
+    if (usedPercent !== null) {
+      const name = pickString(usage, ['name', 'label', 'title']);
+      const kind = classifyKimiUsageName(name);
+      const resetAt = pickRaw(usage, ['reset_at', 'resetAt', 'resetTime', 'reset_time']);
+      windows.push({
+        kind,
+        label: name.trim() || kindLabel(kind),
+        usedPercent,
+        remainingPercent: Math.max(0, Math.min(100, 100 - usedPercent)),
+        // This detail is the FEATURE_CODING weekly quota on both endpoints;
+        // anchor its pace to the canonical 7-day window instead of leaving it
+        // duration-less now that it is the primary weekly source (the members
+        // 7-day ratio it supersedes always carried the 7d duration).
+        windowMinutes: kind === 'weekly' ? KIMI_WEEKLY_WINDOW_MINUTES : undefined,
+        resetsAt: toIso(resetAt),
+        showMeter: true
+      });
+      seenKinds.add(kind);
+    }
+  }
+
   const entries = limitEntries(body);
   const classified = entries.length === 2 ? classifyKimiPair(entries) : entries.map((entry) => ({
     ...entry,
@@ -246,6 +275,7 @@ function parseKimiUsage(rawBody) {
   }));
 
   for (const entry of classified) {
+    if (seenKinds.has(entry.kind)) continue;
     seenKinds.add(entry.kind);
     windows.push({
       kind: entry.kind,
@@ -256,31 +286,6 @@ function parseKimiUsage(rawBody) {
       resetsAt: entry.resetsAt || undefined,
       showMeter: true
     });
-  }
-
-  const usage = body?.usage;
-  if (usage && typeof usage === 'object') {
-    const usedPercent = usedPercentFromDetail(usage);
-    if (usedPercent !== null) {
-      const name = pickString(usage, ['name', 'label', 'title']);
-      const kind = classifyKimiUsageName(name);
-      if (!seenKinds.has(kind)) {
-        const resetAt = pickRaw(usage, ['reset_at', 'resetAt', 'resetTime', 'reset_time']);
-        windows.push({
-          kind,
-          label: name.trim() || kindLabel(kind),
-          usedPercent,
-          remainingPercent: Math.max(0, Math.min(100, 100 - usedPercent)),
-          // This detail is the FEATURE_CODING weekly quota on both endpoints;
-          // anchor its pace to the canonical 7-day window instead of leaving it
-          // duration-less now that it is the primary weekly source (the members
-          // 7-day ratio it supersedes always carried the 7d duration).
-          windowMinutes: kind === 'weekly' ? KIMI_WEEKLY_WINDOW_MINUTES : undefined,
-          resetsAt: toIso(resetAt),
-          showMeter: true
-        });
-      }
-    }
   }
 
   return { windows };

--- a/src/shared/kimiLimits.js
+++ b/src/shared/kimiLimits.js
@@ -3,6 +3,7 @@
 const { normalizeLimitProvider } = require('./limits');
 const { hashKey } = require('./hashKey');
 const { runWithProbeDeadline } = require('./probeDeadline');
+const { BROWSER_USER_AGENT } = require('./browserUserAgent');
 
 const KIMI_FETCH_TIMEOUT_MS = 12_000;
 
@@ -20,6 +21,8 @@ const KIMI_MEMBERSHIP_GRACE_MS = 2000;
 // more than one limits[] entry, so duration-based classification remains
 // defensive. Kimi Code itself has no monthly/billing window here.
 const KIMI_SESSION_MAX_MINUTES = 6 * 60;
+const KIMI_SESSION_WINDOW_MINUTES = 5 * 60;
+const KIMI_WEEKLY_WINDOW_MINUTES = 7 * 24 * 60;
 
 function cleanSecret(value) {
   let raw = value;
@@ -268,6 +271,11 @@ function parseKimiUsage(rawBody) {
           label: name.trim() || kindLabel(kind),
           usedPercent,
           remainingPercent: Math.max(0, Math.min(100, 100 - usedPercent)),
+          // This detail is the FEATURE_CODING weekly quota on both endpoints;
+          // anchor its pace to the canonical 7-day window instead of leaving it
+          // duration-less now that it is the primary weekly source (the members
+          // 7-day ratio it supersedes always carried the 7d duration).
+          windowMinutes: kind === 'weekly' ? KIMI_WEEKLY_WINDOW_MINUTES : undefined,
           resetsAt: toIso(resetAt),
           showMeter: true
         });
@@ -334,14 +342,14 @@ function parseKimiMembershipStats(rawBody) {
     ['ratelimitCode5h', 'ratelimit_code_5h', 'ratelimit5h', 'ratelimit_5h'],
     'session',
     '5-hour',
-    5 * 60
+    KIMI_SESSION_WINDOW_MINUTES
   );
   const weekly = membershipRateWindow(
     body,
     ['ratelimitCode7d', 'ratelimit_code_7d', 'ratelimit7d', 'ratelimit_7d'],
     'weekly',
     'Weekly',
-    7 * 24 * 60
+    KIMI_WEEKLY_WINDOW_MINUTES
   );
   if (session) windows.push(session);
   if (weekly) windows.push(weekly);
@@ -423,6 +431,7 @@ function jwtSessionHeaders(token) {
 }
 
 function kimiWebHeaders(token) {
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   return {
     Authorization: `Bearer ${token}`,
     Cookie: `kimi-auth=${token}`,
@@ -433,6 +442,11 @@ function kimiWebHeaders(token) {
     'connect-protocol-version': '1',
     'x-language': 'en-US',
     'x-msh-platform': 'web',
+    // undici sends `User-Agent: node` by default; the web console rejects
+    // non-browser clients, so present as Chrome like the sibling web-session
+    // providers (mimo/qoder) do.
+    'User-Agent': BROWSER_USER_AGENT,
+    ...(timezone ? { 'r-timezone': timezone } : {}),
     ...jwtSessionHeaders(token)
   };
 }
@@ -493,7 +507,13 @@ async function fetchKimiWebWindows(token, deps = {}) {
   const membershipWindows = membership.value ? parseKimiMembershipStats(membership.value).windows : [];
   const usageWindows = usage.value ? parseKimiWebUsage(usage.value).windows : [];
   return {
-    windows: mergeKimiWindows(membershipWindows, usageWindows),
+    // GetUsages is the authoritative quota source: the FEATURE_CODING detail is
+    // the 7-day used/limit the Kimi console shows, and limits[0] is the 5-hour
+    // rate limit. Membership stats only enrich that baseline with the shared
+    // monthly pool (and may offer 5h/7d ratios as a fallback when GetUsages
+    // lacks a window). mergeKimiWindows keeps the first window of each kind, so
+    // usage must be listed first for its detail to fill the weekly slot.
+    windows: mergeKimiWindows(usageWindows, membershipWindows),
     errors: [membership.error, usage.error].filter(Boolean)
   };
 }
@@ -508,6 +528,9 @@ async function fetchKimiCodeWindows(key, deps = {}) {
   return parseKimiUsage(body).windows;
 }
 
+// First window of each kind wins, so callers list authoritative sources first
+// (usage before membership) and later groups only fill the kinds that are
+// still missing.
 function mergeKimiWindows(...groups) {
   const byKind = new Map();
   for (const windows of groups) {

--- a/tests/shared/kimiLimits.test.js
+++ b/tests/shared/kimiLimits.test.js
@@ -248,7 +248,11 @@ test('parseKimiUsage falls back to the top-level usage block when no matching ki
   assert.equal(usage.windows[0].resetsAt, '2026-08-01T00:00:00.000Z');
 });
 
-test('parseKimiUsage skips the top-level usage block once limits[] already covers its kind', () => {
+test('parseKimiUsage prefers the top-level usage detail over a limits[] window of the same kind', () => {
+  // The FEATURE_CODING detail on top-level `usage` is the authoritative weekly
+  // quota (the number the console shows). A compatible proxy that also reports
+  // a 7-day window in limits[] must not displace it — the same precedence rule
+  // fixed for the membership merge in #343, applied inside the parser.
   const usage = parseKimiUsage({
     limits: [
       { detail: { used: 40, limit: 200, remaining: 160 }, window: { duration: 7, timeUnit: 'DAY' } }
@@ -258,7 +262,28 @@ test('parseKimiUsage skips the top-level usage block once limits[] already cover
 
   assert.equal(usage.windows.length, 1);
   assert.equal(usage.windows[0].kind, 'weekly');
-  assert.equal(usage.windows[0].usedPercent, 20);
+  assert.equal(usage.windows[0].usedPercent, 50);
+});
+
+test('parseKimiUsage keeps the top-level detail for weekly when limits[] carries 5h and 7d windows', () => {
+  // A compatible proxy may flatten two quota windows into limits[] (a 5-hour
+  // rate limit plus a 7-day window) while top-level `usage` still carries the
+  // FEATURE_CODING detail. The detail must win the weekly slot and the 7-day
+  // limit must be dropped, mirroring CodexBar's usage.detail-as-weekly source.
+  const usage = parseKimiUsage({
+    usage: { used: 214, limit: 2048, remaining: 1834, name: 'Weekly quota' },
+    limits: [
+      { detail: { used: 20, limit: 60, remaining: 40 }, window: { duration: 300, timeUnit: 'TIME_UNIT_MINUTE' } },
+      { detail: { used: 40, limit: 200, remaining: 160 }, window: { duration: 7, timeUnit: 'DAY' } }
+    ]
+  });
+
+  assert.equal(usage.windows.length, 2);
+  const session = usage.windows.find((w) => w.kind === 'session');
+  const weekly = usage.windows.find((w) => w.kind === 'weekly');
+  assert.equal(session.usedPercent, (20 / 60) * 100);
+  assert.equal(weekly.usedPercent, (214 / 2048) * 100);
+  assert.equal(weekly.windowMinutes, 7 * 24 * 60);
 });
 
 test('fetchKimiLimits returns notConfigured without an API key', async () => {
@@ -335,7 +360,13 @@ test('fetchKimiLimits prefers web membership windows when a web token is configu
   assert.equal(requests.some((request) => request.url === KIMI_CODE_USAGES_URL), false);
   assert.equal(requests[0].init.headers.Authorization, 'Bearer web-token');
   assert.equal(requests[0].init.headers.Cookie, 'kimi-auth=web-token');
-  assert.equal(requests[0].init.headers['User-Agent'], BROWSER_USER_AGENT);
+  // Both web endpoints share the browser-presenting headers (the console
+  // rejects undici's default `node` agent); assert on both requests so a future
+  // per-endpoint header divergence is caught, not just the first call.
+  for (const request of requests) {
+    assert.equal(request.init.headers['User-Agent'], BROWSER_USER_AGENT);
+    assert.equal(request.init.headers['r-timezone'], Intl.DateTimeFormat().resolvedOptions().timeZone);
+  }
   assert.equal(provider.source, 'web');
   assert.equal(provider.status, 'ok');
   assert.deepEqual(provider.windows.map((window) => window.kind), ['session', 'weekly', 'billing']);

--- a/tests/shared/kimiLimits.test.js
+++ b/tests/shared/kimiLimits.test.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 const { hashKey } = require('../../src/shared/hashKey');
+const { BROWSER_USER_AGENT } = require('../../src/shared/browserUserAgent');
 
 const {
   KIMI_CODE_USAGES_URL,
@@ -334,6 +335,7 @@ test('fetchKimiLimits prefers web membership windows when a web token is configu
   assert.equal(requests.some((request) => request.url === KIMI_CODE_USAGES_URL), false);
   assert.equal(requests[0].init.headers.Authorization, 'Bearer web-token');
   assert.equal(requests[0].init.headers.Cookie, 'kimi-auth=web-token');
+  assert.equal(requests[0].init.headers['User-Agent'], BROWSER_USER_AGENT);
   assert.equal(provider.source, 'web');
   assert.equal(provider.status, 'ok');
   assert.deepEqual(provider.windows.map((window) => window.kind), ['session', 'weekly', 'billing']);
@@ -406,6 +408,94 @@ test('fetchKimiLimits keeps web 5-hour and weekly windows when monthly enrichmen
 
   assert.equal(provider.status, 'ok');
   assert.deepEqual(provider.windows.map((window) => window.kind), ['session', 'weekly']);
+});
+
+test('fetchKimiLimits uses the GetUsages detail for weekly, not the membership 7-day ratio', async () => {
+  // Canonical shapes: GetUsages carries the FEATURE_CODING weekly used/limit
+  // (the number the Kimi console shows) plus the 5-hour limit, while the
+  // membership stats carry only the shared monthly pool and a Code 7-day ratio.
+  // The weekly slot must come from the GetUsages detail — regression for #343,
+  // where merging membership first let ratelimitCode7d overwrite it.
+  const provider = await fetchKimiLimits(
+    { kimiWebAccessToken: 'web-token' },
+    {
+      env: {},
+      now: () => Date.parse('2026-07-19T00:00:00Z'),
+      fetch: async (url) => {
+        if (String(url) === KIMI_MEMBERSHIP_STATS_URL) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              subscriptionBalance: { feature: 'FEATURE_OMNI', type: 'SUBSCRIPTION', amountUsedRatio: 0.25 },
+              ratelimitCode7d: { ratio: 0.48, enabled: true }
+            })
+          };
+        }
+        assert.equal(String(url), KIMI_WEB_USAGES_URL);
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            usages: [{
+              scope: 'FEATURE_CODING',
+              detail: { used: 214, limit: 2048 },
+              limits: [{ detail: { used: 20, limit: 60 }, window: { duration: 300, timeUnit: 'TIME_UNIT_MINUTE' } }]
+            }]
+          })
+        };
+      }
+    }
+  );
+
+  assert.equal(provider.status, 'ok');
+  assert.deepEqual(provider.windows.map((window) => window.kind), ['session', 'weekly', 'billing']);
+  const weekly = provider.windows.find((window) => window.kind === 'weekly');
+  assert.ok(weekly);
+  assert.equal(weekly.usedPercent, (214 / 2048) * 100);
+  assert.equal(weekly.windowMinutes, 7 * 24 * 60);
+  const session = provider.windows.find((window) => window.kind === 'session');
+  assert.equal(session.usedPercent, (20 / 60) * 100);
+  assert.equal(provider.windows.find((window) => window.kind === 'billing').usedPercent, 25);
+});
+
+test('fetchKimiLimits falls back to the membership 7-day ratio when GetUsages lacks a weekly detail', async () => {
+  // When the FEATURE_CODING detail carries no usable used/limit, the merged
+  // weekly slot fills from ratelimitCode7d instead of disappearing.
+  const provider = await fetchKimiLimits(
+    { kimiWebAccessToken: 'web-token' },
+    {
+      env: {},
+      now: () => Date.parse('2026-07-19T00:00:00Z'),
+      fetch: async (url) => {
+        if (String(url) === KIMI_MEMBERSHIP_STATS_URL) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              subscriptionBalance: { feature: 'FEATURE_OMNI', type: 'SUBSCRIPTION', amountUsedRatio: 0.25 },
+              ratelimitCode7d: { ratio: 0.48, enabled: true }
+            })
+          };
+        }
+        assert.equal(String(url), KIMI_WEB_USAGES_URL);
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            usages: [{
+              scope: 'FEATURE_CODING',
+              detail: { limit: 2048 },
+              limits: [{ detail: { used: 20, limit: 60 }, window: { duration: 300, timeUnit: 'TIME_UNIT_MINUTE' } }]
+            }]
+          })
+        };
+      }
+    }
+  );
+
+  assert.equal(provider.status, 'ok');
+  assert.equal(provider.windows.find((window) => window.kind === 'weekly').usedPercent, 48);
 });
 
 test('fetchKimiLimits bounds monthly enrichment without delaying web usage windows', async () => {


### PR DESCRIPTION
## Summary

The weekly quota slot merged membership windows first, so the `GetSubscriptionStats` `ratelimitCode7d` ratio could overwrite the `GetUsages` FEATURE_CODING `detail` (used/limit) — the numbers the Kimi console actually shows. Whenever the subscription 7-day ratio and the coding weekly quota disagree, the widget's weekly gauge drifts from the console, which is the suspected root cause behind #343.

## Changes

- List usage windows first in `mergeKimiWindows` so the GetUsages `detail` fills the weekly slot; membership only backfills missing windows plus the monthly pool (`src/shared/kimiLimits.js`).
- Apply the same precedence inside `parseKimiUsage`: the top-level `usage` detail wins the weekly slot, and `limits[]` only backfills kinds it does not cover — so a compatible proxy reporting both a 5-hour and a 7-day limit cannot displace the console number.
- Carry `windowMinutes` (7 days) on the detail-based weekly window.
- Present web probes as a browser — undici's default `User-Agent: node` is rejected by the web console. The sibling web-session providers (mimo/qoder) already sent `BROWSER_USER_AGENT`; Kimi was the gap.
- Add the `r-timezone` header to web probes.
- Regression tests: the weekly slot comes from the GetUsages detail, and the membership 7-day ratio / an extra 7-day `limits[]` window only fill in when the detail lacks a weekly used count.

## Verification

`npm run verify` — 2473 tests pass, 1 pre-existing skip.

Fixes #343
