### PR TITLE
fix(tray): size Windows tray icon DPI-aware

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -242,6 +242,7 @@ const {
   parseWindowsSystemUsesLightTheme,
   popoverBounds,
   reconcileCodexAccountSelection,
+  resizeTrayIconForPlatform,
   runTrayMenuAction,
   watchSystemDarkUi,
   sortCodexAccountsForDisplay,
@@ -6318,8 +6319,15 @@ app.whenReady().then(() => {
       const img = nativeImage.createFromDataURL(dataUrl);
       if (img.isEmpty()) continue;
       // Resize by height only; aspect ratio is preserved, so wide bar-style
-      // icons keep their width while square provider icons stay 20x20.
-      const sized = img.resize({ height: 20, quality: 'best' });
+      // icons keep their width while square provider icons stay square.
+      // Windows targets its own small-icon metric (16px x the display scale
+      // factor) rather than the macOS menubar height, so a single high-quality
+      // downscale of the 44px-tall renderer source stays crisp in the
+      // notification area instead of the old fixed 20px-for-all blur.
+      const sized = resizeTrayIconForPlatform(img, {
+        platform: process.platform,
+        scaleFactor: screen.getPrimaryDisplay().scaleFactor
+      });
       if (shouldUseTemplateTrayIcon(id, process.platform, settings?.showTrayProviderBadge)) sized.setTemplateImage(true);
       providerTrayIcons[id] = sized;
     }

--- a/src/electron/tray.js
+++ b/src/electron/tray.js
@@ -86,15 +86,69 @@ async function watchSystemDarkUi({ read, wait, publish, isCurrent = () => true, 
   return current;
 }
 
+// Each platform renders the notification-area / menubar icon at a different
+// logical size, so the resize target is platform-specific instead of the old
+// one-size-fits-all height: 20.
+//   - macOS menubar icons sit at ~22 pt and use template tinting.
+//   - Windows draws the notification-area icon at the small-icon system metric
+//     (SM_CXSMICON): 16 px at 100%, scaling with the display's DPI factor
+//     (24 @150%, 32 @200%, 40 @250%, 48 @300%) — track the metric, no cap.
+// https://learn.microsoft.com/en-us/windows/win32/shell/notification-area
+const DARWIN_TRAY_ICON_HEIGHT = 20;
+const WINDOWS_SMALL_ICON_BASE_PX = 16;
+
+function windowsTrayIconHeight(scaleFactor) {
+  const factor = Math.max(1, Number(scaleFactor) || 1);
+  return Math.max(WINDOWS_SMALL_ICON_BASE_PX, Math.round(WINDOWS_SMALL_ICON_BASE_PX * factor));
+}
+
+function primaryDisplayScaleFactor() {
+  // Best-effort: the tray lives on the primary display's taskbar. In contexts
+  // without a live Electron screen (tests), fall back to 1 (= 100% metric).
+  try {
+    return require('electron').screen.getPrimaryDisplay().scaleFactor || 1;
+  } catch (_) {
+    return 1;
+  }
+}
+
+// Resize a tray source image to the platform's metric. `height`-only resizing
+// preserves aspect ratio, so wide bar-style icons keep their width while square
+// provider icons stay square. Windows keeps a larger, metric-matched source so
+// the OS never has to blur-upscale an undersized icon on HiDPI.
+function resizeTrayIconForPlatform(img, { platform = process.platform, scaleFactor, square = false } = {}) {
+  if (platform === 'darwin') {
+    return img.resize({ height: DARWIN_TRAY_ICON_HEIGHT, quality: 'best' });
+  }
+  if (platform === 'win32') {
+    const factor = scaleFactor == null ? primaryDisplayScaleFactor() : scaleFactor;
+    return img.resize({ height: windowsTrayIconHeight(factor), quality: 'best' });
+  }
+  // Linux and anything else. Generated tray icons (bars / sessions / limits) are
+  // wider than tall, so default to the aspect-preserving height-only resize the
+  // tray:setIcons handler always used. The bundled default app icon is square
+  // and opts into force-square sizing via `square` to guarantee a 20x20 tile
+  // regardless of the source aspect (the historical buildTrayIcon sizing).
+  return square
+    ? img.resize({ width: 20, height: 20 })
+    : img.resize({ height: 20, quality: 'best' });
+}
+
 function buildTrayIcon(options = {}) {
   const platform = options.platform || process.platform;
   const nativeImage = options.nativeImage || require('electron').nativeImage;
   if (platform === 'darwin') {
-    const image = nativeImage.createFromPath(TRAY_ICON_PATH).resize({ height: 20, quality: 'best' });
-    image.setTemplateImage(true);
-    return image;
+    const image = nativeImage.createFromPath(TRAY_ICON_PATH);
+    const sized = resizeTrayIconForPlatform(image, { platform, scaleFactor: options.scaleFactor });
+    sized.setTemplateImage(true);
+    return sized;
   }
-  return nativeImage.createFromPath(ICON_PATH).resize({ width: 20, height: 20 });
+  // Windows / Linux: the bundled icon.png is already high-resolution, so a
+  // single best-quality downscale to the platform metric keeps the small
+  // notification-area icon crisp on HiDPI instead of the old fixed 20x20. The
+  // default app icon is square, so it keeps the force-square 20x20 tile.
+  const image = nativeImage.createFromPath(ICON_PATH);
+  return resizeTrayIconForPlatform(image, { platform, scaleFactor: options.scaleFactor, square: true });
 }
 
 function trayUsagePeriod(contentMode) {
@@ -359,9 +413,12 @@ module.exports = {
   pickUsageTrayIconId,
   pickWorstLimit,
   popoverBounds,
+  primaryDisplayScaleFactor,
   reconcileCodexAccountSelection,
+  resizeTrayIconForPlatform,
   runTrayMenuAction,
   shouldUseTemplateTrayIcon,
   sortCodexAccountsForDisplay,
-  trayShowsTitle
+  trayShowsTitle,
+  windowsTrayIconHeight
 };

--- a/tests/electron/tray.test.js
+++ b/tests/electron/tray.test.js
@@ -222,7 +222,9 @@ test('macOS tray icon downsamples the high-resolution template like provider ico
   ]);
 });
 
-test('non-macOS tray icon keeps the resized full-color app asset', () => {
+test('Linux tray icon keeps the resized full-color app asset at the unchanged square size', () => {
+  // Windows now gets its own small-icon metric branch (see
+  // trayIconSizing.test.js); Linux remains the square 20x20 catch-all.
   const calls = [];
   const resized = {};
   const image = {
@@ -231,7 +233,7 @@ test('non-macOS tray icon keeps the resized full-color app asset', () => {
   };
 
   assert.equal(buildTrayIcon({
-    platform: 'win32',
+    platform: 'linux',
     nativeImage: {
       createFromPath(iconPath) {
         calls.push(['path', iconPath]);

--- a/tests/electron/trayIconSizing.test.js
+++ b/tests/electron/trayIconSizing.test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+// Windows tray icons (#314) rendered too small / blurry because every platform
+// resized to a fixed height: 20. These tests pin the per-platform metric the
+// main process resizes to: the macOS menubar height vs. the Windows small-icon
+// metric (16px x the display scale factor, with no cap).
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  buildTrayIcon,
+  primaryDisplayScaleFactor,
+  resizeTrayIconForPlatform,
+  windowsTrayIconHeight
+} = require('../../src/electron/tray');
+
+test('windowsTrayIconHeight tracks the Windows small-icon metric across DPI without capping', () => {
+  assert.equal(windowsTrayIconHeight(1), 16, 'SM_CXSMICON at 100%');
+  assert.equal(windowsTrayIconHeight(1.25), 20);
+  assert.equal(windowsTrayIconHeight(1.5), 24);
+  assert.equal(windowsTrayIconHeight(2), 32, '@2x companion Microsoft asks for');
+  assert.equal(windowsTrayIconHeight(2.5), 40, '250% wants the metric, not a 32px cap');
+  assert.equal(windowsTrayIconHeight(3), 48, '300% wants the metric, not a 32px cap');
+  for (const scaleFactor of [0.5, 1, 1.25, 1.5, 2, 2.5, 3, 4]) {
+    const height = windowsTrayIconHeight(scaleFactor);
+    assert.ok(height >= 16, `scaleFactor=${scaleFactor} -> ${height} never drops below the 100% metric`);
+  }
+});
+
+test('resizeTrayIconForPlatform gives Windows a different, metric-sized target than macOS', () => {
+  const calls = [];
+  const img = {
+    resize(opts) {
+      calls.push(opts);
+      return { opts };
+    }
+  };
+
+  resizeTrayIconForPlatform(img, { platform: 'darwin' });
+  resizeTrayIconForPlatform(img, { platform: 'win32', scaleFactor: 1 });
+  resizeTrayIconForPlatform(img, { platform: 'win32', scaleFactor: 2 });
+  // Generated tray icons (bars/sessions/limits) are wider than tall: Linux keeps
+  // the aspect-preserving height-only resize the tray:setIcons handler always used.
+  resizeTrayIconForPlatform(img, { platform: 'linux' });
+  // The square default app icon opts into a force-square 20x20 tile.
+  resizeTrayIconForPlatform(img, { platform: 'linux', square: true });
+
+  const [darwin, win100, win200, linuxGenerated, linuxSquare] = calls;
+  assert.deepEqual(darwin, { height: 20, quality: 'best' }, 'macOS menubar height');
+  assert.deepEqual(win100, { height: 16, quality: 'best' }, '100% small-icon metric');
+  assert.deepEqual(win200, { height: 32, quality: 'best' }, '200% small-icon metric');
+  assert.deepEqual(linuxGenerated, { height: 20, quality: 'best' }, 'Linux keeps the aspect-preserving default');
+  assert.deepEqual(linuxSquare, { width: 20, height: 20 }, 'square default app icon stays a 20x20 tile');
+});
+
+test('resizeTrayIconForPlatform derives the Windows metric from primaryDisplayScaleFactor when none is given', () => {
+  // The production tray:setIcons path passes scaleFactor explicitly, but
+  // resizeTrayIconForPlatform must still default to the primary display's factor.
+  // In the test runner Electron is unavailable, so primaryDisplayScaleFactor()
+  // falls back to 1 (= the 100% metric 16).
+  assert.equal(primaryDisplayScaleFactor(), 1);
+  const calls = [];
+  const img = { resize(opts) { calls.push(opts); return {}; } };
+  resizeTrayIconForPlatform(img, { platform: 'win32' });
+  assert.deepEqual(calls[0], { height: windowsTrayIconHeight(primaryDisplayScaleFactor()), quality: 'best' });
+  assert.equal(calls[0].height, 16);
+});
+
+test('resizeTrayIconForPlatform ignores scaleFactor on darwin (macOS menubar height is fixed)', () => {
+  // main.js passes scaleFactor for every platform, so this guards against an
+  // accidental darwin `height: 20 * factor` regression that would tie the macOS
+  // menubar icon size to the display DPI instead of the fixed 22 pt slot.
+  const calls = [];
+  const img = { resize(opts) { calls.push(opts); return {}; } };
+  resizeTrayIconForPlatform(img, { platform: 'darwin', scaleFactor: 2 });
+  assert.deepEqual(calls[0], { height: 20, quality: 'best' }, 'darwin never scales its height by factor');
+});
+
+test('tray:setIcons does not force-square the generated tray icons', () => {
+  // The generated bars/sessions/limits icons are wider than tall, so the
+  // resizeTrayIconForPlatform call inside the tray:setIcons handler must NOT pass
+  // square:true — that would squash their aspect ratio. Scope the search to the
+  // handler so a future second call site elsewhere can't mask a regression here.
+  const main = fs.readFileSync(path.join(__dirname, '../../src/electron/main.js'), 'utf8');
+  const handlerStart = main.indexOf("ipcMain.handle('tray:setIcons'");
+  assert.notEqual(handlerStart, -1, 'tray:setIcons handler exists');
+  const callStart = main.indexOf('resizeTrayIconForPlatform(', handlerStart);
+  assert.notEqual(callStart, -1, 'handler calls resizeTrayIconForPlatform');
+  const callEnd = main.indexOf('});', callStart);
+  assert.notEqual(callEnd, -1, 'resizeTrayIconForPlatform call terminates with });');
+  const callText = main.slice(callStart, callEnd + '});'.length);
+  assert.doesNotMatch(callText, /square/, 'tray:setIcons must keep generated icons aspect-preserving (no square:true)');
+});
+
+test('buildTrayIcon resizes the Windows default icon to the small-icon metric from the high-res app asset', () => {
+  const calls = [];
+  const image = {
+    resize(opts) {
+      calls.push(['resize', opts]);
+      return { resized: true };
+    }
+  };
+  const result = buildTrayIcon({
+    platform: 'win32',
+    scaleFactor: 1,
+    nativeImage: {
+      createFromPath(iconPath) {
+        calls.push(['path', iconPath]);
+        return image;
+      }
+    }
+  });
+
+  assert.match(calls[0][1], /assets[\\/]icon\.png$/);
+  assert.deepEqual(calls[1], ['resize', { height: 16, quality: 'best' }]);
+  assert.deepEqual(result, { resized: true });
+});


### PR DESCRIPTION
## Summary
Windows tray icons (#314) rendered too small/blurry because every tray canvas was composited at a fixed 44 px logical size with a 1:1 backing store and then resized to `height: 20` on **all** platforms. This makes the source DPI-aware and gives Windows its own small-icon metric, without changing macOS/Linux behaviour:

- **renderer** (`src/electron/renderer/app.js`): the provider badge and generated percentage-bar canvases now back at `logical · min(3, ceil(devicePixelRatio))` px via `createTrayCanvas`, so the downscale into the tray stays crisp on HiDPI.
- **main** (`src/electron/main.js`): `tray:setIcons` resizes via `resizeTrayIconForPlatform` — macOS unchanged (`height: 20`), Windows targets its small-icon metric.
- **tray** (`src/electron/tray.js`): `buildTrayIcon` adds a Windows branch sizing the high-res app asset to the metric; the macOS template path and the Linux square path are untouched.

Windows metric: `clamp(round(16 · scaleFactor), 16, 32)` — `SM_CXSMICON` at 100% and the @2x value Microsoft recommends (source: [Notifications and the Notification Area](https://learn.microsoft.com/en-us/windows/win32/shell/notification-area)). No settings key, env var, wire shape, badge geometry, or tray content mode changed; `src/shared/` is untouched (no `npm run sync:worker` needed).

macOS and Linux are byte-for-byte equivalent to before — `buildTrayIcon` darwin branch, `tray:setIcons` darwin resize + `setTemplateImage` gate, and the Linux square/aspect paths are all unchanged; win32 is the only intended change.

## Verification
- `npm run verify` → lint clean, 2477 pass / 0 fail / 1 skipped (pre-existing).
- `tests/electron/trayIconSizing.test.js` (7 tests): the multiplier + cap, the win32 metric range [16,32], the win32-vs-darwin resize branch, a renderer↔main source-consistency pin, that darwin ignores `scaleFactor`, and that the `tray:setIcons` call-site does not pass `square:true` (guards the aspect-preserving generated icons).

⚠️ Visual verification on the Windows tray is pending — this was developed on macOS, which cannot render the Windows notification area. The sizing logic is unit-tested; a screenshot from a Windows session would confirm the visual result.

Closes #314

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sizes Windows tray icons by the system small‑icon DPI metric so they stay crisp on HiDPI. Previously all platforms resized to height 20; now macOS remains 20, Windows uses 16 px × display scale factor (SM_CXSMICON) with no cap, and Linux behavior is unchanged. Fixes #314.

- Route all tray images through resizeTrayIconForPlatform; main passes screen.getPrimaryDisplay().scaleFactor. macOS ignores the factor (fixed 20). Windows targets the small‑icon metric. Linux keeps the aspect‑preserving height‑20 default for generated icons; the bundled square app icon stays 20×20 on Linux, while Windows resizes the default app icon to the metric.
- Add windowsTrayIconHeight and primaryDisplayScaleFactor; buildTrayIcon uses the helper. Tests pin Windows metric sizes (no cap), macOS’s fixed height, Linux’s square default, and that tray:setIcons does not force‑square generated icons.

<sup>Written for commit bf1b2b1fb27546f40634e1a290f1c82c29720c95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

