### PR TITLE
fix(collector): bound OpenCode watcher to Tokscale sources

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -36,7 +36,7 @@ Token Monitor は **トークン使用量**、**アカウント制限**、**セ�
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`, `~/.claude/transcripts/` | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/opencode*.db`（1.2+）および/または `~/.local/share/opencode/storage/message/`（legacy／未移行） | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/`（`opencode*.db`、`storage/message/`） | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` または `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/`（Cursor 同期で更新） | ✅ | ✅ | — |

--- a/README.ja.md
+++ b/README.ja.md
@@ -36,7 +36,7 @@ Token Monitor は **トークン使用量**、**アカウント制限**、**セ�
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`, `~/.claude/transcripts/` | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/` | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/opencode*.db`（1.2+）および/または `~/.local/share/opencode/storage/message/`（legacy／未移行） | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` または `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/`（Cursor 同期で更新） | ✅ | ✅ | — |

--- a/README.ko.md
+++ b/README.ko.md
@@ -36,7 +36,7 @@ Token Monitor는 **토큰 사용량**, **계정 한도**, **세션 상세**를 �
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`, `~/.claude/transcripts/` | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/opencode*.db` (1.2+) 및/또는 `~/.local/share/opencode/storage/message/` (legacy/미마이그레이션) | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/` (`opencode*.db`, `storage/message/`) | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` 또는 `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/` (Cursor 동기화로 갱신) | ✅ | ✅ | — |

