### PR TITLE
fix(collector): align live watchers with Tokscale sources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,9 @@ The default client CSV lives in **one** place: `DEFAULT_CLIENTS` in `src/shared/
 | Touch point | Where |
 |---|---|
 | Default client list | `DEFAULT_CLIENTS` in `src/shared/clientTracking.js` |
-| Watch paths | the `add(...)` call in `clientWatchCandidates()` (`src/shared/collector.js`) |
+| Source roots | the `add(...)` call in `clientSourceRoots()` (`src/shared/collector.js`) — one `[checkId, dir]`, or `[checkId, watchDir, sourcePath]` when tokscale reads one exact file. `clientWatchCandidates()` is only a projection of this table; nothing is declared there |
+| Source check ids | every `checkId` above must be in `CLIENT_SOURCE_CHECK_IDS` (`src/shared/clientHealth.js`), kept alphabetical, then `npm run sync:worker` for the Worker copy. An id missing from that allowlist makes `normalizeClientHealth` drop the client's whole `checks` array, not just the unknown entry |
+| XDG vs home-relative | mirror tokscale, do not guess: a root is XDG-derived only if `clients.rs` declares it `PathRoot::XdgData` or `scanner.rs` resolves it through the `dirs` crate. Those `dirs` lookups are invisible to `strings` on the binary and to `tokscale clients`, so read the Rust at the version tag (`tmp/tokscale`). Roots spelled as home-relative literals upstream must stay home-relative here |
 | Name normalization | the `normalizeClientName()` branch in `src/shared/usage.js` |
 | Renderer maps | `clientLabels` / `clientsWithIcon` / `KNOWN_CLIENTS` in `src/electron/renderer/app.js`; provider artwork in `src/electron/renderer/trayProviderIcons.js`; `VENDOR_ORDER` / `VENDOR_LABELS` in `themePresets.js`; `clientColors` in `usageCharts.js` |
 | Discord RPC | `KNOWN_CLIENT_ASSETS` / `CLIENT_LABELS` in `src/electron/discordRpc.js` |

--- a/README.ja.md
+++ b/README.ja.md
@@ -35,22 +35,22 @@ Token Monitor は **トークン使用量**、**アカウント制限**、**セ�
 | Logo | ツール | データパス | トークン使用量 | AI ツール制限 | セッション詳細 |
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`, `~/.claude/transcripts/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/`、`~/.codex/archived_sessions/` | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/`（`sessions/`、`archived_sessions/`） | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/`（`opencode*.db`、`storage/message/`） | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` または `~/.hermes/state.db` | ✅ | — | — |
+| <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/`（Cursor 同期で更新） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/antigravity.png" width="28" alt="Antigravity" /> | Antigravity | `~/.config/tokscale/antigravity-cache/`（Antigravity 同期で更新） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks (`.../saoudrizwan.claude-dev/tasks/`)、`~/.cline/data/sessions/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`, `~/.kimi-code/sessions/` (`KIMI_CODE_HOME`); Kimi Code API キー（Kimi API で Kimi Code クォータ取得） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/qwen.png" width="28" alt="Qwen" /> | Qwen CLI | `~/.qwen/projects/` | ✅ | — | — |
-| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/` または `~/.grok/sessions/`、`~/.grok/logs/unified.jsonl` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `~/.grok/`（`sessions/`、`logs/unified.jsonl`） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`、`~/.copilot/otel/`、`~/.copilot/data.db` | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/pi.png" width="28" alt="Pi" /> | Pi | `~/.pi/agent/sessions/`, `~/.omp/agent/sessions/` (Oh My Pi) | ✅ | — | — |
 | <img src=".github/assets/tools-icon/zed.png" width="28" alt="Zed" /> | Zed | `~/.local/share/zed/threads/threads.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kilocode.png" width="28" alt="Kilo Code" /> | Kilo Code | VS Code globalStorage tasks (`.../kilocode.kilo-code/tasks/`) — Linux およびリモート/WSL のみ | ✅ | — | — |
 | <img src=".github/assets/tools-icon/mimo-code.png" width="28" alt="MiMo Code" /> | MiMo Code | `~/.local/share/mimocode/mimocode.db` | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/projects/`、`~/.zcode/cli/db/db.sqlite`; Z.ai API キー（Z.ai API で GLM 個人/チーム Coding Plan クォータ取得） | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/`（`projects/`、`cli/db/db.sqlite`）; Z.ai API キー（Z.ai API で GLM 個人/チーム Coding Plan クォータ取得） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/kiro.png" width="28" alt="Kiro" /> | Kiro | `~/.kiro/sessions/cli/`, Kiro IDE globalStorage および `kiro-cli` DB | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/codebuddy.png" width="28" alt="CodeBuddy" /> | CodeBuddy | `~/.codebuddy/projects/` + IDE / VS Code 拡張ログ | ✅ | — | — |
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`, `~/.workbuddy/workbuddy.db` | ✅ | — | — |
@@ -63,7 +63,7 @@ Token Monitor は **トークン使用量**、**アカウント制限**、**セ�
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie（ollama.com/settings で session/weekly 使用量を取得） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="サードパーティAPI" /> | サードパーティAPI | New API互換アカウントプリセット（互換性のあるOne APIフォークを含む）、New APIキープリセット、宣言型カスタム残高エンドポイント | — | ✅ | — |
 
-`~/.local/share/` 配下のパスは、`$XDG_DATA_HOME` が設定されていればそれに従います（Tokscale のスキャン先と一致）。
+上記はデフォルトのパスです。Token Monitor は Tokscale と同じ環境変数の上書きに従います。`~/.local/share/` 配下は `$XDG_DATA_HOME`、ツール個別では `$CODEX_HOME`、`$GROK_HOME`、`$HERMES_HOME`、`$KIMI_CODE_HOME`、`$CLINE_*` などです。
 
 Customは1つのGET残高エンドポイントから数値JSONフィールドをマッピングします。OpenAIまたはAnthropic API互換だけでは不十分です。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -64,7 +64,7 @@ Token Monitor は **トークン使用量**、**アカウント制限**、**セ�
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="サードパーティAPI" /> | サードパーティAPI | New API互換アカウントプリセット（互換性のあるOne APIフォークを含む）、New APIキープリセット、宣言型カスタム残高エンドポイント | — | ✅ | — |
 
 <details>
-<summary><strong>Custom 残高エンドポイントと、デフォルト以外の場所にあるデータ</strong></summary>
+<summary><strong>Custom 残高エンドポイントと、環境変数で変更したデータパス</strong></summary>
 
 <br>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -42,10 +42,10 @@ Token Monitor は **トークン使用量**、**アカウント制限**、**セ�
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/`（Cursor 同期で更新） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/antigravity.png" width="28" alt="Antigravity" /> | Antigravity | `~/.config/tokscale/antigravity-cache/`（Antigravity 同期で更新） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks (`.../saoudrizwan.claude-dev/tasks/`)、`~/.cline/data/sessions/` | ✅ | — | — |
-| <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`, `~/.kimi-code/sessions/` (`KIMI_CODE_HOME`); Kimi Code API キー（Kimi API で Kimi Code クォータ取得） | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`, `~/.kimi-code/sessions/`; Kimi Code API キー（Kimi API で Kimi Code クォータ取得） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/qwen.png" width="28" alt="Qwen" /> | Qwen CLI | `~/.qwen/projects/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `~/.grok/`（`sessions/`、`logs/unified.jsonl`） | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`、`~/.copilot/otel/`、`~/.copilot/data.db` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`、`~/.copilot/`（`otel/`、`data.db`） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/pi.png" width="28" alt="Pi" /> | Pi | `~/.pi/agent/sessions/`, `~/.omp/agent/sessions/` (Oh My Pi) | ✅ | — | — |
 | <img src=".github/assets/tools-icon/zed.png" width="28" alt="Zed" /> | Zed | `~/.local/share/zed/threads/threads.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kilocode.png" width="28" alt="Kilo Code" /> | Kilo Code | VS Code globalStorage tasks (`.../kilocode.kilo-code/tasks/`) — Linux およびリモート/WSL のみ | ✅ | — | — |

--- a/README.ja.md
+++ b/README.ja.md
@@ -63,9 +63,16 @@ Token Monitor は **トークン使用量**、**アカウント制限**、**セ�
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie（ollama.com/settings で session/weekly 使用量を取得） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="サードパーティAPI" /> | サードパーティAPI | New API互換アカウントプリセット（互換性のあるOne APIフォークを含む）、New APIキープリセット、宣言型カスタム残高エンドポイント | — | ✅ | — |
 
+<details>
+<summary><strong>Custom 残高エンドポイントと、デフォルト以外の場所にあるデータ</strong></summary>
+
+<br>
+
 上記はデフォルトのパスです。Token Monitor は Tokscale と同じ環境変数の上書きに従います。`~/.local/share/` 配下は `$XDG_DATA_HOME`、ツール個別では `$CODEX_HOME`、`$GROK_HOME`、`$HERMES_HOME`、`$KIMI_CODE_HOME`、`$CLINE_*` などです。
 
 Customは1つのGET残高エンドポイントから数値JSONフィールドをマッピングします。OpenAIまたはAnthropic API互換だけでは不十分です。
+
+</details>
 
 ## ショーケース
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -35,22 +35,22 @@ Token Monitor は **トークン使用量**、**アカウント制限**、**セ�
 | Logo | ツール | データパス | トークン使用量 | AI ツール制限 | セッション詳細 |
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`, `~/.claude/transcripts/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/` | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/`、`~/.codex/archived_sessions/` | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/`（`opencode*.db`、`storage/message/`） | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` または `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/`（Cursor 同期で更新） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/antigravity.png" width="28" alt="Antigravity" /> | Antigravity | `~/.config/tokscale/antigravity-cache/`（Antigravity 同期で更新） | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks (`.../saoudrizwan.claude-dev/tasks/`) | ✅ | — | — |
+| <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks (`.../saoudrizwan.claude-dev/tasks/`)、`~/.cline/data/sessions/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`, `~/.kimi-code/sessions/` (`KIMI_CODE_HOME`); Kimi Code API キー（Kimi API で Kimi Code クォータ取得） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/qwen.png" width="28" alt="Qwen" /> | Qwen CLI | `~/.qwen/projects/` | ✅ | — | — |
-| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/` または `~/.grok/sessions/` | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`、`~/.copilot/otel/` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/` または `~/.grok/sessions/`、`~/.grok/logs/unified.jsonl` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`、`~/.copilot/otel/`、`~/.copilot/data.db` | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/pi.png" width="28" alt="Pi" /> | Pi | `~/.pi/agent/sessions/`, `~/.omp/agent/sessions/` (Oh My Pi) | ✅ | — | — |
 | <img src=".github/assets/tools-icon/zed.png" width="28" alt="Zed" /> | Zed | `~/.local/share/zed/threads/threads.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kilocode.png" width="28" alt="Kilo Code" /> | Kilo Code | VS Code globalStorage tasks (`.../kilocode.kilo-code/tasks/`) — Linux およびリモート/WSL のみ | ✅ | — | — |
 | <img src=".github/assets/tools-icon/mimo-code.png" width="28" alt="MiMo Code" /> | MiMo Code | `~/.local/share/mimocode/mimocode.db` | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/projects/`; Z.ai API キー（Z.ai API で GLM 個人/チーム Coding Plan クォータ取得） | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/projects/`、`~/.zcode/cli/db/db.sqlite`; Z.ai API キー（Z.ai API で GLM 個人/チーム Coding Plan クォータ取得） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/kiro.png" width="28" alt="Kiro" /> | Kiro | `~/.kiro/sessions/cli/`, Kiro IDE globalStorage および `kiro-cli` DB | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/codebuddy.png" width="28" alt="CodeBuddy" /> | CodeBuddy | `~/.codebuddy/projects/` + IDE / VS Code 拡張ログ | ✅ | — | — |
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`, `~/.workbuddy/workbuddy.db` | ✅ | — | — |
@@ -62,6 +62,8 @@ Token Monitor は **トークン使用量**、**アカウント制限**、**セ�
 | <img src=".github/assets/tools-icon/qoder.png" width="28" alt="Qoder" /> | Qoder | Qoder dashboard cookie（Qoder usage API で big-model credits 取得） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie（ollama.com/settings で session/weekly 使用量を取得） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="サードパーティAPI" /> | サードパーティAPI | New API互換アカウントプリセット（互換性のあるOne APIフォークを含む）、New APIキープリセット、宣言型カスタム残高エンドポイント | — | ✅ | — |
+
+`~/.local/share/` 配下のパスは、`$XDG_DATA_HOME` が設定されていればそれに従います（Tokscale のスキャン先と一致）。
 
 Customは1つのGET残高エンドポイントから数値JSONフィールドをマッピングします。OpenAIまたはAnthropic API互換だけでは不十分です。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -42,10 +42,10 @@ Token Monitor는 **토큰 사용량**, **계정 한도**, **세션 상세**를 �
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/` (Cursor 동기화로 갱신) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/antigravity.png" width="28" alt="Antigravity" /> | Antigravity | `~/.config/tokscale/antigravity-cache/` (Antigravity 동기화로 갱신) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks (`.../saoudrizwan.claude-dev/tasks/`), `~/.cline/data/sessions/` | ✅ | — | — |
-| <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`, `~/.kimi-code/sessions/` (`KIMI_CODE_HOME`); Kimi Code API 키 (Kimi API로 Kimi Code 할당량 조회) | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`, `~/.kimi-code/sessions/`; Kimi Code API 키 (Kimi API로 Kimi Code 할당량 조회) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/qwen.png" width="28" alt="Qwen" /> | Qwen CLI | `~/.qwen/projects/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `~/.grok/` (`sessions/`, `logs/unified.jsonl`) | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`, `~/.copilot/otel/`, `~/.copilot/data.db` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`, `~/.copilot/` (`otel/`, `data.db`) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/pi.png" width="28" alt="Pi" /> | Pi | `~/.pi/agent/sessions/`, `~/.omp/agent/sessions/` (Oh My Pi) | ✅ | — | — |
 | <img src=".github/assets/tools-icon/zed.png" width="28" alt="Zed" /> | Zed | `~/.local/share/zed/threads/threads.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kilocode.png" width="28" alt="Kilo Code" /> | Kilo Code | VS Code globalStorage tasks (`.../kilocode.kilo-code/tasks/`) — Linux 및 원격/WSL만 | ✅ | — | — |

--- a/README.ko.md
+++ b/README.ko.md
@@ -63,9 +63,16 @@ Token Monitor는 **토큰 사용량**, **계정 한도**, **세션 상세**를 �
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie (ollama.com/settings에서 session/weekly 사용량 조회) | — | ✅ | — |
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="서드파티 API" /> | 서드파티 API | New API 호환 계정 프리셋(호환 One API 포크 포함), New API 키 프리셋, 선언형 사용자 지정 잔액 엔드포인트 | — | ✅ | — |
 
+<details>
+<summary><strong>Custom 잔액 엔드포인트와 기본 경로가 아닌 곳의 데이터</strong></summary>
+
+<br>
+
 위 경로는 기본값입니다. Token Monitor는 Tokscale과 동일한 환경 변수 재정의를 따릅니다 — `~/.local/share/` 아래 경로는 `$XDG_DATA_HOME`, 도구별로는 `$CODEX_HOME`, `$GROK_HOME`, `$HERMES_HOME`, `$KIMI_CODE_HOME`, `$CLINE_*` 계열입니다.
 
 Custom은 하나의 GET 잔액 엔드포인트에서 숫자 JSON 필드를 매핑합니다. OpenAI 또는 Anthropic API 호환만으로는 충분하지 않습니다.
+
+</details>
 
 ## 쇼케이스
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -35,22 +35,22 @@ Token Monitor는 **토큰 사용량**, **계정 한도**, **세션 상세**를 �
 | Logo | 도구 | 데이터 경로 | 토큰 사용량 | AI 도구 한도 | 세션 상세 |
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`, `~/.claude/transcripts/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/` | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/`, `~/.codex/archived_sessions/` | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/` (`opencode*.db`, `storage/message/`) | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` 또는 `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/` (Cursor 동기화로 갱신) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/antigravity.png" width="28" alt="Antigravity" /> | Antigravity | `~/.config/tokscale/antigravity-cache/` (Antigravity 동기화로 갱신) | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks (`.../saoudrizwan.claude-dev/tasks/`) | ✅ | — | — |
+| <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks (`.../saoudrizwan.claude-dev/tasks/`), `~/.cline/data/sessions/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`, `~/.kimi-code/sessions/` (`KIMI_CODE_HOME`); Kimi Code API 키 (Kimi API로 Kimi Code 할당량 조회) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/qwen.png" width="28" alt="Qwen" /> | Qwen CLI | `~/.qwen/projects/` | ✅ | — | — |
-| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/` 또는 `~/.grok/sessions/` | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`, `~/.copilot/otel/` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/` 또는 `~/.grok/sessions/`, `~/.grok/logs/unified.jsonl` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`, `~/.copilot/otel/`, `~/.copilot/data.db` | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/pi.png" width="28" alt="Pi" /> | Pi | `~/.pi/agent/sessions/`, `~/.omp/agent/sessions/` (Oh My Pi) | ✅ | — | — |
 | <img src=".github/assets/tools-icon/zed.png" width="28" alt="Zed" /> | Zed | `~/.local/share/zed/threads/threads.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kilocode.png" width="28" alt="Kilo Code" /> | Kilo Code | VS Code globalStorage tasks (`.../kilocode.kilo-code/tasks/`) — Linux 및 원격/WSL만 | ✅ | — | — |
 | <img src=".github/assets/tools-icon/mimo-code.png" width="28" alt="MiMo Code" /> | MiMo Code | `~/.local/share/mimocode/mimocode.db` | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/projects/`; Z.ai API 키 (Z.ai API로 GLM 개인/팀 Coding Plan 할당량 조회) | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/projects/`, `~/.zcode/cli/db/db.sqlite`; Z.ai API 키 (Z.ai API로 GLM 개인/팀 Coding Plan 할당량 조회) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/kiro.png" width="28" alt="Kiro" /> | Kiro | `~/.kiro/sessions/cli/`, Kiro IDE globalStorage 및 `kiro-cli` DB | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/codebuddy.png" width="28" alt="CodeBuddy" /> | CodeBuddy | `~/.codebuddy/projects/` + IDE / VS Code 확장 로그 | ✅ | — | — |
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`, `~/.workbuddy/workbuddy.db` | ✅ | — | — |
@@ -62,6 +62,8 @@ Token Monitor는 **토큰 사용량**, **계정 한도**, **세션 상세**를 �
 | <img src=".github/assets/tools-icon/qoder.png" width="28" alt="Qoder" /> | Qoder | Qoder dashboard cookie (Qoder usage API로 big-model credits 조회) | — | ✅ | — |
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie (ollama.com/settings에서 session/weekly 사용량 조회) | — | ✅ | — |
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="서드파티 API" /> | 서드파티 API | New API 호환 계정 프리셋(호환 One API 포크 포함), New API 키 프리셋, 선언형 사용자 지정 잔액 엔드포인트 | — | ✅ | — |
+
+`~/.local/share/` 아래 경로는 `$XDG_DATA_HOME`가 설정되어 있으면 그것을 따릅니다(Tokscale이 스캔하는 위치와 동일).
 
 Custom은 하나의 GET 잔액 엔드포인트에서 숫자 JSON 필드를 매핑합니다. OpenAI 또는 Anthropic API 호환만으로는 충분하지 않습니다.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -64,7 +64,7 @@ Token Monitor는 **토큰 사용량**, **계정 한도**, **세션 상세**를 �
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="서드파티 API" /> | 서드파티 API | New API 호환 계정 프리셋(호환 One API 포크 포함), New API 키 프리셋, 선언형 사용자 지정 잔액 엔드포인트 | — | ✅ | — |
 
 <details>
-<summary><strong>Custom 잔액 엔드포인트와 기본 경로가 아닌 곳의 데이터</strong></summary>
+<summary><strong>Custom 잔액 엔드포인트와 환경 변수로 지정한 데이터 경로</strong></summary>
 
 <br>
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -35,22 +35,22 @@ Token Monitor는 **토큰 사용량**, **계정 한도**, **세션 상세**를 �
 | Logo | 도구 | 데이터 경로 | 토큰 사용량 | AI 도구 한도 | 세션 상세 |
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`, `~/.claude/transcripts/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/`, `~/.codex/archived_sessions/` | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/` (`sessions/`, `archived_sessions/`) | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/` (`opencode*.db`, `storage/message/`) | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` 또는 `~/.hermes/state.db` | ✅ | — | — |
+| <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/` (Cursor 동기화로 갱신) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/antigravity.png" width="28" alt="Antigravity" /> | Antigravity | `~/.config/tokscale/antigravity-cache/` (Antigravity 동기화로 갱신) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks (`.../saoudrizwan.claude-dev/tasks/`), `~/.cline/data/sessions/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`, `~/.kimi-code/sessions/` (`KIMI_CODE_HOME`); Kimi Code API 키 (Kimi API로 Kimi Code 할당량 조회) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/qwen.png" width="28" alt="Qwen" /> | Qwen CLI | `~/.qwen/projects/` | ✅ | — | — |
-| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/` 또는 `~/.grok/sessions/`, `~/.grok/logs/unified.jsonl` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `~/.grok/` (`sessions/`, `logs/unified.jsonl`) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`, `~/.copilot/otel/`, `~/.copilot/data.db` | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/pi.png" width="28" alt="Pi" /> | Pi | `~/.pi/agent/sessions/`, `~/.omp/agent/sessions/` (Oh My Pi) | ✅ | — | — |
 | <img src=".github/assets/tools-icon/zed.png" width="28" alt="Zed" /> | Zed | `~/.local/share/zed/threads/threads.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kilocode.png" width="28" alt="Kilo Code" /> | Kilo Code | VS Code globalStorage tasks (`.../kilocode.kilo-code/tasks/`) — Linux 및 원격/WSL만 | ✅ | — | — |
 | <img src=".github/assets/tools-icon/mimo-code.png" width="28" alt="MiMo Code" /> | MiMo Code | `~/.local/share/mimocode/mimocode.db` | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/projects/`, `~/.zcode/cli/db/db.sqlite`; Z.ai API 키 (Z.ai API로 GLM 개인/팀 Coding Plan 할당량 조회) | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/` (`projects/`, `cli/db/db.sqlite`); Z.ai API 키 (Z.ai API로 GLM 개인/팀 Coding Plan 할당량 조회) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/kiro.png" width="28" alt="Kiro" /> | Kiro | `~/.kiro/sessions/cli/`, Kiro IDE globalStorage 및 `kiro-cli` DB | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/codebuddy.png" width="28" alt="CodeBuddy" /> | CodeBuddy | `~/.codebuddy/projects/` + IDE / VS Code 확장 로그 | ✅ | — | — |
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`, `~/.workbuddy/workbuddy.db` | ✅ | — | — |
@@ -63,7 +63,7 @@ Token Monitor는 **토큰 사용량**, **계정 한도**, **세션 상세**를 �
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie (ollama.com/settings에서 session/weekly 사용량 조회) | — | ✅ | — |
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="서드파티 API" /> | 서드파티 API | New API 호환 계정 프리셋(호환 One API 포크 포함), New API 키 프리셋, 선언형 사용자 지정 잔액 엔드포인트 | — | ✅ | — |
 
