### PR TITLE
fix(updater): release the quit flags when an install never starts

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -4301,7 +4301,12 @@ let skipForcedQuit = false;
 // quitAndInstall() returns void: nothing reports back whether the installer
 // launched. If it did not, the process stays alive holding two flags that
 // between them make Exit a no-op and disable the forced exit for the rest of
-// the session. Every way out of that call releases them again.
+// the session. Every signal we do get releases them again: a synchronous throw,
+// an updater error, and where the failure would otherwise be silent, a grace
+// timer. One case is still uncovered, and predates all of this: a macOS
+// hand-off that stalls while reporting nothing, for which MacUpdater forwards
+// no terminal event. Closing that needs the flags claimed at the hand-off
+// itself rather than at the request, which is a lifecycle change of its own.
 let updateInstallQuitPending = false;
 let updateInstallQuitTimer = null;
 

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -4297,6 +4297,22 @@ let quitInProgress = false;
 // itself, so the exit below has to stand down or the install never runs.
 let skipForcedQuit = false;
 
+// quitAndInstall() returns void: nothing reports back whether the installer
+// launched. If it did not, the process stays alive holding two flags that
+// between them make Exit a no-op and disable the forced exit for the rest of
+// the session. Every way out of that call releases them again.
+let updateInstallQuitPending = false;
+let updateInstallQuitTimer = null;
+const UPDATE_INSTALL_QUIT_GRACE_MS = 10 * 1000;
+
+function releaseUpdateInstallQuit() {
+  if (!updateInstallQuitPending) return;
+  updateInstallQuitPending = false;
+  if (updateInstallQuitTimer) { clearTimeout(updateInstallQuitTimer); updateInstallQuitTimer = null; }
+  quitRequested = false;
+  skipForcedQuit = false;
+}
+
 // The single quit path. Teardown above is what used to hang, so it runs
 // synchronously and cheaply, and then app.exit() ends the process without
 // another trip through Electron's shutdown events.
@@ -4538,9 +4554,15 @@ function configureNativeAppUpdater() {
     setNativeAppUpdateState({ phase: 'downloaded', version: latest?.version || info?.version || appUpdateNativeState.version || null, progress: 100, error: null });
   });
   autoUpdater.on('error', (error) => {
+    // Released before the busy guard below, deliberately: update-downloaded has
+    // already cleared appUpdateNativeBusy by the time an install can fail, so a
+    // rollback behind that guard would never run and the quit flags would stay
+    // stuck for the rest of the session.
+    const wasInstalling = updateInstallQuitPending;
+    releaseUpdateInstallQuit();
     // Availability checks use the same provider but report through
-    // appUpdateLastError. Only a real download attempt owns installError.
-    if (!appUpdateNativeBusy) return;
+    // appUpdateLastError. Only a real download or install attempt owns installError.
+    if (!appUpdateNativeBusy && !wasInstalling) return;
     appUpdateNativeBusy = false;
     setNativeAppUpdateState({ phase: 'error', progress: null, error: error?.message || String(error || 'Update failed') });
   });
@@ -4773,13 +4795,26 @@ function installDownloadedAppUpdate() {
     downloadedVersion: appUpdateNativeState.version,
     latest
   })) return deriveAppUpdateState();
-  quitRequested = true;
   // quitAndInstall goes through before-quit, and electron-updater owns the
   // restart from there. Stand the forced exit down or the installer never runs.
+  // Both flags are claimed through the helper so every exit from this call
+  // releases them again; see releaseUpdateInstallQuit.
+  updateInstallQuitPending = true;
+  quitRequested = true;
   skipForcedQuit = true;