--- a/README.ko.md
+++ b/README.ko.md
@@ -36,7 +36,7 @@ Token Monitor는 **토큰 사용량**, **계정 한도**, **세션 상세**를 �
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`, `~/.claude/transcripts/` | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/` | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/opencode*.db` (1.2+) 및/또는 `~/.local/share/opencode/storage/message/` (legacy/미마이그레이션) | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` 또는 `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/` (Cursor 동기화로 갱신) | ✅ | ✅ | — |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Token Monitor supports token usage, account-limit checks, and session details se
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`, `~/.claude/transcripts/` | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/` | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/opencode*.db` (1.2+) and/or `~/.local/share/opencode/storage/message/` (legacy/unmigrated) | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` or `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/` (kept fresh by Cursor sync) | ✅ | ✅ | — |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Token Monitor supports token usage, account-limit checks, and session details se
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`, `~/.claude/transcripts/` | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/opencode*.db` (1.2+) and/or `~/.local/share/opencode/storage/message/` (legacy/unmigrated) | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/` (`opencode*.db`, `storage/message/`) | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` or `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/` (kept fresh by Cursor sync) | ✅ | ✅ | — |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,7 +36,7 @@ Token Monitor 对 Token 用量、账户额度和 session 明细分别支持：
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`、`~/.claude/transcripts/` | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/opencode*.db`（1.2+）和/或 `~/.local/share/opencode/storage/message/`（legacy／未迁移） | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/`（`opencode*.db`、`storage/message/`） | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` 或 `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/`（由 Cursor 同步保持更新） | ✅ | ✅ | — |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,7 +36,7 @@ Token Monitor 对 Token 用量、账户额度和 session 明细分别支持：
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`、`~/.claude/transcripts/` | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/` | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/opencode*.db`（1.2+）和/或 `~/.local/share/opencode/storage/message/`（legacy／未迁移） | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` 或 `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/`（由 Cursor 同步保持更新） | ✅ | ✅ | — |

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -36,7 +36,7 @@ Token Monitor 對 Token 用量、帳戶額度與 session 明細分別支援：
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`、`~/.claude/transcripts/` | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/opencode*.db`（1.2+）和/或 `~/.local/share/opencode/storage/message/`（legacy／未遷移） | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/`（`opencode*.db`、`storage/message/`） | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` 或 `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/`（由 Cursor 同步保持更新） | ✅ | ✅ | — |

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -36,7 +36,7 @@ Token Monitor 對 Token 用量、帳戶額度與 session 明細分別支援：
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`、`~/.claude/transcripts/` | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/` | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/opencode*.db`（1.2+）和/或 `~/.local/share/opencode/storage/message/`（legacy／未遷移） | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` 或 `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/`（由 Cursor 同步保持更新） | ✅ | ✅ | — |

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1077,8 +1077,8 @@ function clientSourceRoots(clientsCsv) {
   add('codex', ['codex-sessions', path.join(home, '.codex', 'sessions')]);
   const hermesHome = resolveHermesHome({ env: process.env, homeDir: home });
   add('hermes', ['hermes-home', hermesHome], ...hermesProfileWatchDirs(hermesHome).map((dir) => ['hermes-profile', dir]));
-  // Tokscale 4.10.0 reads OpenCode's direct opencode*.db family and also keeps
-  // the legacy storage/message/**/*.json source for unmigrated data. The
+  // Within the default OpenCode data root, Tokscale 4.10.0 reads the direct
+  // opencode*.db family and the legacy storage/message/*/*.json source. The
   // watcher prunes the rest of this broad app data root below.
   add('opencode', ['opencode-data', path.join(home, '.local', 'share', 'opencode')]);
   add('openclaw', ['openclaw-agents', path.join(home, '.openclaw', 'agents')]);

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1077,6 +1077,9 @@ function clientSourceRoots(clientsCsv) {
   add('codex', ['codex-sessions', path.join(home, '.codex', 'sessions')]);
   const hermesHome = resolveHermesHome({ env: process.env, homeDir: home });
   add('hermes', ['hermes-home', hermesHome], ...hermesProfileWatchDirs(hermesHome).map((dir) => ['hermes-profile', dir]));
+  // Tokscale 4.10.0 reads OpenCode's direct opencode*.db family and also keeps
+  // the legacy storage/message/**/*.json source for unmigrated data. The
+  // watcher prunes the rest of this broad app data root below.
   add('opencode', ['opencode-data', path.join(home, '.local', 'share', 'opencode')]);
   add('openclaw', ['openclaw-agents', path.join(home, '.openclaw', 'agents')]);
   add('cursor', ['tokscale-cursor-cache', path.join(home, '.config', 'tokscale', 'cursor-cache')]);
@@ -1288,6 +1291,11 @@ function clientsForWatchPath(filePath, rootsByClient) {
 // never recurses into an ignored dir (so the runaway poll is gone), yet a
 // newly created state.db-wal is still seen on the next top-level readdir.
 const HERMES_DB_FILES = new Set(['state.db', 'state.db-wal', 'state.db-shm']);
+// OpenCode discovers only direct opencode.db / opencode-<channel>.db files.
+// WAL/SHM are not database inputs to tokscale, but they are the live-write
+// signals that must remain watched so a transaction committed before a
+// checkpoint refreshes the usage view.
+const OPENCODE_DB_WATCH_PATTERN = /^opencode(?:-[A-Za-z0-9._-]+)?\.db(?:-(?:wal|shm))?$/;
 // MiMo Code keeps a multi-gigabyte log/ tree alongside its SQLite state files.
 // A plain recursive watch of ~/.local/share/mimocode storms the watcher (every
 // SQLite WAL/SHM transaction is a chokidar event, the log dir holds thousands
@@ -1333,9 +1341,11 @@ function watchIgnoreMatcher(clientsCsv) {
     ? antigravityDataRoots().map((dir) => path.resolve(canonicalWatchPath(dir)))
     : [];
   const antigravityRootSet = new Set(antigravityRoots);
+  const opencodeRoots = (candidates.opencode || []).map((dir) => path.resolve(canonicalWatchPath(dir)));
+  const opencodeRootSet = new Set(opencodeRoots);
   const micodeRoots = (candidates.micode || []).map((dir) => path.resolve(canonicalWatchPath(dir)));
   const micodeRootSet = new Set(micodeRoots);
-  if (hermesRoots.length === 0 && copilotRoots.length === 0 && antigravityRoots.length === 0 && micodeRoots.length === 0) return undefined;
+  if (hermesRoots.length === 0 && copilotRoots.length === 0 && antigravityRoots.length === 0 && opencodeRoots.length === 0 && micodeRoots.length === 0) return undefined;
   return (target) => {
     const resolved = path.resolve(target);
     // Every explicit watch root stays watched — the home dir AND each profile
@@ -1369,6 +1379,25 @@ function watchIgnoreMatcher(clientsCsv) {
       if (ANTIGRAVITY_SHALLOW_SOURCE_DIRS.has(firstChild)) return parts.length > 2;
       return false;
     }
+    if (opencodeRootSet.has(resolved)) return false;
+    for (const root of opencodeRoots) {
+      if (!resolved.startsWith(root + path.sep)) continue;
+      const parts = path.relative(root, resolved).split(path.sep);
+      if (parts.length === 1) {
+        // Keep the root's readdir visible for newly created channel DBs, but
+        // do not descend into unrelated app files or directories.
+        return parts[0] !== 'storage' && !OPENCODE_DB_WATCH_PATTERN.test(parts[0]);
+      }
+      if (parts[0] !== 'storage') return true;
+      if (parts.length === 2) return parts[1] !== 'message';
+      if (parts[1] !== 'message') return true;
+      // Tokscale's legacy OpenCode source is storage/message/*/*.json. Keep
+      // the message root, one session directory, and its direct JSON files;
+      // prune deeper runtime trees before chokidar allocates more watches.
+      if (parts.length === 3) return false;
+      if (parts.length === 4) return !parts[3].endsWith('.json');
+      return true;
+    }
     if (micodeRootSet.has(resolved)) return false;
     for (const root of micodeRoots) {
       if (!resolved.startsWith(root + path.sep)) continue;
@@ -1378,7 +1407,7 @@ function watchIgnoreMatcher(clientsCsv) {
       if (path.dirname(resolved) !== root) return true;
       return !MICODE_DB_WATCH_PATTERN.test(path.basename(resolved));
     }
-    return false; // paths outside the bounded Hermes/Copilot/Antigravity/MiCode roots are never ignored
+    return false; // paths outside the bounded client roots are never ignored
   };
 }
 

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -134,6 +134,60 @@ test('watchIgnoreMatcher keeps every direct Tokscale MiMo database variant but p
   }
 });
 
+test('watchIgnoreMatcher bounds OpenCode to its database family and legacy message source', () => {
+  const root = path.join('.local', 'share', 'opencode');
+  const tmp = withTmpHome([
+    root,
+    path.join(root, 'storage', 'message'),
+    path.join(root, 'storage', 'message', 'session-1'),
+    path.join(root, 'storage', 'session_diff'),
+    path.join(root, 'log'),
+    path.join(root, 'snapshot')
+  ]);
+  const originalHomedir = os.homedir;
+  os.homedir = () => tmp;
+  try {
+    const { watchIgnoreMatcher, watchPathsForClients } = freshCollector();
+    const ignored = watchIgnoreMatcher('opencode');
+    const dataRoot = path.join(tmp, root);
+    assert.deepEqual(watchPathsForClients('opencode'), [dataRoot]);
+    assert.equal(typeof ignored, 'function');
+
+    const kept = [
+      dataRoot,
+      path.join(dataRoot, 'opencode.db'),
+      path.join(dataRoot, 'opencode.db-wal'),
+      path.join(dataRoot, 'opencode.db-shm'),
+      path.join(dataRoot, 'opencode-stable.db'),
+      path.join(dataRoot, 'opencode-nightly.db-wal'),
+      path.join(dataRoot, 'storage'),
+      path.join(dataRoot, 'storage', 'message'),
+      path.join(dataRoot, 'storage', 'message', 'session-1'),
+      path.join(dataRoot, 'storage', 'message', 'session-1', 'msg.json'),
+      path.join(dataRoot, 'storage', 'message', 'legacy.json')
+    ];
+    for (const target of kept) assert.equal(ignored(target), false, target);
+
+    const pruned = [
+      path.join(dataRoot, 'account.json'),
+      path.join(dataRoot, 'other.db'),
+      path.join(dataRoot, 'opencode.db-journal'),
+      path.join(dataRoot, 'log'),
+      path.join(dataRoot, 'log', 'runtime.log'),
+      path.join(dataRoot, 'snapshot'),
+      path.join(dataRoot, 'storage', 'session_diff'),
+      path.join(dataRoot, 'storage', 'message', 'session-1', 'nested'),
+      path.join(dataRoot, 'storage', 'message', 'session-1', 'nested', 'msg.json'),
+      path.join(dataRoot, 'storage', 'message', 'session-1', 'not-json.txt')
+    ];
+    for (const target of pruned) assert.equal(ignored(target), true, target);
+  } finally {
+    os.homedir = originalHomedir;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test('watchPathsForClients watches Antigravity source and CLI data but not the sync cache', () => {
   // The IDE source roots are read by `antigravity sync`, while the CLI writes
   // parse-local SQLite that we do not touch. Both are safe watch inputs; the


### PR DESCRIPTION
Fixes #348

## Summary

- Bound the native OpenCode watcher within OpenCode's default data root to the sources Tokscale 4.10.0 actually reads.
- Keep direct `opencode.db` / `opencode-<channel>.db` files and their WAL/SHM sidecars.
- Preserve the legacy `storage/message/*/*.json` source for unmigrated data.
- Prune unrelated OpenCode runtime trees and deeper non-source paths before chokidar allocates watches.
- Add regression coverage for channel databases, SQLite sidecars, legacy JSON, and unrelated files.

Tokscale is already at the latest stable version, `4.10.0`, so no dependency files changed.

## Verification

- `node --test tests/shared/collectorLoadGuards.test.js` — 59 passed
- `npm run verify` — 2474 passed, 1 skipped
- Tokscale 4.10.0 OpenCode JSON smoke test passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the OpenCode watcher to only the sources Tokscale 4.10.0 reads, preventing runaway watches while keeping live refresh via WAL/SHM. Updated the tools table to clarify `opencode*.db` and legacy `storage/message/` paths. Fixes #348.

- **Bug Fixes**
  - Watch only `opencode.db` and `opencode-<channel>.db` plus `-wal`/`-shm`; keep `storage/message/*/*.json`.
  - Prune unrelated runtime paths in `~/.local/share/opencode/` before chokidar allocates watches.
  - Add tests and localized README updates reflecting supported OpenCode data paths.

<sup>Written for commit d9fb733f06eb42aca9281a333746630837e084d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

