### PR TITLE
refactor(collector): resolve overlapping watch roots by union

### DIFF
--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1498,236 +1498,166 @@ const ANTIGRAVITY_SOURCE_FILES = new Set(['agyhub_summaries_proto.pb']);
 // Watching `brain/` itself still catches a new session directory appearing.
 const ANTIGRAVITY_SHALLOW_SOURCE_DIRS = new Set(['brain']);
 
-function watchIgnoreMatcher(clientsCsv) {
+// A watch policy answers one question about one source root: given a path
+// inside it, does this source want the event? It never sees the root itself,
+// which is always kept, so `parts` is a non-empty relative path already split.
+//
+// Roots overlap. An explicit CODEX_HOME can sit inside another client's data
+// root, a custom Copilot exporter can name a file inside OpenCode's, and two
+// clients can resolve to the same directory outright. chokidar's `ignored` is
+// global to the instance, so every root containing a path shares one answer for
+// it, and the only safe one is the union of what they read: prune when EVERY
+// containing root declines the path, keep it as soon as one wants it.
+//
+// This replaced an ordered chain of per-client branches in which the first
+// matching root answered for all of them, so overlap resolved by declaration
+// order rather than by what tokscale reads. A bounded root pruned an
+// equally-rooted recursive source out of existence, two bounded roots resolved
+// by whichever branch was written first, and the exporter needed its own checks
+// hoisted above the chain to survive a broader root declared over it.
+const KEEP_EVERYTHING = () => false;
+const EMPTY_SET = new Set();
+
+// Tokscale opens one exact database directly under this root instead of walking
+// it. Keep the direct children it names — including the WAL/SHM sidecars, which
+// are the live-write signal even though tokscale never parses them as databases
+// — so a database created later is still discovered, and never recurse into the
+// runtime files beside it.
+function directChildOnly(isSource) {
+  return (parts) => parts.length > 1 || !isSource(parts[0]);
+}
+
+// Every source root of every tracked client, paired with its policy. Bounded
+// roots are counted so a client set with nothing to prune can skip the matcher
+// entirely rather than hand chokidar a predicate that always answers false.
+function watchPolicyEntries(clientsCsv) {
   const candidates = clientWatchCandidates(clientsCsv);
   // canonicalWatchPath must be applied here too: chokidar reports events under
   // whatever root it was handed, so a matcher built on the uncanonicalised path
   // would stop matching on Windows and silently un-prune the Hermes runtime
   // (issue #38) while the watch itself still worked.
-  const hermesRoots = (candidates.hermes || []).map((dir) => path.resolve(canonicalWatchPath(dir)));
-  const hermesRootSet = new Set(hermesRoots);
-  const copilotRoots = (candidates.copilot || [])
-    .filter((dir) => path.basename(dir) === 'workspaceStorage')
-    .map((dir) => path.resolve(canonicalWatchPath(dir)));
-  const copilotDataRoots = (candidates.copilot || [])
-    .filter((dir) => path.basename(dir) === '.copilot')
-    .map((dir) => path.resolve(canonicalWatchPath(dir)));
-  const copilotDataRootSet = new Set(copilotDataRoots);
-  const copilotExporter = copilotExporterWatch(os.homedir());
-  const canonicalCopilotExporter = copilotExporter ? copilotExporter.canonicalFile : null;
-  const copilotExporterRoots = copilotExporter
-    ? [path.resolve(canonicalWatchPath(copilotExporter.dir))]
-    : [];
-  const copilotExporterRootSet = new Set(copilotExporterRoots);
+  const canonicalRoot = (dir) => path.resolve(canonicalWatchPath(dir));
+  const entries = [];
+  const claimed = new Map();
+  let boundedCount = 0;
+  // Same-root duplicates within one client (Kiro's cased globalStorage spellings,
+  // Zed's per-platform roots) collapse here. Duplicates ACROSS clients must not:
+  // two policies on one directory is precisely the overlap the union resolves,
+  // which is why `claimed` is keyed per client — an identical path under two
+  // clients would otherwise let the bounded one swallow the recursive one, the
+  // very failure this table replaced.
+  const bound = (client, dirs, policy) => {
+    if (!claimed.has(client)) claimed.set(client, new Set());
+    const seen = claimed.get(client);
+    for (const dir of dirs) seen.add(dir);
+    for (const root of new Set(dirs.map(canonicalRoot))) {
+      entries.push({ root, prefix: root + path.sep, policy });
+      boundedCount += 1;
+    }
+  };
+  const withBasename = (client, basename) =>
+    (candidates[client] || []).filter((dir) => path.basename(dir) === basename);
+
+  // Hermes: the SQLite trio is the only source, at any depth. Each explicit
+  // watch root — the home AND every profile dir under it — is kept by the
+  // matcher itself, so a profile's own database still reports.
+  bound('hermes', candidates.hermes || [], (parts) => !HERMES_DB_FILES.has(parts[parts.length - 1]));
+
+  bound('copilot', withBasename('copilot', '.copilot'), (parts) => {
+    if (parts[0] === 'otel') return false;
+    if (parts.length === 1) return !COPILOT_DB_WATCH_PATTERN.test(parts[0]);
+    return true;
+  });
+  bound('copilot', withBasename('copilot', 'workspaceStorage'), (parts) => {
+    if (parts.length === 1) return false; // workspace hash dir
+    if (parts[1] === 'chatSessions') return false;
+    if (parts.length === 2 && parts[1] === 'workspace.json') return false;
+    return true;
+  });
+  // Tokscale ingests exactly the file COPILOT_OTEL_FILE_EXPORTER_PATH names
+  // (`path.is_file()`, no glob), but that file need not exist yet, so its parent
+  // is what gets watched. The parent is an arbitrary user-chosen directory and
+  // can be $HOME — everything in it except that one file is pruned, and
+  // watchAttributionRootsForClients keeps it from becoming a copilot prefix.
+  const exporter = copilotExporterWatch(os.homedir());
+  if (exporter) bound('copilot', [exporter.dir], (_parts, resolved) => resolved !== exporter.canonicalFile);
+
   const antigravityEnabled = String(clientsCsv || '').split(',').map((value) => value.trim().toLowerCase()).includes('antigravity');
-  const antigravityRoots = antigravityEnabled
-    ? antigravityDataRoots().map((dir) => path.resolve(canonicalWatchPath(dir)))
-    : [];
-  const antigravityRootSet = new Set(antigravityRoots);
-  const opencodeRoots = (candidates.opencode || []).map((dir) => path.resolve(canonicalWatchPath(dir)));
-  const opencodeRootSet = new Set(opencodeRoots);
-  const micodeRoots = (candidates.micode || []).map((dir) => path.resolve(canonicalWatchPath(dir)));
-  const micodeRootSet = new Set(micodeRoots);
-  const kiroCliRoots = (candidates.kiro || [])
-    .filter((dir) => path.basename(dir) === 'kiro-cli')
-    .map((dir) => path.resolve(canonicalWatchPath(dir)));
-  const kiroCliRootSet = new Set(kiroCliRoots);
-  const zedRoots = (candidates.zed || [])
-    .filter((dir) => path.basename(dir) === 'threads')
-    .map((dir) => path.resolve(canonicalWatchPath(dir)));
-  const zedRootSet = new Set(zedRoots);
-  const codebuddyExtensionRoots = (candidates.codebuddy || [])
-    .filter((dir) => path.basename(dir) === 'Logs')
-    .map((dir) => path.resolve(canonicalWatchPath(dir)));
-  const codebuddyExtensionRootSet = new Set(codebuddyExtensionRoots);
-  const grokUnifiedRoots = (candidates.grok || [])
-    .filter((dir) => path.basename(dir) === 'logs')
-    .map((dir) => path.resolve(canonicalWatchPath(dir)));
-  const grokUnifiedRootSet = new Set(grokUnifiedRoots);
-  const zcodeDbRoots = (candidates.zcode || [])
-    .filter((dir) => path.basename(dir) === 'db')
-    .map((dir) => path.resolve(canonicalWatchPath(dir)));
-  const zcodeDbRootSet = new Set(zcodeDbRoots);
-  const boundedWatchRootSet = new Set([
-    ...hermesRoots,
-    ...copilotRoots,
-    ...copilotDataRoots,
-    ...antigravityRoots,
-    ...opencodeRoots,
-    ...micodeRoots,
-    ...grokUnifiedRoots,
-    ...zcodeDbRoots,
-    ...kiroCliRoots,
-    ...zedRoots,
-    ...codebuddyExtensionRoots
-  ]);
-  // `ignored` is global to the chokidar instance, while the roots below may
-  // overlap. Keep every non-Copilot recursive source in the union before the
-  // custom exporter branch gets a chance to prune its parent directory. The
-  // bounded roots above are handled by their client-specific branches below;
-  // self-synced cache roots are never handed to chokidar in the first place.
-  const antigravityCliRoots = antigravityEnabled && dirExists(antigravityCliDataDir())
-    ? [path.resolve(canonicalWatchPath(antigravityCliDataDir()))]
-    : [];
-  const recursiveWatchRootSet = new Set([
+  bound('antigravity', antigravityEnabled ? antigravityDataRoots() : [], (parts) => {
+    if (parts.length === 1) {
+      return !ANTIGRAVITY_SOURCE_DIRS.has(parts[0]) && !ANTIGRAVITY_SOURCE_FILES.has(parts[0]);
+    }
+    const firstChild = parts[0];
+    if (!ANTIGRAVITY_SOURCE_DIRS.has(firstChild)) return true;
+    // brain/<session> is kept (a new session shows up there); brain/<session>/**
+    // is not — see ANTIGRAVITY_SHALLOW_SOURCE_DIRS.
+    if (ANTIGRAVITY_SHALLOW_SOURCE_DIRS.has(firstChild)) return parts.length > 2;
+    return false;
+  });
+
+  bound('opencode', candidates.opencode || [], (parts) => {
+    if (parts.length === 1) {
+      // Keep the root's readdir visible for newly created channel DBs, but
+      // do not descend into unrelated app files or directories.
+      return parts[0] !== 'storage' && !OPENCODE_DB_WATCH_PATTERN.test(parts[0]);
+    }
+    if (parts[0] !== 'storage') return true;
+    if (parts.length === 2) return parts[1] !== 'message';
+    if (parts[1] !== 'message') return true;
+    // Tokscale's legacy OpenCode source is storage/message/*/*.json. Keep
+    // the message root, one session directory, and its direct JSON files;
+    // prune deeper runtime trees before chokidar allocates more watches.
+    if (parts.length === 3) return false;
+    if (parts.length === 4) return !parts[3].endsWith('.json');
+    return true;
+  });
+
+  // Tokscale reads only direct children of each MiMo root, so log/* and every
+  // other recursive subtree is pruned before chokidar descends into it.
+  bound('micode', candidates.micode || [], directChildOnly((name) => MICODE_DB_WATCH_PATTERN.test(name)));
+  // The dual-source Grok scanner derives exactly logs/unified.jsonl from each
+  // Grok home.
+  bound('grok', withBasename('grok', 'logs'), directChildOnly((name) => name === GROK_UNIFIED_LOG_FILE));
+  // ZCode v2 is a direct SQLite path, not a recursive project source.
+  bound('zcode', withBasename('zcode', 'db'), directChildOnly((name) => ZCODE_DB_WATCH_PATTERN.test(name)));
+  bound('kiro', withBasename('kiro', 'kiro-cli'), directChildOnly((name) => KIRO_DB_WATCH_PATTERN.test(name)));
+  bound('zed', withBasename('zed', 'threads'), directChildOnly((name) => ZED_DB_WATCH_PATTERN.test(name)));
+  bound('codebuddy', withBasename('codebuddy', 'Logs'), (parts) => !CODEBUDDY_EXTENSION_SOURCE_DIRS.has(parts[0]));
+
+  // Everything left is a recursive transcript tree: tokscale walks it, so every
+  // path inside it is a potential source. Copilot is excluded wholesale because
+  // each of its roots is bounded above, and the self-synced cache roots are
+  // never handed to chokidar in the first place. The parse-local Antigravity CLI
+  // dir is added back explicitly — it shares the umbrella client id but is
+  // written by `agy`, not by our sync.
+  const recursive = [
     ...Object.entries(candidates)
       .filter(([client]) => client !== 'copilot' && !SELF_SYNCED_CLIENTS.has(client))
-      .flatMap(([, roots]) => roots)
-      .map((dir) => path.resolve(canonicalWatchPath(dir)))
-      .filter((dir) => !boundedWatchRootSet.has(dir)),
-    ...antigravityCliRoots
-  ]);
-  if (
-    hermesRoots.length === 0
-    && copilotRoots.length === 0
-    && copilotDataRoots.length === 0
-    && copilotExporterRoots.length === 0
-    && antigravityRoots.length === 0
-    && opencodeRoots.length === 0
-    && micodeRoots.length === 0
-    && kiroCliRoots.length === 0
-    && zedRoots.length === 0
-    && codebuddyExtensionRoots.length === 0
-    && grokUnifiedRoots.length === 0
-    && zcodeDbRoots.length === 0
-  ) return undefined;
+      .flatMap(([client, dirs]) => dirs.filter((dir) => !(claimed.get(client) || EMPTY_SET).has(dir))),
+    ...(antigravityEnabled && dirExists(antigravityCliDataDir()) ? [antigravityCliDataDir()] : [])
+  ];
+  for (const root of new Set(recursive.map(canonicalRoot))) {
+    entries.push({ root, prefix: root + path.sep, policy: KEEP_EVERYTHING });
+  }
+  return { entries, boundedCount };
+}
+
+function watchIgnoreMatcher(clientsCsv) {
+  const { entries, boundedCount } = watchPolicyEntries(clientsCsv);
+  if (boundedCount === 0) return undefined;
   return (target) => {
     const resolved = path.resolve(target);
-    // These explicit exporter paths/parents are roots in their own right. A
-    // broad bounded client root (for example OpenCode) must not prune either
-    // one before its own source-specific branch gets to classify the path.
-    if (canonicalCopilotExporter && resolved === canonicalCopilotExporter) return false;
-    if (copilotExporterRootSet.has(resolved)) return false;
-    // `ignored` is global to the chokidar instance, so a recursive source that
-    // sits *inside* a bounded client's root has to stay visible — an explicit
-    // CODEX_HOME or CLINE_SESSION_DATA_DIR nested under another client's data
-    // root would otherwise be pruned by that client's rule.
-    //
-    // That nested case is the only overlap this guarantees, and it is the only
-    // one covered by a test. Overlap between roots is NOT resolved in general:
-    // a recursive root equal to a bounded root loses (it is filtered out of the
-    // set above), a recursive root that is an *ancestor* of a bounded root wins
-    // and cancels that client's pruning entirely, and two bounded roots resolve
-    // by whichever branch below is written first. All three need a specificity
-    // rule this ordered chain cannot express — see the table-driven follow-up.
-    for (const root of recursiveWatchRootSet) {
-      if (resolved === root || resolved.startsWith(root + path.sep)) return false;
-    }
-    // Every explicit watch root stays watched — the home dir AND each profile
-    // dir. A profile dir lives under the home root, so the child-prune below
-    // would otherwise ignore it (basename isn't a db file) before we recognise
-    // it as a watch root in its own right, silencing profile-db change events.
-    if (hermesRootSet.has(resolved)) return false;
-    for (const root of hermesRoots) {
-      if (resolved.startsWith(root + path.sep)) return !HERMES_DB_FILES.has(path.basename(resolved));
-    }
-    if (copilotDataRootSet.has(resolved)) return false;
-    for (const root of copilotDataRoots) {
-      if (!resolved.startsWith(root + path.sep)) continue;
-      // The exporter file and its parent already returned above, so neither can
-      // reach this branch — do not re-test them here. Two earlier copies of that
-      // rule lived in this loop and only ever restated the top of the function.
-      const parts = path.relative(root, resolved).split(path.sep);
-      if (parts[0] === 'otel') return false;
-      if (parts.length === 1) return !COPILOT_DB_WATCH_PATTERN.test(parts[0]);
-      return true;
-    }
-    for (const root of copilotRoots) {
+    let contained = false;
+    for (const { root, prefix, policy } of entries) {
+      // A watch root is a source in its own right — a Hermes profile dir inside
+      // the Hermes home, the parent of a database created later — so it survives
+      // whatever the roots around it would say about a path at that depth.
       if (resolved === root) return false;
-      if (!resolved.startsWith(root + path.sep)) continue;
-      const parts = path.relative(root, resolved).split(path.sep);
-      if (parts.length === 1) return false; // workspace hash dir
-      if (parts[1] === 'chatSessions') return false;
-      if (parts.length === 2 && parts[1] === 'workspace.json') return false;
-      return true;
+      if (!resolved.startsWith(prefix)) continue;
+      contained = true;
+      if (!policy(path.relative(root, resolved).split(path.sep), resolved)) return false;
     }
-    if (antigravityRootSet.has(resolved)) return false;
-    for (const root of antigravityRoots) {
-      if (!resolved.startsWith(root + path.sep)) continue;
-      const parts = path.relative(root, resolved).split(path.sep);
-      if (parts.length === 1) {
-        return !ANTIGRAVITY_SOURCE_DIRS.has(parts[0]) && !ANTIGRAVITY_SOURCE_FILES.has(parts[0]);
-      }
-      const firstChild = parts[0];
-      if (!ANTIGRAVITY_SOURCE_DIRS.has(firstChild)) return true;
-      // brain/<session> is kept (a new session shows up there); brain/<session>/**
-      // is not — see ANTIGRAVITY_SHALLOW_SOURCE_DIRS.
-      if (ANTIGRAVITY_SHALLOW_SOURCE_DIRS.has(firstChild)) return parts.length > 2;
-      return false;
-    }
-    if (opencodeRootSet.has(resolved)) return false;
-    for (const root of opencodeRoots) {
-      if (!resolved.startsWith(root + path.sep)) continue;
-      const parts = path.relative(root, resolved).split(path.sep);
-      if (parts.length === 1) {
-        // Keep the root's readdir visible for newly created channel DBs, but
-        // do not descend into unrelated app files or directories.
-        return parts[0] !== 'storage' && !OPENCODE_DB_WATCH_PATTERN.test(parts[0]);
-      }
-      if (parts[0] !== 'storage') return true;
-      if (parts.length === 2) return parts[1] !== 'message';
-      if (parts[1] !== 'message') return true;
-      // Tokscale's legacy OpenCode source is storage/message/*/*.json. Keep
-      // the message root, one session directory, and its direct JSON files;
-      // prune deeper runtime trees before chokidar allocates more watches.
-      if (parts.length === 3) return false;
-      if (parts.length === 4) return !parts[3].endsWith('.json');
-      return true;
-    }
-    if (micodeRootSet.has(resolved)) return false;
-    for (const root of micodeRoots) {
-      if (!resolved.startsWith(root + path.sep)) continue;
-      // Tokscale reads only direct children of each MiMo root. Keep those
-      // database names and their WAL/SHM sidecars, but prune log/* and every
-      // other recursive subtree before chokidar descends into it.
-      if (path.dirname(resolved) !== root) return true;
-      return !MICODE_DB_WATCH_PATTERN.test(path.basename(resolved));
-    }
-    if (grokUnifiedRootSet.has(resolved)) return false;
-    for (const root of grokUnifiedRoots) {
-      if (!resolved.startsWith(root + path.sep)) continue;
-      // The dual-source Grok scanner derives exactly logs/unified.jsonl from
-      // each Grok home. Keep the log parent visible for a file created later,
-      // but do not recurse through unrelated log files.
-      if (path.dirname(resolved) !== root) return true;
-      return path.basename(resolved) !== GROK_UNIFIED_LOG_FILE;
-    }
-    if (zcodeDbRootSet.has(resolved)) return false;
-    for (const root of zcodeDbRoots) {
-      if (!resolved.startsWith(root + path.sep)) continue;
-      // ZCode v2 is a direct SQLite path, not a recursive project source.
-      // Keep WAL/SHM as event signals without treating them as databases.
-      if (path.dirname(resolved) !== root) return true;
-      return !ZCODE_DB_WATCH_PATTERN.test(path.basename(resolved));
-    }
-    if (kiroCliRootSet.has(resolved)) return false;
-    for (const root of kiroCliRoots) {
-      if (!resolved.startsWith(root + path.sep)) continue;
-      // Tokscale opens only the direct data.sqlite3 path. Keep the parent
-      // watched so a fresh install or a recreated database is discovered, but
-      // never recurse into other kiro-cli runtime files and directories.
-      if (path.dirname(resolved) !== root) return true;
-      return !KIRO_DB_WATCH_PATTERN.test(path.basename(resolved));
-    }
-    if (zedRootSet.has(resolved)) return false;
-    for (const root of zedRoots) {
-      if (!resolved.startsWith(root + path.sep)) continue;
-      // Tokscale resolves threads/threads.db directly. WAL/SHM remain live
-      // write signals even though they are not parsed as separate databases.
-      if (path.dirname(resolved) !== root) return true;
-      return !ZED_DB_WATCH_PATTERN.test(path.basename(resolved));
-    }
-    if (codebuddyExtensionRootSet.has(resolved)) return false;
-    for (const root of codebuddyExtensionRoots) {
-      if (!resolved.startsWith(root + path.sep)) continue;
-      const parts = path.relative(root, resolved).split(path.sep);
-      return !CODEBUDDY_EXTENSION_SOURCE_DIRS.has(parts[0]);
-    }
-    for (const root of copilotExporterRoots) {
-      if (!resolved.startsWith(root + path.sep)) continue;
-      return true;
-    }
-    return false; // paths outside the bounded client roots are never ignored
+    return contained; // a path under no source root at all is never ignored
   };
 }
 

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -1606,14 +1606,18 @@ test('watchIgnoreMatcher lets a recursive ancestor override a bounded root insid
     process.env.CODEX_HOME = path.join(tmp, 'nest');
     process.env.GROK_HOME = path.join(tmp, 'nest', 'sessions', 'grok');
     const { watchIgnoreMatcher } = freshCollector();
-    const ignored = watchIgnoreMatcher('codex,grok');
+    const ignored = watchIgnoreMatcher('codex,grok,zcode');
     const grokLogs = path.join(tmp, 'nest', 'sessions', 'grok', 'logs');
 
     assert.equal(ignored(path.join(grokLogs, 'unified.jsonl')), false);
     assert.equal(ignored(path.join(grokLogs, 'other.log')), false);
     assert.equal(ignored(path.join(grokLogs, 'archive', 'unified.jsonl')), false);
-    // Outside the Codex tree the same Grok rule still prunes.
-    assert.equal(ignored(path.join(tmp, 'nest', 'archived_sessions', 'run.jsonl')), false);
+    // An ancestor suspends pruning under itself, not everywhere: ZCode's root is
+    // home-relative, so it sits outside the Codex tree and still prunes. Asserting
+    // this on another Codex root would prove nothing — the ancestor covers those.
+    const zcodeDb = path.join(tmp, '.zcode', 'cli', 'db');
+    assert.equal(ignored(path.join(zcodeDb, 'db.sqlite')), false);
+    assert.equal(ignored(path.join(zcodeDb, 'cache')), true);
   } finally {
     os.homedir = originalHomedir;
     delete require.cache[collectorPath];

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -1563,6 +1563,91 @@ test('watchIgnoreMatcher preserves recursive sources nested under bounded roots'
   }
 });
 
+// The three ways two source roots can overlap. `ignored` is one predicate for
+// the whole chokidar instance, so each of these is a case where two clients
+// need different answers about the same path and only one can be given: the
+// union of what they read. An ordered branch chain answered from whichever root
+// it happened to test first, which is why all three are pinned here.
+
+test('watchIgnoreMatcher keeps a recursive source rooted on a bounded root', () => {
+  const shared = 'shared-root';
+  const tmp = withTmpHome([shared]);
+  const originalHomedir = os.homedir;
+  os.homedir = () => tmp;
+  try {
+    // Hermes prunes everything but its SQLite trio; the Cline CLI session dir is
+    // a recursive transcript tree. Pointed at one directory, Hermes' rule would
+    // erase Cline's source unless the recursive root gets a say at equal depth.
+    process.env.HERMES_HOME = path.join(tmp, shared);
+    process.env.CLINE_SESSION_DATA_DIR = path.join(tmp, shared);
+    const { watchIgnoreMatcher } = freshCollector();
+    const ignored = watchIgnoreMatcher('hermes,cline');
+    const root = path.join(tmp, shared);
+
+    assert.equal(ignored(root), false);
+    assert.equal(ignored(path.join(root, 'state.db')), false);
+    assert.equal(ignored(path.join(root, 'session.jsonl')), false);
+    assert.equal(ignored(path.join(root, 'nested', 'task.json')), false);
+  } finally {
+    os.homedir = originalHomedir;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('watchIgnoreMatcher lets a recursive ancestor override a bounded root inside it', () => {
+  const tmp = withTmpHome([path.join('nest', 'sessions', 'grok', 'logs')]);
+  const originalHomedir = os.homedir;
+  os.homedir = () => tmp;
+  try {
+    // Grok keeps only logs/unified.jsonl, but here that log dir sits inside a
+    // Codex transcript tree, which tokscale walks in full. Pruning Grok's
+    // siblings would drop paths Codex reads, so the ancestor wins.
+    process.env.CODEX_HOME = path.join(tmp, 'nest');
+    process.env.GROK_HOME = path.join(tmp, 'nest', 'sessions', 'grok');
+    const { watchIgnoreMatcher } = freshCollector();
+    const ignored = watchIgnoreMatcher('codex,grok');
+    const grokLogs = path.join(tmp, 'nest', 'sessions', 'grok', 'logs');
+
+    assert.equal(ignored(path.join(grokLogs, 'unified.jsonl')), false);
+    assert.equal(ignored(path.join(grokLogs, 'other.log')), false);
+    assert.equal(ignored(path.join(grokLogs, 'archive', 'unified.jsonl')), false);
+    // Outside the Codex tree the same Grok rule still prunes.
+    assert.equal(ignored(path.join(tmp, 'nest', 'archived_sessions', 'run.jsonl')), false);
+  } finally {
+    os.homedir = originalHomedir;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('watchIgnoreMatcher unions two bounded roots on one directory', () => {
+  const tmp = withTmpHome([path.join('shared', 'logs')]);
+  const originalHomedir = os.homedir;
+  os.homedir = () => tmp;
+  try {
+    // Both clients bound the same directory to a different single file. Neither
+    // rule may answer for the other, and what neither wants is still pruned —
+    // the union must not degrade into watching everything.
+    process.env.HERMES_HOME = path.join(tmp, 'shared', 'logs');
+    process.env.GROK_HOME = path.join(tmp, 'shared');
+    const { watchIgnoreMatcher } = freshCollector();
+    const ignored = watchIgnoreMatcher('hermes,grok');
+    const root = path.join(tmp, 'shared', 'logs');
+
+    assert.equal(ignored(root), false);
+    assert.equal(ignored(path.join(root, 'state.db')), false);
+    assert.equal(ignored(path.join(root, 'state.db-wal')), false);
+    assert.equal(ignored(path.join(root, 'unified.jsonl')), false);
+    assert.equal(ignored(path.join(root, 'other.log')), true);
+    assert.equal(ignored(path.join(root, 'archive', 'unified.jsonl')), true);
+  } finally {
+    os.homedir = originalHomedir;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test('watchIgnoreMatcher keeps an exporter file after Windows path canonicalization', () => {
   const exporter = path.join('.copilot', 'custom-export', 'copilot.jsonl');
   const { base, alias, real } = withAliasedTmpHome([path.dirname(exporter)]);


### PR DESCRIPTION
Follow-up to #352, which documented three ways two watch roots can overlap and left them unresolved because the ordered branch chain could not express a rule for them.

## The problem

chokidar's `ignored` is a single predicate for the whole instance, but the roots behind it overlap. An explicit `CODEX_HOME` can sit inside another client's data root, a custom Copilot exporter can name a file inside OpenCode's, and two clients can resolve to one directory outright. The matcher was an ordered chain of per-client branches, so the first branch that matched a path answered for every root containing it — overlap resolved by declaration order rather than by what tokscale actually reads.

That is not a cosmetic ordering issue. When a root loses that vote it loses its *source*: the path is pruned, chokidar never watches it, and that client only refreshes on the next full tick.

## The rule

Each root now carries its own policy, and a path is pruned only when **every** root containing it declines — kept as soon as one wants it. Union is the only answer a shared predicate can give safely here, and it makes the table order-independent by construction.

| Overlap | Before | After |
|---|---|---|
| Recursive source rooted on a bounded root | dropped from the recursive set, erased by the bounded rule | survives — the recursive source is kept |
| Two bounded roots on one directory | first branch answered for both | union of both keep-sets; a path neither wants is still pruned |
| Recursive ancestor containing a bounded root | ancestor wins, cancels the pruning | unchanged, and correct — tokscale walks that tree, so everything in it is a source |

The third row is behaviour-preserving on purpose. It was the one direction the chain already got right, and it is pinned now so the table cannot quietly invert it. Note this is also why "longest matching root wins" would have been the wrong rule: it would hand that case to the *bounded* root and prune paths a recursive client reads.

**None of the three occurs in the default 47-root set.** It contains no cross-client equality and no cross-client nesting, so reaching one requires an explicit environment override that places one client's source inside or on another's (`HERMES_HOME` onto `CLINE_SESSION_DATA_DIR`, and so on). The restructuring therefore preserves the default topology while making supported custom layouts order-independent — which is why this is typed `refactor` rather than `fix`.

## What that removes

- The exporter's two checks hoisted above the chain, which existed only so a broader root declared over it could not prune it first.
- The equality carve-out that filtered a recursive root out of the set whenever a bounded root shared its path — the direct cause of row 1.
- Five near-identical branches for clients sharing the "tokscale opens one exact database directly under this root" shape, now one `directChildOnly` helper.
- The per-client root `Set`s, the bounded/recursive split, and the multi-way emptiness test, which collapse into one table pass.

Net `-70` lines in `collector.js`, and it benchmarks slightly faster than the chain it replaces (860 vs 962 ns/path over the default client set) because each root precomputes its prefix once instead of rebuilding it per path.

## Verification

- `npm run verify` — lint clean, 2494 pass / 0 fail / 1 skipped.
- The three new tests were run against `main`'s matcher to confirm they are not vacuous: rows 1 and 2 fail there, row 3 passes (it is the pinning case).
- No wire-shape, settings, env var or endpoint change; `docs/API.md` and the Worker copies are untouched.
