### PR TITLE
refactor(session): drive the period filter by an injected clock

### DIFF
--- a/src/shared/sessionDetail.js
+++ b/src/shared/sessionDetail.js
@@ -299,7 +299,8 @@ function readSessionDetail({ client, sessionId, period = 'total', sessionCost = 
     return { found: false, client, sessionId, period, exchanges: [], totals: totalsOf([], sessionCost) };
   }
   const events = parseByClient(client, text);
-  const grouped = filterExchangesByPeriod(groupEvents(events), period, new Date());
+  const now = new Date((deps.now || Date.now)());
+  const grouped = filterExchangesByPeriod(groupEvents(events), period, now);
   distributeCost(grouped, sessionCost);
   return { found: true, client, sessionId, period, exchanges: grouped, totals: totalsOf(grouped, sessionCost) };
 }

--- a/tests/shared/sessionDetail.test.js
+++ b/tests/shared/sessionDetail.test.js
@@ -232,3 +232,33 @@ test('readSessionDetail reports not found instead of throwing', () => {
   assert.equal(detail.found, false);
   assert.deepEqual(detail.exchanges, []);
 });
+
+test('readSessionDetail filters by the injected clock and passes the period cost through', () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-detail-'));
+  const id = 'injected-clock';
+  // Freeze "now" at YESTERDAY noon (local time). One exchange sits on that injected
+  // "today", the other on the wall clock's today. Which one survives the 'today'
+  // filter therefore proves whether the injected clock (not new Date()) drove it.
+  const now = new Date();
+  const nowMs = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1, 12, 0, 0).getTime();
+  const injectedTodayTs = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1, 1, 0, 0).toISOString();
+  const wallTodayTs = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 1, 0, 0).toISOString();
+  writeClaudeSession(home, id, [
+    JSON.stringify({ type: 'user', timestamp: injectedTodayTs, message: { role: 'user', content: 'injected today' } }),
+    JSON.stringify({ type: 'assistant', timestamp: injectedTodayTs, message: { role: 'assistant', usage: { input_tokens: 80, output_tokens: 20, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }, content: [] } }),
+    JSON.stringify({ type: 'user', timestamp: wallTodayTs, message: { role: 'user', content: 'wall today' } }),
+    JSON.stringify({ type: 'assistant', timestamp: wallTodayTs, message: { role: 'assistant', usage: { input_tokens: 40, output_tokens: 10, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }, content: [] } })
+  ]);
+
+  // The renderer reads sessionCost from the period-scoped row (tokscale applies the
+  // date filter before grouping messages into sessions), so it must pass through
+  // untouched — no rescaling in readSessionDetail.
+  const todayDetail = readSessionDetail({ client: 'claude', sessionId: id, period: 'today', sessionCost: 0.75, home, deps: { now: () => nowMs } });
+  assert.equal(todayDetail.exchanges.length, 1);
+  assert.equal(todayDetail.totals.totalTokens, 100); // the injected-today exchange, not the wall-today one
+  assert.ok(Math.abs(todayDetail.totals.costUsd - 0.75) < 1e-9);
+
+  const totalDetail = readSessionDetail({ client: 'claude', sessionId: id, period: 'total', sessionCost: 1.5, home, deps: { now: () => nowMs } });
+  assert.equal(totalDetail.totals.totalTokens, 150);
+  assert.ok(Math.abs(totalDetail.totals.costUsd - 1.5) < 1e-9);
+});


### PR DESCRIPTION
`readSessionDetail` resolved the period filter against the wall clock, so a test could not pin which day it landed on. It now accepts `deps.now`, the same injected clock the OpenCode and Reasonix paths already take.

The test freezes `now` a day back, places one exchange on that injected day and one on the wall clock's today, and asserts the injected one survives the `today` filter. It also asserts that the `sessionCost` handed in passes through untouched, since the renderer already supplies the selected period's cost.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-day session cost inflation and makes period filtering deterministic by accepting an injected clock. Previously, the period filter used the wall clock and `readSessionDetail` could attribute the full session cost; now it respects `deps.now` and uses the provided period-scoped cost for distribution and totals.

- Accept `deps.now` and drive `period` filtering from it; tests freeze “now” to prove the injected clock is used.
- Pass the provided `sessionCost` through to `distributeCost` and totals; preserve full-cost behavior for `total` and avoid NaN on zero-token sessions.
- Callers should pass a period-scoped `sessionCost` for non-`total` periods and may inject `deps.now` to control filtering.

<sup>Written for commit 5c4e2d6ccfd1545058bc32dbdf3565b976b3f071. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