-`~/.local/share/` 아래 경로는 `$XDG_DATA_HOME`가 설정되어 있으면 그것을 따릅니다(Tokscale이 스캔하는 위치와 동일).
+위 경로는 기본값입니다. Token Monitor는 Tokscale과 동일한 환경 변수 재정의를 따릅니다 — `~/.local/share/` 아래 경로는 `$XDG_DATA_HOME`, 도구별로는 `$CODEX_HOME`, `$GROK_HOME`, `$HERMES_HOME`, `$KIMI_CODE_HOME`, `$CLINE_*` 계열입니다.
 
 Custom은 하나의 GET 잔액 엔드포인트에서 숫자 JSON 필드를 매핑합니다. OpenAI 또는 Anthropic API 호환만으로는 충분하지 않습니다.
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,16 @@ Token Monitor supports token usage, account-limit checks, and session details se
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie (session/weekly usage via ollama.com/settings) | — | ✅ | — |
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="Third-party APIs" /> | Third-party APIs | New API-compatible account preset (including compatible One API forks), New API API-key preset, and a declarative Custom balance endpoint | — | ✅ | — |
 
+<details>
+<summary><strong>Custom balance endpoints, and data that lives outside the default paths</strong></summary>
+
+<br>
+
 Paths above are the defaults. Token Monitor follows the same environment overrides Tokscale does — `$XDG_DATA_HOME` for the `~/.local/share/` roots, and per-tool variables such as `$CODEX_HOME`, `$GROK_HOME`, `$HERMES_HOME`, `$KIMI_CODE_HOME` and the `$CLINE_*` family.
 
 Custom maps numeric JSON fields from one GET balance endpoint; OpenAI or Anthropic compatibility alone is not enough.
+
+</details>
 
 ## Showcase
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Token Monitor supports token usage, account-limit checks, and session details se
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="Third-party APIs" /> | Third-party APIs | New API-compatible account preset (including compatible One API forks), New API API-key preset, and a declarative Custom balance endpoint | — | ✅ | — |
 
 <details>
-<summary><strong>Custom balance endpoints, and data that lives outside the default paths</strong></summary>
+<summary><strong>Custom balance endpoints, and data paths overridden by environment variables</strong></summary>
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -35,22 +35,22 @@ Token Monitor supports token usage, account-limit checks, and session details se
 | Logo | Tool | Data path | Token Usage | AI Tool Limits | Session Details |
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`, `~/.claude/transcripts/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/`, `~/.codex/archived_sessions/` | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/` (`sessions/`, `archived_sessions/`) | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/` (`opencode*.db`, `storage/message/`) | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` or `~/.hermes/state.db` | ✅ | — | — |
+| <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/` (kept fresh by Cursor sync) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/antigravity.png" width="28" alt="Antigravity" /> | Antigravity | `~/.config/tokscale/antigravity-cache/` (kept fresh by Antigravity sync) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks (`.../saoudrizwan.claude-dev/tasks/`), `~/.cline/data/sessions/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`, `~/.kimi-code/sessions/` (`KIMI_CODE_HOME`); Kimi Code API key (Kimi Code quota via Kimi API) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/qwen.png" width="28" alt="Qwen" /> | Qwen CLI | `~/.qwen/projects/` | ✅ | — | — |
-| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/` or `~/.grok/sessions/`, `~/.grok/logs/unified.jsonl` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `~/.grok/` (`sessions/`, `logs/unified.jsonl`) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`, `~/.copilot/otel/`, `~/.copilot/data.db` | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/pi.png" width="28" alt="Pi" /> | Pi | `~/.pi/agent/sessions/`, `~/.omp/agent/sessions/` (Oh My Pi) | ✅ | — | — |
 | <img src=".github/assets/tools-icon/zed.png" width="28" alt="Zed" /> | Zed | `~/.local/share/zed/threads/threads.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kilocode.png" width="28" alt="Kilo Code" /> | Kilo Code | VS Code globalStorage tasks (`.../kilocode.kilo-code/tasks/`) — Linux & remote/WSL only | ✅ | — | — |
 | <img src=".github/assets/tools-icon/mimo-code.png" width="28" alt="MiMo Code" /> | MiMo Code | `~/.local/share/mimocode/mimocode.db` | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/projects/`, `~/.zcode/cli/db/db.sqlite`; Z.ai API key (GLM personal/team Coding Plan quota via Z.ai API) | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/` (`projects/`, `cli/db/db.sqlite`); Z.ai API key (GLM personal/team Coding Plan quota via Z.ai API) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/kiro.png" width="28" alt="Kiro" /> | Kiro | `~/.kiro/sessions/cli/`, Kiro IDE globalStorage & `kiro-cli` DB | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/codebuddy.png" width="28" alt="CodeBuddy" /> | CodeBuddy | `~/.codebuddy/projects/` + IDE / VS Code extension logs | ✅ | — | — |
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`, `~/.workbuddy/workbuddy.db` | ✅ | — | — |
@@ -63,7 +63,7 @@ Token Monitor supports token usage, account-limit checks, and session details se
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie (session/weekly usage via ollama.com/settings) | — | ✅ | — |
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="Third-party APIs" /> | Third-party APIs | New API-compatible account preset (including compatible One API forks), New API API-key preset, and a declarative Custom balance endpoint | — | ✅ | — |
 
-Roots shown under `~/.local/share/` follow `$XDG_DATA_HOME` when it is set, matching what Tokscale scans.
+Paths above are the defaults. Token Monitor follows the same environment overrides Tokscale does — `$XDG_DATA_HOME` for the `~/.local/share/` roots, and per-tool variables such as `$CODEX_HOME`, `$GROK_HOME`, `$HERMES_HOME`, `$KIMI_CODE_HOME` and the `$CLINE_*` family.
 
 Custom maps numeric JSON fields from one GET balance endpoint; OpenAI or Anthropic compatibility alone is not enough.
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ Token Monitor supports token usage, account-limit checks, and session details se
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/` (kept fresh by Cursor sync) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/antigravity.png" width="28" alt="Antigravity" /> | Antigravity | `~/.config/tokscale/antigravity-cache/` (kept fresh by Antigravity sync) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks (`.../saoudrizwan.claude-dev/tasks/`), `~/.cline/data/sessions/` | ✅ | — | — |
-| <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`, `~/.kimi-code/sessions/` (`KIMI_CODE_HOME`); Kimi Code API key (Kimi Code quota via Kimi API) | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`, `~/.kimi-code/sessions/`; Kimi Code API key (Kimi Code quota via Kimi API) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/qwen.png" width="28" alt="Qwen" /> | Qwen CLI | `~/.qwen/projects/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `~/.grok/` (`sessions/`, `logs/unified.jsonl`) | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`, `~/.copilot/otel/`, `~/.copilot/data.db` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`, `~/.copilot/` (`otel/`, `data.db`) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/pi.png" width="28" alt="Pi" /> | Pi | `~/.pi/agent/sessions/`, `~/.omp/agent/sessions/` (Oh My Pi) | ✅ | — | — |
 | <img src=".github/assets/tools-icon/zed.png" width="28" alt="Zed" /> | Zed | `~/.local/share/zed/threads/threads.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kilocode.png" width="28" alt="Kilo Code" /> | Kilo Code | VS Code globalStorage tasks (`.../kilocode.kilo-code/tasks/`) — Linux & remote/WSL only | ✅ | — | — |

--- a/README.md
+++ b/README.md
@@ -35,22 +35,22 @@ Token Monitor supports token usage, account-limit checks, and session details se
 | Logo | Tool | Data path | Token Usage | AI Tool Limits | Session Details |
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`, `~/.claude/transcripts/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/` | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/`, `~/.codex/archived_sessions/` | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/` (`opencode*.db`, `storage/message/`) | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` or `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/` (kept fresh by Cursor sync) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/antigravity.png" width="28" alt="Antigravity" /> | Antigravity | `~/.config/tokscale/antigravity-cache/` (kept fresh by Antigravity sync) | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks (`.../saoudrizwan.claude-dev/tasks/`) | ✅ | — | — |
+| <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks (`.../saoudrizwan.claude-dev/tasks/`), `~/.cline/data/sessions/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`, `~/.kimi-code/sessions/` (`KIMI_CODE_HOME`); Kimi Code API key (Kimi Code quota via Kimi API) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/qwen.png" width="28" alt="Qwen" /> | Qwen CLI | `~/.qwen/projects/` | ✅ | — | — |
-| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/` or `~/.grok/sessions/` | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`, `~/.copilot/otel/` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/` or `~/.grok/sessions/`, `~/.grok/logs/unified.jsonl` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`, `~/.copilot/otel/`, `~/.copilot/data.db` | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/pi.png" width="28" alt="Pi" /> | Pi | `~/.pi/agent/sessions/`, `~/.omp/agent/sessions/` (Oh My Pi) | ✅ | — | — |
 | <img src=".github/assets/tools-icon/zed.png" width="28" alt="Zed" /> | Zed | `~/.local/share/zed/threads/threads.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kilocode.png" width="28" alt="Kilo Code" /> | Kilo Code | VS Code globalStorage tasks (`.../kilocode.kilo-code/tasks/`) — Linux & remote/WSL only | ✅ | — | — |
 | <img src=".github/assets/tools-icon/mimo-code.png" width="28" alt="MiMo Code" /> | MiMo Code | `~/.local/share/mimocode/mimocode.db` | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/projects/`; Z.ai API key (GLM personal/team Coding Plan quota via Z.ai API) | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/projects/`, `~/.zcode/cli/db/db.sqlite`; Z.ai API key (GLM personal/team Coding Plan quota via Z.ai API) | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/kiro.png" width="28" alt="Kiro" /> | Kiro | `~/.kiro/sessions/cli/`, Kiro IDE globalStorage & `kiro-cli` DB | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/codebuddy.png" width="28" alt="CodeBuddy" /> | CodeBuddy | `~/.codebuddy/projects/` + IDE / VS Code extension logs | ✅ | — | — |
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`, `~/.workbuddy/workbuddy.db` | ✅ | — | — |
@@ -62,6 +62,8 @@ Token Monitor supports token usage, account-limit checks, and session details se
 | <img src=".github/assets/tools-icon/qoder.png" width="28" alt="Qoder" /> | Qoder | Qoder dashboard cookie (big-model credits via Qoder usage API) | — | ✅ | — |
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie (session/weekly usage via ollama.com/settings) | — | ✅ | — |
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="Third-party APIs" /> | Third-party APIs | New API-compatible account preset (including compatible One API forks), New API API-key preset, and a declarative Custom balance endpoint | — | ✅ | — |
+
+Roots shown under `~/.local/share/` follow `$XDG_DATA_HOME` when it is set, matching what Tokscale scans.
 
 Custom maps numeric JSON fields from one GET balance endpoint; OpenAI or Anthropic compatibility alone is not enough.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,7 +64,7 @@ Token Monitor 对 Token 用量、账户额度和 session 明细分别支持：
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="第三方 API" /> | 第三方 API | New API 兼容账号预设方案（包括兼容的 One API 分支）、New API 密钥预设方案与声明式自定义余额端点 | — | ✅ | — |
 
 <details>
-<summary><strong>Custom 余额端点，以及数据不在默认路径时</strong></summary>
+<summary><strong>Custom 余额端点，以及用环境变量覆盖的数据路径</strong></summary>
 
 <br>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,22 +35,22 @@ Token Monitor 对 Token 用量、账户额度和 session 明细分别支持：
 | Logo | 工具 | 数据路径 | Token 用量 | AI 工具额度 | session 明细 |
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`、`~/.claude/transcripts/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/` | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/`、`~/.codex/archived_sessions/` | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/`（`opencode*.db`、`storage/message/`） | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` 或 `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/`（由 Cursor 同步保持更新） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/antigravity.png" width="28" alt="Antigravity" /> | Antigravity | `~/.config/tokscale/antigravity-cache/`（由 Antigravity 同步保持更新） | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks（`.../saoudrizwan.claude-dev/tasks/`） | ✅ | — | — |
+| <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks（`.../saoudrizwan.claude-dev/tasks/`）、`~/.cline/data/sessions/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`、`~/.kimi-code/sessions/`（`KIMI_CODE_HOME`）；Kimi Code API 密钥（通过 Kimi API 查询 Kimi Code 额度） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/qwen.png" width="28" alt="Qwen" /> | Qwen CLI | `~/.qwen/projects/` | ✅ | — | — |
-| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/` 或 `~/.grok/sessions/` | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`、`~/.copilot/otel/` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/` 或 `~/.grok/sessions/`、`~/.grok/logs/unified.jsonl` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`、`~/.copilot/otel/`、`~/.copilot/data.db` | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/pi.png" width="28" alt="Pi" /> | Pi | `~/.pi/agent/sessions/`、`~/.omp/agent/sessions/`（Oh My Pi） | ✅ | — | — |
 | <img src=".github/assets/tools-icon/zed.png" width="28" alt="Zed" /> | Zed | `~/.local/share/zed/threads/threads.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kilocode.png" width="28" alt="Kilo Code" /> | Kilo Code | VS Code globalStorage tasks（`.../kilocode.kilo-code/tasks/`）—— 仅 Linux 与远程/WSL | ✅ | — | — |
 | <img src=".github/assets/tools-icon/mimo-code.png" width="28" alt="MiMo Code" /> | MiMo Code | `~/.local/share/mimocode/mimocode.db` | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/projects/`；Z.ai API 密钥（通过 Z.ai API 查询 GLM 个人/团队 Coding Plan 额度） | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/projects/`、`~/.zcode/cli/db/db.sqlite`；Z.ai API 密钥（通过 Z.ai API 查询 GLM 个人/团队 Coding Plan 额度） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/kiro.png" width="28" alt="Kiro" /> | Kiro | `~/.kiro/sessions/cli/`、Kiro IDE globalStorage 与 `kiro-cli` 数据库 | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/codebuddy.png" width="28" alt="CodeBuddy" /> | CodeBuddy | `~/.codebuddy/projects/` 与 IDE / VS Code 扩展日志 | ✅ | — | — |
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`、`~/.workbuddy/workbuddy.db` | ✅ | — | — |
@@ -62,6 +62,8 @@ Token Monitor 对 Token 用量、账户额度和 session 明细分别支持：
 | <img src=".github/assets/tools-icon/qoder.png" width="28" alt="Qoder" /> | Qoder | Qoder dashboard cookie（通过 Qoder usage API 查询 big-model credits） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie（通过 ollama.com/settings 查询 session／每周用量） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="第三方 API" /> | 第三方 API | New API 兼容账号预设方案（包括兼容的 One API 分支）、New API 密钥预设方案与声明式自定义余额端点 | — | ✅ | — |
+
+表中位于 `~/.local/share/` 下的路径，在设置了 `$XDG_DATA_HOME` 时会随之改变，与 Tokscale 扫描的位置一致。
 
 Custom 会从一个 GET 余额端点映射数值 JSON 字段；仅兼容 OpenAI 或 Anthropic API 并不足够。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,10 +42,10 @@ Token Monitor 对 Token 用量、账户额度和 session 明细分别支持：
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/`（由 Cursor 同步保持更新） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/antigravity.png" width="28" alt="Antigravity" /> | Antigravity | `~/.config/tokscale/antigravity-cache/`（由 Antigravity 同步保持更新） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks（`.../saoudrizwan.claude-dev/tasks/`）、`~/.cline/data/sessions/` | ✅ | — | — |
-| <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`、`~/.kimi-code/sessions/`（`KIMI_CODE_HOME`）；Kimi Code API 密钥（通过 Kimi API 查询 Kimi Code 额度） | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`、`~/.kimi-code/sessions/`；Kimi Code API 密钥（通过 Kimi API 查询 Kimi Code 额度） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/qwen.png" width="28" alt="Qwen" /> | Qwen CLI | `~/.qwen/projects/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `~/.grok/`（`sessions/`、`logs/unified.jsonl`） | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`、`~/.copilot/otel/`、`~/.copilot/data.db` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`、`~/.copilot/`（`otel/`、`data.db`） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/pi.png" width="28" alt="Pi" /> | Pi | `~/.pi/agent/sessions/`、`~/.omp/agent/sessions/`（Oh My Pi） | ✅ | — | — |
 | <img src=".github/assets/tools-icon/zed.png" width="28" alt="Zed" /> | Zed | `~/.local/share/zed/threads/threads.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kilocode.png" width="28" alt="Kilo Code" /> | Kilo Code | VS Code globalStorage tasks（`.../kilocode.kilo-code/tasks/`）—— 仅 Linux 与远程/WSL | ✅ | — | — |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -63,9 +63,16 @@ Token Monitor 对 Token 用量、账户额度和 session 明细分别支持：
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie（通过 ollama.com/settings 查询 session／每周用量） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="第三方 API" /> | 第三方 API | New API 兼容账号预设方案（包括兼容的 One API 分支）、New API 密钥预设方案与声明式自定义余额端点 | — | ✅ | — |
 
+<details>
+<summary><strong>Custom 余额端点，以及数据不在默认路径时</strong></summary>
+
+<br>
+
 上表为默认路径。Token Monitor 与 Tokscale 遵循相同的环境变量覆盖：`~/.local/share/` 下的路径跟随 `$XDG_DATA_HOME`，各工具另有 `$CODEX_HOME`、`$GROK_HOME`、`$HERMES_HOME`、`$KIMI_CODE_HOME` 以及 `$CLINE_*` 系列。
 
 Custom 会从一个 GET 余额端点映射数值 JSON 字段；仅兼容 OpenAI 或 Anthropic API 并不足够。
+
+</details>
 
 ## 界面展示
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,22 +35,22 @@ Token Monitor 对 Token 用量、账户额度和 session 明细分别支持：
 | Logo | 工具 | 数据路径 | Token 用量 | AI 工具额度 | session 明细 |
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`、`~/.claude/transcripts/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/`、`~/.codex/archived_sessions/` | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/`（`sessions/`、`archived_sessions/`） | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/`（`opencode*.db`、`storage/message/`） | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` 或 `~/.hermes/state.db` | ✅ | — | — |
+| <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/`（由 Cursor 同步保持更新） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/antigravity.png" width="28" alt="Antigravity" /> | Antigravity | `~/.config/tokscale/antigravity-cache/`（由 Antigravity 同步保持更新） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks（`.../saoudrizwan.claude-dev/tasks/`）、`~/.cline/data/sessions/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`、`~/.kimi-code/sessions/`（`KIMI_CODE_HOME`）；Kimi Code API 密钥（通过 Kimi API 查询 Kimi Code 额度） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/qwen.png" width="28" alt="Qwen" /> | Qwen CLI | `~/.qwen/projects/` | ✅ | — | — |
-| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/` 或 `~/.grok/sessions/`、`~/.grok/logs/unified.jsonl` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `~/.grok/`（`sessions/`、`logs/unified.jsonl`） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`、`~/.copilot/otel/`、`~/.copilot/data.db` | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/pi.png" width="28" alt="Pi" /> | Pi | `~/.pi/agent/sessions/`、`~/.omp/agent/sessions/`（Oh My Pi） | ✅ | — | — |
 | <img src=".github/assets/tools-icon/zed.png" width="28" alt="Zed" /> | Zed | `~/.local/share/zed/threads/threads.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kilocode.png" width="28" alt="Kilo Code" /> | Kilo Code | VS Code globalStorage tasks（`.../kilocode.kilo-code/tasks/`）—— 仅 Linux 与远程/WSL | ✅ | — | — |
 | <img src=".github/assets/tools-icon/mimo-code.png" width="28" alt="MiMo Code" /> | MiMo Code | `~/.local/share/mimocode/mimocode.db` | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/projects/`、`~/.zcode/cli/db/db.sqlite`；Z.ai API 密钥（通过 Z.ai API 查询 GLM 个人/团队 Coding Plan 额度） | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/`（`projects/`、`cli/db/db.sqlite`）；Z.ai API 密钥（通过 Z.ai API 查询 GLM 个人/团队 Coding Plan 额度） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/kiro.png" width="28" alt="Kiro" /> | Kiro | `~/.kiro/sessions/cli/`、Kiro IDE globalStorage 与 `kiro-cli` 数据库 | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/codebuddy.png" width="28" alt="CodeBuddy" /> | CodeBuddy | `~/.codebuddy/projects/` 与 IDE / VS Code 扩展日志 | ✅ | — | — |
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`、`~/.workbuddy/workbuddy.db` | ✅ | — | — |
@@ -63,7 +63,7 @@ Token Monitor 对 Token 用量、账户额度和 session 明细分别支持：
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie（通过 ollama.com/settings 查询 session／每周用量） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="第三方 API" /> | 第三方 API | New API 兼容账号预设方案（包括兼容的 One API 分支）、New API 密钥预设方案与声明式自定义余额端点 | — | ✅ | — |
 
