### PR TITLE
fix(limits): recognize GLM CREDIT_LIMIT quota windows

### DIFF
--- a/src/shared/zaiLimits.js
+++ b/src/shared/zaiLimits.js
@@ -221,9 +221,16 @@ function parseZaiUsage(quotaBody, subscriptionBody = null) {
   for (const limit of limits) {
     if (!limit || typeof limit !== 'object') continue;
     const type = String(limit.type || limit.limit_type || '').trim().toUpperCase();
-    if (type === 'TOKENS_LIMIT' && zaiUsedPercent(limit) !== null) {
+    const usedPercent = zaiUsedPercent(limit);
+    if (usedPercent === null) continue;
+    // BigModel CN now labels the coding-plan windows CREDIT_LIMIT instead of
+    // TOKENS_LIMIT (same fields and unit/number encodings). The MCP monthly
+    // bucket can still arrive as the misleading unit=5/number=1 (1-minute)
+    // marker, which is never a real window, so keep it on the billing path.
+    const windowMinutes = zaiWindowMinutes(numberOrNull(limit.unit), numberOrNull(limit.number));
+    if ((type === 'TOKENS_LIMIT' || type === 'CREDIT_LIMIT') && windowMinutes !== 1) {
       tokenLimits.push(limit);
-    } else if (type === 'TIME_LIMIT' && zaiUsedPercent(limit) !== null) {
+    } else if (type === 'TIME_LIMIT' || (type === 'CREDIT_LIMIT' && windowMinutes === 1)) {
       timeLimit = limit;
     }
   }

--- a/src/shared/zaiLimits.js
+++ b/src/shared/zaiLimits.js
@@ -221,16 +221,15 @@ function parseZaiUsage(quotaBody, subscriptionBody = null) {
   for (const limit of limits) {
     if (!limit || typeof limit !== 'object') continue;
     const type = String(limit.type || limit.limit_type || '').trim().toUpperCase();
-    const usedPercent = zaiUsedPercent(limit);
-    if (usedPercent === null) continue;
-    // BigModel CN now labels the coding-plan windows CREDIT_LIMIT instead of
-    // TOKENS_LIMIT (same fields and unit/number encodings). The MCP monthly
-    // bucket can still arrive as the misleading unit=5/number=1 (1-minute)
-    // marker, which is never a real window, so keep it on the billing path.
-    const windowMinutes = zaiWindowMinutes(numberOrNull(limit.unit), numberOrNull(limit.number));
-    if ((type === 'TOKENS_LIMIT' || type === 'CREDIT_LIMIT') && windowMinutes !== 1) {
+    // GLM coding-plan windows can arrive as CREDIT_LIMIT in addition to the
+    // legacy TOKENS_LIMIT; both share the same fields and unit/number window
+    // encodings, so CREDIT_LIMIT is treated as a token-window type. MCP stays
+    // on the TIME_LIMIT path below.
+    if (type === 'TOKENS_LIMIT' && zaiUsedPercent(limit) !== null) {
       tokenLimits.push(limit);
-    } else if (type === 'TIME_LIMIT' || (type === 'CREDIT_LIMIT' && windowMinutes === 1)) {
+    } else if (type === 'CREDIT_LIMIT' && zaiUsedPercent(limit) !== null) {
+      tokenLimits.push(limit);
+    } else if (type === 'TIME_LIMIT' && zaiUsedPercent(limit) !== null) {
       timeLimit = limit;
     }
   }

--- a/tests/shared/zaiLimits.test.js
+++ b/tests/shared/zaiLimits.test.js
@@ -87,7 +87,7 @@ test('parseZaiUsage treats a single 5-hour token limit as the old-plan session w
   assert.equal(usage.windows.find((window) => window.kind === 'weekly'), undefined);
 });
 
-test('parseZaiUsage recognizes CREDIT_LIMIT entries from BigModel CN as token windows', () => {
+test('parseZaiUsage recognizes CREDIT_LIMIT entries as token windows', () => {
   const usage = parseZaiUsage({
     data: {
       level: 'lite',
@@ -110,23 +110,22 @@ test('parseZaiUsage recognizes CREDIT_LIMIT entries from BigModel CN as token wi
   assert.equal(Math.round(usage.windows[1].usedPercent), 12);
 });
 
-test('parseZaiUsage routes a CREDIT_LIMIT MCP marker to the billing bucket', () => {
+test('parseZaiUsage retains a legacy 1-minute TOKENS_LIMIT entry as a token window', () => {
+  // The old format could carry the MCP marker as a TOKENS_LIMIT with
+  // unit=5/number=1 (1-minute); it must stay a token window, not be dropped.
   const usage = parseZaiUsage({
     data: {
       limits: [
-        { type: 'CREDIT_LIMIT', unit: 3, number: 5, usage: 2000, currentValue: 620, remaining: 1379, percentage: 31 },
-        { type: 'CREDIT_LIMIT', unit: 5, number: 1, usage: 100, currentValue: 13, remaining: 87, percentage: 13 }
+        { type: 'TOKENS_LIMIT', unit: 5, number: 1, percentage: 12, nextResetTime: '2026-07-07T18:00:00Z' }
       ]
     }
   }, null);
 
-  assert.equal(usage.windows.length, 2);
+  assert.equal(usage.windows.length, 1);
   assert.equal(usage.windows[0].kind, 'session');
   assert.equal(usage.windows[0].label, '5-hour');
-  assert.equal(usage.windows[1].kind, 'billing');
-  assert.equal(usage.windows[1].label, 'MCP');
-  assert.equal(usage.windows[1].resetDescription, 'Monthly');
-  assert.equal(usage.windows.find((window) => window.kind === 'weekly'), undefined);
+  assert.equal(usage.windows[0].usedPercent, 12);
+  assert.equal(usage.windows[0].windowMinutes, 1);
 });
 
 test('parseZaiUsage reads official plan labels from subscription or quota payloads', () => {

--- a/tests/shared/zaiLimits.test.js
+++ b/tests/shared/zaiLimits.test.js
@@ -87,6 +87,48 @@ test('parseZaiUsage treats a single 5-hour token limit as the old-plan session w
   assert.equal(usage.windows.find((window) => window.kind === 'weekly'), undefined);
 });
 
+test('parseZaiUsage recognizes CREDIT_LIMIT entries from BigModel CN as token windows', () => {
+  const usage = parseZaiUsage({
+    data: {
+      level: 'lite',
+      limits: [
+        { type: 'CREDIT_LIMIT', unit: 3, number: 5, usage: 2000, currentValue: 620, remaining: 1379, percentage: 31, nextResetTime: 1786115117702 },
+        { type: 'CREDIT_LIMIT', unit: 6, number: 1, usage: 10000, currentValue: 1248, remaining: 8751, percentage: 12, nextResetTime: 1786668792998 }
+      ]
+    }
+  }, null);
+
+  assert.equal(usage.plan, 'Lite');
+  assert.equal(usage.windows.length, 2);
+  assert.equal(usage.windows[0].kind, 'session');
+  assert.equal(usage.windows[0].label, '5-hour');
+  assert.equal(usage.windows[0].windowMinutes, 5 * 60);
+  assert.equal(Math.round(usage.windows[0].usedPercent), 31);
+  assert.equal(usage.windows[1].kind, 'weekly');
+  assert.equal(usage.windows[1].label, 'Weekly');
+  assert.equal(usage.windows[1].windowMinutes, 7 * 24 * 60);
+  assert.equal(Math.round(usage.windows[1].usedPercent), 12);
+});
+
+test('parseZaiUsage routes a CREDIT_LIMIT MCP marker to the billing bucket', () => {
+  const usage = parseZaiUsage({
+    data: {
+      limits: [
+        { type: 'CREDIT_LIMIT', unit: 3, number: 5, usage: 2000, currentValue: 620, remaining: 1379, percentage: 31 },
+        { type: 'CREDIT_LIMIT', unit: 5, number: 1, usage: 100, currentValue: 13, remaining: 87, percentage: 13 }
+      ]
+    }
+  }, null);
+
+  assert.equal(usage.windows.length, 2);
+  assert.equal(usage.windows[0].kind, 'session');
+  assert.equal(usage.windows[0].label, '5-hour');
+  assert.equal(usage.windows[1].kind, 'billing');
+  assert.equal(usage.windows[1].label, 'MCP');
+  assert.equal(usage.windows[1].resetDescription, 'Monthly');
+  assert.equal(usage.windows.find((window) => window.kind === 'weekly'), undefined);
+});
+
 test('parseZaiUsage reads official plan labels from subscription or quota payloads', () => {
   assert.equal(
     parseZaiUsage({ data: { level: 'lite', limits: [] } }, { data: [{ planName: 'Lite' }] }).plan,

--- a/tests/shared/zaiLimits.test.js
+++ b/tests/shared/zaiLimits.test.js
@@ -111,8 +111,9 @@ test('parseZaiUsage recognizes CREDIT_LIMIT entries as token windows', () => {
 });
 
 test('parseZaiUsage retains a legacy 1-minute TOKENS_LIMIT entry as a token window', () => {
-  // The old format could carry the MCP marker as a TOKENS_LIMIT with
-  // unit=5/number=1 (1-minute); it must stay a token window, not be dropped.
+  // Pins the existing routing: a 1-minute TOKENS_LIMIT stays a token window.
+  // Recognizing CREDIT_LIMIT must not reroute or drop it. (The MCP marker is
+  // TIME_LIMIT with unit=5/number=1 — a different branch.)
   const usage = parseZaiUsage({
     data: {
       limits: [


### PR DESCRIPTION
## Summary

GLM coding-plan quota responses can carry the window entries as `CREDIT_LIMIT` in addition to the legacy `TOKENS_LIMIT` — both share the same fields (`usage`/`remaining`/`currentValue`/`percentage`) and the same window encodings (`unit:3,number:5` → 5-hour, `unit:6,number:1` → weekly). `parseZaiUsage` previously only recognized `TOKENS_LIMIT`/`TIME_LIMIT`, so a valid `CREDIT_LIMIT` response parsed into zero windows and the account showed as `unavailable`. This change adds a dedicated `CREDIT_LIMIT` branch treated purely as a token-window type; the `TOKENS_LIMIT` and `TIME_LIMIT` branches are left exactly as they were, and MCP stays on the `TIME_LIMIT` path.

## Reproduction

`GET https://open.bigmodel.cn/api/monitor/usage/quota/limit` with a valid coding-plan key returns `data.limits` entries typed `CREDIT_LIMIT` (e.g. `{"type":"CREDIT_LIMIT","unit":3,"number":5,"usage":2000,...,"percentage":31}`). Before this change the probe reported `unavailable` even with a valid key; after it, the account shows Live with 5-hour and Weekly meters.

## Screenshots

**Before — official build, GLM account shows Unavailable even with a valid key:**
![before-fixed-1](https://raw.githubusercontent.com/azzgo/token-monitor/pr/351-screenshots/.github/assets/pr-351/before-fixed-1.png)
![before-fixed-2](https://raw.githubusercontent.com/azzgo/token-monitor/pr/351-screenshots/.github/assets/pr-351/before-fixed-2.png)

**After — with this fix, the same key shows Live with 5-hour / Weekly meters:**
![fixed](https://raw.githubusercontent.com/azzgo/token-monitor/pr/351-screenshots/.github/assets/pr-351/fixed.png)

## Verification

- `npm run verify` — lint clean; 2476 tests pass, 0 fail (new cases: `CREDIT_LIMIT` token windows, plus a regression test pinning the legacy 1-minute `TOKENS_LIMIT` routing).
- End-to-end with a real coding-plan key: `fetchZaiLimits({ zaiApiRegion: 'bigmodel-cn' })` now returns `status: 'ok'` with 5-hour / Weekly windows.

## Notes / follow-up

Auth failures on this endpoint come back as HTTP 200 with a body error envelope (`{"code":1000|1001,"success":false}`) rather than a 401/403, and `fetchJson` only inspects `response.ok`, so an invalid/expired key currently collapses into `unavailable` instead of `unauthorized`. Out of scope for this PR; a follow-up could classify the body error codes and surface the official message.

Fixes #310