-  // isSilent: skip the NSIS installer UI on Windows so the update feels seamless
-  // (per-user install needs no elevation); isForceRunAfter relaunches the app.
-  autoUpdater.quitAndInstall(true, true);
+  if (updateInstallQuitTimer) clearTimeout(updateInstallQuitTimer);
+  // Nothing reports a failed handoff, so still being here after the grace period
+  // is the signal. unref'd: the fallback must never be the reason we stay up.
+  updateInstallQuitTimer = setTimeout(releaseUpdateInstallQuit, UPDATE_INSTALL_QUIT_GRACE_MS);
+  updateInstallQuitTimer.unref?.();
+  try {
+    // isSilent: skip the NSIS installer UI on Windows so the update feels seamless
+    // (per-user install needs no elevation); isForceRunAfter relaunches the app.
+    autoUpdater.quitAndInstall(true, true);
+  } catch (error) {
+    releaseUpdateInstallQuit();
+    setNativeAppUpdateState({ phase: 'error', progress: null, error: error?.message || String(error || 'Update failed') });
+  }
   return deriveAppUpdateState();
 }
 

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -178,6 +178,7 @@ const {
   diagnosticConfigurationFromSettings,
   envelopeFromSettings,
   limitsConfigFromSettings,
+  updateInstallQuitGraceMs,
   usageConfigFromSettings
 } = require('./runtimeConfig');
 const {
@@ -4303,7 +4304,6 @@ let skipForcedQuit = false;
 // the session. Every way out of that call releases them again.
 let updateInstallQuitPending = false;
 let updateInstallQuitTimer = null;
-const UPDATE_INSTALL_QUIT_GRACE_MS = 10 * 1000;
 
 function releaseUpdateInstallQuit() {
   if (!updateInstallQuitPending) return;
@@ -4803,10 +4803,16 @@ function installDownloadedAppUpdate() {
   quitRequested = true;
   skipForcedQuit = true;
   if (updateInstallQuitTimer) clearTimeout(updateInstallQuitTimer);
-  // Nothing reports a failed handoff, so still being here after the grace period
-  // is the signal. unref'd: the fallback must never be the reason we stay up.
-  updateInstallQuitTimer = setTimeout(releaseUpdateInstallQuit, UPDATE_INSTALL_QUIT_GRACE_MS);
-  updateInstallQuitTimer.unref?.();
+  // On the platforms whose install path fails silently, still being here after the
+  // grace period is the only signal there is. Where the hand-off is unbounded
+  // instead, updateInstallQuitGraceMs returns null and we wait for the error
+  // event rather than race the installer. unref'd either way: the fallback must
+  // never be the reason we stay up.
+  const graceMs = updateInstallQuitGraceMs();
+  if (graceMs !== null) {
+    updateInstallQuitTimer = setTimeout(releaseUpdateInstallQuit, graceMs);
+    updateInstallQuitTimer.unref?.();
+  }
   try {
     // isSilent: skip the NSIS installer UI on Windows so the update feels seamless
     // (per-user install needs no elevation); isForceRunAfter relaunches the app.

--- a/src/electron/runtimeConfig.js
+++ b/src/electron/runtimeConfig.js
@@ -172,6 +172,26 @@ function classifySettingsChange(previous = {}, next = {}) {
   };
 }
 
+// How long to wait before assuming an update install never handed off, or null
+// when waiting at all would be wrong. electron-updater's two install paths fail
+// in opposite ways, so this cannot be one number for both.
+//
+// BaseUpdater (Windows, Linux) runs install() synchronously and quits on the next
+// tick when it worked. When it did not, it silently resets its own state and
+// emits nothing at all, so a timer is the only thing that can ever restore the
+// quit flags, and it can be short because success never takes this long.
+//
+// MacUpdater often does not quit from quitAndInstall() at all: when Squirrel has
+// not finished it registers an update-downloaded listener, kicks off a native
+// check, and the real quit follows whenever that completes, with no upper bound.
+// A timer there would clear the flags mid-handoff and let the forced exit
+// pre-empt the installer, which is the one thing they exist to prevent. Native
+// errors are forwarded to the updater's error event, so that path is covered
+// without guessing at a deadline.
+function updateInstallQuitGraceMs(platform = process.platform) {
+  return platform === 'darwin' ? null : 10 * 1000;
+}
+
 module.exports = {
   LIMIT_PROVIDER_SETTING_KEYS,
   classifySettingsChange,
@@ -179,5 +199,6 @@ module.exports = {
   envelopeFromSettings,
   limitsConfigFromSettings,
   normalizeAllTimeSince,
+  updateInstallQuitGraceMs,
   usageConfigFromSettings
 };

--- a/src/shared/anchorSeed.js
+++ b/src/shared/anchorSeed.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { computePeriodWindows, configFingerprint, localTodayKey } = require('./collector');
+const { collectorAnchorTrust, computePeriodWindows } = require('./collector');
 const { mergePeriods } = require('./usage');
 
 // The collector persists every full scan to collector-anchor.json so it can
@@ -10,12 +10,12 @@ const { mergePeriods } = require('./usage');
 // (today + month + `--since allTimeSince`, run serially to avoid the CPU spike
 // from issue #15).
 //
-// The validation here has to be startCollector's, not a subset of it. An anchor
-// the collector is about to discard, because the tracked-client list or
-// allTimeSince changed, would otherwise show the previous configuration's
-// totals for a minute and then drop them, which reads as a counting bug rather
-// than a seed being replaced. Returns a device record, or null when the anchor
-// cannot be trusted.
+// Whether the anchor may be reused at all is collectorAnchorTrust's call, shared
+// with startCollector so the two cannot drift: an anchor the collector is about
+// to discard would otherwise show the previous configuration's totals for a
+// minute and then drop them, which reads as a counting bug rather than a seed
+// being replaced. Seeding then adds one rule of its own, below.
+// Returns a device record, or null when the anchor cannot be used.
 function deviceRecordFromAnchor(saved, options = {}) {
   const {
     envelope = {},
@@ -28,16 +28,14 @@ function deviceRecordFromAnchor(saved, options = {}) {
     platform = '',
     now = new Date()
   } = options;
-  if (!saved || saved.dateKey !== localTodayKey(now)) return null;
-  if (!saved.today || !saved.month || !saved.allTime) return null;
-  if (saved.configFingerprint !== configFingerprint(clients, allTimeSince, projectsEnabled)) return null;
-  // startCollector trusts fullScanAt only when it parses and is not in the
-  // future, and refuses to reuse the anchor otherwise. Seeding is stricter still
-  // and declines outright: the timestamp becomes this record's updatedAt and the
-  // window the archive projection is evaluated against, so a snapshot of unknown
-  // age must not be presented as one taken now.
-  const capturedAtMs = Date.parse(saved.fullScanAt || '');
-  if (!Number.isFinite(capturedAtMs) || capturedAtMs > now.getTime()) return null;
+  const trust = collectorAnchorTrust(saved, { clients, allTimeSince, projectsEnabled, now });
+  if (!trust) return null;
+  // The seed's own rule, and the one place it is stricter than the collector.
+  // A capture time the collector cannot trust only costs it a full scan, but
+  // here that timestamp becomes the record's updatedAt and the instant the
+  // archive projection is evaluated at, so a snapshot of unknown age must not
+  // be presented as one taken now.
+  if (trust.capturedAtMs === null) return null;
   // The anchor keeps host periods and the WSL bundle apart, the way
   // collectUsageOnce does before summing them. Same local day is established
   // above, so all three windows are safe to merge.
@@ -52,7 +50,7 @@ function deviceRecordFromAnchor(saved, options = {}) {
     : wslScanEnabled === false
       ? { state: 'disabled', detected: [], withData: [] }
       : (saved.wslStatus || null);
-  const at = new Date(capturedAtMs).toISOString();
+  const at = new Date(trust.capturedAtMs).toISOString();
   return {
     ...envelope,
     hostname,

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1997,6 +1997,25 @@ function configFingerprint(clientsCsv, allTimeSince, projectsEnabled = true) {
   return `${normalizeClientsCsv(clientsCsv)}|${allTimeSince}|projects:${projectsEnabled !== false ? 'on' : 'off'}`;
 }
 
+// The one place that decides whether a persisted anchor may be reused, shared by
+// startCollector and by the widget's cold-start seed. Two consumers with two
+// copies of these rules is how they drift, and a drifted copy shows the previous
+// configuration's totals as if they were current.
+//
+// Returns null when the anchor is unusable at all. Otherwise `capturedAtMs` is
+// the moment it was written, or null when that moment cannot be trusted: the
+// collector still reuses the periods then and simply forces a full scan, while
+// a seed has nothing to stand on and declines.
+function collectorAnchorTrust(saved, options = {}) {
+  const { clients = '', allTimeSince = '', projectsEnabled = true, now = new Date() } = options;
+  if (!saved || saved.dateKey !== localTodayKey(now)) return null;
+  if (!saved.today || !saved.month || !saved.allTime) return null;
+  if (saved.configFingerprint !== configFingerprint(clients, allTimeSince, projectsEnabled)) return null;
+  const parsed = Date.parse(saved.fullScanAt || '');
+  const capturedAtMs = Number.isFinite(parsed) && parsed <= now.getTime() ? parsed : null;
+  return { capturedAtMs };
+}
+
 // Force a full scan at least this often even when the anchor is otherwise
 // valid, so a long-running session periodically rescans month/allTime
 // and picks up any changes that the delta-derivation might miss.
@@ -2226,35 +2245,31 @@ function startCollector(options) {
   if (options.anchorPersistenceEnabled !== false) {
     try {
       const saved = readJson(anchorPath, null);
-      if (saved && saved.dateKey === localTodayKey()) {
-        const fp = configFingerprint(clients, allTimeSince, options.projectsEnabled);
-        if (saved.configFingerprint === fp) {
-          anchor = {
-            dateKey: saved.dateKey,
-            today: saved.today,
-            month: saved.month,
-            allTime: saved.allTime,
-            // Per-client partitions are deliberately rebuilt by the first
-            // anchored all-client tick after restart. Persisted partitions
-            // could be stale for clients that changed while the app was down.
-            todayPartitions: null
-          };
-          // Don't restore a persisted WSL snapshot when WSL scanning is now off —
-          // the configFingerprint intentionally ignores the toggle (host periods
-          // stay valid), so without this gate a warm-scan preview would briefly
-          // re-merge the old WSL totals before the first full tick clears them.
-          wslAnchor = options.wslScanEnabled !== false ? (saved.wslBundle || null) : null;
-          wslStatusAnchor = options.wslScanEnabled !== false ? (saved.wslStatus || null) : null;
-          if (saved.fullScanAt) {
-            const parsed = Date.parse(saved.fullScanAt);
-            // Only trust timestamps that are valid and not in the future.
-            // Invalid, future, or missing timestamps leave lastFullScanAt at 0,
-            // which forces a full scan on the first interval tick (see loop()).
-            if (Number.isFinite(parsed) && parsed <= Date.now()) {
-              lastFullScanAt = parsed;
-            }
-          }
-        }
+      const trust = collectorAnchorTrust(saved, {
+        clients,
+        allTimeSince,
+        projectsEnabled: options.projectsEnabled
+      });
+      if (trust) {
+        anchor = {
+          dateKey: saved.dateKey,
+          today: saved.today,
+          month: saved.month,
+          allTime: saved.allTime,
+          // Per-client partitions are deliberately rebuilt by the first
+          // anchored all-client tick after restart. Persisted partitions
+          // could be stale for clients that changed while the app was down.
+          todayPartitions: null
+        };
+        // Don't restore a persisted WSL snapshot when WSL scanning is now off —
+        // the configFingerprint intentionally ignores the toggle (host periods
+        // stay valid), so without this gate a warm-scan preview would briefly
+        // re-merge the old WSL totals before the first full tick clears them.
+        wslAnchor = options.wslScanEnabled !== false ? (saved.wslBundle || null) : null;
+        wslStatusAnchor = options.wslScanEnabled !== false ? (saved.wslStatus || null) : null;
+        // An untrustworthy capture time leaves lastFullScanAt at 0, which forces
+        // a full scan on the first interval tick (see loop()).
+        if (trust.capturedAtMs !== null) lastFullScanAt = trust.capturedAtMs;
       }
     } catch (_) {}
   }
@@ -2824,6 +2839,7 @@ module.exports = {
   clientsForWatchPath,
   clientWatchCandidates,
   computePeriodWindows,
+  collectorAnchorTrust,
   configFingerprint,
   deriveClientHealth,
   deriveClientStatus,

--- a/src/shared/deviceRuntime.js
+++ b/src/shared/deviceRuntime.js
@@ -117,15 +117,15 @@ function createDeviceRuntime(options = {}, deps = {}) {
   const limitsRuntime = makeLimitsRuntime(limitsOptions, limitsDeps);
 
   // Clearing `active` first is what severs the downstream callbacks; the child
-  // stops are cleanup. `options` is passed through untouched so the quit path can
-  // reach the collector with `skipCloseWatchers`.
+  // stops are cleanup. `options` reaches the collector only: `skipCloseWatchers`
+  // is its concern, not part of a teardown protocol the other two share.
   function stop(options = {}) {
     if (!active) return;
     active = false;
     deviceState.stop();
     usageRuntime?.stop?.(options);
-    limitsRuntime?.stop?.(options);
-    sink?.stop?.(options);
+    limitsRuntime?.stop?.();
+    sink?.stop?.();
   }
 
   return {

--- a/tests/electron/updateInstallQuit.test.js
+++ b/tests/electron/updateInstallQuit.test.js
@@ -14,6 +14,26 @@ const test = require('node:test');
 const ROOT = path.resolve(__dirname, '../..');
 const main = fs.readFileSync(path.join(ROOT, 'src/electron/main.js'), 'utf8');
 
+const { updateInstallQuitGraceMs } = require('../../src/electron/runtimeConfig');
+
+test('the grace period exists only where a failed hand-off is silent', () => {
+  // BaseUpdater runs install() synchronously and quits on the next tick when it
+  // worked; when it did not it resets its own state and emits nothing, so the
+  // timer is the only recovery and success never approaches it.
+  for (const platform of ['win32', 'linux']) {
+    const graceMs = updateInstallQuitGraceMs(platform);
+    assert.ok(graceMs > 0, `${platform} needs a fallback`);
+    assert.ok(graceMs >= 5_000, `${platform} must not race a next-tick quit`);
+  }
+
+  // MacUpdater frequently returns from quitAndInstall() without quitting: it
+  // waits on a native update-downloaded that has no deadline, and the real quit
+  // follows whenever that lands. A timer would clear the flags mid-hand-off and
+  // let the forced exit pre-empt the installer. Native errors are forwarded, so
+  // the failure path stays covered without one.
+  assert.equal(updateInstallQuitGraceMs('darwin'), null);
+});
+
 function functionSource(signature) {
   const start = main.indexOf(signature);
   assert.ok(start >= 0, `${signature} not found`);
@@ -31,8 +51,11 @@ test('the install hand-off claims the quit flags through the release helper', ()
   const guarded = /try \{[\s\S]*?autoUpdater\.quitAndInstall\([\s\S]*?\} catch \(error\) \{[\s\S]*?releaseUpdateInstallQuit\(\);/.exec(install);
   assert.ok(guarded, 'quitAndInstall must release the flags when it throws');
 
-  // Nothing reports a failed hand-off, so still being alive later is the signal.
-  assert.match(install, /setTimeout\(releaseUpdateInstallQuit, UPDATE_INSTALL_QUIT_GRACE_MS\)/);
+  // Where a failed hand-off is silent, still being alive later is the signal, and
+  // where it is unbounded the policy returns null so no timer is armed at all.
+  assert.match(install, /const graceMs = updateInstallQuitGraceMs\(\);/);
+  assert.match(install, /if \(graceMs !== null\) \{/);
+  assert.match(install, /setTimeout\(releaseUpdateInstallQuit, graceMs\)/);
   // The fallback must never be the reason the process stays up.
   assert.match(install, /updateInstallQuitTimer\.unref\?\.\(\)/);
 });

--- a/tests/electron/updateInstallQuit.test.js
+++ b/tests/electron/updateInstallQuit.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+// quitAndInstall() reports nothing back, so the app can be left running with the
+// flags that were claimed on the way in. Those two flags make the tray Exit a
+// no-op and disable the forced exit, which would strand the user in an app that
+// cannot be quit until it is restarted. main.js cannot be required outside
+// Electron, hence the source-level contract.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.resolve(__dirname, '../..');
+const main = fs.readFileSync(path.join(ROOT, 'src/electron/main.js'), 'utf8');
+
+function functionSource(signature) {
+  const start = main.indexOf(signature);
+  assert.ok(start >= 0, `${signature} not found`);
+  const end = main.indexOf('\nfunction ', start + signature.length);
+  return main.slice(start, end === -1 ? main.length : end);
+}
+
+test('the install hand-off claims the quit flags through the release helper', () => {
+  const install = functionSource('function installDownloadedAppUpdate()');
+  assert.match(install, /updateInstallQuitPending = true;/);
+  assert.match(install, /quitRequested = true;/);
+  assert.match(install, /skipForcedQuit = true;/);
+
+  // A synchronous throw leaves the app running, so it has to give them back.
+  const guarded = /try \{[\s\S]*?autoUpdater\.quitAndInstall\([\s\S]*?\} catch \(error\) \{[\s\S]*?releaseUpdateInstallQuit\(\);/.exec(install);
+  assert.ok(guarded, 'quitAndInstall must release the flags when it throws');
+
+  // Nothing reports a failed hand-off, so still being alive later is the signal.
+  assert.match(install, /setTimeout\(releaseUpdateInstallQuit, UPDATE_INSTALL_QUIT_GRACE_MS\)/);
+  // The fallback must never be the reason the process stays up.
+  assert.match(install, /updateInstallQuitTimer\.unref\?\.\(\)/);
+});
+
+test('the release helper puts back everything the hand-off took', () => {
+  const release = functionSource('function releaseUpdateInstallQuit()');
+  assert.match(release, /updateInstallQuitPending = false;/);
+  assert.match(release, /clearTimeout\(updateInstallQuitTimer\)/);
+  // Both flags, not just the one this change introduced: quitRequested has been
+  // set here since before the forced exit existed, and on its own it is already
+  // enough to make requestAppQuit return early forever.
+  assert.match(release, /quitRequested = false;/);
+  assert.match(release, /skipForcedQuit = false;/);
+});
+
+test('an updater error releases the install flags ahead of the download guard', () => {
+  const handler = main.slice(main.indexOf("autoUpdater.on('error'"));
+  const body = handler.slice(0, handler.indexOf('\n  });'));
+  const releaseAt = body.indexOf('releaseUpdateInstallQuit();');
+  const guardAt = body.indexOf('if (!appUpdateNativeBusy');
+  assert.ok(releaseAt >= 0 && guardAt >= 0);
+  // update-downloaded has already cleared appUpdateNativeBusy by the time an
+  // install can fail, so a rollback behind that guard would never run.
+  assert.ok(releaseAt < guardAt, 'the rollback has to come before the early return');
+  assert.match(body, /wasInstalling/);
+});

--- a/tests/shared/collectorAnchorPersistence.test.js
+++ b/tests/shared/collectorAnchorPersistence.test.js
@@ -477,3 +477,35 @@ function waitForCondition(predicate, timeoutMs = 4000) {
     }, 5);
   });
 }
+
+test('anchor trust separates "cannot be reused" from "cannot be dated"', () => {
+  // One policy, two consumers: startCollector reuses the periods and only loses
+  // its incremental shortcut when the capture time is unusable, while the
+  // widget's cold-start seed has nothing to stand on and declines. Keeping that
+  // split in one function is what stops the two from drifting apart.
+  const { collectorAnchorTrust, configFingerprint } = freshCollector();
+  const now = new Date(2026, 7, 8, 10, 0, 0);
+  const anchor = (overrides = {}) => ({
+    dateKey: '2026-08-08',
+    today: {}, month: {}, allTime: {},
+    configFingerprint: configFingerprint('claude', '2024-01-01', true),
+    fullScanAt: new Date(now.getTime() - 60_000).toISOString(),
+    ...overrides
+  });
+  const options = { clients: 'claude', allTimeSince: '2024-01-01', projectsEnabled: true, now };
+
+  assert.equal(collectorAnchorTrust(anchor(), options).capturedAtMs, now.getTime() - 60_000);
+
+  // Unusable outright.
+  assert.equal(collectorAnchorTrust(null, options), null);
+  assert.equal(collectorAnchorTrust(anchor({ dateKey: '2026-08-07' }), options), null);
+  assert.equal(collectorAnchorTrust(anchor({ allTime: null }), options), null);
+  assert.equal(collectorAnchorTrust(anchor(), { ...options, clients: 'claude,codex' }), null);
+  assert.equal(collectorAnchorTrust(anchor(), { ...options, projectsEnabled: false }), null);
+
+  // Usable, but undatable.
+  assert.equal(collectorAnchorTrust(anchor({ fullScanAt: undefined }), options).capturedAtMs, null);
+  assert.equal(collectorAnchorTrust(anchor({ fullScanAt: 'nope' }), options).capturedAtMs, null);
+  const future = new Date(now.getTime() + 60_000).toISOString();
+  assert.equal(collectorAnchorTrust(anchor({ fullScanAt: future }), options).capturedAtMs, null);
+});


### PR DESCRIPTION
Three pieces of maintainer cleanup behind #337 and #339, both of them on failure paths.

### A failed update install leaves an app that cannot be quit

`autoUpdater.quitAndInstall()` returns `void`, and nothing reports back whether the installer actually launched. When it does not, the process is still running while the two flags claimed on the way in stay set:

- `quitRequested`, which predates this work, is on its own enough to make the tray Exit a permanent no-op
- `skipForcedQuit`, added in #337, stands the forced exit down as well

So a failed update strands the user in an app that only a restart can close.

Both flags are now claimed and released together: on a synchronous throw from `quitAndInstall()`, on an updater `error`, on a grace timer where one is safe, and on success, where the process is gone anyway.

The release runs **before** the error handler's own guard. `update-downloaded` has already cleared `appUpdateNativeBusy` by the time an install can fail, so a rollback placed after `if (!appUpdateNativeBusy) return` would never execute.

The grace timer is deliberately not unconditional, because electron-updater's two install paths fail in opposite ways:

- `BaseUpdater` (Windows, Linux) runs `install()` synchronously and quits on the next tick when it worked. When it did not, it resets its own state and emits nothing at all, so the timer is the only recovery that exists, and 10 seconds cannot race a next-tick quit.
- `MacUpdater` frequently returns from `quitAndInstall()` without quitting. With `autoInstallOnAppQuit` off it registers a native `update-downloaded` listener, kicks off a check, and the real quit follows whenever that completes, with no upper bound. A timer there would clear `skipForcedQuit` mid-hand-off and let the forced exit pre-empt the installer, which is exactly what it exists to prevent. Native errors are forwarded to the updater's error event, so that path stays covered without guessing a deadline.

`updateInstallQuitGraceMs()` holds that split as a plain function of the platform so the reasoning is testable rather than a constant nobody can question.

**Known gap, unchanged by this PR:** a macOS hand-off that stalls while reporting nothing at all still leaves the flags set, because `MacUpdater` forwards no terminal event for that case. That has been true since the flags were first set here, and closing it properly means claiming them at the hand-off (`before-quit-for-update`) instead of at the request, so a watchdog can run everywhere without racing the installer. That is a lifecycle change with its own review surface, including attempt ownership for repeated install clicks, and belongs in its own PR.

### One copy of the anchor acceptance rules

`startCollector()` and the cold-start seed from #339 each carried their own answer to "may this anchor be reused". They agree today, but the next condition added to the collector would drift them apart, and a drifted copy renders the previous configuration's totals as if they were current.

`collectorAnchorTrust()` is now the single answer. It reports usability and datability separately, because the two consumers treat the latter differently: the collector reuses an anchor it cannot date and merely loses its incremental shortcut, while the seed has nothing to stand on and declines. Keeping that split inside one function is what stops the copies from reappearing.

One behaviour change falls out of the merge: `startCollector()` never checked that `today`, `month` and `allTime` were actually present, so a truncated anchor was loaded with missing periods. The seed did check, and the shared policy keeps the stricter rule, so a corrupt anchor is now rejected outright.

### `deviceRuntime.stop()`

`skipCloseWatchers` is the collector's concern. It is no longer handed to the limits runtime and the sink, which have no use for it, so it stops looking like part of a teardown protocol the three of them share.

`npm run verify` is green (2524 tests).

Refs #325
Refs #320