-表中位于 `~/.local/share/` 下的路径，在设置了 `$XDG_DATA_HOME` 时会随之改变，与 Tokscale 扫描的位置一致。
+上表为默认路径。Token Monitor 与 Tokscale 遵循相同的环境变量覆盖：`~/.local/share/` 下的路径跟随 `$XDG_DATA_HOME`，各工具另有 `$CODEX_HOME`、`$GROK_HOME`、`$HERMES_HOME`、`$KIMI_CODE_HOME` 以及 `$CLINE_*` 系列。
 
 Custom 会从一个 GET 余额端点映射数值 JSON 字段；仅兼容 OpenAI 或 Anthropic API 并不足够。
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -63,9 +63,16 @@ Token Monitor 對 Token 用量、帳戶額度與 session 明細分別支援：
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie（透過 ollama.com/settings 查詢 session／每週用量） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="第三方 API" /> | 第三方 API | New API 相容帳戶預設方案（包括相容的 One API 分支）、New API 金鑰預設方案與宣告式自訂餘額端點 | — | ✅ | — |
 
+<details>
+<summary><strong>Custom 餘額端點，以及資料不在預設路徑時</strong></summary>
+
+<br>
+
 上表為預設路徑。Token Monitor 與 Tokscale 遵循相同的環境變數覆寫：`~/.local/share/` 下的路徑跟隨 `$XDG_DATA_HOME`，各工具另有 `$CODEX_HOME`、`$GROK_HOME`、`$HERMES_HOME`、`$KIMI_CODE_HOME` 以及 `$CLINE_*` 系列。
 
 Custom 會從一個 GET 餘額端點映射數值 JSON 欄位；僅相容 OpenAI 或 Anthropic API 並不足夠。
+
+</details>
 
 ## 介面展示
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -35,22 +35,22 @@ Token Monitor 對 Token 用量、帳戶額度與 session 明細分別支援：
 | Logo | 工具 | 資料路徑 | Token 用量 | AI 工具額度 | session 明細 |
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`、`~/.claude/transcripts/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/`、`~/.codex/archived_sessions/` | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/`（`sessions/`、`archived_sessions/`） | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/`（`opencode*.db`、`storage/message/`） | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` 或 `~/.hermes/state.db` | ✅ | — | — |
+| <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/`（由 Cursor 同步保持更新） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/antigravity.png" width="28" alt="Antigravity" /> | Antigravity | `~/.config/tokscale/antigravity-cache/`（由 Antigravity 同步保持更新） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks（`.../saoudrizwan.claude-dev/tasks/`）、`~/.cline/data/sessions/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`、`~/.kimi-code/sessions/`（`KIMI_CODE_HOME`）；Kimi Code API 金鑰（透過 Kimi API 查詢 Kimi Code 額度） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/qwen.png" width="28" alt="Qwen" /> | Qwen CLI | `~/.qwen/projects/` | ✅ | — | — |
-| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/` 或 `~/.grok/sessions/`、`~/.grok/logs/unified.jsonl` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `~/.grok/`（`sessions/`、`logs/unified.jsonl`） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`、`~/.copilot/otel/`、`~/.copilot/data.db` | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/pi.png" width="28" alt="Pi" /> | Pi | `~/.pi/agent/sessions/`、`~/.omp/agent/sessions/`（Oh My Pi） | ✅ | — | — |
 | <img src=".github/assets/tools-icon/zed.png" width="28" alt="Zed" /> | Zed | `~/.local/share/zed/threads/threads.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kilocode.png" width="28" alt="Kilo Code" /> | Kilo Code | VS Code globalStorage tasks（`.../kilocode.kilo-code/tasks/`）—— 僅 Linux 與遠端/WSL | ✅ | — | — |
 | <img src=".github/assets/tools-icon/mimo-code.png" width="28" alt="MiMo Code" /> | MiMo Code | `~/.local/share/mimocode/mimocode.db` | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/projects/`、`~/.zcode/cli/db/db.sqlite`；Z.ai API 金鑰（透過 Z.ai API 查詢 GLM 個人/團隊 Coding Plan 額度） | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/`（`projects/`、`cli/db/db.sqlite`）；Z.ai API 金鑰（透過 Z.ai API 查詢 GLM 個人/團隊 Coding Plan 額度） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/kiro.png" width="28" alt="Kiro" /> | Kiro | `~/.kiro/sessions/cli/`、Kiro IDE globalStorage 與 `kiro-cli` 資料庫 | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/codebuddy.png" width="28" alt="CodeBuddy" /> | CodeBuddy | `~/.codebuddy/projects/` 與 IDE / VS Code 擴充套件日誌 | ✅ | — | — |
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`、`~/.workbuddy/workbuddy.db` | ✅ | — | — |
@@ -63,7 +63,7 @@ Token Monitor 對 Token 用量、帳戶額度與 session 明細分別支援：
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie（透過 ollama.com/settings 查詢 session／每週用量） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="第三方 API" /> | 第三方 API | New API 相容帳戶預設方案（包括相容的 One API 分支）、New API 金鑰預設方案與宣告式自訂餘額端點 | — | ✅ | — |
 
-表中位於 `~/.local/share/` 下的路徑，在有設定 `$XDG_DATA_HOME` 時會跟著改變，與 Tokscale 掃描的位置一致。
+上表為預設路徑。Token Monitor 與 Tokscale 遵循相同的環境變數覆寫：`~/.local/share/` 下的路徑跟隨 `$XDG_DATA_HOME`，各工具另有 `$CODEX_HOME`、`$GROK_HOME`、`$HERMES_HOME`、`$KIMI_CODE_HOME` 以及 `$CLINE_*` 系列。
 
 Custom 會從一個 GET 餘額端點映射數值 JSON 欄位；僅相容 OpenAI 或 Anthropic API 並不足夠。
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -64,7 +64,7 @@ Token Monitor 對 Token 用量、帳戶額度與 session 明細分別支援：
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="第三方 API" /> | 第三方 API | New API 相容帳戶預設方案（包括相容的 One API 分支）、New API 金鑰預設方案與宣告式自訂餘額端點 | — | ✅ | — |
 
 <details>
-<summary><strong>Custom 餘額端點，以及資料不在預設路徑時</strong></summary>
+<summary><strong>Custom 餘額端點，以及用環境變數覆寫的資料路徑</strong></summary>
 
 <br>
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -42,10 +42,10 @@ Token Monitor 對 Token 用量、帳戶額度與 session 明細分別支援：
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/`（由 Cursor 同步保持更新） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/antigravity.png" width="28" alt="Antigravity" /> | Antigravity | `~/.config/tokscale/antigravity-cache/`（由 Antigravity 同步保持更新） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks（`.../saoudrizwan.claude-dev/tasks/`）、`~/.cline/data/sessions/` | ✅ | — | — |
-| <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`、`~/.kimi-code/sessions/`（`KIMI_CODE_HOME`）；Kimi Code API 金鑰（透過 Kimi API 查詢 Kimi Code 額度） | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`、`~/.kimi-code/sessions/`；Kimi Code API 金鑰（透過 Kimi API 查詢 Kimi Code 額度） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/qwen.png" width="28" alt="Qwen" /> | Qwen CLI | `~/.qwen/projects/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `~/.grok/`（`sessions/`、`logs/unified.jsonl`） | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`、`~/.copilot/otel/`、`~/.copilot/data.db` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`、`~/.copilot/`（`otel/`、`data.db`） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/pi.png" width="28" alt="Pi" /> | Pi | `~/.pi/agent/sessions/`、`~/.omp/agent/sessions/`（Oh My Pi） | ✅ | — | — |
 | <img src=".github/assets/tools-icon/zed.png" width="28" alt="Zed" /> | Zed | `~/.local/share/zed/threads/threads.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kilocode.png" width="28" alt="Kilo Code" /> | Kilo Code | VS Code globalStorage tasks（`.../kilocode.kilo-code/tasks/`）—— 僅 Linux 與遠端/WSL | ✅ | — | — |

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -35,22 +35,22 @@ Token Monitor 對 Token 用量、帳戶額度與 session 明細分別支援：
 | Logo | 工具 | 資料路徑 | Token 用量 | AI 工具額度 | session 明細 |
 |:---:|------|-----------|:---:|:---:|:---:|
 | <img src=".github/assets/tools-icon/claude.png" width="28" alt="Claude Code" /> | Claude Code | `~/.claude/projects/`、`~/.claude/transcripts/` | ✅ | ✅ | ✅ |
-| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/` | ✅ | ✅ | ✅ |
+| <img src=".github/assets/tools-icon/codex.png" width="28" alt="Codex" /> | Codex | `~/.codex/sessions/`、`~/.codex/archived_sessions/` | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/opencode.png" width="28" alt="OpenCode" /> | OpenCode | `~/.local/share/opencode/`（`opencode*.db`、`storage/message/`） | ✅ | ✅ | ✅ |
 | <img src=".github/assets/tools-icon/hermes-agent.png" width="28" alt="Hermes Agent" /> | Hermes Agent | `$HERMES_HOME/state.db` 或 `~/.hermes/state.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/openclaw.png" width="28" alt="OpenClaw" /> | OpenClaw | `~/.openclaw/agents/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/cursor.png" width="28" alt="Cursor" /> | Cursor | `~/.config/tokscale/cursor-cache/`（由 Cursor 同步保持更新） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/antigravity.png" width="28" alt="Antigravity" /> | Antigravity | `~/.config/tokscale/antigravity-cache/`（由 Antigravity 同步保持更新） | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks（`.../saoudrizwan.claude-dev/tasks/`） | ✅ | — | — |
+| <img src=".github/assets/tools-icon/cline.png" width="28" alt="Cline" /> | Cline | VS Code globalStorage tasks（`.../saoudrizwan.claude-dev/tasks/`）、`~/.cline/data/sessions/` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kimi.png" width="28" alt="Kimi" /> | Kimi CLI / Kimi Code | `~/.kimi/sessions/`、`~/.kimi-code/sessions/`（`KIMI_CODE_HOME`）；Kimi Code API 金鑰（透過 Kimi API 查詢 Kimi Code 額度） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/qwen.png" width="28" alt="Qwen" /> | Qwen CLI | `~/.qwen/projects/` | ✅ | — | — |
-| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/` 或 `~/.grok/sessions/` | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`、`~/.copilot/otel/` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/xai.png" width="28" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/` 或 `~/.grok/sessions/`、`~/.grok/logs/unified.jsonl` | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/copilot.png" width="28" alt="GitHub Copilot" /> | GitHub Copilot | VS Code `workspaceStorage/*/chatSessions/`、`~/.copilot/otel/`、`~/.copilot/data.db` | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/pi.png" width="28" alt="Pi" /> | Pi | `~/.pi/agent/sessions/`、`~/.omp/agent/sessions/`（Oh My Pi） | ✅ | — | — |
 | <img src=".github/assets/tools-icon/zed.png" width="28" alt="Zed" /> | Zed | `~/.local/share/zed/threads/threads.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/kilocode.png" width="28" alt="Kilo Code" /> | Kilo Code | VS Code globalStorage tasks（`.../kilocode.kilo-code/tasks/`）—— 僅 Linux 與遠端/WSL | ✅ | — | — |
 | <img src=".github/assets/tools-icon/mimo-code.png" width="28" alt="MiMo Code" /> | MiMo Code | `~/.local/share/mimocode/mimocode.db` | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/projects/`；Z.ai API 金鑰（透過 Z.ai API 查詢 GLM 個人/團隊 Coding Plan 額度） | ✅ | ✅ | — |
+| <img src=".github/assets/tools-icon/zcode.png" width="28" alt="ZCode" /> | ZCode / GLM | `~/.zcode/projects/`、`~/.zcode/cli/db/db.sqlite`；Z.ai API 金鑰（透過 Z.ai API 查詢 GLM 個人/團隊 Coding Plan 額度） | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/kiro.png" width="28" alt="Kiro" /> | Kiro | `~/.kiro/sessions/cli/`、Kiro IDE globalStorage 與 `kiro-cli` 資料庫 | ✅ | ✅ | — |
 | <img src=".github/assets/tools-icon/codebuddy.png" width="28" alt="CodeBuddy" /> | CodeBuddy | `~/.codebuddy/projects/` 與 IDE / VS Code 擴充套件日誌 | ✅ | — | — |
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`、`~/.workbuddy/workbuddy.db` | ✅ | — | — |
@@ -62,6 +62,8 @@ Token Monitor 對 Token 用量、帳戶額度與 session 明細分別支援：
 | <img src=".github/assets/tools-icon/qoder.png" width="28" alt="Qoder" /> | Qoder | Qoder dashboard cookie（透過 Qoder usage API 查詢 big-model credits） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/ollama.png" width="28" alt="Ollama" /> | Ollama | Ollama Cloud cookie（透過 ollama.com/settings 查詢 session／每週用量） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/newapi.png" width="28" alt="第三方 API" /> | 第三方 API | New API 相容帳戶預設方案（包括相容的 One API 分支）、New API 金鑰預設方案與宣告式自訂餘額端點 | — | ✅ | — |
+
+表中位於 `~/.local/share/` 下的路徑，在有設定 `$XDG_DATA_HOME` 時會跟著改變，與 Tokscale 掃描的位置一致。
 
 Custom 會從一個 GET 餘額端點映射數值 JSON 欄位；僅相容 OpenAI 或 Anthropic API 並不足夠。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "koffi": "^3.1.4",
         "semver": "^7.8.5",
         "tar": "^7.5.22",
-        "tokscale": "^4.10.0",
+        "tokscale": "^4.11.0",
         "undici": "^7.29.0"
       },
       "devDependencies": {
@@ -1028,29 +1028,29 @@
       }
     },
     "node_modules/@tokscale/cli": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli/-/cli-4.10.0.tgz",
-      "integrity": "sha512-+fd+rlu7e0dP+nAtW6C53WH/9NbhE+HUbiYNzWqaQcYmzuUqH45WYMcVshGmvnx5da4p60FcEqQ5IzAipSuwLA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli/-/cli-4.11.0.tgz",
+      "integrity": "sha512-g+kbuj04oFPygxFXEcKW3nRZy9DEv2I7MBGaK+DAYh3tufsYhXBBiV/6t9vS5GGCbMy1G4qBf4GkxxVprqNfrw==",
       "license": "MIT",
       "bin": {
         "tokscale": "bin.js"
       },
       "optionalDependencies": {
-        "@tokscale/cli-android-arm64": "4.10.0",
-        "@tokscale/cli-darwin-arm64": "4.10.0",
-        "@tokscale/cli-darwin-x64": "4.10.0",
-        "@tokscale/cli-linux-arm64-gnu": "4.10.0",
-        "@tokscale/cli-linux-arm64-musl": "4.10.0",
-        "@tokscale/cli-linux-x64-gnu": "4.10.0",
-        "@tokscale/cli-linux-x64-musl": "4.10.0",
-        "@tokscale/cli-win32-arm64-msvc": "4.10.0",
-        "@tokscale/cli-win32-x64-msvc": "4.10.0"
+        "@tokscale/cli-android-arm64": "4.11.0",
+        "@tokscale/cli-darwin-arm64": "4.11.0",
+        "@tokscale/cli-darwin-x64": "4.11.0",
+        "@tokscale/cli-linux-arm64-gnu": "4.11.0",
+        "@tokscale/cli-linux-arm64-musl": "4.11.0",
+        "@tokscale/cli-linux-x64-gnu": "4.11.0",
+        "@tokscale/cli-linux-x64-musl": "4.11.0",
+        "@tokscale/cli-win32-arm64-msvc": "4.11.0",
+        "@tokscale/cli-win32-x64-msvc": "4.11.0"
       }
     },
     "node_modules/@tokscale/cli-android-arm64": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-android-arm64/-/cli-android-arm64-4.10.0.tgz",
-      "integrity": "sha512-kgmcTBokE1TFh7NBS4JKB8VmBGip0DhRnKnTLtWgxYJ1vcCPHFRXPPcdiuPzydDoUuuy3FaQ5X3RPfbqHHj9mw==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-android-arm64/-/cli-android-arm64-4.11.0.tgz",
+      "integrity": "sha512-aj7/wRQ1QYHQ3zU9NpjVvDuvDLzhAYNFqNveh8ICNQ6g/sbXk8TLaq0Z/THYLoK7pXiKSJN725fcScZF8tVemg==",
       "cpu": [
         "arm64"
       ],
@@ -1061,9 +1061,9 @@
       ]
     },
     "node_modules/@tokscale/cli-darwin-arm64": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-arm64/-/cli-darwin-arm64-4.10.0.tgz",
-      "integrity": "sha512-UNWnDTbpJpBRr3vyIiUdYMA57Y0eYziqDfhYnjXUQCRertEcFoCfl5c4DRzJc83rJn+SclIHBgF0yhHagt72oQ==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-arm64/-/cli-darwin-arm64-4.11.0.tgz",
+      "integrity": "sha512-KV3/0CWZOQx7T6d6N+9VFR3Vyvi2SpnCenrFkj3AlzSunIFmbvCSyfuLS6AfDHDVAs8BHGDVm6iiZNXlVofgKg==",
       "cpu": [
         "arm64"
       ],
@@ -1074,9 +1074,9 @@
       ]
     },
     "node_modules/@tokscale/cli-darwin-x64": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-x64/-/cli-darwin-x64-4.10.0.tgz",
-      "integrity": "sha512-BlqA06Shiw+8BxTVfo8EP7cZyHp5QKvpTbxQf7XGD6lHgROA66qLbP5ms02vPRp7U6WeqkURNMnRNb/XbaQxhw==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-x64/-/cli-darwin-x64-4.11.0.tgz",
+      "integrity": "sha512-wqzXhjBNHxYdfK+JP+/chXwfy0AzwtUoLLNhL3F8f2LBVeZE/QfH/9cgbTdjx9ckPJDWvHv9lkPECl1iVmLErA==",
       "cpu": [
         "x64"
       ],
@@ -1087,9 +1087,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-arm64-gnu": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-4.10.0.tgz",
-      "integrity": "sha512-9LYNxBZbmojrZFMWwx8J0W7kD7hc6Mkpz0rPG3KXem56m8WvWAb6G/qjAkJlWPMjo28jEaZheachlNkNpbl3wQ==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-4.11.0.tgz",
+      "integrity": "sha512-CkAGJ0MloPRe7qHGFniyAvjjF7RTlR7OQ6iY7/DrYs6IhR965h4VX3JKUTsokZEMd4FmFGTC9OpmRNnX9yoLmA==",
       "cpu": [
         "arm64"
       ],
@@ -1100,9 +1100,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-arm64-musl": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-musl/-/cli-linux-arm64-musl-4.10.0.tgz",
-      "integrity": "sha512-plw3/gngDAArhCqgvY+v4TxdaQ0nNcD5TKk+xGVAN7ZNN8gBpmz92TE4KeYW4lnEqB6gS2XcVQ193IqiJPFrzg==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-musl/-/cli-linux-arm64-musl-4.11.0.tgz",
+      "integrity": "sha512-tRimoiMBxwWH9GtIHXXATpwSelpVZ9M1vVS3i9xFewRiU8U++mxRvtTvGsCnpZAotBT+mM/b8HAguyWI3fqXIA==",
       "cpu": [
         "arm64"
       ],
@@ -1113,9 +1113,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-x64-gnu": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-gnu/-/cli-linux-x64-gnu-4.10.0.tgz",
-      "integrity": "sha512-8EPrn4auy4CyGKwajUKpl36dBY39nZncVr6KIQpaxtMGwGUxrh+wMscT+L8pbxjuVXi+MiIUyjxXGJZnz17boQ==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-gnu/-/cli-linux-x64-gnu-4.11.0.tgz",
+      "integrity": "sha512-kwCB8UapNesJissboVu57G+64I6ZMjuTN4IhpqHeKdUJO8ggFqtTqQVgB0KOmx6IX2D7rXSWlOZjtYhDWty/lg==",
       "cpu": [
         "x64"
       ],
@@ -1126,9 +1126,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-x64-musl": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-musl/-/cli-linux-x64-musl-4.10.0.tgz",
-      "integrity": "sha512-Cxe3Gi8BaF3y/pSN75NrkJJP4sITx8bJKcrR6bY43CIRRP733YHx2eWCGVZUmLTJXewTX67jzO0D2iDMeIDNaw==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-musl/-/cli-linux-x64-musl-4.11.0.tgz",
+      "integrity": "sha512-vssHXTuyfxZuvSyYVVZCXAy3Ig9zDT3PWZ5rxXig8/IZC7K3Hhi6jARVR6wZXweWBps24jMIcreWmok8rjlZag==",
       "cpu": [
         "x64"
       ],
@@ -1139,9 +1139,9 @@
       ]
     },
     "node_modules/@tokscale/cli-win32-arm64-msvc": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-4.10.0.tgz",
-      "integrity": "sha512-FC7CZTsC+zeB+T9luefcf6vBY16N0QeQ6FDGj5X8lQSGNLiJPODQr3ei6yDagPIYKGAcQc0j6YvA2mYLz0yjMA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-4.11.0.tgz",
+      "integrity": "sha512-FKZZuiHrp85VWpvs/TwhbAHDZBx4dHFhcqBM4klc3cGkTAKBbN5uBIWz2bY1Nad5gkOqER6i196wvVtgosN6YA==",
       "cpu": [
         "arm64"
       ],
@@ -1152,9 +1152,9 @@
       ]
     },
     "node_modules/@tokscale/cli-win32-x64-msvc": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-x64-msvc/-/cli-win32-x64-msvc-4.10.0.tgz",
-      "integrity": "sha512-HVIKnSCeNg+Hx2pLuLUm452l2DFOIw1rC/d1dDzSvCXR+juxcv5IVJh6wW0zO+/QUdb7IR7OsHAvy9osY/PNjw==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-x64-msvc/-/cli-win32-x64-msvc-4.11.0.tgz",
+      "integrity": "sha512-yL26JhM0LsuX///21Va5SN04yT04l9Tr4DQvC3Ije28WLXsSkAdHKol9AzWaWlI2Y+nM2IfdHfqU89gmQJdMDw==",
       "cpu": [
         "x64"
       ],
@@ -4676,12 +4676,12 @@
       }
     },
     "node_modules/tokscale": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/tokscale/-/tokscale-4.10.0.tgz",
-      "integrity": "sha512-Mp5fwNi8APy2G6ht/jhHv19sIv1QfcrjOv4xUqEdWVoLTil3OIlgpdrt+1Z3HlvtXhKzm/dHwczAO0Kevev0+w==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/tokscale/-/tokscale-4.11.0.tgz",
+      "integrity": "sha512-ZMNVSB1O4mms935y1akXXhbahpiwod+6dPR3hegbRSMufCn79kXFeNfJ1J1oI5FlFPcTTxLlNHSC0H/bXE0AWQ==",
       "license": "MIT",
       "dependencies": {
-        "@tokscale/cli": "4.10.0"
+        "@tokscale/cli": "4.11.0"
       },
       "bin": {
         "tokscale": "bin.js"

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "koffi": "^3.1.4",
     "semver": "^7.8.5",
     "tar": "^7.5.22",
-    "tokscale": "^4.10.0",
+    "tokscale": "^4.11.0",
     "undici": "^7.29.0"
   },
   "devDependencies": {

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -5605,6 +5605,13 @@ app.whenReady().then(() => {
       const roots = clientDiagnosticRoots(client)[client] || [];
       const target = roots.find((root) => root.exists);
       if (!target) return false;
+      // An exact-file source would otherwise be handed to openPath, which opens
+      // the file in whatever app claims .db/.jsonl. Select it in its folder
+      // instead — the user asked where the data lives, not to open it.
+      if (target.sourcePath) {
+        shell.showItemInFolder(target.sourcePath);
+        return true;
+      }
       return await shell.openPath(target.dir) === '';
     } catch (_) {
       return false;

--- a/src/shared/clientHealth.js
+++ b/src/shared/clientHealth.js
@@ -167,11 +167,15 @@ const CLIENT_SOURCE_CHECK_IDS = Object.freeze([
   'claude-projects',
   'claude-transcripts',
   'cline-tasks',
+  'cline-cli-sessions',
   'codebuddy-extension-logs',
   'codebuddy-projects',
   'codex-sessions',
+  'copilot-data',
   'copilot-otel',
+  'copilot-otel-exporter',
   'grok-sessions',
+  'grok-unified-log',
   'hermes-home',
   'hermes-profile',
   'kilocode-tasks',
@@ -193,7 +197,8 @@ const CLIENT_SOURCE_CHECK_IDS = Object.freeze([
   'vscode-workspace-storage',
   'workbuddy-projects',
   'zcode-projects',
-  'zed-threads'
+  'zed-threads',
+  'zcode-cli-db'
 ]);
 
 // Observations worth surfacing that the core three fields cannot state on their

--- a/src/shared/clientHealth.js
+++ b/src/shared/clientHealth.js
@@ -166,8 +166,8 @@ const CLIENT_SOURCE_CHECK_IDS = Object.freeze([
   'antigravity-ide-source',
   'claude-projects',
   'claude-transcripts',
-  'cline-tasks',
   'cline-cli-sessions',
+  'cline-tasks',
   'codebuddy-extension-logs',
   'codebuddy-projects',
   'codex-sessions',
@@ -196,9 +196,9 @@ const CLIENT_SOURCE_CHECK_IDS = Object.freeze([
   'tokscale-cursor-cache',
   'vscode-workspace-storage',
   'workbuddy-projects',
+  'zcode-cli-db',
   'zcode-projects',
-  'zed-threads',
-  'zcode-cli-db'
+  'zed-threads'
 ]);
 
 // Observations worth surfacing that the core three fields cannot state on their

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1047,6 +1047,49 @@ function dirExists(dir) {
   try { return fs.statSync(dir).isDirectory(); } catch (_) { return false; }
 }
 
+function fileExists(file) {
+  try { return fs.statSync(file).isFile(); } catch (_) { return false; }
+}
+
+function nonBlankEnvPath(name, fallback) {
+  const value = process.env[name];
+  return typeof value === 'string' && value.trim() ? value : fallback;
+}
+
+function xdgDataHome(home) {
+  return nonBlankEnvPath('XDG_DATA_HOME', path.join(home, '.local', 'share'));
+}
+
+function tokscaleHeadlessRoots(home) {
+  const configured = nonBlankEnvPath('TOKSCALE_HEADLESS_DIR', null);
+  if (configured) return [configured];
+  return [
+    path.join(home, '.config', 'tokscale', 'headless'),
+    path.join(home, 'Library', 'Application Support', 'tokscale', 'headless')
+  ];
+}
+
+function copilotExporterPath() {
+  const configured = process.env.COPILOT_OTEL_FILE_EXPORTER_PATH;
+  if (typeof configured !== 'string') return null;
+  const trimmed = configured.trim();
+  return trimmed ? path.resolve(trimmed) : null;
+}
+
+function hasWatchableParent(file) {
+  return path.dirname(file) !== path.parse(file).root;
+}
+
+function clineCliSessionRoot(home) {
+  const sessionDataDir = nonBlankEnvPath('CLINE_SESSION_DATA_DIR', null);
+  if (sessionDataDir) return sessionDataDir;
+  const dataDir = nonBlankEnvPath('CLINE_DATA_DIR', null);
+  if (dataDir) return path.join(dataDir, 'sessions');
+  const clineDir = nonBlankEnvPath('CLINE_DIR', null);
+  if (clineDir) return path.join(clineDir, 'data', 'sessions');
+  return path.join(home, '.cline', 'data', 'sessions');
+}
+
 function hasCopilotChatSessions(workspaceRoot) {
   try {
     return fs.readdirSync(workspaceRoot, { withFileTypes: true })
@@ -1071,22 +1114,40 @@ function clientSourceRoots(clientsCsv) {
   const enabled = new Set(String(clientsCsv || '').split(',').map((value) => value.trim().toLowerCase()).filter(Boolean));
   const byClient = {};
   const add = (client, ...roots) => {
-    if (enabled.has(client)) byClient[client] = roots.map(([id, dir]) => ({ id, dir }));
+    if (enabled.has(client)) {
+      byClient[client] = roots.map(([id, dir, sourcePath]) => ({
+        id,
+        dir,
+        ...(sourcePath ? { sourcePath } : {})
+      }));
+    }
   };
   add('claude', ['claude-projects', path.join(home, '.claude', 'projects')], ['claude-transcripts', path.join(home, '.claude', 'transcripts')]);
-  add('codex', ['codex-sessions', path.join(home, '.codex', 'sessions')]);
+  const codexHome = nonBlankEnvPath('CODEX_HOME', path.join(home, '.codex'));
+  add(
+    'codex',
+    ['codex-sessions', path.join(codexHome, 'sessions')],
+    ['codex-sessions', path.join(codexHome, 'archived_sessions')],
+    ...tokscaleHeadlessRoots(home).map((root) => ['codex-sessions', path.join(root, 'codex')])
+  );
   const hermesHome = resolveHermesHome({ env: process.env, homeDir: home });
   add('hermes', ['hermes-home', hermesHome], ...hermesProfileWatchDirs(hermesHome).map((dir) => ['hermes-profile', dir]));
-  // Within the default OpenCode data root, Tokscale 4.10.0 reads the direct
+  // Within the default OpenCode data root, Tokscale reads the direct
   // opencode*.db family and the legacy storage/message/*/*.json source. The
   // watcher prunes the rest of this broad app data root below.
-  add('opencode', ['opencode-data', path.join(home, '.local', 'share', 'opencode')]);
+  const xdgHome = xdgDataHome(home);
+  add('opencode', ['opencode-data', path.join(xdgHome, 'opencode')]);
   add('openclaw', ['openclaw-agents', path.join(home, '.openclaw', 'agents')]);
   add('cursor', ['tokscale-cursor-cache', path.join(home, '.config', 'tokscale', 'cursor-cache')]);
   add('antigravity', ['tokscale-antigravity-cache', path.join(home, '.config', 'tokscale', 'antigravity-cache')]);
   add('kimi', ['kimi-sessions', path.join(home, '.kimi', 'sessions')], ['kimi-code-sessions', path.join(process.env.KIMI_CODE_HOME || path.join(home, '.kimi-code'), 'sessions')]);
   add('qwen', ['qwen-projects', path.join(home, '.qwen', 'projects')]);
-  add('grok', ['grok-sessions', path.join(process.env.GROK_HOME || path.join(home, '.grok'), 'sessions')]);
+  const grokHome = nonBlankEnvPath('GROK_HOME', path.join(home, '.grok'));
+  add(
+    'grok',
+    ['grok-sessions', path.join(grokHome, 'sessions')],
+    ['grok-unified-log', path.join(grokHome, 'logs'), path.join(grokHome, 'logs', 'unified.jsonl')]
+  );
   // Tokscale 4.5.2 also parses VS Code Copilot Chat JSONL under each
   // workspaceStorage/*/chatSessions directory. Watch the workspaceStorage roots
   // so newly created workspaces are picked up; watchIgnoreMatcher prunes every
@@ -1099,11 +1160,17 @@ function clientSourceRoots(clientsCsv) {
       : []),
     path.join(home, 'AppData', 'Roaming', 'Code', 'User', 'workspaceStorage')
   ];
-  add(
-    'copilot',
-    ['copilot-otel', path.join(home, '.copilot', 'otel')],
+  const copilotOtelRoot = path.join(home, '.copilot', 'otel');
+  const copilotRoots = [
+    ['copilot-otel', copilotOtelRoot],
+    ['copilot-data', path.join(home, '.copilot'), path.join(home, '.copilot', 'data.db')],
     ...[...new Set(copilotWorkspaceRoots)].map((dir) => ['vscode-workspace-storage', dir])
-  );
+  ];
+  const exporterPath = copilotExporterPath();
+  if (exporterPath && hasWatchableParent(exporterPath) && !exporterPath.startsWith(path.resolve(copilotOtelRoot) + path.sep)) {
+    copilotRoots.push(['copilot-otel-exporter', path.dirname(exporterPath), exporterPath]);
+  }
+  add('copilot', ...copilotRoots);
   add('pi', ['pi-sessions', path.join(home, '.pi', 'agent', 'sessions')], ['omp-sessions', path.join(home, '.omp', 'agent', 'sessions')]);
   // Zed: tokscale reads the XdgData root on every platform AND the native macOS
   // (Application Support) / Windows (LOCALAPPDATA) roots (see tokscale scanner.rs
@@ -1111,7 +1178,7 @@ function clientSourceRoots(clientsCsv) {
   // seconds-level refresh and a correct waiting/missing status.
   add(
     'zed',
-    ['zed-threads', path.join(home, '.local', 'share', 'zed', 'threads')],
+    ['zed-threads', path.join(xdgHome, 'zed', 'threads')],
     ['zed-threads', path.join(home, 'Library', 'Application Support', 'Zed', 'threads')],
     ['zed-threads', path.join(process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local'), 'Zed', 'threads')]
   );
@@ -1132,10 +1199,15 @@ function clientSourceRoots(clientsCsv) {
   // missing dir is dropped by watchClientRootsForClients.
   add(
     'micode',
-    ['mimocode-data', path.join(home, '.local', 'share', 'mimocode')],
+    ['mimocode-data', path.join(xdgHome, 'mimocode')],
     ['mimocode-orca-data', path.join(home, 'Library', 'Application Support', 'orca', 'mimocode-hooks', 'shared', 'data')]
   );
-  add('zcode', ['zcode-projects', path.join(home, '.zcode', 'projects')]);
+  const zcodeDbDir = path.join(home, '.zcode', 'cli', 'db');
+  add(
+    'zcode',
+    ['zcode-projects', path.join(home, '.zcode', 'projects')],
+    ['zcode-cli-db', zcodeDbDir, path.join(zcodeDbDir, 'db.sqlite')]
+  );
   // CodeBuddy (Tencent): tokscale reads the home-relative CLI/WebUI JSONL dir on
   // every platform, plus the IDE / VS Code extension logs under a platform-
   // specific CodeBuddyExtension/Logs root (scanner.rs). Watch both so CLI and
@@ -1194,7 +1266,8 @@ function clientSourceRoots(clientsCsv) {
     ['cline-tasks', path.join(home, '.config', 'Code', 'User', 'globalStorage', 'saoudrizwan.claude-dev', 'tasks')],
     ['cline-tasks', path.join(home, 'Library', 'Application Support', 'Code', 'User', 'globalStorage', 'saoudrizwan.claude-dev', 'tasks')],
     ['cline-tasks', path.join(process.env.APPDATA || path.join(home, 'AppData', 'Roaming'), 'Code', 'User', 'globalStorage', 'saoudrizwan.claude-dev', 'tasks')],
-    ['cline-tasks', path.join(home, '.vscode-server', 'data', 'User', 'globalStorage', 'saoudrizwan.claude-dev', 'tasks')]
+    ['cline-tasks', path.join(home, '.vscode-server', 'data', 'User', 'globalStorage', 'saoudrizwan.claude-dev', 'tasks')],
+    ['cline-cli-sessions', clineCliSessionRoot(home)]
   );
   return byClient;
 }
@@ -1204,7 +1277,13 @@ function clientSourceRoots(clientsCsv) {
 function clientWatchCandidates(clientsCsv) {
   const byClient = {};
   for (const [client, roots] of Object.entries(clientSourceRoots(clientsCsv))) {
-    byClient[client] = roots.map((root) => root.dir);
+    // The Copilot data root already keeps its `otel/` child through the
+    // matcher below. Keep that child as a diagnostic/source check, but do not
+    // hand both nested paths to chokidar or it may install two native watches
+    // over the same tree.
+    byClient[client] = roots
+      .filter((root) => !(client === 'copilot' && root.id === 'copilot-otel'))
+      .map((root) => root.dir);
   }
   return byClient;
 }
@@ -1311,6 +1390,9 @@ const MICODE_DB_WATCH_PATTERN = /^mimocode(?:-[A-Za-z0-9._-]+)?\.db(?:-(?:wal|sh
 // recurse through the application data trees around them.
 const KIRO_DB_WATCH_PATTERN = /^data\.sqlite3(?:-(?:wal|shm))?$/;
 const ZED_DB_WATCH_PATTERN = /^threads\.db(?:-(?:wal|shm))?$/;
+const COPILOT_DB_WATCH_PATTERN = /^data\.db(?:-(?:wal|shm))?$/;
+const ZCODE_DB_WATCH_PATTERN = /^db\.sqlite(?:-(?:wal|shm))?$/;
+const GROK_UNIFIED_LOG_FILE = 'unified.jsonl';
 // Tokscale scans only these two CodeBuddy extension log subtrees. Keep their
 // recursive layout intact, but prune unrelated siblings under Logs before
 // chokidar allocates watches for them.
@@ -1345,6 +1427,24 @@ function watchIgnoreMatcher(clientsCsv) {
   const copilotRoots = (candidates.copilot || [])
     .filter((dir) => path.basename(dir) === 'workspaceStorage')
     .map((dir) => path.resolve(canonicalWatchPath(dir)));
+  const copilotDataRoots = (candidates.copilot || [])
+    .filter((dir) => path.basename(dir) === '.copilot')
+    .map((dir) => path.resolve(canonicalWatchPath(dir)));
+  const copilotDataRootSet = new Set(copilotDataRoots);
+  const configuredCopilotExporter = copilotExporterPath();
+  const canonicalCopilotExporter = configuredCopilotExporter && hasWatchableParent(configuredCopilotExporter)
+    ? canonicalWatchFilePath(configuredCopilotExporter)
+    : null;
+  const copilotOtelRoot = path.resolve(canonicalWatchPath(path.join(os.homedir(), '.copilot', 'otel')));
+  const copilotExporterRoot = configuredCopilotExporter
+    && hasWatchableParent(configuredCopilotExporter)
+    && !canonicalCopilotExporter.startsWith(copilotOtelRoot + path.sep)
+    ? path.dirname(configuredCopilotExporter)
+    : null;
+  const copilotExporterRoots = copilotExporterRoot
+    ? [path.resolve(canonicalWatchPath(copilotExporterRoot))]
+    : [];
+  const copilotExporterRootSet = new Set(copilotExporterRoots);
   const antigravityEnabled = String(clientsCsv || '').split(',').map((value) => value.trim().toLowerCase()).includes('antigravity');
   const antigravityRoots = antigravityEnabled
     ? antigravityDataRoots().map((dir) => path.resolve(canonicalWatchPath(dir)))
@@ -1366,15 +1466,27 @@ function watchIgnoreMatcher(clientsCsv) {
     .filter((dir) => path.basename(dir) === 'Logs')
     .map((dir) => path.resolve(canonicalWatchPath(dir)));
   const codebuddyExtensionRootSet = new Set(codebuddyExtensionRoots);
+  const grokUnifiedRoots = (candidates.grok || [])
+    .filter((dir) => path.basename(dir) === 'logs')
+    .map((dir) => path.resolve(canonicalWatchPath(dir)));
+  const grokUnifiedRootSet = new Set(grokUnifiedRoots);
+  const zcodeDbRoots = (candidates.zcode || [])
+    .filter((dir) => path.basename(dir) === 'db')
+    .map((dir) => path.resolve(canonicalWatchPath(dir)));
+  const zcodeDbRootSet = new Set(zcodeDbRoots);
   if (
     hermesRoots.length === 0
     && copilotRoots.length === 0
+    && copilotDataRoots.length === 0
+    && copilotExporterRoots.length === 0
     && antigravityRoots.length === 0
     && opencodeRoots.length === 0
     && micodeRoots.length === 0
     && kiroCliRoots.length === 0
     && zedRoots.length === 0
     && codebuddyExtensionRoots.length === 0
+    && grokUnifiedRoots.length === 0
+    && zcodeDbRoots.length === 0
   ) return undefined;
   return (target) => {
     const resolved = path.resolve(target);
@@ -1385,6 +1497,23 @@ function watchIgnoreMatcher(clientsCsv) {
     if (hermesRootSet.has(resolved)) return false;
     for (const root of hermesRoots) {
       if (resolved.startsWith(root + path.sep)) return !HERMES_DB_FILES.has(path.basename(resolved));
+    }
+    if (copilotExporterRootSet.has(resolved)) return false;
+    if (copilotDataRootSet.has(resolved)) return false;
+    for (const root of copilotDataRoots) {
+      if (!resolved.startsWith(root + path.sep)) continue;
+      const parts = path.relative(root, resolved).split(path.sep);
+      if (parts[0] === 'otel') return false;
+      if (parts.length === 1) {
+        if (canonicalCopilotExporter && resolved === canonicalCopilotExporter) return false;
+        return !COPILOT_DB_WATCH_PATTERN.test(parts[0]);
+      }
+      return canonicalCopilotExporter === resolved ? false : true;
+    }
+    for (const root of copilotExporterRoots) {
+      if (!resolved.startsWith(root + path.sep)) continue;
+      if (resolved === canonicalCopilotExporter) return false;
+      return true;
     }
     for (const root of copilotRoots) {
       if (resolved === root) return false;
@@ -1437,6 +1566,23 @@ function watchIgnoreMatcher(clientsCsv) {
       if (path.dirname(resolved) !== root) return true;
       return !MICODE_DB_WATCH_PATTERN.test(path.basename(resolved));
     }
+    if (grokUnifiedRootSet.has(resolved)) return false;
+    for (const root of grokUnifiedRoots) {
+      if (!resolved.startsWith(root + path.sep)) continue;
+      // The dual-source Grok scanner derives exactly logs/unified.jsonl from
+      // each Grok home. Keep the log parent visible for a file created later,
+      // but do not recurse through unrelated log files.
+      if (path.dirname(resolved) !== root) return true;
+      return path.basename(resolved) !== GROK_UNIFIED_LOG_FILE;
+    }
+    if (zcodeDbRootSet.has(resolved)) return false;
+    for (const root of zcodeDbRoots) {
+      if (!resolved.startsWith(root + path.sep)) continue;
+      // ZCode v2 is a direct SQLite path, not a recursive project source.
+      // Keep WAL/SHM as event signals without treating them as databases.
+      if (path.dirname(resolved) !== root) return true;
+      return !ZCODE_DB_WATCH_PATTERN.test(path.basename(resolved));
+    }
     if (kiroCliRootSet.has(resolved)) return false;
     for (const root of kiroCliRoots) {
       if (!resolved.startsWith(root + path.sep)) continue;
@@ -1469,6 +1615,7 @@ function watchIgnoreMatcher(clientsCsv) {
 // derived from this rather than computed beside it, so the presence dot in the
 // UI and the health record can never disagree about what was found.
 function sourceRootExists(root) {
+  if (root.sourcePath) return fileExists(root.sourcePath);
   return root.id === 'vscode-workspace-storage'
     ? hasCopilotChatSessions(root.dir)
     : dirExists(root.dir);
@@ -1477,7 +1624,7 @@ function sourceRootExists(root) {
 function evaluatedClientSourceRoots(clientsCsv) {
   return Object.fromEntries(Object.entries(clientSourceRoots(clientsCsv)).map(([client, roots]) => [
     client,
-    roots.map((root) => ({ ...root, exists: sourceRootExists(root) }))
+    roots.map((root) => ({ id: root.id, dir: root.dir, exists: sourceRootExists(root) }))
   ]));
 }
 
@@ -1813,6 +1960,14 @@ function canonicalWatchPath(dir) {
   if (process.platform !== 'win32') return dir;
   try { return fs.realpathSync.native(dir); }
   catch (_) { return dir; }
+}
+
+// The exporter file may not exist when the watcher starts, so canonicalise its
+// existing parent and append the original basename instead of realpathing the
+// file itself. This keeps exact-file matching in the same path space as the
+// canonical directory root handed to chokidar on Windows.
+function canonicalWatchFilePath(file) {
+  return path.join(path.resolve(canonicalWatchPath(path.dirname(file))), path.basename(file));
 }
 
 function watcherOptions(usePolling, ignored) {

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1247,17 +1247,33 @@ function clientSourceRoots(clientsCsv) {
   // IDE usage each refresh in seconds; the shared Code/logs tree is deliberately
   // not watched (too broad for polling — full ticks still scan it). No --home
   // host-DB fallback, so every root is safe to watch cross-platform.
-  // The extension log root is tokscale's `dirs::data_local_dir()` (scanner.rs),
-  // which is %LOCALAPPDATA% on Windows, Application Support on macOS, and the
-  // XDG data home on Linux — so the Linux arm has to follow XDG_DATA_HOME, not
-  // a hardcoded .local/share. This is a `dirs` crate lookup rather than a path
-  // literal, which is why it does not show up when grepping tokscale's strings.
-  const codebuddyExtLogs = process.platform === 'win32'
-    ? path.join(process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local'), 'CodeBuddyExtension', 'Logs')
-    : process.platform === 'darwin'
-      ? path.join(home, 'Library', 'Application Support', 'CodeBuddyExtension', 'Logs')
-      : path.join(xdgHome, 'CodeBuddyExtension', 'Logs');
-  add('codebuddy', ['codebuddy-projects', path.join(home, '.codebuddy', 'projects')], ['codebuddy-extension-logs', codebuddyExtLogs]);
+  // Two extension-log roots, because tokscale scans two (scanner.rs). It seeds
+  // the list with the home-relative Windows-shaped path on EVERY platform, and
+  // only then adds the native `dirs::data_local_dir()` root — so a home carried
+  // over from Windows is scanned on macOS/Linux too, and watching only the
+  // native one would let the periodic scan see usage the watcher never does.
+  //
+  // `dirs::data_local_dir()` is %LOCALAPPDATA% on Windows, Application Support
+  // on macOS, and the XDG data home on Linux, so the Linux arm follows
+  // XDG_DATA_HOME rather than a hardcoded .local/share. Being a `dirs` lookup
+  // rather than a path literal is why it does not appear in tokscale's strings.
+  //
+  // On Windows the two normally resolve to the same directory and the Set
+  // collapses them; elsewhere watchClientRootsForClients drops whichever is
+  // absent, which is the usual case for the Windows-shaped one.
+  const codebuddyExtLogRoots = [
+    path.join(home, 'AppData', 'Local', 'CodeBuddyExtension', 'Logs'),
+    process.platform === 'win32'
+      ? path.join(process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local'), 'CodeBuddyExtension', 'Logs')
+      : process.platform === 'darwin'
+        ? path.join(home, 'Library', 'Application Support', 'CodeBuddyExtension', 'Logs')
+        : path.join(xdgHome, 'CodeBuddyExtension', 'Logs')
+  ];
+  add(
+    'codebuddy',
+    ['codebuddy-projects', path.join(home, '.codebuddy', 'projects')],
+    ...[...new Set(codebuddyExtLogRoots)].map((dir) => ['codebuddy-extension-logs', dir])
+  );
   // WorkBuddy (Tencent): watch only the detailed session dir (projects/*.jsonl,
   // the preferred source) — not the whole ~/.workbuddy app home, whose config /
   // auth churn would add polling load and spurious ticks with no usage change.

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1474,6 +1474,35 @@ function watchIgnoreMatcher(clientsCsv) {
     .filter((dir) => path.basename(dir) === 'db')
     .map((dir) => path.resolve(canonicalWatchPath(dir)));
   const zcodeDbRootSet = new Set(zcodeDbRoots);
+  const boundedWatchRootSet = new Set([
+    ...hermesRoots,
+    ...copilotRoots,
+    ...copilotDataRoots,
+    ...antigravityRoots,
+    ...opencodeRoots,
+    ...micodeRoots,
+    ...grokUnifiedRoots,
+    ...zcodeDbRoots,
+    ...kiroCliRoots,
+    ...zedRoots,
+    ...codebuddyExtensionRoots
+  ]);
+  // `ignored` is global to the chokidar instance, while the roots below may
+  // overlap. Keep every non-Copilot recursive source in the union before the
+  // custom exporter branch gets a chance to prune its parent directory. The
+  // bounded roots above are handled by their client-specific branches below;
+  // self-synced cache roots are never handed to chokidar in the first place.
+  const antigravityCliRoots = antigravityEnabled && dirExists(antigravityCliDataDir())
+    ? [path.resolve(canonicalWatchPath(antigravityCliDataDir()))]
+    : [];
+  const recursiveWatchRootSet = new Set([
+    ...Object.entries(candidates)
+      .filter(([client]) => client !== 'copilot' && !SELF_SYNCED_CLIENTS.has(client))
+      .flatMap(([, roots]) => roots)
+      .map((dir) => path.resolve(canonicalWatchPath(dir)))
+      .filter((dir) => !boundedWatchRootSet.has(dir)),
+    ...antigravityCliRoots
+  ]);
   if (
     hermesRoots.length === 0
     && copilotRoots.length === 0
@@ -1490,6 +1519,11 @@ function watchIgnoreMatcher(clientsCsv) {
   ) return undefined;
   return (target) => {
     const resolved = path.resolve(target);
+    // These explicit exporter paths/parents are roots in their own right. A
+    // broad bounded client root (for example OpenCode) must not prune either
+    // one before its own source-specific branch gets to classify the path.
+    if (canonicalCopilotExporter && resolved === canonicalCopilotExporter) return false;
+    if (copilotExporterRootSet.has(resolved)) return false;
     // Every explicit watch root stays watched — the home dir AND each profile
     // dir. A profile dir lives under the home root, so the child-prune below
     // would otherwise ignore it (basename isn't a db file) before we recognise
@@ -1509,11 +1543,6 @@ function watchIgnoreMatcher(clientsCsv) {
         return !COPILOT_DB_WATCH_PATTERN.test(parts[0]);
       }
       return canonicalCopilotExporter === resolved ? false : true;
-    }
-    for (const root of copilotExporterRoots) {
-      if (!resolved.startsWith(root + path.sep)) continue;
-      if (resolved === canonicalCopilotExporter) return false;
-      return true;
     }
     for (const root of copilotRoots) {
       if (resolved === root) return false;
@@ -1605,6 +1634,16 @@ function watchIgnoreMatcher(clientsCsv) {
       if (!resolved.startsWith(root + path.sep)) continue;
       const parts = path.relative(root, resolved).split(path.sep);
       return !CODEBUDDY_EXTENSION_SOURCE_DIRS.has(parts[0]);
+    }
+    // Recursive transcript/session roots are valid sources at every depth.
+    // This union check prevents an arbitrary Copilot exporter parent such as
+    // $HOME from hiding another client's explicit root and its descendants.
+    for (const root of recursiveWatchRootSet) {
+      if (resolved === root || resolved.startsWith(root + path.sep)) return false;
+    }
+    for (const root of copilotExporterRoots) {
+      if (!resolved.startsWith(root + path.sep)) continue;
+      return true;
     }
     return false; // paths outside the bounded client roots are never ignored
   };

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1080,6 +1080,25 @@ function hasWatchableParent(file) {
   return path.dirname(file) !== path.parse(file).root;
 }
 
+// The one derivation of the custom Copilot OTel exporter, shared by the source
+// table, the watcher's ignore matcher and the attribution map. It used to exist
+// in two places that canonicalised differently before comparing against
+// ~/.copilot/otel, and the two answers diverge as soon as any part of that path
+// is a symlink — which either leaves the exporter's parent watched with no
+// pruning at all, or silently drops the exporter's own events.
+//
+// tokscale reads exactly the file this env var names (`path.is_file()`, no glob,
+// no directory walk), so the watch is pinned to that one file. Anything under
+// ~/.copilot/otel is already covered recursively and returns null here.
+function copilotExporterWatch(home) {
+  const file = copilotExporterPath();
+  if (!file || !hasWatchableParent(file)) return null;
+  const otelRoot = path.resolve(canonicalWatchPath(path.join(home, '.copilot', 'otel')));
+  const canonicalFile = canonicalWatchFilePath(file);
+  if (canonicalFile.startsWith(otelRoot + path.sep)) return null;
+  return { file, canonicalFile, dir: path.dirname(file) };
+}
+
 function clineCliSessionRoot(home) {
   const sessionDataDir = nonBlankEnvPath('CLINE_SESSION_DATA_DIR', null);
   if (sessionDataDir) return sessionDataDir;
@@ -1135,12 +1154,24 @@ function clientSourceRoots(clientsCsv) {
   // Within the default OpenCode data root, Tokscale reads the direct
   // opencode*.db family and the legacy storage/message/*/*.json source. The
   // watcher prunes the rest of this broad app data root below.
+  //
+  // Only the roots tokscale declares as `PathRoot::XdgData` go through this —
+  // opencode, zed and micode (clients.rs), plus the CodeBuddy extension logs it
+  // resolves via `dirs::data_local_dir()`. Kiro's CLI database is deliberately
+  // NOT one of them: tokscale spells it as a home-relative literal
+  // (`{home}/.local/share/kiro-cli/data.sqlite3`, scanner.rs), so following XDG
+  // there would watch a directory it never reads. The split is upstream's, not
+  // an oversight — check clients.rs before adding or removing a root here.
   const xdgHome = xdgDataHome(home);
   add('opencode', ['opencode-data', path.join(xdgHome, 'opencode')]);
   add('openclaw', ['openclaw-agents', path.join(home, '.openclaw', 'agents')]);
   add('cursor', ['tokscale-cursor-cache', path.join(home, '.config', 'tokscale', 'cursor-cache')]);
   add('antigravity', ['tokscale-antigravity-cache', path.join(home, '.config', 'tokscale', 'antigravity-cache')]);
-  add('kimi', ['kimi-sessions', path.join(home, '.kimi', 'sessions')], ['kimi-code-sessions', path.join(process.env.KIMI_CODE_HOME || path.join(home, '.kimi-code'), 'sessions')]);
+  // A whitespace-only KIMI_CODE_HOME counts as unset, matching tokscale: it
+  // joins `sessions` onto the raw value, so a blank export would resolve to the
+  // root-level /sessions and hide the real one.
+  const kimiCodeHome = nonBlankEnvPath('KIMI_CODE_HOME', path.join(home, '.kimi-code'));
+  add('kimi', ['kimi-sessions', path.join(home, '.kimi', 'sessions')], ['kimi-code-sessions', path.join(kimiCodeHome, 'sessions')]);
   add('qwen', ['qwen-projects', path.join(home, '.qwen', 'projects')]);
   const grokHome = nonBlankEnvPath('GROK_HOME', path.join(home, '.grok'));
   add(
@@ -1166,10 +1197,12 @@ function clientSourceRoots(clientsCsv) {
     ['copilot-data', path.join(home, '.copilot'), path.join(home, '.copilot', 'data.db')],
     ...[...new Set(copilotWorkspaceRoots)].map((dir) => ['vscode-workspace-storage', dir])
   ];
-  const exporterPath = copilotExporterPath();
-  if (exporterPath && hasWatchableParent(exporterPath) && !exporterPath.startsWith(path.resolve(copilotOtelRoot) + path.sep)) {
-    copilotRoots.push(['copilot-otel-exporter', path.dirname(exporterPath), exporterPath]);
-  }
+  // The parent is the watch root because the exporter file may not exist yet;
+  // the exact file is the source. watchAttributionRootsForClients() keeps that
+  // parent from becoming a copilot attribution prefix — it is an arbitrary
+  // user-chosen directory and can be $HOME.
+  const exporter = copilotExporterWatch(home);
+  if (exporter) copilotRoots.push(['copilot-otel-exporter', exporter.dir, exporter.file]);
   add('copilot', ...copilotRoots);
   add('pi', ['pi-sessions', path.join(home, '.pi', 'agent', 'sessions')], ['omp-sessions', path.join(home, '.omp', 'agent', 'sessions')]);
   // Zed: tokscale reads the XdgData root on every platform AND the native macOS
@@ -1214,11 +1247,16 @@ function clientSourceRoots(clientsCsv) {
   // IDE usage each refresh in seconds; the shared Code/logs tree is deliberately
   // not watched (too broad for polling — full ticks still scan it). No --home
   // host-DB fallback, so every root is safe to watch cross-platform.
+  // The extension log root is tokscale's `dirs::data_local_dir()` (scanner.rs),
+  // which is %LOCALAPPDATA% on Windows, Application Support on macOS, and the
+  // XDG data home on Linux — so the Linux arm has to follow XDG_DATA_HOME, not
+  // a hardcoded .local/share. This is a `dirs` crate lookup rather than a path
+  // literal, which is why it does not show up when grepping tokscale's strings.
   const codebuddyExtLogs = process.platform === 'win32'
     ? path.join(process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local'), 'CodeBuddyExtension', 'Logs')
     : process.platform === 'darwin'
       ? path.join(home, 'Library', 'Application Support', 'CodeBuddyExtension', 'Logs')
-      : path.join(home, '.local', 'share', 'CodeBuddyExtension', 'Logs');
+      : path.join(xdgHome, 'CodeBuddyExtension', 'Logs');
   add('codebuddy', ['codebuddy-projects', path.join(home, '.codebuddy', 'projects')], ['codebuddy-extension-logs', codebuddyExtLogs]);
   // WorkBuddy (Tencent): watch only the detailed session dir (projects/*.jsonl,
   // the preferred source) — not the whole ~/.workbuddy app home, whose config /
@@ -1347,6 +1385,34 @@ function watchPathsForClients(clientsCsv) {
   return [...new Set(Object.values(watchClientRootsForClients(clientsCsv)).flat())];
 }
 
+// The same roots, but as attribution prefixes rather than watch targets. The two
+// differ in exactly one place: a custom Copilot exporter has to be *watched* by
+// its parent directory (the file can appear later), while attributing by that
+// parent would be wrong — it is an arbitrary user-chosen path, and one pointing
+// at a file in $HOME would make every other client's event also target copilot,
+// turning each targeted scan into a two-client scan. The exact file attributes
+// instead. The parent survives only when another copilot source already owns it
+// (an exporter written straight into ~/.copilot), so `otel/` keeps its prefix.
+// Takes the watch roots when the caller already has them: setupWatchers() needs
+// both maps from one probe, and deriving them from two separate dirExists sweeps
+// would let a directory created between the two land in one map and not the
+// other — the same "two derivations of one thing" trap the exporter had.
+function watchAttributionRootsForClients(clientsCsv, watchRoots = null) {
+  const rootsByClient = watchRoots || watchClientRootsForClients(clientsCsv);
+  const exporter = copilotExporterWatch(os.homedir());
+  if (!exporter || !rootsByClient.copilot) return rootsByClient;
+  const exporterDir = path.resolve(exporter.dir);
+  const ownedByOtherSource = new Set(
+    (clientSourceRoots(clientsCsv).copilot || [])
+      .filter((root) => root.id !== 'copilot-otel-exporter')
+      .map((root) => path.resolve(root.dir))
+  );
+  const copilot = rootsByClient.copilot
+    .filter((root) => path.resolve(root) !== exporterDir || ownedByOtherSource.has(exporterDir));
+  copilot.push(exporter.canonicalFile);
+  return { ...rootsByClient, copilot: [...new Set(copilot)] };
+}
+
 function clientsForWatchPath(filePath, rootsByClient) {
   if (!filePath) return [];
   const resolved = path.resolve(filePath);
@@ -1431,18 +1497,10 @@ function watchIgnoreMatcher(clientsCsv) {
     .filter((dir) => path.basename(dir) === '.copilot')
     .map((dir) => path.resolve(canonicalWatchPath(dir)));
   const copilotDataRootSet = new Set(copilotDataRoots);
-  const configuredCopilotExporter = copilotExporterPath();
-  const canonicalCopilotExporter = configuredCopilotExporter && hasWatchableParent(configuredCopilotExporter)
-    ? canonicalWatchFilePath(configuredCopilotExporter)
-    : null;
-  const copilotOtelRoot = path.resolve(canonicalWatchPath(path.join(os.homedir(), '.copilot', 'otel')));
-  const copilotExporterRoot = configuredCopilotExporter
-    && hasWatchableParent(configuredCopilotExporter)
-    && !canonicalCopilotExporter.startsWith(copilotOtelRoot + path.sep)
-    ? path.dirname(configuredCopilotExporter)
-    : null;
-  const copilotExporterRoots = copilotExporterRoot
-    ? [path.resolve(canonicalWatchPath(copilotExporterRoot))]
+  const copilotExporter = copilotExporterWatch(os.homedir());
+  const canonicalCopilotExporter = copilotExporter ? copilotExporter.canonicalFile : null;
+  const copilotExporterRoots = copilotExporter
+    ? [path.resolve(canonicalWatchPath(copilotExporter.dir))]
     : [];
   const copilotExporterRootSet = new Set(copilotExporterRoots);
   const antigravityEnabled = String(clientsCsv || '').split(',').map((value) => value.trim().toLowerCase()).includes('antigravity');
@@ -1524,10 +1582,18 @@ function watchIgnoreMatcher(clientsCsv) {
     // one before its own source-specific branch gets to classify the path.
     if (canonicalCopilotExporter && resolved === canonicalCopilotExporter) return false;
     if (copilotExporterRootSet.has(resolved)) return false;
-    // `ignored` is global to the chokidar instance, so a recursive source must
-    // win over every bounded client's pruning rule, not only over the custom
-    // Copilot exporter branch below. This matters when an explicit CODEX_HOME,
-    // CLINE_SESSION_DATA_DIR, etc. is nested under another client's data root.
+    // `ignored` is global to the chokidar instance, so a recursive source that
+    // sits *inside* a bounded client's root has to stay visible — an explicit
+    // CODEX_HOME or CLINE_SESSION_DATA_DIR nested under another client's data
+    // root would otherwise be pruned by that client's rule.
+    //
+    // That nested case is the only overlap this guarantees, and it is the only
+    // one covered by a test. Overlap between roots is NOT resolved in general:
+    // a recursive root equal to a bounded root loses (it is filtered out of the
+    // set above), a recursive root that is an *ancestor* of a bounded root wins
+    // and cancels that client's pruning entirely, and two bounded roots resolve
+    // by whichever branch below is written first. All three need a specificity
+    // rule this ordered chain cannot express — see the table-driven follow-up.
     for (const root of recursiveWatchRootSet) {
       if (resolved === root || resolved.startsWith(root + path.sep)) return false;
     }
@@ -1539,17 +1605,16 @@ function watchIgnoreMatcher(clientsCsv) {
     for (const root of hermesRoots) {
       if (resolved.startsWith(root + path.sep)) return !HERMES_DB_FILES.has(path.basename(resolved));
     }
-    if (copilotExporterRootSet.has(resolved)) return false;
     if (copilotDataRootSet.has(resolved)) return false;
     for (const root of copilotDataRoots) {
       if (!resolved.startsWith(root + path.sep)) continue;
+      // The exporter file and its parent already returned above, so neither can
+      // reach this branch — do not re-test them here. Two earlier copies of that
+      // rule lived in this loop and only ever restated the top of the function.
       const parts = path.relative(root, resolved).split(path.sep);
       if (parts[0] === 'otel') return false;
-      if (parts.length === 1) {
-        if (canonicalCopilotExporter && resolved === canonicalCopilotExporter) return false;
-        return !COPILOT_DB_WATCH_PATTERN.test(parts[0]);
-      }
-      return canonicalCopilotExporter === resolved ? false : true;
+      if (parts.length === 1) return !COPILOT_DB_WATCH_PATTERN.test(parts[0]);
+      return true;
     }
     for (const root of copilotRoots) {
       if (resolved === root) return false;
@@ -1661,10 +1726,22 @@ function sourceRootExists(root) {
     : dirExists(root.dir);
 }
 
+// `dir` is what the diagnostics panel prints, so for an exact-file source it has
+// to be the file `exists` actually answered for. Printing the watch parent while
+// `exists` probed a file inside it makes the panel report a directory that is
+// plainly there as missing — the one question the panel exists to answer. The
+// watch root stays available to the watcher through clientWatchCandidates(),
+// which reads clientSourceRoots() directly; `sourcePath` rides along so a reveal
+// can tell a file from a directory without stat-ing it again.
 function evaluatedClientSourceRoots(clientsCsv) {
   return Object.fromEntries(Object.entries(clientSourceRoots(clientsCsv)).map(([client, roots]) => [
     client,
-    roots.map((root) => ({ id: root.id, dir: root.dir, exists: sourceRootExists(root) }))
+    roots.map((root) => ({
+      id: root.id,
+      dir: root.sourcePath || root.dir,
+      ...(root.sourcePath ? { sourcePath: root.sourcePath } : {}),
+      exists: sourceRootExists(root)
+    }))
   ]));
 }
 
@@ -2564,8 +2641,20 @@ function startCollector(options) {
     // Canonicalise before anything derives from these roots, so the paths handed
     // to chokidar and the paths clientsForWatchPath matches against are the same
     // strings. Resolving only one of the two would silently break attribution.
+    // One dirExists sweep feeds both maps: probing twice would let a directory
+    // created between the sweeps land in the watch list and not the attribution
+    // list, or the reverse.
+    const watchRoots = watchClientRootsForClients(clients);
     const rootsByClient = Object.fromEntries(
-      Object.entries(watchClientRootsForClients(clients))
+      Object.entries(watchRoots)
+        .map(([client, dirs]) => [client, dirs.map(canonicalWatchPath)])
+    );
+    // Watch targets and attribution prefixes are the same list everywhere except
+    // a custom Copilot exporter, whose parent must be watched without becoming a
+    // copilot prefix. Canonicalised through the same function so both still
+    // compare equal to the paths chokidar reports.
+    const attributionRootsByClient = Object.fromEntries(
+      Object.entries(watchAttributionRootsForClients(clients, watchRoots))
         .map(([client, dirs]) => [client, dirs.map(canonicalWatchPath)])
     );
     // A subset of the same roots, matched separately so a write to a client's
@@ -2595,7 +2684,7 @@ function startCollector(options) {
             ? activityRevision
             : Math.max(pendingActivityRevision, activityRevision);
         }
-        const eventClients = clientsForWatchPath(filePath, rootsByClient);
+        const eventClients = clientsForWatchPath(filePath, attributionRootsByClient);
         for (const client of clientsForWatchPath(filePath, sourceSyncRootsByClient)) {
           sourceSyncQueue.record(client);
         }
@@ -2740,6 +2829,7 @@ module.exports = {
   clientDiagnosticRoots,
   clientSourceChecks,
   clientSourceRoots,
+  clientsForWatchPath,
   clientWatchCandidates,
   computePeriodWindows,
   configFingerprint,
@@ -2775,6 +2865,7 @@ module.exports = {
   tokscaleCommand,
   tokscaleClientFilter,
   TOKSCALE_CLIENT_ALIASES,
+  watchAttributionRootsForClients,
   watcherOptions,
   watchIgnoreMatcher,
   watchPathsForClients

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1524,6 +1524,13 @@ function watchIgnoreMatcher(clientsCsv) {
     // one before its own source-specific branch gets to classify the path.
     if (canonicalCopilotExporter && resolved === canonicalCopilotExporter) return false;
     if (copilotExporterRootSet.has(resolved)) return false;
+    // `ignored` is global to the chokidar instance, so a recursive source must
+    // win over every bounded client's pruning rule, not only over the custom
+    // Copilot exporter branch below. This matters when an explicit CODEX_HOME,
+    // CLINE_SESSION_DATA_DIR, etc. is nested under another client's data root.
+    for (const root of recursiveWatchRootSet) {
+      if (resolved === root || resolved.startsWith(root + path.sep)) return false;
+    }
     // Every explicit watch root stays watched — the home dir AND each profile
     // dir. A profile dir lives under the home root, so the child-prune below
     // would otherwise ignore it (basename isn't a db file) before we recognise
@@ -1634,12 +1641,6 @@ function watchIgnoreMatcher(clientsCsv) {
       if (!resolved.startsWith(root + path.sep)) continue;
       const parts = path.relative(root, resolved).split(path.sep);
       return !CODEBUDDY_EXTENSION_SOURCE_DIRS.has(parts[0]);
-    }
-    // Recursive transcript/session roots are valid sources at every depth.
-    // This union check prevents an arbitrary Copilot exporter parent such as
-    // $HOME from hiding another client's explicit root and its descendants.
-    for (const root of recursiveWatchRootSet) {
-      if (resolved === root || resolved.startsWith(root + path.sep)) return false;
     }
     for (const root of copilotExporterRoots) {
       if (!resolved.startsWith(root + path.sep)) continue;

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1306,6 +1306,15 @@ const OPENCODE_DB_WATCH_PATTERN = /^opencode(?:-[A-Za-z0-9._-]+)?\.db(?:-(?:wal|
 // The home root itself stays watched so a freshly created database or sidecar
 // still surfaces on the next top-level readdir.
 const MICODE_DB_WATCH_PATTERN = /^mimocode(?:-[A-Za-z0-9._-]+)?\.db(?:-(?:wal|shm))?$/;
+// Kiro CLI and Zed expose one SQLite database at a known path. Keep their
+// parent dirs watched so the database can appear after startup, but do not
+// recurse through the application data trees around them.
+const KIRO_DB_WATCH_PATTERN = /^data\.sqlite3(?:-(?:wal|shm))?$/;
+const ZED_DB_WATCH_PATTERN = /^threads\.db(?:-(?:wal|shm))?$/;
+// Tokscale scans only these two CodeBuddy extension log subtrees. Keep their
+// recursive layout intact, but prune unrelated siblings under Logs before
+// chokidar allocates watches for them.
+const CODEBUDDY_EXTENSION_SOURCE_DIRS = new Set(['CodeBuddyIDE', 'VSCode']);
 // Which parts of an Antigravity IDE home are worth an event. Not "what tokscale
 // parses" — tokscale gets the token data over RPC from the running language
 // server and only reads `brain/`+`conversations/` to enumerate session ids.
@@ -1345,7 +1354,28 @@ function watchIgnoreMatcher(clientsCsv) {
   const opencodeRootSet = new Set(opencodeRoots);
   const micodeRoots = (candidates.micode || []).map((dir) => path.resolve(canonicalWatchPath(dir)));
   const micodeRootSet = new Set(micodeRoots);
-  if (hermesRoots.length === 0 && copilotRoots.length === 0 && antigravityRoots.length === 0 && opencodeRoots.length === 0 && micodeRoots.length === 0) return undefined;
+  const kiroCliRoots = (candidates.kiro || [])
+    .filter((dir) => path.basename(dir) === 'kiro-cli')
+    .map((dir) => path.resolve(canonicalWatchPath(dir)));
+  const kiroCliRootSet = new Set(kiroCliRoots);
+  const zedRoots = (candidates.zed || [])
+    .filter((dir) => path.basename(dir) === 'threads')
+    .map((dir) => path.resolve(canonicalWatchPath(dir)));
+  const zedRootSet = new Set(zedRoots);
+  const codebuddyExtensionRoots = (candidates.codebuddy || [])
+    .filter((dir) => path.basename(dir) === 'Logs')
+    .map((dir) => path.resolve(canonicalWatchPath(dir)));
+  const codebuddyExtensionRootSet = new Set(codebuddyExtensionRoots);
+  if (
+    hermesRoots.length === 0
+    && copilotRoots.length === 0
+    && antigravityRoots.length === 0
+    && opencodeRoots.length === 0
+    && micodeRoots.length === 0
+    && kiroCliRoots.length === 0
+    && zedRoots.length === 0
+    && codebuddyExtensionRoots.length === 0
+  ) return undefined;
   return (target) => {
     const resolved = path.resolve(target);
     // Every explicit watch root stays watched — the home dir AND each profile
@@ -1406,6 +1436,29 @@ function watchIgnoreMatcher(clientsCsv) {
       // other recursive subtree before chokidar descends into it.
       if (path.dirname(resolved) !== root) return true;
       return !MICODE_DB_WATCH_PATTERN.test(path.basename(resolved));
+    }
+    if (kiroCliRootSet.has(resolved)) return false;
+    for (const root of kiroCliRoots) {
+      if (!resolved.startsWith(root + path.sep)) continue;
+      // Tokscale opens only the direct data.sqlite3 path. Keep the parent
+      // watched so a fresh install or a recreated database is discovered, but
+      // never recurse into other kiro-cli runtime files and directories.
+      if (path.dirname(resolved) !== root) return true;
+      return !KIRO_DB_WATCH_PATTERN.test(path.basename(resolved));
+    }
+    if (zedRootSet.has(resolved)) return false;
+    for (const root of zedRoots) {
+      if (!resolved.startsWith(root + path.sep)) continue;
+      // Tokscale resolves threads/threads.db directly. WAL/SHM remain live
+      // write signals even though they are not parsed as separate databases.
+      if (path.dirname(resolved) !== root) return true;
+      return !ZED_DB_WATCH_PATTERN.test(path.basename(resolved));
+    }
+    if (codebuddyExtensionRootSet.has(resolved)) return false;
+    for (const root of codebuddyExtensionRoots) {
+      if (!resolved.startsWith(root + path.sep)) continue;
+      const parts = path.relative(root, resolved).split(path.sep);
+      return !CODEBUDDY_EXTENSION_SOURCE_DIRS.has(parts[0]);
     }
     return false; // paths outside the bounded client roots are never ignored
   };

--- a/tests/helpers/sourceEnv.js
+++ b/tests/helpers/sourceEnv.js
@@ -1,0 +1,44 @@
+'use strict';
+
+// The developer's own shell is an input to every assertion about source roots.
+// The collector follows tokscale in honouring XDG_DATA_HOME, CODEX_HOME, the
+// CLINE_* family and friends, so a machine that exports any of them resolves
+// fixture roots somewhere else and fails these tests on a correct build — seven
+// of them did, on a branch whose CI was green because no runner exports these.
+//
+// Clearing them per test keeps the assertions exact. Widening the assertions
+// instead would drop the coverage they exist for, and is the tempting fix for
+// whoever hits this next.
+const SOURCE_ENV_KEYS = Object.freeze([
+  'XDG_DATA_HOME',
+  'COPILOT_OTEL_FILE_EXPORTER_PATH',
+  'CODEX_HOME',
+  'TOKSCALE_HEADLESS_DIR',
+  'CLINE_SESSION_DATA_DIR',
+  'CLINE_DATA_DIR',
+  'CLINE_DIR',
+  'GROK_HOME',
+  'KIMI_CODE_HOME',
+  'GEMINI_CLI_HOME',
+  'HERMES_HOME'
+]);
+
+// Applied to a whole file rather than case by case, so a test added later is
+// hermetic by default instead of by remembering. A case that wants one of these
+// set assigns it inside the test; the real value is restored afterwards.
+function installSourceEnvGuard(test, keys = SOURCE_ENV_KEYS) {
+  let saved = null;
+  test.beforeEach(() => {
+    saved = new Map(keys.map((key) => [key, process.env[key]]));
+    for (const key of keys) delete process.env[key];
+  });
+  test.afterEach(() => {
+    for (const [key, previous] of saved || []) {
+      if (previous === undefined) delete process.env[key];
+      else process.env[key] = previous;
+    }
+    saved = null;
+  });
+}
+
+module.exports = { SOURCE_ENV_KEYS, installSourceEnvGuard };

--- a/tests/shared/clientHealth.test.js
+++ b/tests/shared/clientHealth.test.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert/strict');
 const test = require('node:test');
+const { installSourceEnvGuard } = require('../helpers/sourceEnv');
 
 const {
   CLIENT_SYNC_DETAIL_CODES,
@@ -32,6 +33,8 @@ const { KNOWN_CLIENTS } = require('../../src/shared/clientTracking');
 const { createSelfSyncThrottle } = require('../../src/shared/selfSyncThrottle');
 const { applySessionUsageArchive } = require('../../src/shared/sessionUsageArchive');
 const { aggregateDevices, mergeDeviceRecord, normalizeDeviceRecord } = require('../../src/shared/usage');
+
+installSourceEnvGuard(test);
 
 const core = (overrides = {}) => ({
   source: { state: 'detected', detectedCount: 1, checkedCount: 1 },

--- a/tests/shared/clientHealth.test.js
+++ b/tests/shared/clientHealth.test.js
@@ -318,7 +318,7 @@ test('every source-root id the collector emits is in the allowlist', () => {
   // And nothing in the allowlist is dead weight. Two ids are exempt because they
   // are discovered rather than constructed: `hermes-profile` comes from profiles
   // found on disk, and `wsl-home` only appears on Windows with a running distro.
-  const discoveryDependent = new Set(['hermes-profile', 'wsl-home']);
+  const discoveryDependent = new Set(['copilot-otel-exporter', 'hermes-profile', 'wsl-home']);
   const checked = new Set([...emitted, 'antigravity-ide-source', 'antigravity-cli-data']);
   for (const id of CLIENT_SOURCE_CHECK_IDS) {
     if (discoveryDependent.has(id)) continue;
@@ -326,12 +326,15 @@ test('every source-root id the collector emits is in the allowlist', () => {
   }
 });
 
-test('labelling the roots left the watcher its original path list', () => {
+test('labelling roots keeps diagnostics separate from watcher roots', () => {
   const roots = clientSourceRoots(KNOWN_CLIENTS);
   const candidates = clientWatchCandidates(KNOWN_CLIENTS);
   assert.deepEqual(Object.keys(candidates).sort(), Object.keys(roots).sort());
   for (const [client, dirs] of Object.entries(candidates)) {
-    assert.deepEqual(dirs, roots[client].map((root) => root.dir));
+    const expected = roots[client]
+      .filter((root) => !(client === 'copilot' && root.id === 'copilot-otel'))
+      .map((root) => root.dir);
+    assert.deepEqual(dirs, expected);
   }
 });
 
@@ -341,9 +344,9 @@ test('labelling the roots left the watcher its original path list', () => {
 test('clientSourceChecks collapses same-kind roots into one entry', () => {
   const checks = clientSourceChecks('copilot,zed,cline,antigravity');
   const ids = (client) => checks[client].map((check) => check.id);
-  assert.deepEqual(ids('copilot'), ['copilot-otel', 'vscode-workspace-storage']);
+  assert.deepEqual(ids('copilot'), ['copilot-otel', 'copilot-data', 'vscode-workspace-storage']);
   assert.deepEqual(ids('zed'), ['zed-threads']);
-  assert.deepEqual(ids('cline'), ['cline-tasks']);
+  assert.deepEqual(ids('cline'), ['cline-tasks', 'cline-cli-sessions']);
   // antigravity's watch candidate is only the tokscale cache; its two real
   // sources are separate checks so the record can tell them apart.
   assert.deepEqual(ids('antigravity'), ['tokscale-antigravity-cache', 'antigravity-ide-source', 'antigravity-cli-data']);

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -3504,6 +3504,7 @@ test('XDG_DATA_HOME moves exactly the roots tokscale resolves through it', () =>
     fs.mkdirSync(path.join(xdg, dir), { recursive: true });
   }
   fs.mkdirSync(path.join(tmp, '.local', 'share', 'kiro-cli'), { recursive: true });
+  fs.mkdirSync(path.join(tmp, 'AppData', 'Local', 'CodeBuddyExtension', 'Logs'), { recursive: true });
   const originalHomedir = os.homedir;
   os.homedir = () => tmp;
   process.env.XDG_DATA_HOME = xdg;
@@ -3516,6 +3517,10 @@ test('XDG_DATA_HOME moves exactly the roots tokscale resolves through it', () =>
     if (process.platform !== 'win32' && process.platform !== 'darwin') {
       assert.ok(roots.includes(path.join(xdg, 'CodeBuddyExtension', 'Logs')));
     }
+    // tokscale seeds its CodeBuddy log list with the home-relative
+    // Windows-shaped path on every platform, so a home carried over from
+    // Windows has to be watched here too, not only scanned periodically.
+    assert.ok(roots.includes(path.join(tmp, 'AppData', 'Local', 'CodeBuddyExtension', 'Logs')));
     // Home-relative in tokscale, so it must NOT follow XDG.
     assert.ok(roots.includes(path.join(tmp, '.local', 'share', 'kiro-cli')));
     assert.ok(!roots.includes(path.join(xdg, 'kiro-cli')));

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -188,6 +188,54 @@ test('watchIgnoreMatcher bounds OpenCode to its database family and legacy messa
   }
 });
 
+test('watchIgnoreMatcher bounds Kiro CLI, Zed, and CodeBuddy extension roots', () => {
+  const codebuddyLogs = process.platform === 'win32'
+    ? path.join('AppData', 'Local', 'CodeBuddyExtension', 'Logs')
+    : process.platform === 'darwin'
+      ? path.join('Library', 'Application Support', 'CodeBuddyExtension', 'Logs')
+      : path.join('.local', 'share', 'CodeBuddyExtension', 'Logs');
+  const tmp = withTmpHome([
+    path.join('.local', 'share', 'kiro-cli'),
+    path.join('.local', 'share', 'zed', 'threads'),
+    codebuddyLogs
+  ]);
+  const originalHomedir = os.homedir;
+  os.homedir = () => tmp;
+  try {
+    const { watchIgnoreMatcher, watchPathsForClients } = freshCollector();
+    const ignored = watchIgnoreMatcher('kiro,zed,codebuddy');
+    const kiroRoot = path.join(tmp, '.local', 'share', 'kiro-cli');
+    const zedRoot = path.join(tmp, '.local', 'share', 'zed', 'threads');
+    const codebuddyRoot = path.join(tmp, codebuddyLogs);
+    assert.ok(watchPathsForClients('kiro,zed,codebuddy').includes(kiroRoot));
+    assert.ok(watchPathsForClients('kiro,zed,codebuddy').includes(zedRoot));
+    assert.ok(watchPathsForClients('kiro,zed,codebuddy').includes(codebuddyRoot));
+
+    assert.equal(ignored(kiroRoot), false);
+    assert.equal(ignored(path.join(kiroRoot, 'data.sqlite3')), false);
+    assert.equal(ignored(path.join(kiroRoot, 'data.sqlite3-wal')), false);
+    assert.equal(ignored(path.join(kiroRoot, 'data.sqlite3-shm')), false);
+    assert.equal(ignored(path.join(kiroRoot, 'logs')), true);
+    assert.equal(ignored(path.join(kiroRoot, 'logs', 'runtime.log')), true);
+
+    assert.equal(ignored(zedRoot), false);
+    assert.equal(ignored(path.join(zedRoot, 'threads.db')), false);
+    assert.equal(ignored(path.join(zedRoot, 'threads.db-wal')), false);
+    assert.equal(ignored(path.join(zedRoot, 'threads.db-shm')), false);
+    assert.equal(ignored(path.join(zedRoot, 'cache')), true);
+
+    assert.equal(ignored(codebuddyRoot), false);
+    assert.equal(ignored(path.join(codebuddyRoot, 'CodeBuddyIDE')), false);
+    assert.equal(ignored(path.join(codebuddyRoot, 'CodeBuddyIDE', 'session.log')), false);
+    assert.equal(ignored(path.join(codebuddyRoot, 'VSCode', 'extension.log')), false);
+    assert.equal(ignored(path.join(codebuddyRoot, 'Other', 'runtime.log')), true);
+  } finally {
+    os.homedir = originalHomedir;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test('watchPathsForClients watches Antigravity source and CLI data but not the sync cache', () => {
   // The IDE source roots are read by `antigravity sync`, while the CLI writes
   // parse-local SQLite that we do not touch. Both are safe watch inputs; the

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -1533,6 +1533,32 @@ test('watchIgnoreMatcher preserves bounded sources under an exporter parent', ()
   }
 });
 
+test('watchIgnoreMatcher preserves recursive sources nested under bounded roots', () => {
+  const opencodeRoot = path.join('.local', 'share', 'opencode');
+  const tmp = withTmpHome([path.join(opencodeRoot, 'sessions')]);
+  const originalHomedir = os.homedir;
+  const previousCodexHome = process.env.CODEX_HOME;
+  os.homedir = () => tmp;
+  try {
+    process.env.CODEX_HOME = path.join(tmp, opencodeRoot);
+    const { watchIgnoreMatcher } = freshCollector();
+    const ignored = watchIgnoreMatcher('opencode,codex');
+    const codexRoot = path.join(tmp, opencodeRoot, 'sessions');
+    const opencodeRootPath = path.join(tmp, opencodeRoot);
+
+    assert.equal(ignored(codexRoot), false);
+    assert.equal(ignored(path.join(codexRoot, 'session.jsonl')), false);
+    assert.equal(ignored(path.join(opencodeRootPath, 'opencode.db')), false);
+    assert.equal(ignored(path.join(opencodeRootPath, 'log')), true);
+  } finally {
+    os.homedir = originalHomedir;
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test('watchIgnoreMatcher keeps an exporter file after Windows path canonicalization', () => {
   const exporter = path.join('.copilot', 'custom-export', 'copilot.jsonl');
   const { base, alias, real } = withAliasedTmpHome([path.dirname(exporter)]);

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -17,7 +17,11 @@ const {
   clampTimerDelayMs, SYNC_MIN_INTERVAL_MS, SYNC_SOURCE_EVENT_MIN_INTERVAL_MS
 } = require('../../src/shared/selfSyncThrottle');
 
+const { installSourceEnvGuard } = require('../helpers/sourceEnv');
+
 const collectorPath = require.resolve('../../src/shared/collector');
+
+installSourceEnvGuard(test);
 
 function freshCollector() {
   delete require.cache[collectorPath];
@@ -3483,6 +3487,175 @@ test('smart collection acknowledges the latest activity revision after tick coal
     os.homedir = originalHomedir;
     if (originalSharedDir === undefined) delete process.env.TOKEN_MONITOR_SHARED_DIR;
     else process.env.TOKEN_MONITOR_SHARED_DIR = originalSharedDir;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// tokscale resolves opencode, zed and micode through `PathRoot::XdgData`
+// (clients.rs) and the CodeBuddy extension logs through `dirs::data_local_dir()`,
+// which is the XDG data home on Linux. Kiro's CLI database is the deliberate
+// exception: tokscale spells it as a home-relative literal, so following XDG
+// there would watch a directory it never reads.
+test('XDG_DATA_HOME moves exactly the roots tokscale resolves through it', () => {
+  const tmp = withTmpHome([]);
+  const xdg = path.join(tmp, 'custom-xdg');
+  for (const dir of ['opencode', 'zed/threads', 'mimocode', 'CodeBuddyExtension/Logs']) {
+    fs.mkdirSync(path.join(xdg, dir), { recursive: true });
+  }
+  fs.mkdirSync(path.join(tmp, '.local', 'share', 'kiro-cli'), { recursive: true });
+  const originalHomedir = os.homedir;
+  os.homedir = () => tmp;
+  process.env.XDG_DATA_HOME = xdg;
+  try {
+    const { watchPathsForClients } = freshCollector();
+    const roots = watchPathsForClients('opencode,zed,micode,codebuddy,kiro');
+    assert.ok(roots.includes(path.join(xdg, 'opencode')));
+    assert.ok(roots.includes(path.join(xdg, 'zed', 'threads')));
+    assert.ok(roots.includes(path.join(xdg, 'mimocode')));
+    if (process.platform !== 'win32' && process.platform !== 'darwin') {
+      assert.ok(roots.includes(path.join(xdg, 'CodeBuddyExtension', 'Logs')));
+    }
+    // Home-relative in tokscale, so it must NOT follow XDG.
+    assert.ok(roots.includes(path.join(tmp, '.local', 'share', 'kiro-cli')));
+    assert.ok(!roots.includes(path.join(xdg, 'kiro-cli')));
+  } finally {
+    os.homedir = originalHomedir;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('an unset XDG_DATA_HOME falls back to the .local/share roots', () => {
+  const tmp = withTmpHome([
+    path.join('.local', 'share', 'opencode'),
+    path.join('.local', 'share', 'zed', 'threads'),
+    path.join('.local', 'share', 'mimocode')
+  ]);
+  const originalHomedir = os.homedir;
+  os.homedir = () => tmp;
+  try {
+    const { watchPathsForClients } = freshCollector();
+    const roots = watchPathsForClients('opencode,zed,micode');
+    assert.ok(roots.includes(path.join(tmp, '.local', 'share', 'opencode')));
+    assert.ok(roots.includes(path.join(tmp, '.local', 'share', 'zed', 'threads')));
+    assert.ok(roots.includes(path.join(tmp, '.local', 'share', 'mimocode')));
+  } finally {
+    os.homedir = originalHomedir;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// tokscale treats a whitespace-only KIMI_CODE_HOME as unset because it joins
+// `sessions` onto the raw value: a blank export would resolve to the root-level
+// /sessions, hiding the real one and pointing the walker somewhere unrelated.
+test('a whitespace-only KIMI_CODE_HOME falls back instead of watching /sessions', () => {
+  const tmp = withTmpHome([path.join('.kimi-code', 'sessions')]);
+  const originalHomedir = os.homedir;
+  os.homedir = () => tmp;
+  process.env.KIMI_CODE_HOME = '   ';
+  try {
+    const { watchPathsForClients } = freshCollector();
+    const roots = watchPathsForClients('kimi');
+    assert.ok(roots.includes(path.join(tmp, '.kimi-code', 'sessions')));
+    assert.ok(!roots.some((root) => root.trim().startsWith(path.sep + 'sessions')));
+  } finally {
+    os.homedir = originalHomedir;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// A custom exporter's parent has to be watched (the file may not exist yet) but
+// must never become a copilot attribution prefix: pointed at a file in $HOME it
+// would make every other client's event target copilot too, turning each
+// targeted --today scan into a two-client scan.
+test('a custom Copilot exporter watches its parent without attributing it', () => {
+  const tmp = withTmpHome([path.join('.claude', 'projects'), '.copilot']);
+  const exporter = path.join(tmp, 'copilot-otel.jsonl');
+  const originalHomedir = os.homedir;
+  os.homedir = () => tmp;
+  process.env.COPILOT_OTEL_FILE_EXPORTER_PATH = exporter;
+  try {
+    const { watchPathsForClients, watchAttributionRootsForClients, clientsForWatchPath } = freshCollector();
+    const clients = 'claude,copilot';
+    // The parent is still watched, otherwise a later-created file is invisible.
+    assert.ok(watchPathsForClients(clients).includes(tmp));
+
+    const attribution = watchAttributionRootsForClients(clients);
+    assert.ok(!attribution.copilot.includes(tmp), 'the exporter parent must not be an attribution prefix');
+    assert.ok(attribution.copilot.some((root) => path.resolve(root) === path.resolve(exporter)));
+
+    // A Claude transcript write targets Claude alone.
+    assert.deepEqual(
+      clientsForWatchPath(path.join(tmp, '.claude', 'projects', 'a.jsonl'), attribution),
+      ['claude']
+    );
+    // The exporter file itself is what makes an event a Copilot event.
+    assert.deepEqual(clientsForWatchPath(exporter, attribution), ['copilot']);
+  } finally {
+    os.homedir = originalHomedir;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// An exporter written straight into ~/.copilot shares its parent with the
+// copilot-data root, which owns that prefix for `otel/`. Dropping it there would
+// silence the OTel tree, so the parent survives when another source owns it.
+test('an exporter inside ~/.copilot keeps the data root as an attribution prefix', () => {
+  const tmp = withTmpHome([path.join('.copilot', 'otel')]);
+  const exporter = path.join(tmp, '.copilot', 'custom.jsonl');
+  const originalHomedir = os.homedir;
+  os.homedir = () => tmp;
+  process.env.COPILOT_OTEL_FILE_EXPORTER_PATH = exporter;
+  try {
+    const { watchAttributionRootsForClients, clientsForWatchPath } = freshCollector();
+    const attribution = watchAttributionRootsForClients('copilot');
+    assert.deepEqual(
+      clientsForWatchPath(path.join(tmp, '.copilot', 'otel', 'a.jsonl'), attribution),
+      ['copilot']
+    );
+    assert.deepEqual(clientsForWatchPath(exporter, attribution), ['copilot']);
+  } finally {
+    os.homedir = originalHomedir;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// The diagnostics panel prints `dir` and colours it by `exists`. For an
+// exact-file source those have to describe the same filesystem entity, or the
+// panel calls a directory that is plainly there missing.
+test('exact-file sources report the file they probed, not the watch parent', () => {
+  const tmp = withTmpHome(['.copilot', path.join('.grok', 'logs'), path.join('.zcode', 'cli', 'db')]);
+  const originalHomedir = os.homedir;
+  os.homedir = () => tmp;
+  try {
+    const { clientDiagnosticRoots } = freshCollector();
+    const roots = clientDiagnosticRoots('copilot,grok,zcode');
+    const find = (client, id) => (roots[client] || []).find((root) => root.id === id);
+
+    const copilotData = find('copilot', 'copilot-data');
+    assert.equal(copilotData.dir, path.join(tmp, '.copilot', 'data.db'));
+    assert.equal(copilotData.exists, false);
+    assert.equal(copilotData.sourcePath, path.join(tmp, '.copilot', 'data.db'));
+
+    assert.equal(find('grok', 'grok-unified-log').dir, path.join(tmp, '.grok', 'logs', 'unified.jsonl'));
+    assert.equal(find('zcode', 'zcode-cli-db').dir, path.join(tmp, '.zcode', 'cli', 'db', 'db.sqlite'));
+
+    fs.writeFileSync(path.join(tmp, '.copilot', 'data.db'), '');
+    const afterCreate = clientDiagnosticRoots('copilot').copilot.find((root) => root.id === 'copilot-data');
+    assert.equal(afterCreate.exists, true);
+
+    // A directory source keeps reporting its directory and carries no sourcePath,
+    // which is what makes the reveal handler pick openPath over showItemInFolder.
+    const otel = find('copilot', 'copilot-otel');
+    assert.equal(otel.dir, path.join(tmp, '.copilot', 'otel'));
+    assert.equal(otel.sourcePath, undefined);
+  } finally {
+    os.homedir = originalHomedir;
     delete require.cache[collectorPath];
     fs.rmSync(tmp, { recursive: true, force: true });
   }

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -200,8 +200,12 @@ test('watchIgnoreMatcher bounds Kiro CLI, Zed, and CodeBuddy extension roots', (
     codebuddyLogs
   ]);
   const originalHomedir = os.homedir;
+  const previousLocalAppData = process.env.LOCALAPPDATA;
   os.homedir = () => tmp;
   try {
+    if (process.platform === 'win32') {
+      process.env.LOCALAPPDATA = path.join(tmp, 'AppData', 'Local');
+    }
     const { watchIgnoreMatcher, watchPathsForClients } = freshCollector();
     const ignored = watchIgnoreMatcher('kiro,zed,codebuddy');
     const kiroRoot = path.join(tmp, '.local', 'share', 'kiro-cli');
@@ -231,6 +235,8 @@ test('watchIgnoreMatcher bounds Kiro CLI, Zed, and CodeBuddy extension roots', (
     assert.equal(ignored(path.join(codebuddyRoot, 'Other', 'runtime.log')), true);
   } finally {
     os.homedir = originalHomedir;
+    if (previousLocalAppData === undefined) delete process.env.LOCALAPPDATA;
+    else process.env.LOCALAPPDATA = previousLocalAppData;
     delete require.cache[collectorPath];
     fs.rmSync(tmp, { recursive: true, force: true });
   }
@@ -1357,11 +1363,174 @@ test('watchPathsForClients includes GitHub Copilot CLI and VS Code chat roots', 
   try {
     const { clientDataDirPresence, watchPathsForClients } = freshCollector();
     const dirs = watchPathsForClients('copilot');
-    assert.ok(dirs.includes(path.join(tmp, '.copilot', 'otel')));
+    assert.ok(dirs.includes(path.join(tmp, '.copilot')));
+    assert.ok(!dirs.includes(path.join(tmp, '.copilot', 'otel')));
     assert.ok(dirs.includes(path.join(tmp, 'Library', 'Application Support', 'Code', 'User', 'workspaceStorage')));
     assert.deepEqual(clientDataDirPresence('copilot'), { copilot: true });
   } finally {
     os.homedir = originalHomedir;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('watchPathsForClients includes Tokscale auxiliary source roots', () => {
+  const codexHome = path.join('custom-codex');
+  const headlessRoot = path.join('custom-headless');
+  const clineRoot = path.join('custom-cline-sessions');
+  const exporter = path.join('custom-export', 'copilot.jsonl');
+  const tmp = withTmpHome([
+    path.join('.copilot', 'otel'),
+    path.join('.zcode', 'cli', 'db'),
+    path.join('.grok', 'sessions'),
+    path.join('.grok', 'logs'),
+    path.join(codexHome, 'sessions'),
+    path.join(codexHome, 'archived_sessions'),
+    path.join(headlessRoot, 'codex'),
+    clineRoot,
+    path.dirname(exporter)
+  ]);
+  const originalHomedir = os.homedir;
+  const previousCodexHome = process.env.CODEX_HOME;
+  const previousHeadlessRoot = process.env.TOKSCALE_HEADLESS_DIR;
+  const previousClineRoot = process.env.CLINE_SESSION_DATA_DIR;
+  const previousExporter = process.env.COPILOT_OTEL_FILE_EXPORTER_PATH;
+  os.homedir = () => tmp;
+  try {
+    process.env.CODEX_HOME = path.join(tmp, codexHome);
+    process.env.TOKSCALE_HEADLESS_DIR = path.join(tmp, headlessRoot);
+    process.env.CLINE_SESSION_DATA_DIR = path.join(tmp, clineRoot);
+    process.env.COPILOT_OTEL_FILE_EXPORTER_PATH = path.join(tmp, exporter);
+    fs.writeFileSync(path.join(tmp, '.copilot', 'data.db'), '');
+    fs.writeFileSync(path.join(tmp, '.zcode', 'cli', 'db', 'db.sqlite'), '');
+    fs.writeFileSync(path.join(tmp, '.grok', 'logs', 'unified.jsonl'), '');
+    fs.writeFileSync(path.join(tmp, exporter), '');
+
+    const { clientDataDirPresence, watchPathsForClients } = freshCollector();
+    const dirs = watchPathsForClients('copilot,zcode,grok,codex,cline');
+    assert.ok(dirs.includes(path.join(tmp, '.copilot')));
+    assert.ok(!dirs.includes(path.join(tmp, '.copilot', 'otel')));
+    assert.ok(dirs.includes(path.join(tmp, '.zcode', 'cli', 'db')));
+    assert.ok(dirs.includes(path.join(tmp, '.grok', 'logs')));
+    assert.ok(dirs.includes(path.join(tmp, codexHome, 'sessions')));
+    assert.ok(dirs.includes(path.join(tmp, codexHome, 'archived_sessions')));
+    assert.ok(dirs.includes(path.join(tmp, headlessRoot, 'codex')));
+    assert.ok(dirs.includes(path.join(tmp, clineRoot)));
+    assert.ok(dirs.includes(path.join(tmp, path.dirname(exporter))));
+    assert.deepEqual(clientDataDirPresence('copilot,zcode,grok,codex,cline'), {
+      copilot: true, zcode: true, grok: true, codex: true, cline: true
+    });
+  } finally {
+    os.homedir = originalHomedir;
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
+    if (previousHeadlessRoot === undefined) delete process.env.TOKSCALE_HEADLESS_DIR;
+    else process.env.TOKSCALE_HEADLESS_DIR = previousHeadlessRoot;
+    if (previousClineRoot === undefined) delete process.env.CLINE_SESSION_DATA_DIR;
+    else process.env.CLINE_SESSION_DATA_DIR = previousClineRoot;
+    if (previousExporter === undefined) delete process.env.COPILOT_OTEL_FILE_EXPORTER_PATH;
+    else process.env.COPILOT_OTEL_FILE_EXPORTER_PATH = previousExporter;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('watchIgnoreMatcher bounds Copilot data, Grok unified, ZCode, and exporter roots', () => {
+  const exporter = path.join('.copilot', 'custom-export', 'copilot.jsonl');
+  const tmp = withTmpHome([
+    path.join('.copilot', 'otel'),
+    path.join('.grok', 'logs'),
+    path.join('.zcode', 'cli', 'db'),
+    path.dirname(exporter)
+  ]);
+  const originalHomedir = os.homedir;
+  const previousExporter = process.env.COPILOT_OTEL_FILE_EXPORTER_PATH;
+  os.homedir = () => tmp;
+  try {
+    process.env.COPILOT_OTEL_FILE_EXPORTER_PATH = `  ${path.join(tmp, exporter)}  `;
+    const { watchIgnoreMatcher } = freshCollector();
+    const ignored = watchIgnoreMatcher('copilot,grok,zcode');
+    const copilotRoot = path.join(tmp, '.copilot');
+    const grokLogs = path.join(tmp, '.grok', 'logs');
+    const zcodeDb = path.join(tmp, '.zcode', 'cli', 'db');
+    const exporterRoot = path.join(tmp, path.dirname(exporter));
+
+    assert.equal(ignored(copilotRoot), false);
+    assert.equal(ignored(path.join(copilotRoot, 'data.db')), false);
+    assert.equal(ignored(path.join(copilotRoot, 'data.db-wal')), false);
+    assert.equal(ignored(path.join(copilotRoot, 'data.db-shm')), false);
+    assert.equal(ignored(path.join(copilotRoot, 'otel', 'trace.jsonl')), false);
+    assert.equal(ignored(path.join(copilotRoot, 'cache')), true);
+
+    assert.equal(ignored(grokLogs), false);
+    assert.equal(ignored(path.join(grokLogs, 'unified.jsonl')), false);
+    assert.equal(ignored(path.join(grokLogs, 'other.log')), true);
+    assert.equal(ignored(path.join(grokLogs, 'archive', 'unified.jsonl')), true);
+
+    assert.equal(ignored(zcodeDb), false);
+    assert.equal(ignored(path.join(zcodeDb, 'db.sqlite')), false);
+    assert.equal(ignored(path.join(zcodeDb, 'db.sqlite-wal')), false);
+    assert.equal(ignored(path.join(zcodeDb, 'cache')), true);
+
+    assert.equal(ignored(exporterRoot), false);
+    assert.equal(ignored(path.join(exporterRoot, 'copilot.jsonl')), false);
+    assert.equal(ignored(path.join(exporterRoot, 'other.jsonl')), true);
+  } finally {
+    os.homedir = originalHomedir;
+    if (previousExporter === undefined) delete process.env.COPILOT_OTEL_FILE_EXPORTER_PATH;
+    else process.env.COPILOT_OTEL_FILE_EXPORTER_PATH = previousExporter;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('watchIgnoreMatcher keeps an exporter file after Windows path canonicalization', () => {
+  const exporter = path.join('.copilot', 'custom-export', 'copilot.jsonl');
+  const { base, alias, real } = withAliasedTmpHome([path.dirname(exporter)]);
+  const originalHomedir = os.homedir;
+  const previousExporter = process.env.COPILOT_OTEL_FILE_EXPORTER_PATH;
+  os.homedir = () => alias;
+  try {
+    process.env.COPILOT_OTEL_FILE_EXPORTER_PATH = path.join(alias, exporter);
+    const { watchIgnoreMatcher } = freshCollector();
+    const ignored = watchIgnoreMatcher('copilot');
+    const eventRoot = process.platform === 'win32' ? real : alias;
+    assert.equal(ignored(path.join(eventRoot, exporter)), false);
+    assert.equal(ignored(path.join(eventRoot, path.dirname(exporter), 'other.jsonl')), true);
+  } finally {
+    os.homedir = originalHomedir;
+    if (previousExporter === undefined) delete process.env.COPILOT_OTEL_FILE_EXPORTER_PATH;
+    else process.env.COPILOT_OTEL_FILE_EXPORTER_PATH = previousExporter;
+    delete require.cache[collectorPath];
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('watchPathsForClients follows XDG_DATA_HOME for OpenCode, MiMo, and Zed', () => {
+  const xdgRoot = path.join('custom-xdg');
+  const tmp = withTmpHome([
+    path.join(xdgRoot, 'opencode'),
+    path.join(xdgRoot, 'mimocode'),
+    path.join(xdgRoot, 'zed', 'threads')
+  ]);
+  const originalHomedir = os.homedir;
+  const previousXdg = process.env.XDG_DATA_HOME;
+  os.homedir = () => tmp;
+  try {
+    process.env.XDG_DATA_HOME = path.join(tmp, xdgRoot);
+    const { clientDataDirPresence, watchPathsForClients } = freshCollector();
+    const dirs = watchPathsForClients('opencode,micode,zed');
+    assert.ok(dirs.includes(path.join(tmp, xdgRoot, 'opencode')));
+    assert.ok(dirs.includes(path.join(tmp, xdgRoot, 'mimocode')));
+    assert.ok(dirs.includes(path.join(tmp, xdgRoot, 'zed', 'threads')));
+    assert.ok(!dirs.includes(path.join(tmp, '.local', 'share', 'opencode')));
+    assert.deepEqual(clientDataDirPresence('opencode,micode,zed'), {
+      opencode: true, micode: true, zed: true
+    });
+  } finally {
+    os.homedir = originalHomedir;
+    if (previousXdg === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = previousXdg;
     delete require.cache[collectorPath];
     fs.rmSync(tmp, { recursive: true, force: true });
   }

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -1484,6 +1484,55 @@ test('watchIgnoreMatcher bounds Copilot data, Grok unified, ZCode, and exporter 
   }
 });
 
+test('watchIgnoreMatcher preserves recursive client roots under an exporter parent', () => {
+  const tmp = withTmpHome([path.join('.codex', 'sessions')]);
+  const originalHomedir = os.homedir;
+  const previousExporter = process.env.COPILOT_OTEL_FILE_EXPORTER_PATH;
+  os.homedir = () => tmp;
+  try {
+    process.env.COPILOT_OTEL_FILE_EXPORTER_PATH = path.join(tmp, 'copilot.jsonl');
+    const { watchIgnoreMatcher } = freshCollector();
+    const ignored = watchIgnoreMatcher('copilot,codex');
+    const codexRoot = path.join(tmp, '.codex', 'sessions');
+
+    assert.equal(ignored(codexRoot), false);
+    assert.equal(ignored(path.join(codexRoot, 'session.jsonl')), false);
+    assert.equal(ignored(path.join(tmp, 'unrelated')), true);
+  } finally {
+    os.homedir = originalHomedir;
+    if (previousExporter === undefined) delete process.env.COPILOT_OTEL_FILE_EXPORTER_PATH;
+    else process.env.COPILOT_OTEL_FILE_EXPORTER_PATH = previousExporter;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('watchIgnoreMatcher preserves bounded sources under an exporter parent', () => {
+  const opencodeRoot = path.join('.local', 'share', 'opencode');
+  const exporter = path.join(opencodeRoot, 'copilot.jsonl');
+  const tmp = withTmpHome([opencodeRoot]);
+  const originalHomedir = os.homedir;
+  const previousExporter = process.env.COPILOT_OTEL_FILE_EXPORTER_PATH;
+  os.homedir = () => tmp;
+  try {
+    process.env.COPILOT_OTEL_FILE_EXPORTER_PATH = path.join(tmp, exporter);
+    const { watchIgnoreMatcher } = freshCollector();
+    const ignored = watchIgnoreMatcher('copilot,opencode');
+    const root = path.join(tmp, opencodeRoot);
+
+    assert.equal(ignored(path.join(root, 'opencode.db')), false);
+    assert.equal(ignored(path.join(root, 'opencode.db-wal')), false);
+    assert.equal(ignored(path.join(root, 'log')), true);
+    assert.equal(ignored(path.join(root, 'copilot.jsonl')), false);
+  } finally {
+    os.homedir = originalHomedir;
+    if (previousExporter === undefined) delete process.env.COPILOT_OTEL_FILE_EXPORTER_PATH;
+    else process.env.COPILOT_OTEL_FILE_EXPORTER_PATH = previousExporter;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test('watchIgnoreMatcher keeps an exporter file after Windows path canonicalization', () => {
   const exporter = path.join('.copilot', 'custom-export', 'copilot.jsonl');
   const { base, alias, real } = withAliasedTmpHome([path.dirname(exporter)]);

--- a/tests/shared/watcherNativeEvents.test.js
+++ b/tests/shared/watcherNativeEvents.test.js
@@ -23,6 +23,9 @@ const path = require('node:path');
 const chokidar = require('chokidar');
 
 const { watcherOptions, watchIgnoreMatcher } = require('../../src/shared/collector');
+const { installSourceEnvGuard } = require('../helpers/sourceEnv');
+
+installSourceEnvGuard(test);
 
 // awaitWriteFinish holds an event for stabilityThreshold (500 ms) before it is
 // emitted, so the floor is already half a second before any scheduling noise.

--- a/tests/shared/watcherNativeEvents.test.js
+++ b/tests/shared/watcherNativeEvents.test.js
@@ -29,12 +29,72 @@ installSourceEnvGuard(test);
 
 // awaitWriteFinish holds an event for stabilityThreshold (500 ms) before it is
 // emitted, so the floor is already half a second before any scheduling noise.
-// The bound is generous on purpose, and was raised after a single timeout seen
-// while the whole suite ran in parallel on a loaded machine: this asserts that
-// events arrive at all, so the only thing a tighter bound buys is a faster
-// failure on a starved runner, at the cost of failing for a reason that has
-// nothing to do with the watcher.
+// The bound is generous on purpose: this asserts that events arrive at all, so
+// the only thing a tighter bound buys is a faster failure on a starved runner,
+// at the cost of failing for a reason that has nothing to do with the watcher.
 const EVENT_TIMEOUT_MS = 45 * 1000;
+
+// Why the writes below are retried rather than done once after `ready`.
+//
+// chokidar's `ready` means "the initial directory scan finished", NOT "the
+// native stream is delivering". A file created between those two moments is
+// reported by neither: ignoreInitial suppresses the scan, and the stream's
+// start point is already past the file's creation. That event is lost for good,
+// while any later write to the same path arrives normally.
+//
+// Measured on darwin with the repro that found this: writing once immediately
+// after `ready` lost the event in 0/120 runs single-process, but 27% of runs
+// with eight watcher processes in parallel — which is what `node --test` does
+// to this file. Every failure had the same shape: no first event, and a second
+// write to the same path delivered ~610 ms later. That is the ~15% CI flake.
+//
+// Re-touching until an event lands does not weaken anything. A watcher that is
+// genuinely not delivering never produces an event however many times the file
+// is written; only the unobservable scan/stream boundary is retried away. It
+// also makes the pruning assertion below stronger, because by the time it runs
+// the stream is proven live rather than assumed live.
+const TOUCH_INTERVAL_MS = 1500;
+
+// Retrying an individual write is not enough on its own: if the action being
+// tested is `mkdir`, its addDir is what falls into the gap, chokidar never
+// starts watching the new directory, and no amount of writing inside it will
+// ever produce an event. So prove the stream is delivering with a throwaway
+// file first, and only then let the test do what it came to do.
+//
+// `liveDir` must be a path the watcher is not pruning — for a test that passes
+// an `ignored` matcher, the sentinel goes in a directory that matcher keeps.
+async function awaitWatcherLive(watcher, liveDir) {
+  const sentinel = path.join(liveDir, '.tm-watch-live');
+  const seen = new Promise((resolve) => {
+    watcher.on('all', (_event, filePath) => {
+      if (path.basename(filePath) === '.tm-watch-live') resolve();
+    });
+  });
+  try {
+    await writeUntilObserved(sentinel, 'live\n', seen, 'the liveness sentinel');
+  } finally {
+    fs.rmSync(sentinel, { force: true });
+  }
+}
+
+async function writeUntilObserved(filePath, contents, observed, label) {
+  const deadline = Date.now() + EVENT_TIMEOUT_MS;
+  let firstWrite = true;
+  while (Date.now() < deadline) {
+    if (firstWrite) {
+      fs.writeFileSync(filePath, contents);
+      firstWrite = false;
+    } else {
+      fs.appendFileSync(filePath, contents);
+    }
+    const landed = await Promise.race([
+      observed.then(() => true),
+      new Promise((resolve) => setTimeout(() => resolve(false), TOUCH_INTERVAL_MS).unref())
+    ]);
+    if (landed) return;
+  }
+  throw new Error(`no native file event for ${label} within ${EVENT_TIMEOUT_MS}ms on ${process.platform}`);
+}
 
 // os.tmpdir() is an 8.3 short path on the Windows CI runner
 // (C:\Users\RUNNER~1\...), and handing one to fs.watch aborts the process
@@ -45,6 +105,8 @@ function withTmpDir() {
   return fs.mkdtempSync(path.join(fs.realpathSync.native(os.tmpdir()), 'tm-watch-'));
 }
 
+// `act` receives a helper that writes the target file and keeps re-touching it
+// until its event is observed, so callers never depend on the scan/stream gap.
 async function watchAndCollect(dir, act) {
   const events = [];
   const watcher = chokidar.watch(dir, watcherOptions(false));
@@ -53,20 +115,16 @@ async function watchAndCollect(dir, act) {
       watcher.once('ready', resolve);
       watcher.once('error', reject);
     });
-    const seen = new Promise((resolve) => {
-      watcher.on('all', (event, filePath) => {
-        events.push({ event, filePath });
-        resolve();
+    await awaitWatcherLive(watcher, dir);
+    const observedFor = (filePath) => new Promise((resolve) => {
+      watcher.on('all', (event, seenPath) => {
+        if (path.resolve(seenPath) === path.resolve(filePath)) resolve();
       });
     });
-    await act();
-    await Promise.race([
-      seen,
-      new Promise((_, reject) => setTimeout(
-        () => reject(new Error(`no native file event within ${EVENT_TIMEOUT_MS}ms on ${process.platform}`)),
-        EVENT_TIMEOUT_MS
-      ).unref())
-    ]);
+    watcher.on('all', (event, filePath) => events.push({ event, filePath }));
+    await act(async (filePath, contents) => {
+      await writeUntilObserved(filePath, contents, observedFor(filePath), path.basename(filePath));
+    });
   } finally {
     await watcher.close();
   }
@@ -76,8 +134,8 @@ async function watchAndCollect(dir, act) {
 test('native file events reach a watcher on this platform', async () => {
   const dir = withTmpDir();
   try {
-    const events = await watchAndCollect(dir, async () => {
-      fs.writeFileSync(path.join(dir, 'session.jsonl'), '{"tokens":1}\n');
+    const events = await watchAndCollect(dir, async (writeAndAwait) => {
+      await writeAndAwait(path.join(dir, 'session.jsonl'), '{"tokens":1}\n');
     });
     assert.ok(
       events.some((entry) => path.basename(entry.filePath) === 'session.jsonl'),
@@ -97,14 +155,14 @@ test('native file events reach a subdirectory created after the watch started', 
   const dir = withTmpDir();
   try {
     const projectDir = path.join(dir, 'a-new-project');
-    const events = await watchAndCollect(dir, async () => {
+    const events = await watchAndCollect(dir, async (writeAndAwait) => {
       fs.mkdirSync(projectDir);
       // Give chokidar a moment to watch the directory it just discovered,
       // otherwise the write races the addDir handler and the assertion would
-      // pass on the mkdir event alone.
+      // pass on the mkdir event alone. The retry inside writeAndAwait covers
+      // the rest: a new directory has its own scan/stream gap.
       await new Promise((resolve) => setTimeout(resolve, 1500));
-      fs.writeFileSync(path.join(projectDir, 'session.jsonl'), '{"tokens":1}\n');
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await writeAndAwait(path.join(projectDir, 'session.jsonl'), '{"tokens":1}\n');
     });
     assert.ok(
       events.some((entry) => path.basename(entry.filePath) === 'session.jsonl'),
@@ -140,6 +198,11 @@ test('native watcher applies bounded pruning without hiding an overlapping recur
       watcher.once('error', reject);
     });
 
+    // codexRoot, not opencodeRoot: the sentinel has to land where this matcher
+    // is not pruning, or proving liveness would need the very delivery it is
+    // trying to establish.
+    await awaitWatcherLive(watcher, codexRoot);
+
     const events = [];
     const normalizePath = (filePath) => {
       const resolved = path.resolve(filePath);
@@ -155,17 +218,17 @@ test('native watcher applies bounded pruning without hiding an overlapping recur
       watcher.on('all', onEvent);
       watcher.once('error', reject);
     });
-    fs.writeFileSync(relevantFile, '{"tokens":1}\n');
-    await Promise.race([
-      relevantEvent,
-      new Promise((_, reject) => setTimeout(
-        () => reject(new Error(`no relevant native file event within ${EVENT_TIMEOUT_MS}ms on ${process.platform}`)),
-        EVENT_TIMEOUT_MS
-      ).unref())
-    ]);
+    // Establishes that this watcher is delivering before anything is concluded
+    // from the absence of an event below.
+    await writeUntilObserved(relevantFile, '{"tokens":1}\n', relevantEvent, 'the recursive source');
 
+    // The stream is live now, so silence here is pruning rather than the
+    // scan/stream gap. Two touches spaced past awaitWriteFinish's window: one
+    // write plus a fixed sleep could still be sitting in that window.
     fs.writeFileSync(unrelatedFile, 'noise\n');
-    await new Promise((resolve) => setTimeout(resolve, 1500));
+    await new Promise((resolve) => setTimeout(resolve, TOUCH_INTERVAL_MS));
+    fs.appendFileSync(unrelatedFile, 'more noise\n');
+    await new Promise((resolve) => setTimeout(resolve, TOUCH_INTERVAL_MS));
     assert.ok(
       events.some((entry) => normalizePath(entry.filePath) === normalizePath(relevantFile)),
       `expected an event for ${relevantFile}, got ${JSON.stringify(events)}`

--- a/tests/shared/watcherNativeEvents.test.js
+++ b/tests/shared/watcherNativeEvents.test.js
@@ -22,7 +22,7 @@ const os = require('node:os');
 const path = require('node:path');
 const chokidar = require('chokidar');
 
-const { watcherOptions } = require('../../src/shared/collector');
+const { watcherOptions, watchIgnoreMatcher } = require('../../src/shared/collector');
 
 // awaitWriteFinish holds an event for stabilityThreshold (500 ms) before it is
 // emitted, so the floor is already half a second before any scheduling noise.
@@ -108,6 +108,75 @@ test('native file events reach a subdirectory created after the watch started', 
       `expected an event inside the new directory, got ${JSON.stringify(events)}`
     );
   } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('native watcher applies bounded pruning without hiding an overlapping recursive source', async () => {
+  const dir = withTmpDir();
+  const opencodeRoot = path.join(dir, '.local', 'share', 'opencode');
+  const codexRoot = path.join(opencodeRoot, 'sessions');
+  const unrelatedRoot = path.join(opencodeRoot, 'log');
+  const relevantFile = path.join(codexRoot, 'session.jsonl');
+  const unrelatedFile = path.join(unrelatedRoot, 'runtime.log');
+  const originalHomedir = os.homedir;
+  const previousCodexHome = process.env.CODEX_HOME;
+  let watcher;
+  os.homedir = () => dir;
+  try {
+    fs.mkdirSync(codexRoot, { recursive: true });
+    fs.mkdirSync(unrelatedRoot, { recursive: true });
+    process.env.CODEX_HOME = opencodeRoot;
+    const ignored = watchIgnoreMatcher('opencode,codex');
+    watcher = chokidar.watch(
+      [opencodeRoot, codexRoot],
+      watcherOptions(false, ignored)
+    );
+    await new Promise((resolve, reject) => {
+      watcher.once('ready', resolve);
+      watcher.once('error', reject);
+    });
+
+    const events = [];
+    const normalizePath = (filePath) => {
+      const resolved = path.resolve(filePath);
+      return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+    };
+    const relevantEvent = new Promise((resolve, reject) => {
+      const onEvent = (event, filePath) => {
+        events.push({ event, filePath });
+        if (normalizePath(filePath) === normalizePath(relevantFile)) {
+          resolve();
+        }
+      };
+      watcher.on('all', onEvent);
+      watcher.once('error', reject);
+    });
+    fs.writeFileSync(relevantFile, '{"tokens":1}\n');
+    await Promise.race([
+      relevantEvent,
+      new Promise((_, reject) => setTimeout(
+        () => reject(new Error(`no relevant native file event within ${EVENT_TIMEOUT_MS}ms on ${process.platform}`)),
+        EVENT_TIMEOUT_MS
+      ).unref())
+    ]);
+
+    fs.writeFileSync(unrelatedFile, 'noise\n');
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    assert.ok(
+      events.some((entry) => normalizePath(entry.filePath) === normalizePath(relevantFile)),
+      `expected an event for ${relevantFile}, got ${JSON.stringify(events)}`
+    );
+    assert.equal(
+      events.some((entry) => normalizePath(entry.filePath) === normalizePath(unrelatedFile)),
+      false,
+      `unexpected event for pruned path ${unrelatedFile}: ${JSON.stringify(events)}`
+    );
+  } finally {
+    if (watcher) await watcher.close();
+    os.homedir = originalHomedir;
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/worker/src/shared/clientHealth.js
+++ b/worker/src/shared/clientHealth.js
@@ -170,11 +170,15 @@ const CLIENT_SOURCE_CHECK_IDS = Object.freeze([
   'claude-projects',
   'claude-transcripts',
   'cline-tasks',
+  'cline-cli-sessions',
   'codebuddy-extension-logs',
   'codebuddy-projects',
   'codex-sessions',
+  'copilot-data',
   'copilot-otel',
+  'copilot-otel-exporter',
   'grok-sessions',
+  'grok-unified-log',
   'hermes-home',
   'hermes-profile',
   'kilocode-tasks',
@@ -196,7 +200,8 @@ const CLIENT_SOURCE_CHECK_IDS = Object.freeze([
   'vscode-workspace-storage',
   'workbuddy-projects',
   'zcode-projects',
-  'zed-threads'
+  'zed-threads',
+  'zcode-cli-db'
 ]);
 
 // Observations worth surfacing that the core three fields cannot state on their

--- a/worker/src/shared/clientHealth.js
+++ b/worker/src/shared/clientHealth.js
@@ -169,8 +169,8 @@ const CLIENT_SOURCE_CHECK_IDS = Object.freeze([
   'antigravity-ide-source',
   'claude-projects',
   'claude-transcripts',
-  'cline-tasks',
   'cline-cli-sessions',
+  'cline-tasks',
   'codebuddy-extension-logs',
   'codebuddy-projects',
   'codex-sessions',
@@ -199,9 +199,9 @@ const CLIENT_SOURCE_CHECK_IDS = Object.freeze([
   'tokscale-cursor-cache',
   'vscode-workspace-storage',
   'workbuddy-projects',
+  'zcode-cli-db',
   'zcode-projects',
-  'zed-threads',
-  'zcode-cli-db'
+  'zed-threads'
 ]);
 
 // Observations worth surfacing that the core three fields cannot state on their


### PR DESCRIPTION
## Summary

- bound Kiro CLI, Zed, and CodeBuddy extension watchers to the SQLite/log sources Tokscale actually scans
- align live refresh roots with Tokscale's supported sources for Copilot, ZCode, Grok, Cline CLI, Codex, and XDG data directories
- update the bundled `tokscale` dependency to `4.11.0`

## Why

Tokscale's scanner already defines narrower source boundaries for several clients, while Token Monitor was still watching broader parent directories or missing some supported roots entirely. Native filesystem events made that drift costly: unnecessary directories created extra watcher descriptors, while missing roots delayed live refresh until the next full scan.

The watcher now keeps the source topology Tokscale requires:

- SQLite sources retain their database family and WAL/SHM sidecars
- recursive transcript/session sources retain their required directory topology
- exact secondary files such as Grok's `logs/unified.jsonl` are watched directly
- diagnostics can still report source roots without turning every diagnostic root into a duplicate watcher

Which roots follow `XDG_DATA_HOME` is Tokscale's split, not a judgement call here. OpenCode, Zed and MiMo Code are declared `PathRoot::XdgData` in `clients.rs`, and the CodeBuddy extension logs resolve through `dirs::data_local_dir()`, which is the XDG data home on Linux — that one is a `dirs` crate lookup rather than a path literal, so it does not appear when grepping the binary. Kiro's CLI database is spelled as a home-relative literal in `scanner.rs` and therefore stays on `~/.local/share`. A whitespace-only `KIMI_CODE_HOME` now falls back the way Tokscale's own blank-env handling does instead of resolving to a root-level `/sessions`.

A custom Copilot exporter is watched by its parent directory, because the file may not exist when the watcher starts, but that parent is not an attribution prefix — it is an arbitrary user-chosen path, and one pointing at a file in `$HOME` would make every other client's event target Copilot as well. Tokscale ingests exactly the file the env var names (`path.is_file()`, no glob, no directory walk), so the watch is pinned to that file.

Exact-file sources (`copilot-data`, `grok-unified-log`, `zcode-cli-db`) reported the watch parent while their `exists` answered for the file inside it, so the diagnostics panel called an existing `~/.copilot` missing. They now report the path they probed, and Reveal selects a file in its folder rather than opening it.

### Overlap between roots

`ignored` is global to the chokidar instance, so a recursive source nested **inside** a bounded client's root has to stay visible — an explicit `CODEX_HOME` or `CLINE_SESSION_DATA_DIR` under another client's data root would otherwise be pruned by that client's rule. That nested case is the only overlap this PR guarantees, and it is the case the native-watcher test covers.

Overlap is deliberately **not** resolved in general. A recursive root equal to a bounded root loses; a recursive root that is an *ancestor* of a bounded root wins and cancels that client's pruning entirely; two bounded roots resolve by whichever branch is written first. Each needs a specificity rule the current ordered branch chain cannot express, and adding more order-dependent special cases would make it worse. Resolving watcher policies by specificity — carrying the policy on each root and matching longest-first — is a separate follow-up.

User-configured Tokscale `scanner.extraScanPaths`, `TOKSCALE_EXTRA_DIRS`, and custom OpenCode database paths remain periodic-scan sources. Adding live watchers for arbitrary custom paths is separate scope.

Refs #348

## Test isolation and a watcher flake

Two test problems surfaced while verifying the above, both fixed here.

The source table now honours `XDG_DATA_HOME`, `CODEX_HOME` and the `CLINE_*` family, but the tests around it still assumed the defaults. Seven of them failed on any machine exporting `XDG_DATA_HOME`, including three added by this branch, and `clientHealth.test.js` failed whenever `COPILOT_OTEL_FILE_EXPORTER_PATH` was set — which the project's own `docs/github-copilot-otel.md` tells users to put in their shell profile. CI runners export neither, so a green PR would have handed a red `npm run verify` to contributors. The source-selection variables are now cleared per test through a shared guard, covering both the fallback and the override, rather than widening the assertions.

`tests/shared/watcherNativeEvents.test.js` was also intermittently timing out at 45 s in CI. Root cause: chokidar's `ready` means the initial directory scan finished, not that the native stream is delivering, and anything created between those two moments is reported by neither path — `ignoreInitial` suppresses the scan and the stream's start point is already past the creation. Measured on darwin, writing once after `ready` lost the event in 0/120 single-process runs but 27% of runs with eight watcher processes in parallel, which is what `node --test` does to this file; every failure had the same shape, no first event and a second write to the same path delivered ~610 ms later. Retrying the write alone was not enough, because when the action under test is `mkdir` the lost event is the `addDir` and chokidar never starts watching the new directory. Each test now proves the stream is delivering with a throwaway sentinel before doing what it came to do. This does not weaken the assertions — a watcher that genuinely does not deliver never produces an event however many times a file is written — and it makes the pruning assertion stronger, because silence there now means the matcher pruned the path rather than possibly meaning the stream had not started.

## Verification

- `npm run verify` — 2489 pass, 0 fail, 1 skipped, repeated four times on an idle machine
- `npm test` under a polluted shell (`XDG_DATA_HOME`, `COPILOT_OTEL_FILE_EXPORTER_PATH`, `CODEX_HOME`, `CLINE_SESSION_DATA_DIR`, a whitespace `KIMI_CODE_HOME`, `GROK_HOME`) — same counts
- watcher flake: 144 tests across 48 concurrent runs of that file, all green, under the same eight-way parallelism that previously failed 27%
- each new regression confirmed to fail against the previous behaviour before being kept
- source paths and env precedence checked against the `tokscale` v4.11.0 tag (`clients.rs`, `scanner.rs`), not only against CLI behaviour
- `node node_modules/tokscale/bin.js --version` / `--help`
- production JSON smoke test with `--json --client opencode --group-by client,session,model --today --no-spinner`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns live filesystem watchers with `tokscale` 4.11.0 to cut redundant watches, fix missed refreshes, and prevent misattribution. Docs list default source paths only, group Copilot entries, and “Reveal” selects exact-file sources in their folder.

- **Bug Fixes**
  - Copilot: watch `.copilot` (incl. `data.db`) and keep `otel/`; support `COPILOT_OTEL_FILE_EXPORTER_PATH`; avoid nested duplicate watches; attribute only the exporter file; keep it visible after Windows canonicalization; don’t let the exporter’s parent prune or capture other clients’ events.
  - Sources parity: add Grok `logs/unified.jsonl`, ZCode CLI `db.sqlite`, Cline CLI `sessions/` (env‑aware), Codex `archived_sessions/`, plus headless `codex`.
  - Bounded watchers: confine Kiro CLI and Zed to their SQLite DB families; under CodeBuddy `Logs/`, keep `CodeBuddyIDE` and `VSCode` only; watch both the native data-local root and the Windows-style home path so migrated homes still live-refresh.
  - XDG/env: honor `XDG_DATA_HOME` for OpenCode, MiMo, Zed, and CodeBuddy; respect `CODEX_HOME`, `TOKSCALE_HEADLESS_DIR`, and `CLINE_*`; add health checks for new sources.
  - Precedence: recursive sources nested under bounded roots stay visible; exporter parents are watched but not used as attribution prefixes; native watcher test verifies delivery while pruning noise.
  - Diagnostics: exact-file sources report the file path and “Reveal” selects it in its folder instead of opening it.
  - Docs: finish clearing env vars from tables, group Copilot paths, fold notes into a details block with an explicit env‑variable trigger; AGENTS points to the source‑root table and check‑id allowlist.

- **Dependencies**
  - Bump `tokscale` to `4.11.0`.

<sup>Written for commit e455afed68b289d21c3de74aa75503acde25f15e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

