### PR TITLE
perf(widget): bound history refreshes and stop invisible snapshot churn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
           tests/shared/macWidgetSnapshot.test.js
           tests/electron/macWidgetBridge.test.js
           tests/electron/macWidgetDeepLink.test.js
+          tests/electron/macWidgetHistory.test.js
           tests/electron/macWidgetReloader.test.js
           tests/electron/macWidgetSigning.test.js
           tests/electron/macosProvisioning.test.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           tests/electron/macWidgetBridge.test.js
           tests/electron/macWidgetDeepLink.test.js
           tests/electron/macWidgetHistory.test.js
+          tests/electron/macWidgetSnapshotController.test.js
           tests/electron/macWidgetSnapshotLane.test.js
           tests/electron/macWidgetReloader.test.js
           tests/electron/macWidgetSigning.test.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           tests/electron/macWidgetBridge.test.js
           tests/electron/macWidgetDeepLink.test.js
           tests/electron/macWidgetHistory.test.js
+          tests/electron/macWidgetSnapshotLane.test.js
           tests/electron/macWidgetReloader.test.js
           tests/electron/macWidgetSigning.test.js
           tests/electron/macosProvisioning.test.js

--- a/native/macos/TokenMonitorWidget/WidgetConfigurationIntent.swift
+++ b/native/macos/TokenMonitorWidget/WidgetConfigurationIntent.swift
@@ -108,6 +108,21 @@ enum WidgetPeriodPolicy {
     static func effectivePeriod(for page: WidgetPage, selectedPeriod: WidgetPeriod) -> WidgetPeriod {
         isSelectable(on: page) ? selectedPeriod : .day
     }
+
+    // The gallery renders an entry for every family at once, before the app has
+    // necessarily written a snapshot and before the user has committed to
+    // anything. A nil snapshot there draws the redacted placeholder skeleton,
+    // which reads as a broken widget rather than one that is still loading, so a
+    // preview falls back to representative sample data. A placed widget keeps
+    // nil: inventing numbers on a real instance would be a lie.
+    static func previewAwareSnapshot(
+        loaded: WidgetSnapshot?,
+        period: WidgetPeriod,
+        isPreview: Bool
+    ) -> WidgetSnapshot? {
+        if let loaded { return loaded }
+        return isPreview ? WidgetSnapshot.placeholder.selecting(period) : nil
+    }
 }
 
 enum WidgetFamilyScope: String, Codable, AppEnum, CaseIterable {

--- a/native/macos/TokenMonitorWidget/WidgetSnapshot.swift
+++ b/native/macos/TokenMonitorWidget/WidgetSnapshot.swift
@@ -350,7 +350,6 @@ struct WidgetTrend: Decodable, Equatable {
 }
 
 struct WidgetPresentation: Decodable, Equatable {
-    let defaultPeriod: String
     let currencyCode: String
     let currencySymbol: String
     let currencyRate: Double
@@ -359,7 +358,7 @@ struct WidgetPresentation: Decodable, Equatable {
     let showCost: Bool
     let locale: String
     let theme: String
-    static let `default` = WidgetPresentation(defaultPeriod: "today", currencyCode: "USD", currencySymbol: "$", currencyRate: 1, numberStyle: "compact", compactTokenUnits: "western", showCost: true, locale: "auto", theme: "system")
+    static let `default` = WidgetPresentation(currencyCode: "USD", currencySymbol: "$", currencyRate: 1, numberStyle: "compact", compactTokenUnits: "western", showCost: true, locale: "auto", theme: "system")
 }
 
 struct WidgetStatus: Decodable, Equatable {
@@ -570,10 +569,9 @@ extension WidgetTrend {
 }
 
 extension WidgetPresentation {
-    private enum CodingKeys: String, CodingKey { case defaultPeriod, currencyCode, currencySymbol, currencyRate, numberStyle, compactTokenUnits, showCost, locale, theme }
+    private enum CodingKeys: String, CodingKey { case currencyCode, currencySymbol, currencyRate, numberStyle, compactTokenUnits, showCost, locale, theme }
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        defaultPeriod = c.string(.defaultPeriod, default: "today")
         currencyCode = c.string(.currencyCode, default: "USD")
         currencySymbol = c.string(.currencySymbol, default: "$")
         currencyRate = c.double(.currencyRate, default: 1)
@@ -597,4 +595,58 @@ extension WidgetStatus {
         providerNeedsLogin = c.bool(.providerNeedsLogin)
         noData = c.bool(.noData)
     }
+}
+
+// The sample snapshot the widget gallery and the loading state render.
+// It lives with the model rather than the timeline provider so the test
+// target, which compiles the model but not the provider, can reach it.
+extension WidgetSnapshot {
+    private static func placeholderActivityDays(count: Int) -> [WidgetActivityDay] {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let end = calendar.date(from: DateComponents(year: 2026, month: 7, day: 17))!
+        return (0..<count).map { index in
+            let date = calendar.date(byAdding: .day, value: index - count + 1, to: end)!
+            let parts = calendar.dateComponents([.year, .month, .day], from: date)
+            let key = String(format: "%04d-%02d-%02d", parts.year!, parts.month!, parts.day!)
+            return WidgetActivityDay(date: key, intensity: index % 5)
+        }
+    }
+
+    static let placeholder = WidgetSnapshot(
+        schemaVersion: 6,
+        generatedAt: Date(),
+        overview: WidgetOverview(currentPeriod: "today", totalTokens: 27_800_000, costUsd: 14.86, primaryTool: "codex", updatedAt: Date()),
+        quota: [
+            WidgetQuotaProvider(provider: "codex", status: "ok", updatedAt: Date(), windows: [WidgetLimitWindow(kind: "weekly", usedPercent: 98, remainingPercent: 2, resetsAt: Date().addingTimeInterval(6 * 86_400), windowMinutes: 10_080)]),
+            WidgetQuotaProvider(provider: "mimo", status: "ok", updatedAt: Date(), windows: [], balance: WidgetQuotaBalance(amount: 3.62, currency: "CNY")),
+            WidgetQuotaProvider(provider: "deepseek", status: "ok", updatedAt: Date(), windows: [], balance: WidgetQuotaBalance(amount: 9.33, currency: "CNY")),
+            WidgetQuotaProvider(provider: "antigravity", status: "notConfigured", updatedAt: Date(), windows: [])
+        ],
+        models: [WidgetModel(displayName: "GPT-5.6", totalTokens: 20_900_000, costUsd: 10, sharePercent: 75), WidgetModel(displayName: "MiMo", totalTokens: 2_900_000, costUsd: 2, sharePercent: 11)],
+        activity: WidgetActivity(currentPeriod: "month", activeDays: 18, days: placeholderActivityDays(count: 28)),
+        trend: WidgetTrend(startDate: "07/04", endDate: "07/17", peakTokens: 4_200_000, currentTokens: 2_800_000, points: (1...14).map { WidgetTrendPoint(date: "\($0)", totalTokens: $0 * 200_000, costUsd: 0) }),
+        periods: [
+            .day: WidgetPeriodSnapshot(
+                overview: WidgetOverview(currentPeriod: "today", totalTokens: 27_800_000, costUsd: 14.86, primaryTool: "codex", updatedAt: Date()),
+                models: [WidgetModel(displayName: "GPT-5.6", totalTokens: 20_900_000, costUsd: 10, sharePercent: 75), WidgetModel(displayName: "MiMo", totalTokens: 2_900_000, costUsd: 2, sharePercent: 11)],
+                activity: WidgetActivity(currentPeriod: "today", activeDays: 1, days: placeholderActivityDays(count: 7)),
+                trend: WidgetTrend(startDate: "07/04", endDate: "07/17", peakTokens: 4_200_000, currentTokens: 2_800_000, points: (1...14).map { WidgetTrendPoint(date: "\($0)", totalTokens: $0 * 200_000, costUsd: 0) })
+            ),
+            .month: WidgetPeriodSnapshot(
+                overview: WidgetOverview(currentPeriod: "month", totalTokens: 61_200_000, costUsd: 237.42, primaryTool: "codex", updatedAt: Date()),
+                models: [WidgetModel(displayName: "GPT-5.6", totalTokens: 44_000_000, costUsd: 120, sharePercent: 72), WidgetModel(displayName: "MiMo", totalTokens: 7_000_000, costUsd: 10, sharePercent: 11)],
+                activity: WidgetActivity(currentPeriod: "month", activeDays: 18, days: placeholderActivityDays(count: 28)),
+                trend: WidgetTrend(startDate: "07/04", endDate: "07/17", peakTokens: 9_200_000, currentTokens: 4_800_000, points: (1...14).map { WidgetTrendPoint(date: "\($0)", totalTokens: $0 * 340_000, costUsd: 0) })
+            ),
+            .total: WidgetPeriodSnapshot(
+                overview: WidgetOverview(currentPeriod: "allTime", totalTokens: 180_000_000, costUsd: 620.15, primaryTool: "codex", updatedAt: Date()),
+                models: [WidgetModel(displayName: "GPT-5.6", totalTokens: 120_000_000, costUsd: 220, sharePercent: 67), WidgetModel(displayName: "MiMo", totalTokens: 30_000_000, costUsd: 38, sharePercent: 17)],
+                activity: WidgetActivity(currentPeriod: "allTime", activeDays: 144, days: placeholderActivityDays(count: 180)),
+                trend: WidgetTrend(startDate: "01/01", endDate: "07/17", peakTokens: 18_200_000, currentTokens: 12_800_000, points: (1...14).map { WidgetTrendPoint(date: "\($0)", totalTokens: $0 * 900_000, costUsd: 0) })
+            )
+        ],
+        presentation: .default,
+        status: WidgetStatus(isStale: false, dataAgeSeconds: 30, providerConfigured: true, providerNeedsLogin: false, noData: false)
+    )
 }

--- a/native/macos/TokenMonitorWidget/WidgetTimelineProvider.swift
+++ b/native/macos/TokenMonitorWidget/WidgetTimelineProvider.swift
@@ -17,7 +17,11 @@ struct TokenMonitorTimelineProvider: AppIntentTimelineProvider {
         let now = Date()
         let page = effectivePage(for: configuration, family: context.family)
         let period = WidgetPeriodPolicy.effectivePeriod(for: page, selectedPeriod: currentPeriod())
-        let snapshot = currentSnapshot(period: period)
+        let snapshot = WidgetPeriodPolicy.previewAwareSnapshot(
+            loaded: currentSnapshot(period: period),
+            period: period,
+            isPreview: context.isPreview
+        )
         let selectedActivityDate = selectedActivityDate(in: snapshot, family: context.family, referenceDate: now)
         return TokenMonitorEntry(date: now, snapshot: snapshot, page: page, period: period, selectedActivityDate: selectedActivityDate)
     }
@@ -60,55 +64,4 @@ struct TokenMonitorTimelineProvider: AppIntentTimelineProvider {
             store: store
         )
     }
-}
-
-extension WidgetSnapshot {
-    private static func placeholderActivityDays(count: Int) -> [WidgetActivityDay] {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
-        let end = calendar.date(from: DateComponents(year: 2026, month: 7, day: 17))!
-        return (0..<count).map { index in
-            let date = calendar.date(byAdding: .day, value: index - count + 1, to: end)!
-            let parts = calendar.dateComponents([.year, .month, .day], from: date)
-            let key = String(format: "%04d-%02d-%02d", parts.year!, parts.month!, parts.day!)
-            return WidgetActivityDay(date: key, intensity: index % 5)
-        }
-    }
-
-    static let placeholder = WidgetSnapshot(
-        schemaVersion: 6,
-        generatedAt: Date(),
-        overview: WidgetOverview(currentPeriod: "today", totalTokens: 27_800_000, costUsd: 14.86, primaryTool: "codex", updatedAt: Date()),
-        quota: [
-            WidgetQuotaProvider(provider: "codex", status: "ok", updatedAt: Date(), windows: [WidgetLimitWindow(kind: "weekly", usedPercent: 98, remainingPercent: 2, resetsAt: Date().addingTimeInterval(6 * 86_400), windowMinutes: 10_080)]),
-            WidgetQuotaProvider(provider: "mimo", status: "ok", updatedAt: Date(), windows: [], balance: WidgetQuotaBalance(amount: 3.62, currency: "CNY")),
-            WidgetQuotaProvider(provider: "deepseek", status: "ok", updatedAt: Date(), windows: [], balance: WidgetQuotaBalance(amount: 9.33, currency: "CNY")),
-            WidgetQuotaProvider(provider: "antigravity", status: "notConfigured", updatedAt: Date(), windows: [])
-        ],
-        models: [WidgetModel(displayName: "GPT-5.6", totalTokens: 20_900_000, costUsd: 10, sharePercent: 75), WidgetModel(displayName: "MiMo", totalTokens: 2_900_000, costUsd: 2, sharePercent: 11)],
-        activity: WidgetActivity(currentPeriod: "month", activeDays: 18, days: placeholderActivityDays(count: 28)),
-        trend: WidgetTrend(startDate: "07/04", endDate: "07/17", peakTokens: 4_200_000, currentTokens: 2_800_000, points: (1...14).map { WidgetTrendPoint(date: "\($0)", totalTokens: $0 * 200_000, costUsd: 0) }),
-        periods: [
-            .day: WidgetPeriodSnapshot(
-                overview: WidgetOverview(currentPeriod: "today", totalTokens: 27_800_000, costUsd: 14.86, primaryTool: "codex", updatedAt: Date()),
-                models: [WidgetModel(displayName: "GPT-5.6", totalTokens: 20_900_000, costUsd: 10, sharePercent: 75), WidgetModel(displayName: "MiMo", totalTokens: 2_900_000, costUsd: 2, sharePercent: 11)],
-                activity: WidgetActivity(currentPeriod: "today", activeDays: 1, days: placeholderActivityDays(count: 7)),
-                trend: WidgetTrend(startDate: "07/04", endDate: "07/17", peakTokens: 4_200_000, currentTokens: 2_800_000, points: (1...14).map { WidgetTrendPoint(date: "\($0)", totalTokens: $0 * 200_000, costUsd: 0) })
-            ),
-            .month: WidgetPeriodSnapshot(
-                overview: WidgetOverview(currentPeriod: "month", totalTokens: 61_200_000, costUsd: 237.42, primaryTool: "codex", updatedAt: Date()),
-                models: [WidgetModel(displayName: "GPT-5.6", totalTokens: 44_000_000, costUsd: 120, sharePercent: 72), WidgetModel(displayName: "MiMo", totalTokens: 7_000_000, costUsd: 10, sharePercent: 11)],
-                activity: WidgetActivity(currentPeriod: "month", activeDays: 18, days: placeholderActivityDays(count: 28)),
-                trend: WidgetTrend(startDate: "07/04", endDate: "07/17", peakTokens: 9_200_000, currentTokens: 4_800_000, points: (1...14).map { WidgetTrendPoint(date: "\($0)", totalTokens: $0 * 340_000, costUsd: 0) })
-            ),
-            .total: WidgetPeriodSnapshot(
-                overview: WidgetOverview(currentPeriod: "allTime", totalTokens: 180_000_000, costUsd: 620.15, primaryTool: "codex", updatedAt: Date()),
-                models: [WidgetModel(displayName: "GPT-5.6", totalTokens: 120_000_000, costUsd: 220, sharePercent: 67), WidgetModel(displayName: "MiMo", totalTokens: 30_000_000, costUsd: 38, sharePercent: 17)],
-                activity: WidgetActivity(currentPeriod: "allTime", activeDays: 144, days: placeholderActivityDays(count: 180)),
-                trend: WidgetTrend(startDate: "01/01", endDate: "07/17", peakTokens: 18_200_000, currentTokens: 12_800_000, points: (1...14).map { WidgetTrendPoint(date: "\($0)", totalTokens: $0 * 900_000, costUsd: 0) })
-            )
-        ],
-        presentation: .default,
-        status: WidgetStatus(isStale: false, dataAgeSeconds: 30, providerConfigured: true, providerNeedsLogin: false, noData: false)
-    )
 }

--- a/native/macos/TokenMonitorWidgetTests/WidgetSnapshotDecodingTests.swift
+++ b/native/macos/TokenMonitorWidgetTests/WidgetSnapshotDecodingTests.swift
@@ -1253,3 +1253,58 @@ final class WidgetSnapshotDecodingTests: XCTestCase {
         )
     }
 }
+
+final class WidgetTimelineProviderPreviewTests: XCTestCase {
+    // The gallery is where someone decides whether the widget is worth adding.
+    // Before this fallback existed it rendered the redacted placeholder skeleton
+    // during a cold start, which is indistinguishable from a broken widget.
+    func testGalleryPreviewFallsBackToSampleDataInsteadOfAnEmptySkeleton() {
+        let preview = WidgetPeriodPolicy.previewAwareSnapshot(
+            loaded: nil,
+            period: .day,
+            isPreview: true
+        )
+        XCTAssertNotNil(preview)
+        XCTAssertFalse(preview?.isEmpty ?? true)
+    }
+
+    func testPlacedWidgetKeepsNilRatherThanInventingNumbers() {
+        XCTAssertNil(
+            WidgetPeriodPolicy.previewAwareSnapshot(
+                loaded: nil,
+                period: .day,
+                isPreview: false
+            )
+        )
+    }
+
+    func testARealSnapshotAlwaysWinsOverTheSample() throws {
+        let loaded = try XCTUnwrap(
+            WidgetSnapshot.load(from: Self.writeSnapshotFixture())
+        )
+        let resolved = WidgetPeriodPolicy.previewAwareSnapshot(
+            loaded: loaded,
+            period: .day,
+            isPreview: true
+        )
+        XCTAssertEqual(resolved?.overview.totalTokens, loaded.overview.totalTokens)
+    }
+
+    private static func writeSnapshotFixture() -> URL {
+        let json = """
+        {"schemaVersion":6,"generatedAt":"2026-08-09T07:00:00.000Z",
+         "periods":{"day":{"overview":{"currentPeriod":"today","totalTokens":4242,"costUsd":1.5,
+         "primaryTool":"codex","updatedAt":"2026-08-09T07:00:00.000Z"},"models":[],
+         "activity":{"days":[],"activeDays":0},"trend":{"points":[],"currentTokens":0,"peakTokens":0}}},
+         "quota":[],"presentation":{"currencyCode":"USD","currencySymbol":"$","currencyRate":1,
+         "numberStyle":"compact","compactTokenUnits":"western","showCost":true,"locale":"auto","theme":"system"},
+         "status":{"isStale":false,"sourceStale":false,"dataAgeSeconds":0,"providerConfigured":true,
+         "providerNeedsLogin":false,"noData":false,"sourceUpdatedAt":"2026-08-09T07:00:00.000Z",
+         "snapshotGeneratedAt":"2026-08-09T07:00:00.000Z"}}
+        """
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("preview-fixture-\(UUID().uuidString).json")
+        try? json.data(using: .utf8)?.write(to: url)
+        return url
+    }
+}

--- a/src/electron/historySource.js
+++ b/src/electron/historySource.js
@@ -6,28 +6,40 @@ function parseCompleteHistory(payload) {
   return coerceHistory(payload);
 }
 
+// Which of the four resolutions below a configuration selects. Callers that need
+// to know how expensive a history read will be ask this rather than re-deriving
+// the branches, so the cost model cannot drift from the resolver: only 'remote'
+// is a network round trip, and the other three are in-process.
+function completeHistorySource(options = {}) {
+  const { embeddedHub, hubMode, hubUrl, mode, historyEnabled = true } = options;
+  if (historyEnabled === false) return 'empty';
+  if (mode === 'local') return 'local';
+  if (hubMode === 'host' && embeddedHub) return 'embedded';
+  if (!hubUrl) return 'empty';
+  return 'remote';
+}
+
 async function resolveCompleteHistory(options = {}) {
   const {
     aggregateHistory,
     embeddedHub,
     fetchImpl = globalThis.fetch,
-    hubMode,
     hubUrl,
     localDevice,
-    mode,
     secret,
-    historyEnabled = true,
     timeoutMs = 15_000
   } = options;
   const aggregate = typeof aggregateHistory === 'function' ? aggregateHistory : () => parseCompleteHistory(null);
-  if (historyEnabled === false) return parseCompleteHistory(aggregate([]));
-  if (mode === 'local') {
-    return parseCompleteHistory(aggregate(localDevice ? [localDevice] : []));
+  switch (completeHistorySource(options)) {
+    case 'empty':
+      return parseCompleteHistory(aggregate([]));
+    case 'local':
+      return parseCompleteHistory(aggregate(localDevice ? [localDevice] : []));
+    case 'embedded':
+      return parseCompleteHistory(embeddedHub.hub.getHistory());
+    default:
+      break;
   }
-  if (hubMode === 'host' && embeddedHub) {
-    return parseCompleteHistory(embeddedHub.hub.getHistory());
-  }
-  if (!hubUrl) return parseCompleteHistory(aggregate([]));
   if (typeof fetchImpl !== 'function') throw new Error('History fetch is unavailable');
 
   const url = `${String(hubUrl).replace(/\/$/, '')}/api/history`;
@@ -46,6 +58,7 @@ async function resolveCompleteHistory(options = {}) {
 }
 
 module.exports = {
+  completeHistorySource,
   parseCompleteHistory,
   resolveCompleteHistory
 };

--- a/src/electron/macWidgetBridge.js
+++ b/src/electron/macWidgetBridge.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const fsSync = require('node:fs');
 const fs = require('node:fs/promises');
 const path = require('node:path');
 const { randomUUID } = require('node:crypto');
@@ -44,7 +45,12 @@ async function syncDirectory(fsApi, directory) {
   }
 }
 
-async function writeMacWidgetSnapshot(serializedSnapshot, options = {}) {
+async function discardMacWidgetSnapshot(prepared) {
+  if (!prepared?.tempPath) return;
+  try { await (prepared.fs || fs).unlink(prepared.tempPath); } catch (_) {}
+}
+
+async function prepareMacWidgetSnapshot(serializedSnapshot, options = {}) {
   const platform = options.platform || process.platform;
   if (platform !== 'darwin') return { ok: false, reason: 'unsupported-platform' };
 
@@ -79,13 +85,11 @@ async function writeMacWidgetSnapshot(serializedSnapshot, options = {}) {
     await handle.sync();
     await handle.close();
     handle = null;
-    if (options.isCurrent && !options.isCurrent()) {
-      await fsApi.unlink(tempPath);
-      return { ok: false, reason: 'superseded' };
-    }
-    await fsApi.rename(tempPath, snapshotPath);
-    await syncDirectory(fsApi, directory);
-    return { ok: true, path: snapshotPath, changed: true };
+    return {
+      ok: true,
+      changed: true,
+      prepared: { directory, fs: fsApi, snapshotPath, tempPath }
+    };
   } catch (error) {
     try { await handle?.close(); } catch (_) {}
     try { await fsApi.unlink(tempPath); } catch (_) {}
@@ -94,7 +98,56 @@ async function writeMacWidgetSnapshot(serializedSnapshot, options = {}) {
   }
 }
 
-async function updateMacWidgetSnapshot(stats, options = {}) {
+function createCommitMacWidgetSnapshot(renameSync) {
+  return function commitPreparedSnapshot(prepared, options = {}) {
+    if (!prepared?.tempPath || !prepared?.snapshotPath) {
+      return { ok: false, reason: 'not-prepared' };
+    }
+    try {
+      if (options.isCurrent && !options.isCurrent()) return { ok: false, reason: 'superseded' };
+      renameSync(prepared.tempPath, prepared.snapshotPath);
+      return {
+        ok: true,
+        path: prepared.snapshotPath,
+        changed: true,
+        directory: prepared.directory
+      };
+    } catch (error) {
+      safeLog(options.logger, `[mac-widget] snapshot write failed: ${error?.message || error}`);
+      return { ok: false, reason: 'write-failed', error };
+    }
+  };
+}
+
+const commitMacWidgetSnapshot = createCommitMacWidgetSnapshot(fsSync.renameSync);
+
+async function syncMacWidgetSnapshotDirectory(result, options = {}) {
+  const directory = result?.directory;
+  if (!directory) return;
+  await syncDirectory(options.fs || result.fs || fs, directory);
+}
+
+async function writeMacWidgetSnapshot(serializedSnapshot, options = {}) {
+  const result = await prepareMacWidgetSnapshot(serializedSnapshot, options);
+  if (!result.ok || result.changed === false) return result;
+
+  const prepared = result.prepared;
+  const commitSnapshot = options.renameSync
+    ? createCommitMacWidgetSnapshot(options.renameSync)
+    : commitMacWidgetSnapshot;
+  const committed = commitSnapshot(prepared, {
+    isCurrent: options.isCurrent,
+    logger: options.logger
+  });
+  if (!committed.ok) {
+    await discardMacWidgetSnapshot(prepared);
+    return committed;
+  }
+  await syncMacWidgetSnapshotDirectory({ ...committed, fs: prepared.fs });
+  return { ok: true, path: committed.path, changed: true };
+}
+
+async function prepareMacWidgetSnapshotUpdate(stats, options = {}) {
   let snapshot;
   let serialized;
   const snapshotOptions = options.snapshotOptions || {};
@@ -105,15 +158,40 @@ async function updateMacWidgetSnapshot(stats, options = {}) {
     safeLog(options.logger, `[mac-widget] snapshot serialization failed: ${error?.message || error}`);
     return { ok: false, reason: 'serialization-failed', error };
   }
-  return writeMacWidgetSnapshot(serialized, {
+  return prepareMacWidgetSnapshot(serialized, {
     ...options,
     fingerprint: macWidgetSnapshotFingerprint(snapshot),
     freshnessNow: options.freshnessNow || snapshotOptions.now || snapshot.generatedAt
   });
 }
 
+async function updateMacWidgetSnapshot(stats, options = {}) {
+  const result = await prepareMacWidgetSnapshotUpdate(stats, options);
+  if (!result.ok || result.changed === false) return result;
+  const prepared = result.prepared;
+  const commitSnapshot = options.renameSync
+    ? createCommitMacWidgetSnapshot(options.renameSync)
+    : commitMacWidgetSnapshot;
+  const committed = commitSnapshot(prepared, {
+    isCurrent: options.isCurrent,
+    logger: options.logger
+  });
+  if (!committed.ok) {
+    await discardMacWidgetSnapshot(prepared);
+    return committed;
+  }
+  await syncMacWidgetSnapshotDirectory({ ...committed, fs: prepared.fs });
+  return { ok: true, path: committed.path, changed: true };
+}
+
 module.exports = {
+  commitMacWidgetSnapshot,
+  createCommitMacWidgetSnapshot,
+  discardMacWidgetSnapshot,
+  prepareMacWidgetSnapshot,
+  prepareMacWidgetSnapshotUpdate,
   resolveMacWidgetSnapshotPath,
+  syncMacWidgetSnapshotDirectory,
   updateMacWidgetSnapshot,
   writeMacWidgetSnapshot
 };

--- a/src/electron/macWidgetBridge.js
+++ b/src/electron/macWidgetBridge.js
@@ -50,6 +50,7 @@ async function writeMacWidgetSnapshot(serializedSnapshot, options = {}) {
 
   const snapshotPath = String(options.snapshotPath || '').trim();
   if (!snapshotPath) return { ok: false, reason: 'not-configured' };
+  if (options.isCurrent && !options.isCurrent()) return { ok: false, reason: 'superseded' };
 
   const fsApi = options.fs || fs;
   const logger = options.logger;
@@ -78,6 +79,10 @@ async function writeMacWidgetSnapshot(serializedSnapshot, options = {}) {
     await handle.sync();
     await handle.close();
     handle = null;
+    if (options.isCurrent && !options.isCurrent()) {
+      await fsApi.unlink(tempPath);
+      return { ok: false, reason: 'superseded' };
+    }
     await fsApi.rename(tempPath, snapshotPath);
     await syncDirectory(fsApi, directory);
     return { ok: true, path: snapshotPath, changed: true };

--- a/src/electron/macWidgetHistory.js
+++ b/src/electron/macWidgetHistory.js
@@ -120,9 +120,9 @@ async function resolveMacWidgetHistory(options = {}) {
     .then((history) => {
       if (!history || typeof history !== 'object') throw new Error('history resolver returned no data');
       // A source change while this was in flight makes the answer belong to a
-      // hub nobody is asking about any more; publishing it would reintroduce the
-      // exact mixing the invalidation above exists to prevent.
-      if (sourceKey !== activeSourceKey) return history;
+      // hub nobody is asking about any more. It can neither populate the active
+      // cache nor escape to a caller that may publish it.
+      if (sourceKey !== activeSourceKey) return emptyHistory();
       cachedHistory = history;
       cachedRevision = revision;
       lastAttemptFailed = false;
@@ -153,6 +153,7 @@ function resetMacWidgetHistoryCache() {
   activeSourceKey = '';
   cachedRevision = '';
   lastAttemptAt = null;
+  lastAttemptFailed = false;
   inFlight = null;
 }
 

--- a/src/electron/macWidgetHistory.js
+++ b/src/electron/macWidgetHistory.js
@@ -56,7 +56,7 @@ function macWidgetHistorySourceKey(config = {}) {
     config.mode,
     config.hubMode,
     config.historyEnabled,
-    config.hubUrl || ''
+    String(config.hubUrl || '').replace(/\/$/, '')
   ].join('|');
 }
 
@@ -99,7 +99,11 @@ async function resolveMacWidgetHistory(options = {}) {
   if (inFlight && inFlight.sourceKey === sourceKey) return inFlight.promise;
 
   const floorMs = cachedHistory ? minIntervalMs : retryIntervalMs;
-  if (lastAttemptAt !== null && now - lastAttemptAt < floorMs) {
+  const elapsedMs = lastAttemptAt === null ? null : now - lastAttemptAt;
+  // A wall-clock rollback makes the previous stamp meaningless. Treat a negative
+  // elapsed as due and re-anchor below instead of suppressing refreshes until the
+  // clock catches up, matching the collector's other wall-clock throttle.
+  if (elapsedMs !== null && elapsedMs >= 0 && elapsedMs < floorMs) {
     return cachedHistory || emptyHistory();
   }
 

--- a/src/electron/macWidgetHistory.js
+++ b/src/electron/macWidgetHistory.js
@@ -1,0 +1,153 @@
+'use strict';
+
+// The widget's Activity heatmap and Trend page need the complete history, not
+// the compact window `/api/stats` carries. Two things make that expensive to
+// resolve on every stats push once the extension actually ships:
+//
+//   - `historyRevision` is a content hash of the whole history, so it moves on
+//     essentially every ingest from any device. Keying a cache on it alone turns
+//     a remote `client` into a full `GET /api/history` per push, where the
+//     payload had previously been fetched only when the dashboard opened. Only
+//     that path is remote: `local` and an embedded `host` resolve in process, so
+//     the caller sets the freshness floor from `completeHistorySource()` rather
+//     than paying a staleness cost where there is nothing to save.
+//   - A failed hub request must not reach the snapshot. Empty arrays there blank
+//     the heatmap and the Trend page until some later revision happens to
+//     succeed, which reads as data loss rather than a transient network error.
+//
+// So the revision is treated as a freshness *signal* gated by a time floor, and
+// the last good history is retained across failures.
+//
+// Two floors, because the two states are not the same risk. With a cached copy
+// to serve, the floor is about freshness and can be long. With none — a cold
+// start whose first read failed — there is nothing to show, so waiting out the
+// long floor would strand the widget; but leaving that case unbounded lets every
+// stats push start another request, and the remote read carries a 15 s timeout,
+// so an unreachable hub turns into a continuous queue of them. It gets its own
+// short bounded floor instead: quick enough to recover on its own, bounded
+// enough that pushes cannot stack requests behind a dead hub.
+const DEFAULT_MIN_INTERVAL_MS = 5 * 60_000;
+const DEFAULT_RETRY_INTERVAL_MS = 30_000;
+const EMPTY_HISTORY = Object.freeze({ daily: [], monthly: [], summary: {} });
+
+let cachedHistory = null;
+// The source this cache currently describes. Claimed when a fetch starts, not
+// when one succeeds: the first request is in flight for as long as a hub round
+// trip takes, and every push arriving in that window would otherwise read the
+// unclaimed key as a source change and discard the request it should join.
+let activeSourceKey = '';
+let cachedRevision = '';
+let lastAttemptAt = null;
+let inFlight = null;
+
+function log(logger, message) {
+  try { logger?.(message); } catch (_) {}
+}
+
+function emptyHistory() {
+  return { daily: [], monthly: [], summary: {} };
+}
+
+// The resolver configuration, without the revision. A change here means the
+// cached history describes a different source (another hub, history switched
+// off) and must not be served, however fresh it is.
+function macWidgetHistorySourceKey(config = {}) {
+  return [
+    config.mode,
+    config.hubMode,
+    config.historyEnabled,
+    config.hubUrl || ''
+  ].join('|');
+}
+
+async function resolveMacWidgetHistory(options = {}) {
+  const sourceKey = String(options.sourceKey || '');
+  const revision = String(options.revision || '').trim();
+  const fetchHistory = options.fetchHistory;
+  const logger = options.logger;
+  const now = Number.isFinite(options.now) ? options.now : Date.now();
+  const minIntervalMs = Number.isFinite(options.minIntervalMs)
+    ? Math.max(0, options.minIntervalMs)
+    : DEFAULT_MIN_INTERVAL_MS;
+  // Deliberately independent of minIntervalMs: a caller that sets the freshness
+  // floor to zero because its source is in-process still must not be able to
+  // spin on a failing one.
+  const retryIntervalMs = Number.isFinite(options.retryIntervalMs)
+    ? Math.max(0, options.retryIntervalMs)
+    : DEFAULT_RETRY_INTERVAL_MS;
+
+  if (typeof fetchHistory !== 'function') return cachedHistory || emptyHistory();
+
+  // A different source invalidates the cache outright: serving another hub's
+  // history would be wrong, not merely stale.
+  if (sourceKey !== activeSourceKey) {
+    activeSourceKey = sourceKey;
+    cachedHistory = null;
+    cachedRevision = '';
+    lastAttemptAt = null;
+    inFlight = null;
+  }
+
+  // An exact revision hit is served whatever the floors say: it is the answer,
+  // not a stale stand-in for one.
+  if (cachedHistory && revision && revision === cachedRevision) return cachedHistory;
+
+  // Checked before the floors: a request already on the wire is the answer, just
+  // not arrived yet, so joining it beats both starting a second one and handing
+  // back a stale stand-in. The revision it was started for only decides how its
+  // result gets cached, which is why this matches on the source alone.
+  if (inFlight && inFlight.sourceKey === sourceKey) return inFlight.promise;
+
+  const floorMs = cachedHistory ? minIntervalMs : retryIntervalMs;
+  if (lastAttemptAt !== null && now - lastAttemptAt < floorMs) {
+    return cachedHistory || emptyHistory();
+  }
+
+  // Recorded before the request resolves so that a slow or hanging fetch still
+  // holds the floor closed against the pushes arriving behind it.
+  lastAttemptAt = now;
+
+  const promise = Promise.resolve()
+    .then(() => fetchHistory())
+    .then((history) => {
+      if (!history || typeof history !== 'object') throw new Error('history resolver returned no data');
+      // A source change while this was in flight makes the answer belong to a
+      // hub nobody is asking about any more; publishing it would reintroduce the
+      // exact mixing the invalidation above exists to prevent.
+      if (sourceKey !== activeSourceKey) return history;
+      cachedHistory = history;
+      cachedRevision = revision;
+      return history;
+    })
+    .catch((error) => {
+      log(logger, `[mac-widget] complete history unavailable: ${error?.message || error}`);
+      // Keep whatever last rendered rather than blanking the heatmap. The
+      // revision is left untouched so the next attempt past the floor still
+      // sees this revision as unfetched.
+      return cachedHistory || emptyHistory();
+    });
+
+  inFlight = { sourceKey, revision, promise };
+  try {
+    return await promise;
+  } finally {
+    if (inFlight?.promise === promise) inFlight = null;
+  }
+}
+
+function resetMacWidgetHistoryCache() {
+  cachedHistory = null;
+  activeSourceKey = '';
+  cachedRevision = '';
+  lastAttemptAt = null;
+  inFlight = null;
+}
+
+module.exports = {
+  DEFAULT_MIN_INTERVAL_MS,
+  DEFAULT_RETRY_INTERVAL_MS,
+  EMPTY_HISTORY,
+  macWidgetHistorySourceKey,
+  resetMacWidgetHistoryCache,
+  resolveMacWidgetHistory
+};

--- a/src/electron/macWidgetHistory.js
+++ b/src/electron/macWidgetHistory.js
@@ -38,6 +38,7 @@ let cachedHistory = null;
 let activeSourceKey = '';
 let cachedRevision = '';
 let lastAttemptAt = null;
+let lastAttemptFailed = false;
 let inFlight = null;
 
 function log(logger, message) {
@@ -85,6 +86,7 @@ async function resolveMacWidgetHistory(options = {}) {
     cachedHistory = null;
     cachedRevision = '';
     lastAttemptAt = null;
+    lastAttemptFailed = false;
     inFlight = null;
   }
 
@@ -98,7 +100,9 @@ async function resolveMacWidgetHistory(options = {}) {
   // result gets cached, which is why this matches on the source alone.
   if (inFlight && inFlight.sourceKey === sourceKey) return inFlight.promise;
 
-  const floorMs = cachedHistory ? minIntervalMs : retryIntervalMs;
+  const floorMs = cachedHistory
+    ? Math.max(minIntervalMs, lastAttemptFailed ? retryIntervalMs : 0)
+    : retryIntervalMs;
   const elapsedMs = lastAttemptAt === null ? null : now - lastAttemptAt;
   // A wall-clock rollback makes the previous stamp meaningless. Treat a negative
   // elapsed as due and re-anchor below instead of suppressing refreshes until the
@@ -121,10 +125,15 @@ async function resolveMacWidgetHistory(options = {}) {
       if (sourceKey !== activeSourceKey) return history;
       cachedHistory = history;
       cachedRevision = revision;
+      lastAttemptFailed = false;
       return history;
     })
     .catch((error) => {
       log(logger, `[mac-widget] complete history unavailable: ${error?.message || error}`);
+      // A superseded request belongs to its original source and must not observe
+      // the active source's cache through this module-level state.
+      if (sourceKey !== activeSourceKey) return emptyHistory();
+      lastAttemptFailed = true;
       // Keep whatever last rendered rather than blanking the heatmap. The
       // revision is left untouched so the next attempt past the floor still
       // sees this revision as unfetched.

--- a/src/electron/macWidgetHistory.js
+++ b/src/electron/macWidgetHistory.js
@@ -31,10 +31,14 @@ const DEFAULT_RETRY_INTERVAL_MS = 30_000;
 const EMPTY_HISTORY = Object.freeze({ daily: [], monthly: [], summary: {} });
 
 let cachedHistory = null;
-// The source this cache currently describes. Claimed when a fetch starts, not
-// when one succeeds: the first request is in flight for as long as a hub round
-// trip takes, and every push arriving in that window would otherwise read the
-// unclaimed key as a source change and discard the request it should join.
+// The generation + source pair this cache currently describes. Claimed when a
+// fetch starts, not when one succeeds: the first request is in flight for as
+// long as a hub round trip takes, and every push arriving in that window would
+// otherwise read an unclaimed owner as a change and discard the request it
+// should join. Generation is a separate ownership epoch because a fast
+// A -> B -> A mode switch returns to the same semantic source key while the
+// original A request can still be on the wire.
+let activeGeneration = null;
 let activeSourceKey = '';
 let cachedRevision = '';
 let lastAttemptAt = null;
@@ -62,6 +66,7 @@ function macWidgetHistorySourceKey(config = {}) {
 }
 
 async function resolveMacWidgetHistory(options = {}) {
+  const generation = options.generation;
   const sourceKey = String(options.sourceKey || '');
   const revision = String(options.revision || '').trim();
   const fetchHistory = options.fetchHistory;
@@ -79,9 +84,10 @@ async function resolveMacWidgetHistory(options = {}) {
 
   if (typeof fetchHistory !== 'function') return cachedHistory || emptyHistory();
 
-  // A different source invalidates the cache outright: serving another hub's
-  // history would be wrong, not merely stale.
-  if (sourceKey !== activeSourceKey) {
+  // A different owner invalidates the cache outright: serving another hub's
+  // history or a superseded mode generation would be wrong, not merely stale.
+  if (generation !== activeGeneration || sourceKey !== activeSourceKey) {
+    activeGeneration = generation;
     activeSourceKey = sourceKey;
     cachedHistory = null;
     cachedRevision = '';
@@ -97,8 +103,10 @@ async function resolveMacWidgetHistory(options = {}) {
   // Checked before the floors: a request already on the wire is the answer, just
   // not arrived yet, so joining it beats both starting a second one and handing
   // back a stale stand-in. The revision it was started for only decides how its
-  // result gets cached, which is why this matches on the source alone.
-  if (inFlight && inFlight.sourceKey === sourceKey) return inFlight.promise;
+  // result gets cached, which is why this matches on the owner alone.
+  if (inFlight && inFlight.generation === generation && inFlight.sourceKey === sourceKey) {
+    return inFlight.promise;
+  }
 
   const floorMs = cachedHistory
     ? Math.max(minIntervalMs, lastAttemptFailed ? retryIntervalMs : 0)
@@ -119,10 +127,10 @@ async function resolveMacWidgetHistory(options = {}) {
     .then(() => fetchHistory())
     .then((history) => {
       if (!history || typeof history !== 'object') throw new Error('history resolver returned no data');
-      // A source change while this was in flight makes the answer belong to a
-      // hub nobody is asking about any more. It can neither populate the active
-      // cache nor escape to a caller that may publish it.
-      if (sourceKey !== activeSourceKey) return emptyHistory();
+      // An owner change while this was in flight makes the answer belong to a
+      // mode lifetime nobody is asking about any more. It can neither populate
+      // the active cache nor escape to a caller that may publish it.
+      if (generation !== activeGeneration || sourceKey !== activeSourceKey) return emptyHistory();
       cachedHistory = history;
       cachedRevision = revision;
       lastAttemptFailed = false;
@@ -130,9 +138,9 @@ async function resolveMacWidgetHistory(options = {}) {
     })
     .catch((error) => {
       log(logger, `[mac-widget] complete history unavailable: ${error?.message || error}`);
-      // A superseded request belongs to its original source and must not observe
-      // the active source's cache through this module-level state.
-      if (sourceKey !== activeSourceKey) return emptyHistory();
+      // A superseded request belongs to its original owner and must not observe
+      // the active owner's cache through this module-level state.
+      if (generation !== activeGeneration || sourceKey !== activeSourceKey) return emptyHistory();
       lastAttemptFailed = true;
       // Keep whatever last rendered rather than blanking the heatmap. The
       // revision is left untouched so the next attempt past the floor still
@@ -140,7 +148,7 @@ async function resolveMacWidgetHistory(options = {}) {
       return cachedHistory || emptyHistory();
     });
 
-  inFlight = { sourceKey, revision, promise };
+  inFlight = { generation, sourceKey, revision, promise };
   try {
     return await promise;
   } finally {
@@ -150,6 +158,7 @@ async function resolveMacWidgetHistory(options = {}) {
 
 function resetMacWidgetHistoryCache() {
   cachedHistory = null;
+  activeGeneration = null;
   activeSourceKey = '';
   cachedRevision = '';
   lastAttemptAt = null;

--- a/src/electron/macWidgetReloader.js
+++ b/src/electron/macWidgetReloader.js
@@ -47,6 +47,9 @@ function log(logger, message) {
 }
 
 function launchReload(request, now) {
+  if (request.isCurrent && !request.isCurrent()) {
+    return { ok: false, reason: 'superseded' };
+  }
   const helperPath = resolveWidgetReloaderPath(request);
   if (!helperPath) return { ok: false, reason: 'helper-missing' };
   const widgetKind = String(request.widgetKind || DEFAULT_WIDGET_KIND).trim() || DEFAULT_WIDGET_KIND;

--- a/src/electron/macWidgetSnapshotController.js
+++ b/src/electron/macWidgetSnapshotController.js
@@ -84,9 +84,9 @@ function createMacWidgetSnapshotController(options = {}) {
       } catch (error) {
         safeLog(logger, `[mac-widget] snapshot directory sync failed: ${error?.message || error}`);
       }
-      if (workIsCurrent(work) && committed.changed !== false) {
+      if (ownerIsCurrent(work.owner) && committed.changed !== false) {
         reloadSnapshot?.(work, {
-          isCurrent: () => workIsCurrent(work)
+          isCurrent: () => ownerIsCurrent(work.owner)
         });
       }
     } catch (error) {

--- a/src/electron/macWidgetSnapshotController.js
+++ b/src/electron/macWidgetSnapshotController.js
@@ -1,0 +1,168 @@
+'use strict';
+
+function safeLog(logger, message) {
+  try { logger?.(message); } catch (_) {}
+}
+
+function createMacWidgetSnapshotController(options = {}) {
+  const captureWork = options.captureWork;
+  const resolveHistory = options.resolveHistory;
+  const prepareSnapshot = options.prepareSnapshot;
+  const commitSnapshot = options.commitSnapshot;
+  const syncSnapshot = options.syncSnapshot;
+  const discardSnapshot = options.discardSnapshot;
+  const reloadSnapshot = options.reloadSnapshot;
+  const logger = options.logger;
+  const schedule = options.schedule || setImmediate;
+
+  let sourceEpoch = 1;
+  let nextSequence = 0;
+  let latestSequence = 0;
+  let pendingWork = null;
+  let running = false;
+  let stopped = false;
+  let idleWaiters = [];
+
+  function settleIdle() {
+    if (running || pendingWork) return;
+    const waiters = idleWaiters;
+    idleWaiters = [];
+    for (const resolve of waiters) resolve();
+  }
+
+  function ownerIsCurrent(owner) {
+    return !stopped && owner?.epoch === sourceEpoch;
+  }
+
+  function workIsCurrent(work) {
+    return ownerIsCurrent(work?.owner) && work.sequence === latestSequence;
+  }
+
+  async function discard(prepared) {
+    if (!prepared) return;
+    try {
+      await discardSnapshot?.(prepared);
+    } catch (error) {
+      safeLog(logger, `[mac-widget] temporary snapshot cleanup failed: ${error?.message || error}`);
+    }
+  }
+
+  async function processWork(work) {
+    let prepared = null;
+    try {
+      if (!workIsCurrent(work)) return;
+      const history = await resolveHistory(work);
+      if (!workIsCurrent(work)) return;
+
+      const result = await prepareSnapshot(work, history);
+      prepared = result?.prepared || null;
+      if (!result?.ok || result.changed === false) return;
+      if (!workIsCurrent(work)) {
+        await discard(prepared);
+        prepared = null;
+        return;
+      }
+
+      const committed = commitSnapshot(prepared, {
+        isCurrent: () => workIsCurrent(work)
+      });
+      if (!committed?.ok) {
+        await discard(prepared);
+        prepared = null;
+        return;
+      }
+      const committedPrepared = prepared;
+      prepared = null;
+
+      try {
+        await syncSnapshot?.(work, committed, committedPrepared);
+      } catch (error) {
+        safeLog(logger, `[mac-widget] snapshot directory sync failed: ${error?.message || error}`);
+      }
+      if (workIsCurrent(work) && committed.changed !== false) reloadSnapshot?.(work);
+    } catch (error) {
+      await discard(prepared);
+      safeLog(logger, `[mac-widget] update failed: ${error?.message || error}`);
+    }
+  }
+
+  async function drain() {
+    try {
+      while (pendingWork) {
+        const work = pendingWork;
+        pendingWork = null;
+        await processWork(work);
+      }
+    } finally {
+      running = false;
+      if (pendingWork && !stopped) startDrain();
+      else settleIdle();
+    }
+  }
+
+  function startDrain() {
+    if (running || stopped || !pendingWork) return;
+    running = true;
+    schedule(() => { void drain(); });
+  }
+
+  function captureProducerOwner() {
+    if (stopped) return null;
+    return Object.freeze({ epoch: sourceEpoch });
+  }
+
+  function enqueue(input = {}) {
+    if (!input.stats || !ownerIsCurrent(input.producerOwner) || typeof captureWork !== 'function') return false;
+    const sequence = ++nextSequence;
+    let captured;
+    try {
+      captured = captureWork({
+        stats: input.stats,
+        owner: input.producerOwner
+      });
+    } catch (error) {
+      safeLog(logger, `[mac-widget] work capture failed: ${error?.message || error}`);
+      return false;
+    }
+    if (!captured || !ownerIsCurrent(captured.owner)) return false;
+    const work = Object.freeze({ ...captured, sequence });
+    latestSequence = sequence;
+    pendingWork = work;
+    startDrain();
+    return true;
+  }
+
+  function advanceSourceEpoch() {
+    if (stopped) return sourceEpoch;
+    sourceEpoch += 1;
+    latestSequence = ++nextSequence;
+    pendingWork = null;
+    settleIdle();
+    return sourceEpoch;
+  }
+
+  function stop() {
+    if (stopped) return;
+    sourceEpoch += 1;
+    latestSequence = ++nextSequence;
+    pendingWork = null;
+    stopped = true;
+    settleIdle();
+  }
+
+  function whenIdle() {
+    if (!running && !pendingWork) return Promise.resolve();
+    return new Promise((resolve) => { idleWaiters.push(resolve); });
+  }
+
+  return {
+    advanceSourceEpoch,
+    captureProducerOwner,
+    enqueue,
+    isCurrent: ownerIsCurrent,
+    stop,
+    whenIdle
+  };
+}
+
+module.exports = { createMacWidgetSnapshotController };

--- a/src/electron/macWidgetSnapshotController.js
+++ b/src/electron/macWidgetSnapshotController.js
@@ -15,6 +15,7 @@ function createMacWidgetSnapshotController(options = {}) {
   const logger = options.logger;
   const schedule = options.schedule || setImmediate;
 
+  let producerEpoch = 1;
   let sourceEpoch = 1;
   let nextSequence = 0;
   let latestSequence = 0;
@@ -28,6 +29,10 @@ function createMacWidgetSnapshotController(options = {}) {
     const waiters = idleWaiters;
     idleWaiters = [];
     for (const resolve of waiters) resolve();
+  }
+
+  function producerIsCurrent(owner) {
+    return !stopped && owner?.epoch === producerEpoch;
   }
 
   function ownerIsCurrent(owner) {
@@ -79,7 +84,11 @@ function createMacWidgetSnapshotController(options = {}) {
       } catch (error) {
         safeLog(logger, `[mac-widget] snapshot directory sync failed: ${error?.message || error}`);
       }
-      if (workIsCurrent(work) && committed.changed !== false) reloadSnapshot?.(work);
+      if (workIsCurrent(work) && committed.changed !== false) {
+        reloadSnapshot?.(work, {
+          isCurrent: () => workIsCurrent(work)
+        });
+      }
     } catch (error) {
       await discard(prepared);
       safeLog(logger, `[mac-widget] update failed: ${error?.message || error}`);
@@ -108,17 +117,18 @@ function createMacWidgetSnapshotController(options = {}) {
 
   function captureProducerOwner() {
     if (stopped) return null;
-    return Object.freeze({ epoch: sourceEpoch });
+    return Object.freeze({ epoch: producerEpoch });
   }
 
   function enqueue(input = {}) {
-    if (!input.stats || !ownerIsCurrent(input.producerOwner) || typeof captureWork !== 'function') return false;
+    if (!input.stats || !producerIsCurrent(input.producerOwner) || typeof captureWork !== 'function') return false;
     const sequence = ++nextSequence;
+    const sourceOwner = Object.freeze({ epoch: sourceEpoch });
     let captured;
     try {
       captured = captureWork({
         stats: input.stats,
-        owner: input.producerOwner
+        owner: sourceOwner
       });
     } catch (error) {
       safeLog(logger, `[mac-widget] work capture failed: ${error?.message || error}`);
@@ -141,8 +151,15 @@ function createMacWidgetSnapshotController(options = {}) {
     return sourceEpoch;
   }
 
+  function advanceProducerAndSourceEpoch() {
+    if (stopped) return sourceEpoch;
+    producerEpoch += 1;
+    return advanceSourceEpoch();
+  }
+
   function stop() {
     if (stopped) return;
+    producerEpoch += 1;
     sourceEpoch += 1;
     latestSequence = ++nextSequence;
     pendingWork = null;
@@ -156,6 +173,7 @@ function createMacWidgetSnapshotController(options = {}) {
   }
 
   return {
+    advanceProducerAndSourceEpoch,
     advanceSourceEpoch,
     captureProducerOwner,
     enqueue,

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -3476,8 +3476,9 @@ function ensureMacWidgetSnapshotController() {
       fs: prepared?.fs
     }),
     discardSnapshot: discardMacWidgetSnapshot,
-    reloadSnapshot: (work) => requestMacWidgetReload({
+    reloadSnapshot: (work, options) => requestMacWidgetReload({
       widgetKind: work.widgetKind,
+      isCurrent: options.isCurrent,
       logger: (message) => console.warn(message)
     }),
     logger: (message) => console.warn(message)
@@ -3487,6 +3488,10 @@ function ensureMacWidgetSnapshotController() {
 
 function captureMacWidgetProducerOwner() {
   return ensureMacWidgetSnapshotController()?.captureProducerOwner() || null;
+}
+
+function advanceMacWidgetProducerAndSourceEpoch() {
+  ensureMacWidgetSnapshotController()?.advanceProducerAndSourceEpoch();
 }
 
 function advanceMacWidgetSourceEpoch() {
@@ -4395,7 +4400,7 @@ function exitTrayMode() {
 
 function startMode() {
   hubModeGeneration += 1;
-  advanceMacWidgetSourceEpoch();
+  advanceMacWidgetProducerAndSourceEpoch();
   clearLatestHubStatsCache();
   // Tear down collectors synchronously so they can't double-run while the
   // async reconciliation below is queued.

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -3416,6 +3416,7 @@ function getMacWidgetHistory(stats) {
     sourceKey: macWidgetHistorySourceKey(config)
   };
   return resolveMacWidgetHistory({
+    generation: sourceToken.generation,
     sourceKey: sourceToken.sourceKey,
     revision: stats?.historyRevision,
     // The key and fetch must describe the same immutable source snapshot. Reading

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -151,7 +151,14 @@ const { historyPreview, historyRevision } = require('../shared/history');
 const { completeHistorySource, resolveCompleteHistory } = require('./historySource');
 const { readSessionDetailForPlatform } = require('../shared/sessionDetailResolver');
 const { startDiscordRpc, stopDiscordRpc, updateDiscordRpc } = require('./discordRpc');
-const { resolveMacWidgetSnapshotPath, updateMacWidgetSnapshot } = require('./macWidgetBridge');
+const {
+  commitMacWidgetSnapshot,
+  discardMacWidgetSnapshot,
+  prepareMacWidgetSnapshotUpdate,
+  resolveMacWidgetSnapshotPath,
+  syncMacWidgetSnapshotDirectory
+} = require('./macWidgetBridge');
+const { createMacWidgetSnapshotController } = require('./macWidgetSnapshotController');
 const { macWidgetHistorySourceKey, resolveMacWidgetHistory } = require('./macWidgetHistory');
 const { parseMacWidgetDeepLink } = require('./macWidgetDeepLink');
 const { normalizeWidgetURLScheme } = require('../shared/macWidgetConfig');
@@ -2323,8 +2330,7 @@ let latestHubStatsIdentity = null;
 let hubModeGeneration = 0;
 let tray = null;
 let latestStats = null;
-let pendingMacWidgetStats = null;
-let macWidgetWriteInFlight = false;
+let macWidgetSnapshotController = null;
 let cachedMacWidgetConfiguration;
 let trayRefreshInFlight = false;
 let trayCodexActiveAccountId = '';
@@ -3206,6 +3212,7 @@ function stopSyncCollector(options = {}) {
 function startSyncCollector() {
   stopSyncCollector();
   if (!effectiveHubConfig().url) return;
+  const widgetProducerOwner = captureMacWidgetProducerOwner();
   const syncUploadScheduler = createSyncUploadScheduler({
     intervalMs: syncUploadIntervalMs(),
     upload: postToHub,
@@ -3222,7 +3229,7 @@ function startSyncCollector() {
       const displayStats = composeLocalSyncStats(latestHubStats, lastCollectedDevice);
       if (displayStats) {
         updateDiscordRpcDisplay(displayStats);
-        sendPush({ event: 'stats', data: { type: 'stats', reason: 'local', stats: displayStats, at: new Date().toISOString() } });
+        sendPush({ event: 'stats', data: { type: 'stats', reason: 'local', stats: displayStats, at: new Date().toISOString() } }, { widgetProducerOwner });
       }
       await syncUploadScheduler.enqueue(visibleSummary, revision);
     },
@@ -3298,6 +3305,7 @@ function startHostStats() {
   stopHostStats();
   if (!embeddedHub) return;
   const generation = hubModeGeneration;
+  const widgetProducerOwner = captureMacWidgetProducerOwner();
   const cacheIdentity = currentHubStatsIdentity('host');
   // Host mode presents the same multi-device hub aggregate as connecting to a
   // remote hub, so it reuses the renderer's 'sync' status path (Live / synced
@@ -3308,7 +3316,7 @@ function startHostStats() {
     if (!hubModeRequestIsCurrent(generation, 'host', cacheIdentity)) return;
     setLatestHubStatsCache(stats, 'host', generation, cacheIdentity);
     updateDiscordRpcDisplay(stats);
-    sendPush({ event: 'stats', data: { type: 'stats', reason, stats, at: new Date().toISOString() } });
+    sendPush({ event: 'stats', data: { type: 'stats', reason, stats, at: new Date().toISOString() } }, { widgetProducerOwner });
   };
   embeddedHubUnsub = embeddedHub.hub.onStats((stats, reason) => emit(stats, reason || 'hub'));
   // Prime the renderer with the current snapshot so it isn't blank until the
@@ -3409,82 +3417,85 @@ function getCompleteHistory() {
   return resolveCompleteHistory(historyResolverOptions());
 }
 
-function getMacWidgetHistory(stats) {
-  const config = historyResolverOptions();
-  const sourceToken = {
-    generation: hubModeGeneration,
-    sourceKey: macWidgetHistorySourceKey(config)
-  };
-  return resolveMacWidgetHistory({
-    generation: sourceToken.generation,
-    sourceKey: sourceToken.sourceKey,
-    revision: stats?.historyRevision,
-    // The key and fetch must describe the same immutable source snapshot. Reading
-    // live settings again after an await could label a Hub B response as Hub A.
-    fetchHistory: () => resolveCompleteHistory(config),
-    // Only a remote hub read is worth trading freshness for: it is an HTTP round
-    // trip with a 15s timeout, and `historyRevision` moves on every ingest from
-    // every device. Local and embedded-host history is an in-process
-    // aggregation, so throttling it would buy nothing and only let the Activity
-    // heatmap lag. The failure retry floor still applies to every source.
-    minIntervalMs: completeHistorySource(config) === 'remote' ? undefined : 0,
-    logger: (message) => console.warn(message)
-  }).then((history) => ({ history, sourceToken }));
-}
-
-function macWidgetHistorySourceIsCurrent(sourceToken) {
-  if (!sourceToken || sourceToken.generation !== hubModeGeneration) return false;
-  return sourceToken.sourceKey === macWidgetHistorySourceKey(historyResolverOptions());
-}
-
-function scheduleMacWidgetSnapshot(stats) {
-  if (process.platform !== 'darwin' || !stats) return;
-  pendingMacWidgetStats = stats;
-  if (macWidgetWriteInFlight) return;
-  macWidgetWriteInFlight = true;
-  setImmediate(async () => {
-    try {
-      while (pendingMacWidgetStats) {
-        const nextStats = pendingMacWidgetStats;
-        pendingMacWidgetStats = null;
-        const config = macWidgetConfiguration();
-        if (!config) break;
-        const { history, sourceToken } = await getMacWidgetHistory(nextStats);
-        // A mode/settings change can finish while a remote history request is on
-        // the wire. The queued latest stats own the new generation; never publish
-        // this old generation between the switch and that catch-up write.
-        if (!macWidgetHistorySourceIsCurrent(sourceToken)) continue;
-        const result = await updateMacWidgetSnapshot(nextStats, {
-          snapshotPath: config.snapshotPath,
-          isCurrent: () => macWidgetHistorySourceIsCurrent(sourceToken),
-          snapshotOptions: {
-            presentation: {
-              currencyCode: settings?.currency,
-              currencyRate: effectiveRates?.[normalizeCurrency(settings?.currency)] || 1,
-              compactNumbers: settings?.showCompactTotalTokens !== false,
-              compactTokenUnits: settings?.compactTokenUnits,
-              showCost: true,
-              locale: settings?.language,
-              theme: Object.keys(settings?.themeColors || {}).length ? 'custom' : 'system'
-            },
-            history
-          },
-          logger: (message) => console.warn(message)
-        });
-        if (result.ok && result.changed !== false) {
-          requestMacWidgetReload({
-            widgetKind: config.widgetKind,
-            logger: (message) => console.warn(message)
-          });
-        }
-      }
-    } catch (error) {
-      console.warn(`[mac-widget] update failed: ${error?.message || error}`);
-    } finally {
-      macWidgetWriteInFlight = false;
-      if (pendingMacWidgetStats) scheduleMacWidgetSnapshot(pendingMacWidgetStats);
-    }
+function macWidgetPresentation() {
+  return Object.freeze({
+    currencyCode: settings?.currency,
+    currencyRate: effectiveRates?.[normalizeCurrency(settings?.currency)] || 1,
+    compactNumbers: settings?.showCompactTotalTokens !== false,
+    compactTokenUnits: settings?.compactTokenUnits,
+    showCost: true,
+    locale: settings?.language,
+    theme: Object.keys(settings?.themeColors || {}).length ? 'custom' : 'system'
   });
+}
+
+function captureMacWidgetWork({ stats, owner }) {
+  const widget = macWidgetConfiguration();
+  if (!widget) return null;
+  const resolverConfig = Object.freeze({ ...historyResolverOptions() });
+  return {
+    stats,
+    owner: Object.freeze({
+      epoch: owner.epoch,
+      sourceKey: macWidgetHistorySourceKey(resolverConfig)
+    }),
+    resolverConfig,
+    presentation: macWidgetPresentation(),
+    snapshotPath: widget.snapshotPath,
+    widgetKind: widget.widgetKind
+  };
+}
+
+function ensureMacWidgetSnapshotController() {
+  if (process.platform !== 'darwin') return null;
+  if (macWidgetSnapshotController) return macWidgetSnapshotController;
+  macWidgetSnapshotController = createMacWidgetSnapshotController({
+    captureWork: captureMacWidgetWork,
+    resolveHistory: (work) => resolveMacWidgetHistory({
+      generation: work.owner.epoch,
+      sourceKey: work.owner.sourceKey,
+      revision: work.stats?.historyRevision,
+      fetchHistory: () => resolveCompleteHistory(work.resolverConfig),
+      minIntervalMs: completeHistorySource(work.resolverConfig) === 'remote' ? undefined : 0,
+      logger: (message) => console.warn(message)
+    }),
+    prepareSnapshot: (work, history) => prepareMacWidgetSnapshotUpdate(work.stats, {
+      snapshotPath: work.snapshotPath,
+      snapshotOptions: {
+        presentation: work.presentation,
+        history
+      },
+      logger: (message) => console.warn(message)
+    }),
+    commitSnapshot: (prepared, options) => commitMacWidgetSnapshot(prepared, {
+      isCurrent: options.isCurrent,
+      logger: (message) => console.warn(message)
+    }),
+    syncSnapshot: (_work, committed, prepared) => syncMacWidgetSnapshotDirectory({
+      ...committed,
+      fs: prepared?.fs
+    }),
+    discardSnapshot: discardMacWidgetSnapshot,
+    reloadSnapshot: (work) => requestMacWidgetReload({
+      widgetKind: work.widgetKind,
+      logger: (message) => console.warn(message)
+    }),
+    logger: (message) => console.warn(message)
+  });
+  return macWidgetSnapshotController;
+}
+
+function captureMacWidgetProducerOwner() {
+  return ensureMacWidgetSnapshotController()?.captureProducerOwner() || null;
+}
+
+function advanceMacWidgetSourceEpoch() {
+  ensureMacWidgetSnapshotController()?.advanceSourceEpoch();
+}
+
+function scheduleMacWidgetSnapshot(stats, producerOwner) {
+  if (process.platform !== 'darwin' || !stats) return false;
+  return ensureMacWidgetSnapshotController()?.enqueue({ stats, producerOwner }) || false;
 }
 
 // Two options, both for the cold-start seed and neither for live stats.
@@ -3499,7 +3510,7 @@ function sendPush(payload, options = {}) {
   if (payload?.data?.stats) {
     injectLocalDeviceStatus(payload.data.stats);
     latestStats = payload.data.stats;
-    scheduleMacWidgetSnapshot(latestStats);
+    scheduleMacWidgetSnapshot(latestStats, options.widgetProducerOwner);
     syncTrayCodexActiveAccount();
     updateTrayDisplay();
     if (!options.skipExport && settings.exportAutoEnabled && settings.exportDir && Date.now() - lastExportAt >= exportIntervalMs()) {
@@ -3654,7 +3665,7 @@ function stopLocalCollector(options = {}) {
 // going, instead of zeros for the tens of seconds it takes. deviceRecordFromAnchor
 // owns the trust rules; anything it rejects leaves the renderer on its normal
 // wait-for-real-data path.
-function primeLocalStatsFromAnchor(usageOptions) {
+function primeLocalStatsFromAnchor(usageOptions, widgetProducerOwner) {
   // Cold start only. startMode() re-enters here on structural settings changes
   // as well, and there the numbers already collected are newer than any anchor.
   if (lastCollectedDevice) return;
@@ -3694,17 +3705,18 @@ function primeLocalStatsFromAnchor(usageOptions) {
   sendPush({
     event: 'stats',
     data: { type: 'stats', reason: 'anchor', stats: localStats, at: deviceRecord.receivedAt }
-  }, { skipExport: true, deferToRenderer: true });
+  }, { skipExport: true, deferToRenderer: true, widgetProducerOwner });
 }
 
 function startLocalCollector() {
   stopLocalCollector();
+  const widgetProducerOwner = captureMacWidgetProducerOwner();
   mode = 'local';
   sendStatus(false, { reason: 'collecting' });
   // One config object for both, so the fingerprint the seed validates against
   // cannot drift from the one the collector will compute.
   const usageOptions = electronUsageConfig('collector');
-  primeLocalStatsFromAnchor(usageOptions);
+  primeLocalStatsFromAnchor(usageOptions, widgetProducerOwner);
   deviceRuntimeHandle = createDeviceRuntime({
     envelope: electronDeviceEnvelope(),
     initialLimits: lastCollectedDevice?.limits,
@@ -3719,7 +3731,7 @@ function startLocalCollector() {
       lastCollectedDevice = localDevice;
       localStats = withHistoryPreview(aggregateDevices([localDevice], 0), [localDevice]);
       updateDiscordRpcDisplay(localStats);
-      sendPush({ event: 'stats', data: { type: 'stats', reason, stats: localStats, at: new Date().toISOString() } });
+      sendPush({ event: 'stats', data: { type: 'stats', reason, stats: localStats, at: new Date().toISOString() } }, { widgetProducerOwner });
       sendStatus(true, { reason });
     },
     onDiagnosticEvent: recordDiagnosticEvent,
@@ -3756,6 +3768,7 @@ function parseSseChunk(chunk) {
 async function startStatsStream(options = {}) {
   stopStatsStream();
   const generation = hubModeGeneration;
+  const widgetProducerOwner = captureMacWidgetProducerOwner();
   if (settings?.hubMode !== 'client') return;
   const cacheIdentity = currentHubStatsIdentity('client');
   if (options.resetSnapshot) {
@@ -3800,7 +3813,7 @@ async function startStatsStream(options = {}) {
             parsed = { ...parsed, data: { ...parsed.data, stats: displayStats } };
             updateDiscordRpcDisplay(displayStats);
           }
-          sendPush(parsed);
+          sendPush(parsed, { widgetProducerOwner });
         }
       }
     }
@@ -4139,6 +4152,7 @@ function sendMainWindowEvent(channel, payload, isStillCurrent) {
 
 async function refreshFromTray() {
   if (trayRefreshInFlight) return;
+  const widgetProducerOwner = captureMacWidgetProducerOwner();
   trayRefreshInFlight = true;
   try {
     const stats = await fetchStats({ force: true });
@@ -4146,7 +4160,7 @@ async function refreshFromTray() {
     // result when fetchStats returned a different object (for example, a remote hub
     // fetch while an external headless agent owns collection).
     if (stats && stats !== latestStats) {
-      sendPush({ event: 'stats', data: { stats, mode, reason: 'manual' } });
+      sendPush({ event: 'stats', data: { stats, mode, reason: 'manual' } }, { widgetProducerOwner });
     }
   } catch (error) {
     console.warn(`[tray] refresh failed: ${error.message}`);
@@ -4381,6 +4395,7 @@ function exitTrayMode() {
 
 function startMode() {
   hubModeGeneration += 1;
+  advanceMacWidgetSourceEpoch();
   clearLatestHubStatsCache();
   // Tear down collectors synchronously so they can't double-run while the
   // async reconciliation below is queued.
@@ -4475,6 +4490,7 @@ function stopAll() {
   stopStatsStream();
   stopHostStats();
   stopSyncCollector({ skipCloseWatchers: true });
+  macWidgetSnapshotController?.stop();
   // Fire-and-forget on purpose. server.close() does not complete until every
   // in-flight request does, so awaiting it hands a remote device on the embedded
   // hub the power to hold our own exit open. The listening socket closes with
@@ -5764,6 +5780,11 @@ app.whenReady().then(() => {
       applyNativeMaterial();
     }
     const runtimeChange = classifySettingsChange(previousRuntimeSettings, settings);
+    const widgetHistorySourceChanged = previousRuntimeSettings.historyEnabled !== settings.historyEnabled;
+    if (widgetHistorySourceChanged && !runtimeChange.modeStructural) {
+      advanceMacWidgetSourceEpoch();
+      scheduleMacWidgetSnapshot(latestStats, captureMacWidgetProducerOwner());
+    }
     const limitInvalidations = settingsLimitInvalidationPlan(runtimeChange);
     if (runtimeChange.modeStructural) {
       for (const { scope, reason, options } of limitInvalidations) {

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -148,10 +148,11 @@ const {
   normalizeMimoCookieHeader
 } = require('../shared/mimoLimits');
 const { historyPreview, historyRevision } = require('../shared/history');
-const { resolveCompleteHistory } = require('./historySource');
+const { completeHistorySource, resolveCompleteHistory } = require('./historySource');
 const { readSessionDetailForPlatform } = require('../shared/sessionDetailResolver');
 const { startDiscordRpc, stopDiscordRpc, updateDiscordRpc } = require('./discordRpc');
 const { resolveMacWidgetSnapshotPath, updateMacWidgetSnapshot } = require('./macWidgetBridge');
+const { macWidgetHistorySourceKey, resolveMacWidgetHistory } = require('./macWidgetHistory');
 const { parseMacWidgetDeepLink } = require('./macWidgetDeepLink');
 const { normalizeWidgetURLScheme } = require('../shared/macWidgetConfig');
 const { DEFAULT_WIDGET_KIND, requestMacWidgetReload, resetMacWidgetReloadThrottle } = require('./macWidgetReloader');
@@ -2324,9 +2325,6 @@ let tray = null;
 let latestStats = null;
 let pendingMacWidgetStats = null;
 let macWidgetWriteInFlight = false;
-let cachedMacWidgetHistory = null;
-let cachedMacWidgetHistoryKey = '';
-let macWidgetHistoryRequest = null;
 let cachedMacWidgetConfiguration;
 let trayRefreshInFlight = false;
 let trayCodexActiveAccountId = '';
@@ -3411,39 +3409,20 @@ function getCompleteHistory() {
   return resolveCompleteHistory(historyResolverOptions());
 }
 
-async function getMacWidgetHistory(stats) {
-  const revision = String(stats?.historyRevision || '').trim();
+function getMacWidgetHistory(stats) {
   const config = historyResolverOptions();
-  const key = [
-    config.mode,
-    config.hubMode,
-    config.historyEnabled,
-    config.hubUrl || '',
-    revision
-  ].join('|');
-  if (revision && cachedMacWidgetHistoryKey === key && cachedMacWidgetHistory) {
-    return cachedMacWidgetHistory;
-  }
-  if (macWidgetHistoryRequest?.key === key) return macWidgetHistoryRequest.promise;
-
-  const promise = getCompleteHistory()
-    .then((history) => {
-      if (revision) {
-        cachedMacWidgetHistory = history;
-        cachedMacWidgetHistoryKey = key;
-      }
-      return history;
-    })
-    .catch((error) => {
-      console.warn(`[mac-widget] complete history unavailable: ${error?.message || error}`);
-      return { daily: [], monthly: [], summary: {} };
-    });
-  macWidgetHistoryRequest = { key, promise };
-  try {
-    return await promise;
-  } finally {
-    if (macWidgetHistoryRequest?.promise === promise) macWidgetHistoryRequest = null;
-  }
+  return resolveMacWidgetHistory({
+    sourceKey: macWidgetHistorySourceKey(config),
+    revision: stats?.historyRevision,
+    fetchHistory: getCompleteHistory,
+    // Only a remote hub read is worth trading freshness for: it is an HTTP round
+    // trip with a 15s timeout, and `historyRevision` moves on every ingest from
+    // every device. Local and embedded-host history is an in-process
+    // aggregation, so throttling it would buy nothing and only let the Activity
+    // heatmap lag. The failure retry floor still applies to every source.
+    minIntervalMs: completeHistorySource(config) === 'remote' ? undefined : 0,
+    logger: (message) => console.warn(message)
+  });
 }
 
 function scheduleMacWidgetSnapshot(stats) {
@@ -3463,7 +3442,6 @@ function scheduleMacWidgetSnapshot(stats) {
           snapshotPath: config.snapshotPath,
           snapshotOptions: {
             presentation: {
-              defaultPeriod: settings?.lastViewState?.period,
               currencyCode: settings?.currency,
               currencyRate: effectiveRates?.[normalizeCurrency(settings?.currency)] || 1,
               compactNumbers: settings?.showCompactTotalTokens !== false,

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -3411,10 +3411,16 @@ function getCompleteHistory() {
 
 function getMacWidgetHistory(stats) {
   const config = historyResolverOptions();
+  const sourceToken = {
+    generation: hubModeGeneration,
+    sourceKey: macWidgetHistorySourceKey(config)
+  };
   return resolveMacWidgetHistory({
-    sourceKey: macWidgetHistorySourceKey(config),
+    sourceKey: sourceToken.sourceKey,
     revision: stats?.historyRevision,
-    fetchHistory: getCompleteHistory,
+    // The key and fetch must describe the same immutable source snapshot. Reading
+    // live settings again after an await could label a Hub B response as Hub A.
+    fetchHistory: () => resolveCompleteHistory(config),
     // Only a remote hub read is worth trading freshness for: it is an HTTP round
     // trip with a 15s timeout, and `historyRevision` moves on every ingest from
     // every device. Local and embedded-host history is an in-process
@@ -3422,7 +3428,12 @@ function getMacWidgetHistory(stats) {
     // heatmap lag. The failure retry floor still applies to every source.
     minIntervalMs: completeHistorySource(config) === 'remote' ? undefined : 0,
     logger: (message) => console.warn(message)
-  });
+  }).then((history) => ({ history, sourceToken }));
+}
+
+function macWidgetHistorySourceIsCurrent(sourceToken) {
+  if (!sourceToken || sourceToken.generation !== hubModeGeneration) return false;
+  return sourceToken.sourceKey === macWidgetHistorySourceKey(historyResolverOptions());
 }
 
 function scheduleMacWidgetSnapshot(stats) {
@@ -3437,9 +3448,14 @@ function scheduleMacWidgetSnapshot(stats) {
         pendingMacWidgetStats = null;
         const config = macWidgetConfiguration();
         if (!config) break;
-        const history = await getMacWidgetHistory(nextStats);
+        const { history, sourceToken } = await getMacWidgetHistory(nextStats);
+        // A mode/settings change can finish while a remote history request is on
+        // the wire. The queued latest stats own the new generation; never publish
+        // this old generation between the switch and that catch-up write.
+        if (!macWidgetHistorySourceIsCurrent(sourceToken)) continue;
         const result = await updateMacWidgetSnapshot(nextStats, {
           snapshotPath: config.snapshotPath,
+          isCurrent: () => macWidgetHistorySourceIsCurrent(sourceToken),
           snapshotOptions: {
             presentation: {
               currencyCode: settings?.currency,

--- a/src/shared/macWidgetSnapshot.js
+++ b/src/shared/macWidgetSnapshot.js
@@ -12,7 +12,6 @@ const KNOWN_LIMIT_STATUSES = new Set([
   'sourceRateLimited', 'unavailable', 'error'
 ]);
 const KNOWN_WINDOW_KINDS = new Set(['session', 'weekly', 'billing']);
-const PERIODS = new Set(['today', 'month', 'allTime']);
 const CURRENCIES = Object.freeze({ USD: '$', TWD: 'NT$', HKD: 'HK$', CNY: '¥' });
 
 function finiteNumber(value, fallback = 0) {
@@ -106,11 +105,6 @@ function isLikelySensitivePathOrUrl(value) {
     || /(?:^|[\\/])(?:\.\.?)(?:[\\/]|$)/.test(raw)
     || /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(raw)
   );
-}
-
-function normalizedPeriod(value) {
-  const period = String(value || '').trim();
-  return PERIODS.has(period) ? period : 'today';
 }
 
 function periodStats(stats, period) {
@@ -433,12 +427,11 @@ function buildPeriodSnapshot(stats, period, generatedAt, history, sourceUpdatedA
   return { overview, models, activity, trend };
 }
 
-function buildPresentation(source = {}, period = 'today') {
+function buildPresentation(source = {}) {
   const currencyCode = String(source.currencyCode || source.currency || 'USD').trim().toUpperCase();
   const safeCurrency = Object.hasOwn(CURRENCIES, currencyCode) ? currencyCode : 'USD';
   const locale = String(source.locale || 'auto').trim();
   return {
-    defaultPeriod: normalizedPeriod(source.defaultPeriod || period),
     currencyCode: safeCurrency,
     currencySymbol: CURRENCIES[safeCurrency],
     currencyRate: Math.max(0.000001, finiteNumber(source.currencyRate, 1)),
@@ -476,7 +469,7 @@ function buildMacWidgetSnapshot(stats, options = {}) {
   const safeNow = Number.isNaN(now.getTime()) ? new Date() : now;
   const generatedAt = safeNow.toISOString();
   const sourceFreshness = resolveWidgetSourceFreshness(stats, safeNow);
-  const presentation = buildPresentation(options.presentation, options.presentation?.defaultPeriod);
+  const presentation = buildPresentation(options.presentation);
   const quota = buildQuota(stats?.limits);
   const history = options.history;
   const periods = {
@@ -484,9 +477,14 @@ function buildMacWidgetSnapshot(stats, options = {}) {
     month: buildPeriodSnapshot(stats, 'month', generatedAt, history, sourceFreshness.sourceUpdatedAt, safeNow),
     total: buildPeriodSnapshot(stats, 'allTime', generatedAt, history, sourceFreshness.sourceUpdatedAt, safeNow)
   };
-  const defaultPeriod = normalizedPeriod(presentation.defaultPeriod);
-  const defaultKey = defaultPeriod === 'month' ? 'month' : defaultPeriod === 'allTime' ? 'total' : 'day';
-  const selected = periods[defaultKey];
+  // The top-level mirror is the schemaVersion 1 shape. Every reader from
+  // version 2 on takes `periods.day` and ignores it, so it is pinned to the same
+  // period rather than tracking anything: sourcing it from the app's own
+  // Today/Month/AllTime tab used to rewrite the snapshot and spend a
+  // `WidgetCenter.reloadTimelines()` on a change no widget could render, and
+  // WidgetKit reload budgets are finite. Each widget picks its own period
+  // through the AppIntent instead.
+  const selected = periods.day;
   return {
     schemaVersion: MAC_WIDGET_SCHEMA_VERSION,
     generatedAt,

--- a/tests/electron/anchorSeedWiring.test.js
+++ b/tests/electron/anchorSeedWiring.test.js
@@ -48,7 +48,7 @@ test('only the seed waits for the renderer, so the deferral cannot queue up', ()
 
 test('the seed runs before the collector and only on a cold start', () => {
   const localCollector = functionSource('function startLocalCollector()');
-  const seedAt = localCollector.indexOf('primeLocalStatsFromAnchor(usageOptions);');
+  const seedAt = localCollector.indexOf('primeLocalStatsFromAnchor(usageOptions, widgetProducerOwner);');
   const runtimeAt = localCollector.indexOf('createDeviceRuntime(');
   assert.ok(seedAt >= 0, 'the seed has to run');
   assert.ok(runtimeAt > seedAt, 'the seed has to land before the first scan starts');

--- a/tests/electron/diagnosticHubCacheWiring.test.js
+++ b/tests/electron/diagnosticHubCacheWiring.test.js
@@ -16,7 +16,7 @@ test('late Hub responses cannot replace the active mode cache', () => {
     mainSource,
     /function hubModeRequestIsCurrent\(generation, expectedMode, expectedIdentity = null\)[\s\S]*generation === hubModeGeneration[\s\S]*currentHubStatsIdentity\(expectedMode\) === expectedIdentity/
   );
-  assert.match(mainSource, /function startMode\(\) \{\s*hubModeGeneration \+= 1;\s*clearLatestHubStatsCache\(\);/);
+  assert.match(mainSource, /function startMode\(\) \{\s*hubModeGeneration \+= 1;\s*advanceMacWidgetSourceEpoch\(\);\s*clearLatestHubStatsCache\(\);/);
   assert.match(mainSource, /function setLatestHubStatsCache\(stats, source, generation, identity\)/);
   assert.match(
     mainSource,

--- a/tests/electron/diagnosticHubCacheWiring.test.js
+++ b/tests/electron/diagnosticHubCacheWiring.test.js
@@ -16,7 +16,7 @@ test('late Hub responses cannot replace the active mode cache', () => {
     mainSource,
     /function hubModeRequestIsCurrent\(generation, expectedMode, expectedIdentity = null\)[\s\S]*generation === hubModeGeneration[\s\S]*currentHubStatsIdentity\(expectedMode\) === expectedIdentity/
   );
-  assert.match(mainSource, /function startMode\(\) \{\s*hubModeGeneration \+= 1;\s*advanceMacWidgetSourceEpoch\(\);\s*clearLatestHubStatsCache\(\);/);
+  assert.match(mainSource, /function startMode\(\) \{\s*hubModeGeneration \+= 1;\s*advanceMacWidgetProducerAndSourceEpoch\(\);\s*clearLatestHubStatsCache\(\);/);
   assert.match(mainSource, /function setLatestHubStatsCache\(stats, source, generation, identity\)/);
   assert.match(
     mainSource,

--- a/tests/electron/macWidgetBridge.test.js
+++ b/tests/electron/macWidgetBridge.test.js
@@ -211,8 +211,18 @@ test('compares stable snapshot content instead of rewriting for clock-only chang
 
     assert.equal((await updateMacWidgetSnapshot(limitsChanged, {
       ...options,
-      snapshotOptions: { ...options.snapshotOptions, presentation: { defaultPeriod: 'month' } }
+      snapshotOptions: { ...options.snapshotOptions, presentation: { currencyCode: 'CNY', currencyRate: 7.1 } }
     })).changed, true);
+
+    // The app's own period tab is deliberately not part of the snapshot, so
+    // switching it must not reach disk or spend a WidgetKit reload.
+    assert.equal((await updateMacWidgetSnapshot(limitsChanged, {
+      ...options,
+      snapshotOptions: {
+        ...options.snapshotOptions,
+        presentation: { currencyCode: 'CNY', currencyRate: 7.1, defaultPeriod: 'month' }
+      }
+    })).changed, false);
   });
 });
 

--- a/tests/electron/macWidgetBridge.test.js
+++ b/tests/electron/macWidgetBridge.test.js
@@ -1,12 +1,17 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fsSync = require('node:fs');
 const fs = require('node:fs/promises');
 const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 const {
+  commitMacWidgetSnapshot,
+  createCommitMacWidgetSnapshot,
+  prepareMacWidgetSnapshot,
   resolveMacWidgetSnapshotPath,
+  syncMacWidgetSnapshotDirectory,
   updateMacWidgetSnapshot,
   writeMacWidgetSnapshot
 } = require('../../src/electron/macWidgetBridge');
@@ -43,6 +48,59 @@ test('atomically replaces the snapshot and removes temporary files', async () =>
   });
 });
 
+test('final owner check and formal rename run in one non-yielding commit stack', async () => {
+  await withTempDirectory(async (directory) => {
+    const snapshotPath = path.join(directory, 'snapshot.json');
+    await fs.writeFile(snapshotPath, 'last good snapshot', 'utf8');
+    const prepared = await prepareMacWidgetSnapshot('new snapshot', {
+      platform: 'darwin',
+      snapshotPath
+    });
+    const events = [];
+    let current = true;
+
+    const commitSnapshot = createCommitMacWidgetSnapshot((from, to) => {
+      events.push('rename');
+      fsSync.renameSync(from, to);
+    });
+    const result = commitSnapshot(prepared.prepared, {
+      isCurrent() {
+        events.push('check');
+        queueMicrotask(() => {
+          current = false;
+          events.push('transition');
+        });
+        return current;
+      }
+    });
+    events.push('returned');
+    await Promise.resolve();
+
+    assert.deepEqual(events, ['check', 'rename', 'returned', 'transition']);
+    assert.deepEqual(result, { ok: true, path: snapshotPath, changed: true, directory });
+    assert.equal(await fs.readFile(snapshotPath, 'utf8'), 'new snapshot');
+    await syncMacWidgetSnapshotDirectory(result);
+  });
+});
+
+test('a superseded prepared snapshot is discarded before formal publish', async () => {
+  await withTempDirectory(async (directory) => {
+    const snapshotPath = path.join(directory, 'snapshot.json');
+    const prepared = await prepareMacWidgetSnapshot('new snapshot', {
+      platform: 'darwin',
+      snapshotPath
+    });
+
+    const result = commitMacWidgetSnapshot(prepared.prepared, {
+      isCurrent: () => false
+    });
+
+    assert.deepEqual(result, { ok: false, reason: 'superseded' });
+    await fs.unlink(prepared.prepared.tempPath);
+    await assert.rejects(fs.access(snapshotPath));
+  });
+});
+
 test('discards a snapshot whose source generation expires before atomic publish', async () => {
   await withTempDirectory(async (directory) => {
     const snapshotPath = path.join(directory, 'snapshot.json');
@@ -72,15 +130,13 @@ test('keeps the previous snapshot and reports a controlled failure when rename f
     const snapshotPath = path.join(directory, 'snapshot.json');
     await fs.writeFile(snapshotPath, 'last good snapshot', 'utf8');
     const messages = [];
-    const failingFs = {
-      ...fs,
-      async rename() { throw new Error('simulated rename failure'); }
-    };
+    const failingFs = { ...fs };
 
     const result = await writeMacWidgetSnapshot('new snapshot', {
       platform: 'darwin',
       snapshotPath,
       fs: failingFs,
+      renameSync() { throw new Error('simulated rename failure'); },
       logger: (message) => messages.push(message)
     });
 
@@ -256,10 +312,6 @@ test('does not rewrite production-shaped aggregate stats when only updatedAt adv
     const counters = { rename: 0, tempSync: 0 };
     const trackingFs = {
       ...fs,
-      async rename(...args) {
-        counters.rename += 1;
-        return fs.rename(...args);
-      },
       async open(...args) {
         const handle = await fs.open(...args);
         const originalSync = handle.sync.bind(handle);
@@ -279,6 +331,10 @@ test('does not rewrite production-shaped aggregate stats when only updatedAt adv
       platform: 'darwin',
       snapshotPath,
       fs: trackingFs,
+      renameSync(...args) {
+        counters.rename += 1;
+        return fsSync.renameSync(...args);
+      },
       snapshotOptions: {
         now: '2026-07-16T09:00:05Z',
         history: { daily: [], monthly: [], summary: {} }

--- a/tests/electron/macWidgetBridge.test.js
+++ b/tests/electron/macWidgetBridge.test.js
@@ -43,6 +43,30 @@ test('atomically replaces the snapshot and removes temporary files', async () =>
   });
 });
 
+test('discards a snapshot whose source generation expires before atomic publish', async () => {
+  await withTempDirectory(async (directory) => {
+    const snapshotPath = path.join(directory, 'snapshot.json');
+    let checks = 0;
+
+    const result = await updateMacWidgetSnapshot({
+      periods: { today: { totalTokens: 42, costUsd: 0.5 } }
+    }, {
+      platform: 'darwin',
+      snapshotPath,
+      isCurrent: () => {
+        checks += 1;
+        return checks === 1;
+      }
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'superseded');
+    assert.equal(checks, 2);
+    await assert.rejects(fs.access(snapshotPath));
+    assert.deepEqual(await fs.readdir(directory), []);
+  });
+});
+
 test('keeps the previous snapshot and reports a controlled failure when rename fails', async () => {
   await withTempDirectory(async (directory) => {
     const snapshotPath = path.join(directory, 'snapshot.json');

--- a/tests/electron/macWidgetHistory.test.js
+++ b/tests/electron/macWidgetHistory.test.js
@@ -227,6 +227,29 @@ test('a stale source failure cannot return the active source cache', async () =>
   assert.deepEqual(staleResult, { daily: [], monthly: [], summary: {} });
 });
 
+test('a stale source success is discarded instead of reaching its caller', async () => {
+  let releaseSourceA;
+  let markSourceAStarted;
+  const sourceAStarted = new Promise((resolve) => { markSourceAStarted = resolve; });
+  const sourceAResult = resolveMacWidgetHistory({
+    sourceKey: 'hub-a',
+    revision: 'a1',
+    now: 0,
+    fetchHistory: () => {
+      markSourceAStarted();
+      return new Promise((resolve) => { releaseSourceA = resolve; });
+    }
+  });
+  await sourceAStarted;
+
+  await resolveMacWidgetHistory({
+    sourceKey: 'hub-b', revision: 'b1', now: 1, fetchHistory: () => history('hub-b')
+  });
+  releaseSourceA(history('hub-a'));
+
+  assert.deepEqual(await sourceAResult, { daily: [], monthly: [], summary: {} });
+});
+
 test('an in-process source opts out of the freshness floor but keeps the retry floor', async () => {
   let calls = 0;
   const fetchHistory = () => { calls += 1; return history(`call-${calls}`); };

--- a/tests/electron/macWidgetHistory.test.js
+++ b/tests/electron/macWidgetHistory.test.js
@@ -172,6 +172,61 @@ test('recovery after a cold failure needs only the retry floor, not the freshnes
   assert.equal(calls, 2);
 });
 
+test('a warm-cache failure uses the retry floor even when freshness is immediate', async () => {
+  let calls = 0;
+  const fetchHistory = () => {
+    calls += 1;
+    if (calls === 1) return history('good');
+    throw new Error('aggregation failed');
+  };
+  const retryIntervalMs = 30_000;
+
+  await resolveMacWidgetHistory({
+    sourceKey: 's', revision: 'r1', fetchHistory, now: 0, minIntervalMs: 0, retryIntervalMs
+  });
+  const afterFailure = await resolveMacWidgetHistory({
+    sourceKey: 's', revision: 'r2', fetchHistory, now: 10, minIntervalMs: 0, retryIntervalMs
+  });
+  const insideRetryFloor = await resolveMacWidgetHistory({
+    sourceKey: 's', revision: 'r3', fetchHistory, now: 11, minIntervalMs: 0, retryIntervalMs
+  });
+
+  assert.equal(calls, 2, 'a last-good cache must not make a failing source retry per push');
+  assert.equal(afterFailure.summary.label, 'good');
+  assert.equal(insideRetryFloor.summary.label, 'good');
+
+  await resolveMacWidgetHistory({
+    sourceKey: 's', revision: 'r4', fetchHistory, now: 10 + retryIntervalMs, minIntervalMs: 0, retryIntervalMs
+  });
+  assert.equal(calls, 3, 'the bounded retry becomes due without discarding last-good history');
+});
+
+test('a stale source failure cannot return the active source cache', async () => {
+  let rejectSourceA;
+  let markSourceAStarted;
+  const sourceAStarted = new Promise((resolve) => { markSourceAStarted = resolve; });
+  const sourceAResult = resolveMacWidgetHistory({
+    sourceKey: 'hub-a',
+    revision: 'a1',
+    now: 0,
+    logger: () => {},
+    fetchHistory: () => {
+      markSourceAStarted();
+      return new Promise((resolve, reject) => { rejectSourceA = reject; });
+    }
+  });
+  await sourceAStarted;
+
+  const sourceBResult = await resolveMacWidgetHistory({
+    sourceKey: 'hub-b', revision: 'b1', now: 1, fetchHistory: () => history('hub-b')
+  });
+  rejectSourceA(new Error('hub-a failed after the source changed'));
+  const staleResult = await sourceAResult;
+
+  assert.equal(sourceBResult.summary.label, 'hub-b');
+  assert.deepEqual(staleResult, { daily: [], monthly: [], summary: {} });
+});
+
 test('an in-process source opts out of the freshness floor but keeps the retry floor', async () => {
   let calls = 0;
   const fetchHistory = () => { calls += 1; return history(`call-${calls}`); };

--- a/tests/electron/macWidgetHistory.test.js
+++ b/tests/electron/macWidgetHistory.test.js
@@ -19,6 +19,10 @@ test.after(() => resetMacWidgetHistoryCache());
 test('the source key ignores the revision so a moving hash cannot invalidate the cache', () => {
   const config = { mode: 'client', hubMode: 'client', historyEnabled: true, hubUrl: 'http://hub' };
   assert.equal(macWidgetHistorySourceKey(config), macWidgetHistorySourceKey({ ...config }));
+  assert.equal(
+    macWidgetHistorySourceKey(config),
+    macWidgetHistorySourceKey({ ...config, hubUrl: 'http://hub/' })
+  );
   assert.notEqual(
     macWidgetHistorySourceKey(config),
     macWidgetHistorySourceKey({ ...config, hubUrl: 'http://other' })
@@ -61,6 +65,20 @@ test('a moving revision is throttled by the time floor', async () => {
   });
   assert.equal(calls, 2);
   assert.equal(afterFloor.summary.label, 'call-2');
+});
+
+test('a backwards clock step expires the warm-cache freshness floor', async () => {
+  let calls = 0;
+  const fetchHistory = () => { calls += 1; return history(`call-${calls}`); };
+  const minIntervalMs = 60_000;
+
+  await resolveMacWidgetHistory({ sourceKey: 's', revision: 'r1', fetchHistory, now: 600_000, minIntervalMs });
+  const afterRollback = await resolveMacWidgetHistory({
+    sourceKey: 's', revision: 'r2', fetchHistory, now: 300_000, minIntervalMs
+  });
+
+  assert.equal(calls, 2);
+  assert.equal(afterRollback.summary.label, 'call-2');
 });
 
 test('a failed fetch keeps the last good history instead of blanking the heatmap', async () => {
@@ -109,6 +127,26 @@ test('a cold start failure is bounded by the retry floor instead of refetching p
     sourceKey: 's', revision: 'r99', fetchHistory, now: retryIntervalMs, minIntervalMs, retryIntervalMs
   });
   assert.equal(calls, 2, 'the retry floor expires on its own, without needing a new revision');
+});
+
+test('a backwards clock step expires the cold-failure retry floor', async () => {
+  let calls = 0;
+  const fetchHistory = () => {
+    calls += 1;
+    if (calls === 1) throw new Error('hub unreachable');
+    return history('recovered');
+  };
+  const retryIntervalMs = 30_000;
+
+  await resolveMacWidgetHistory({
+    sourceKey: 's', revision: 'r1', fetchHistory, now: 600_000, retryIntervalMs
+  });
+  const afterRollback = await resolveMacWidgetHistory({
+    sourceKey: 's', revision: 'r2', fetchHistory, now: 300_000, retryIntervalMs
+  });
+
+  assert.equal(calls, 2);
+  assert.equal(afterRollback.summary.label, 'recovered');
 });
 
 test('recovery after a cold failure needs only the retry floor, not the freshness floor', async () => {

--- a/tests/electron/macWidgetHistory.test.js
+++ b/tests/electron/macWidgetHistory.test.js
@@ -1,0 +1,205 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  DEFAULT_MIN_INTERVAL_MS,
+  macWidgetHistorySourceKey,
+  resetMacWidgetHistoryCache,
+  resolveMacWidgetHistory
+} = require('../../src/electron/macWidgetHistory');
+
+function history(label) {
+  return { daily: [{ date: '2026-08-09', totalTokens: 1, label }], monthly: [], summary: { label } };
+}
+
+test.beforeEach(() => resetMacWidgetHistoryCache());
+test.after(() => resetMacWidgetHistoryCache());
+
+test('the source key ignores the revision so a moving hash cannot invalidate the cache', () => {
+  const config = { mode: 'client', hubMode: 'client', historyEnabled: true, hubUrl: 'http://hub' };
+  assert.equal(macWidgetHistorySourceKey(config), macWidgetHistorySourceKey({ ...config }));
+  assert.notEqual(
+    macWidgetHistorySourceKey(config),
+    macWidgetHistorySourceKey({ ...config, hubUrl: 'http://other' })
+  );
+  assert.notEqual(
+    macWidgetHistorySourceKey(config),
+    macWidgetHistorySourceKey({ ...config, historyEnabled: false })
+  );
+});
+
+test('an unchanged revision is served from cache without refetching', async () => {
+  let calls = 0;
+  const fetchHistory = () => { calls += 1; return history('a'); };
+
+  const first = await resolveMacWidgetHistory({ sourceKey: 's', revision: 'r1', fetchHistory, now: 0 });
+  const second = await resolveMacWidgetHistory({ sourceKey: 's', revision: 'r1', fetchHistory, now: 1_000 });
+
+  assert.equal(calls, 1);
+  assert.deepEqual(second, first);
+});
+
+test('a moving revision is throttled by the time floor', async () => {
+  let calls = 0;
+  const fetchHistory = () => { calls += 1; return history(`call-${calls}`); };
+  const minIntervalMs = 60_000;
+
+  await resolveMacWidgetHistory({ sourceKey: 's', revision: 'r1', fetchHistory, now: 0, minIntervalMs });
+  // Every ingest from any device moves the revision; without a floor each of
+  // these would be a full history request.
+  for (let index = 0; index < 5; index += 1) {
+    const result = await resolveMacWidgetHistory({
+      sourceKey: 's', revision: `r${index + 2}`, fetchHistory, now: 1_000 * (index + 1), minIntervalMs
+    });
+    assert.equal(result.summary.label, 'call-1');
+  }
+  assert.equal(calls, 1);
+
+  const afterFloor = await resolveMacWidgetHistory({
+    sourceKey: 's', revision: 'r9', fetchHistory, now: minIntervalMs, minIntervalMs
+  });
+  assert.equal(calls, 2);
+  assert.equal(afterFloor.summary.label, 'call-2');
+});
+
+test('a failed fetch keeps the last good history instead of blanking the heatmap', async () => {
+  let calls = 0;
+  const fetchHistory = () => {
+    calls += 1;
+    if (calls === 1) return history('good');
+    throw new Error('hub unreachable');
+  };
+  const warnings = [];
+  const minIntervalMs = 10;
+
+  await resolveMacWidgetHistory({ sourceKey: 's', revision: 'r1', fetchHistory, now: 0, minIntervalMs });
+  const afterFailure = await resolveMacWidgetHistory({
+    sourceKey: 's', revision: 'r2', fetchHistory, now: 100, minIntervalMs, logger: (m) => warnings.push(m)
+  });
+
+  assert.equal(calls, 2);
+  assert.equal(afterFailure.summary.label, 'good');
+  assert.equal(afterFailure.daily.length, 1);
+  assert.match(warnings[0], /complete history unavailable/);
+});
+
+test('a cold start failure is bounded by the retry floor instead of refetching per push', async () => {
+  let calls = 0;
+  const fetchHistory = () => { calls += 1; throw new Error('hub unreachable'); };
+  const minIntervalMs = 5 * 60_000;
+  const retryIntervalMs = 30_000;
+
+  const first = await resolveMacWidgetHistory({
+    sourceKey: 's', revision: 'r1', fetchHistory, now: 0, minIntervalMs, retryIntervalMs
+  });
+  assert.deepEqual(first.daily, []);
+  assert.equal(calls, 1);
+
+  // Without the floor each of these would open another request, and the remote
+  // read carries a 15s timeout, so they would stack up behind a dead hub.
+  for (let index = 0; index < 10; index += 1) {
+    await resolveMacWidgetHistory({
+      sourceKey: 's', revision: `r${index + 2}`, fetchHistory, now: 1_000 * (index + 1), minIntervalMs, retryIntervalMs
+    });
+  }
+  assert.equal(calls, 1, 'pushes inside the retry floor must not refetch');
+
+  await resolveMacWidgetHistory({
+    sourceKey: 's', revision: 'r99', fetchHistory, now: retryIntervalMs, minIntervalMs, retryIntervalMs
+  });
+  assert.equal(calls, 2, 'the retry floor expires on its own, without needing a new revision');
+});
+
+test('recovery after a cold failure needs only the retry floor, not the freshness floor', async () => {
+  let calls = 0;
+  const fetchHistory = () => {
+    calls += 1;
+    if (calls === 1) throw new Error('hub unreachable');
+    return history('recovered');
+  };
+  const minIntervalMs = 5 * 60_000;
+  const retryIntervalMs = 30_000;
+
+  await resolveMacWidgetHistory({ sourceKey: 's', revision: 'r1', fetchHistory, now: 0, minIntervalMs, retryIntervalMs });
+  const recovered = await resolveMacWidgetHistory({
+    sourceKey: 's', revision: 'r2', fetchHistory, now: retryIntervalMs, minIntervalMs, retryIntervalMs
+  });
+
+  assert.equal(recovered.summary.label, 'recovered');
+  // And once there is something to serve, the long freshness floor takes over.
+  await resolveMacWidgetHistory({
+    sourceKey: 's', revision: 'r3', fetchHistory, now: retryIntervalMs + 1_000, minIntervalMs, retryIntervalMs
+  });
+  assert.equal(calls, 2);
+});
+
+test('an in-process source opts out of the freshness floor but keeps the retry floor', async () => {
+  let calls = 0;
+  const fetchHistory = () => { calls += 1; return history(`call-${calls}`); };
+
+  // local / embedded-host history is a synchronous aggregation, so throttling it
+  // would only make the heatmap lag.
+  await resolveMacWidgetHistory({ sourceKey: 's', revision: 'r1', fetchHistory, now: 0, minIntervalMs: 0 });
+  await resolveMacWidgetHistory({ sourceKey: 's', revision: 'r2', fetchHistory, now: 1, minIntervalMs: 0 });
+  const third = await resolveMacWidgetHistory({ sourceKey: 's', revision: 'r3', fetchHistory, now: 2, minIntervalMs: 0 });
+  assert.equal(calls, 3);
+  assert.equal(third.summary.label, 'call-3');
+
+  resetMacWidgetHistoryCache();
+  let failures = 0;
+  const failing = () => { failures += 1; throw new Error('aggregation failed'); };
+  await resolveMacWidgetHistory({ sourceKey: 's', revision: 'r1', fetchHistory: failing, now: 0, minIntervalMs: 0 });
+  await resolveMacWidgetHistory({ sourceKey: 's', revision: 'r2', fetchHistory: failing, now: 1, minIntervalMs: 0 });
+  assert.equal(failures, 1, 'a zero freshness floor must not let a failing source spin');
+});
+
+test('a changed source drops the cache rather than serving another hub history', async () => {
+  let calls = 0;
+  const fetchHistory = () => { calls += 1; return history(`call-${calls}`); };
+  const minIntervalMs = 60_000;
+
+  await resolveMacWidgetHistory({ sourceKey: 'hub-a', revision: 'r1', fetchHistory, now: 0, minIntervalMs });
+  const switched = await resolveMacWidgetHistory({
+    sourceKey: 'hub-b', revision: 'r1', fetchHistory, now: 1, minIntervalMs
+  });
+
+  assert.equal(calls, 2, 'the time floor must not survive a source change');
+  assert.equal(switched.summary.label, 'call-2');
+});
+
+test('concurrent pushes for the same revision share one request', async () => {
+  let calls = 0;
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const fetchHistory = async () => { calls += 1; await gate; return history('shared'); };
+
+  const pending = [
+    resolveMacWidgetHistory({ sourceKey: 's', revision: 'r1', fetchHistory, now: 0 }),
+    resolveMacWidgetHistory({ sourceKey: 's', revision: 'r1', fetchHistory, now: 1 }),
+    resolveMacWidgetHistory({ sourceKey: 's', revision: 'r1', fetchHistory, now: 2 })
+  ];
+  release();
+  const results = await Promise.all(pending);
+
+  assert.equal(calls, 1);
+  for (const result of results) assert.equal(result.summary.label, 'shared');
+});
+
+test('the default floor is long enough to matter on a busy hub', () => {
+  assert.ok(DEFAULT_MIN_INTERVAL_MS >= 60_000);
+});
+
+// The widget derives its throttling policy from this classifier, so a drift
+// between it and resolveCompleteHistory's branches would silently either
+// throttle a free read or hammer a remote one.
+test('the history source classifier matches what the resolver actually does', () => {
+  const { completeHistorySource } = require('../../src/electron/historySource');
+  assert.equal(completeHistorySource({ mode: 'local' }), 'local');
+  assert.equal(completeHistorySource({ mode: 'sync', hubMode: 'host', embeddedHub: {} }), 'embedded');
+  assert.equal(completeHistorySource({ mode: 'sync', hubMode: 'client', hubUrl: 'http://hub' }), 'remote');
+  assert.equal(completeHistorySource({ mode: 'sync', hubMode: 'client' }), 'empty');
+  assert.equal(completeHistorySource({ mode: 'local', historyEnabled: false }), 'empty');
+  // A host that never managed to start its embedded hub still has to fetch.
+  assert.equal(completeHistorySource({ mode: 'sync', hubMode: 'host', hubUrl: 'http://hub' }), 'remote');
+});

--- a/tests/electron/macWidgetHistory.test.js
+++ b/tests/electron/macWidgetHistory.test.js
@@ -250,6 +250,83 @@ test('a stale source success is discarded instead of reaching its caller', async
   assert.deepEqual(await sourceAResult, { daily: [], monthly: [], summary: {} });
 });
 
+test('a new generation does not join an old in-flight request for the same source', async () => {
+  let calls = 0;
+  let releaseGenerationOne;
+  let markGenerationOneStarted;
+  const generationOneStarted = new Promise((resolve) => { markGenerationOneStarted = resolve; });
+  const generationOneResult = resolveMacWidgetHistory({
+    generation: 1,
+    sourceKey: 'hub-a',
+    revision: 'a1',
+    now: 0,
+    fetchHistory: () => {
+      calls += 1;
+      markGenerationOneStarted();
+      return new Promise((resolve) => { releaseGenerationOne = resolve; });
+    }
+  });
+  await generationOneStarted;
+
+  const generationThreeResult = resolveMacWidgetHistory({
+    generation: 3,
+    sourceKey: 'hub-a',
+    revision: 'a3',
+    now: 1,
+    fetchHistory: () => {
+      calls += 1;
+      return history('hub-a-generation-3');
+    }
+  });
+  await Promise.resolve();
+  const callsBeforeRelease = calls;
+  releaseGenerationOne(history('hub-a-generation-1'));
+
+  assert.equal(callsBeforeRelease, 2, 'the generation-three request must not join generation one');
+  assert.equal((await generationThreeResult).summary.label, 'hub-a-generation-3');
+  assert.deepEqual(await generationOneResult, { daily: [], monthly: [], summary: {} });
+});
+
+test('returning to the same source in a new generation does not reuse the old generation cache', async () => {
+  let calls = 0;
+  let releaseGenerationOne;
+  let markGenerationOneStarted;
+  const generationOneStarted = new Promise((resolve) => { markGenerationOneStarted = resolve; });
+  const generationOneResult = resolveMacWidgetHistory({
+    generation: 1,
+    sourceKey: 'hub-a',
+    revision: 'a1',
+    now: 0,
+    fetchHistory: () => {
+      calls += 1;
+      markGenerationOneStarted();
+      return new Promise((resolve) => { releaseGenerationOne = resolve; });
+    }
+  });
+  await generationOneStarted;
+
+  // The serial snapshot lane is still waiting for generation one while the mode
+  // changes A -> B -> A. Generation three reaches this resolver only after the
+  // old request completes, so the semantic source key alone cannot reveal that
+  // its cache belongs to a superseded mode lifetime.
+  releaseGenerationOne(history('hub-a-generation-1'));
+  await generationOneResult;
+
+  const generationThreeResult = await resolveMacWidgetHistory({
+    generation: 3,
+    sourceKey: 'hub-a',
+    revision: 'a3',
+    now: 1,
+    fetchHistory: () => {
+      calls += 1;
+      return history('hub-a-generation-3');
+    }
+  });
+
+  assert.equal(calls, 2, 'a new generation must fetch even when it returns to the same source key');
+  assert.equal(generationThreeResult.summary.label, 'hub-a-generation-3');
+});
+
 test('an in-process source opts out of the freshness floor but keeps the retry floor', async () => {
   let calls = 0;
   const fetchHistory = () => { calls += 1; return history(`call-${calls}`); };

--- a/tests/electron/macWidgetIntegration.test.js
+++ b/tests/electron/macWidgetIntegration.test.js
@@ -63,9 +63,37 @@ test('publishes final stats to the macOS Widget from the single sendPush outlet'
   const end = mainSource.indexOf('\nfunction statsHistoryRevision', start);
   assert.ok(start >= 0 && end > start, 'sendPush function should exist');
   const sendPush = mainSource.slice(start, end);
-  assert.match(sendPush, /latestStats = payload\.data\.stats;\s+scheduleMacWidgetSnapshot\(latestStats\);/);
-  assert.equal((mainSource.match(/scheduleMacWidgetSnapshot\(latestStats\)/g) || []).length, 1);
+  assert.match(sendPush, /latestStats = payload\.data\.stats;\s+scheduleMacWidgetSnapshot\(latestStats, options\.widgetProducerOwner\);/);
+  assert.equal((mainSource.match(/scheduleMacWidgetSnapshot\(latestStats, options\.widgetProducerOwner\)/g) || []).length, 1);
   assert.match(mainSource, /compactTokenUnits: settings\?\.compactTokenUnits/);
+});
+
+test('Widget producers carry lifetime ownership through the sendPush outlet', () => {
+  for (const signature of [
+    'function startSyncCollector()',
+    'function startHostStats()',
+    'function startLocalCollector()',
+    'async function startStatsStream(options = {})',
+    'async function refreshFromTray()'
+  ]) {
+    const start = mainSource.indexOf(signature);
+    const end = mainSource.indexOf('\nfunction ', start + signature.length);
+    assert.ok(start >= 0, `${signature} should exist`);
+    const source = mainSource.slice(start, end === -1 ? mainSource.length : end);
+    assert.match(source, /const widgetProducerOwner = captureMacWidgetProducerOwner\(\);/);
+    assert.match(source, /sendPush\([\s\S]*\{ widgetProducerOwner \}\)/);
+  }
+});
+
+test('Widget source ownership advances for mode and history-policy transitions', () => {
+  assert.match(
+    mainSource,
+    /function startMode\(\) \{\s*hubModeGeneration \+= 1;\s*advanceMacWidgetSourceEpoch\(\);/
+  );
+  assert.match(
+    mainSource,
+    /const widgetHistorySourceChanged = previousRuntimeSettings\.historyEnabled !== settings\.historyEnabled;\s*if \(widgetHistorySourceChanged && !runtimeChange\.modeStructural\) \{\s*advanceMacWidgetSourceEpoch\(\);\s*scheduleMacWidgetSnapshot\(latestStats, captureMacWidgetProducerOwner\(\)\);/
+  );
 });
 
 test('keeps Widget packaging opt-in and injects artifacts only after a successful build', () => {

--- a/tests/electron/macWidgetIntegration.test.js
+++ b/tests/electron/macWidgetIntegration.test.js
@@ -85,14 +85,18 @@ test('Widget producers carry lifetime ownership through the sendPush outlet', ()
   }
 });
 
-test('Widget source ownership advances for mode and history-policy transitions', () => {
+test('Widget ownership advances producer lifetime only for mode transitions', () => {
   assert.match(
     mainSource,
-    /function startMode\(\) \{\s*hubModeGeneration \+= 1;\s*advanceMacWidgetSourceEpoch\(\);/
+    /function startMode\(\) \{\s*hubModeGeneration \+= 1;\s*advanceMacWidgetProducerAndSourceEpoch\(\);/
   );
   assert.match(
     mainSource,
     /const widgetHistorySourceChanged = previousRuntimeSettings\.historyEnabled !== settings\.historyEnabled;\s*if \(widgetHistorySourceChanged && !runtimeChange\.modeStructural\) \{\s*advanceMacWidgetSourceEpoch\(\);\s*scheduleMacWidgetSnapshot\(latestStats, captureMacWidgetProducerOwner\(\)\);/
+  );
+  assert.match(
+    mainSource,
+    /reloadSnapshot: \(work, options\) => requestMacWidgetReload\(\{\s*widgetKind: work\.widgetKind,\s*isCurrent: options\.isCurrent,/
   );
 });
 

--- a/tests/electron/macWidgetReloader.test.js
+++ b/tests/electron/macWidgetReloader.test.js
@@ -84,6 +84,41 @@ function fakeScheduler(start = 1_000_000) {
   };
 }
 
+test('drops a throttled reload when its owner expires before the timer fires', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'token-monitor-reloader-'));
+  try {
+    resetMacWidgetReloadThrottle();
+    const helper = path.join(root, 'TokenMonitorWidgetReloader');
+    fs.writeFileSync(helper, '');
+    const scheduler = fakeScheduler();
+    const calls = [];
+    let current = true;
+    const request = (widgetKind, isCurrent) => requestMacWidgetReload({
+      platform: 'darwin',
+      helperPath: helper,
+      widgetKind,
+      now: scheduler.now(),
+      scheduler,
+      isCurrent,
+      execFile: (file, args, callback) => {
+        calls.push([file, args]);
+        callback(null);
+      }
+    });
+
+    assert.equal(request('leading').ok, true);
+    assert.equal(request('stale-trailing', () => current).reason, 'throttled');
+    current = false;
+    scheduler.advance(30_000);
+
+    assert.deepEqual(calls, [[helper, ['leading']]]);
+    assert.equal(scheduler.pendingCount(), 0);
+  } finally {
+    resetMacWidgetReloadThrottle();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('coalesces throttled changes into one trailing reload using the latest kind', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'token-monitor-reloader-'));
   try {

--- a/tests/electron/macWidgetSnapshotController.test.js
+++ b/tests/electron/macWidgetSnapshotController.test.js
@@ -1,0 +1,227 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { createMacWidgetSnapshotController } = require('../../src/electron/macWidgetSnapshotController');
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, reject, resolve };
+}
+
+function history(label) {
+  return { daily: [], monthly: [], summary: { label } };
+}
+
+function nextTurn() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function createHarness(overrides = {}) {
+  const prepared = [];
+  const discarded = [];
+  const published = [];
+  const reloaded = [];
+  const captures = [];
+  const controller = createMacWidgetSnapshotController({
+    captureWork({ stats, owner }) {
+      const context = {
+        stats,
+        owner: Object.freeze({ ...owner, sourceKey: stats.source }),
+        resolverConfig: Object.freeze({ source: stats.source }),
+        presentation: Object.freeze({ currencyCode: stats.currency || 'USD' }),
+        snapshotPath: '/tmp/snapshot.json',
+        widgetKind: 'TokenMonitorWidget'
+      };
+      captures.push(context);
+      return context;
+    },
+    async resolveHistory(work) {
+      return history(work.resolverConfig.source);
+    },
+    async prepareSnapshot(work, resolvedHistory) {
+      const value = { work, history: resolvedHistory, tempPath: `/tmp/${work.sequence}.tmp` };
+      prepared.push(value);
+      return { ok: true, changed: true, prepared: value };
+    },
+    commitSnapshot(value, options) {
+      if (!options.isCurrent()) return { ok: false, reason: 'superseded' };
+      published.push({ source: value.work.stats.source, history: value.history.summary.label });
+      return { ok: true, changed: true };
+    },
+    async syncSnapshot() {},
+    async discardSnapshot(value) {
+      discarded.push(value.tempPath);
+    },
+    reloadSnapshot(work) {
+      reloaded.push(work.stats.source);
+    },
+    logger() {},
+    ...overrides
+  });
+  return { captures, controller, discarded, prepared, published, reloaded };
+}
+
+test('queued stats cannot acquire a newer source owner before the lane starts', async () => {
+  const harness = createHarness();
+  const ownerA = harness.controller.captureProducerOwner();
+
+  assert.equal(harness.controller.enqueue({ stats: { source: 'hub-a' }, producerOwner: ownerA }), true);
+  harness.controller.advanceSourceEpoch();
+  const ownerB = harness.controller.captureProducerOwner();
+  assert.equal(harness.controller.enqueue({ stats: { source: 'hub-b' }, producerOwner: ownerB }), true);
+
+  await harness.controller.whenIdle();
+
+  assert.deepEqual(harness.published, [{ source: 'hub-b', history: 'hub-b' }]);
+  assert.deepEqual(harness.reloaded, ['hub-b']);
+  assert.equal(harness.captures.length, 2);
+});
+
+test('a late producer callback is rejected instead of being relabeled with the current epoch', async () => {
+  const harness = createHarness();
+  const ownerA = harness.controller.captureProducerOwner();
+  harness.controller.advanceSourceEpoch();
+
+  assert.equal(harness.controller.enqueue({ stats: { source: 'hub-a' }, producerOwner: ownerA }), false);
+  await nextTurn();
+
+  assert.deepEqual(harness.captures, []);
+  assert.deepEqual(harness.published, []);
+});
+
+test('an on-off-on source transition isolates old same-source history completion', async () => {
+  const oldHistory = deferred();
+  let historyCalls = 0;
+  const harness = createHarness({
+    resolveHistory(work) {
+      historyCalls += 1;
+      return historyCalls === 1 ? oldHistory.promise : history(`current-${work.owner.epoch}`);
+    }
+  });
+  const ownerOne = harness.controller.captureProducerOwner();
+  harness.controller.enqueue({ stats: { source: 'enabled' }, producerOwner: ownerOne });
+  await nextTurn();
+
+  harness.controller.advanceSourceEpoch();
+  harness.controller.advanceSourceEpoch();
+  const ownerThree = harness.controller.captureProducerOwner();
+  harness.controller.enqueue({ stats: { source: 'enabled' }, producerOwner: ownerThree });
+  oldHistory.resolve(history('stale-epoch-one'));
+
+  await harness.controller.whenIdle();
+
+  assert.equal(historyCalls, 2);
+  assert.deepEqual(harness.published, [{ source: 'enabled', history: `current-${ownerThree.epoch}` }]);
+});
+
+test('latest work supersedes an active prepared snapshot and removes its temp file', async () => {
+  const firstPrepared = deferred();
+  const harness = createHarness({
+    async prepareSnapshot(work, resolvedHistory) {
+      const value = { work, history: resolvedHistory, tempPath: `/tmp/${work.sequence}.tmp` };
+      harness.prepared.push(value);
+      if (work.stats.source === 'first') await firstPrepared.promise;
+      return { ok: true, changed: true, prepared: value };
+    }
+  });
+  const owner = harness.controller.captureProducerOwner();
+  harness.controller.enqueue({ stats: { source: 'first' }, producerOwner: owner });
+  await nextTurn();
+  harness.controller.enqueue({ stats: { source: 'second' }, producerOwner: owner });
+  firstPrepared.resolve();
+
+  await harness.controller.whenIdle();
+
+  assert.deepEqual(harness.discarded, ['/tmp/1.tmp']);
+  assert.deepEqual(harness.published, [{ source: 'second', history: 'second' }]);
+});
+
+test('a transition during post-commit directory sync suppresses the stale reload', async () => {
+  const syncing = deferred();
+  const syncStarted = deferred();
+  const harness = createHarness({
+    async syncSnapshot() {
+      syncStarted.resolve();
+      await syncing.promise;
+    }
+  });
+  const owner = harness.controller.captureProducerOwner();
+  harness.controller.enqueue({ stats: { source: 'hub-a' }, producerOwner: owner });
+  await syncStarted.promise;
+
+  harness.controller.advanceSourceEpoch();
+  syncing.resolve();
+  await harness.controller.whenIdle();
+
+  assert.deepEqual(harness.published, [{ source: 'hub-a', history: 'hub-a' }]);
+  assert.deepEqual(harness.reloaded, []);
+});
+
+test('stop invalidates pending and in-flight work and rejects old producers', async () => {
+  const pendingHistory = deferred();
+  const harness = createHarness({ resolveHistory: () => pendingHistory.promise });
+  const owner = harness.controller.captureProducerOwner();
+  harness.controller.enqueue({ stats: { source: 'hub-a' }, producerOwner: owner });
+  await nextTurn();
+
+  harness.controller.stop();
+  assert.equal(harness.controller.enqueue({ stats: { source: 'hub-a' }, producerOwner: owner }), false);
+  pendingHistory.resolve(history('hub-a'));
+  await harness.controller.whenIdle();
+
+  assert.deepEqual(harness.published, []);
+  assert.deepEqual(harness.reloaded, []);
+});
+
+test('enqueue captures resolver and presentation context before live settings change', async () => {
+  const gate = deferred();
+  let liveSource = 'hub-a';
+  let liveCurrency = 'USD';
+  const published = [];
+  const controller = createMacWidgetSnapshotController({
+    captureWork({ stats, owner }) {
+      return {
+        stats,
+        owner: Object.freeze({ ...owner, sourceKey: liveSource }),
+        resolverConfig: Object.freeze({ source: liveSource }),
+        presentation: Object.freeze({ currencyCode: liveCurrency }),
+        snapshotPath: '/tmp/snapshot.json',
+        widgetKind: 'TokenMonitorWidget'
+      };
+    },
+    async resolveHistory(work) {
+      await gate.promise;
+      return history(work.resolverConfig.source);
+    },
+    async prepareSnapshot(work, resolvedHistory) {
+      return { ok: true, changed: true, prepared: { work, resolvedHistory } };
+    },
+    commitSnapshot(value, options) {
+      if (!options.isCurrent()) return { ok: false, reason: 'superseded' };
+      published.push({
+        history: value.resolvedHistory.summary.label,
+        currency: value.work.presentation.currencyCode
+      });
+      return { ok: true, changed: true };
+    },
+    async syncSnapshot() {},
+    async discardSnapshot() {},
+    reloadSnapshot() {},
+    logger() {}
+  });
+  const owner = controller.captureProducerOwner();
+  controller.enqueue({ stats: { source: 'stats-a' }, producerOwner: owner });
+  liveSource = 'hub-b';
+  liveCurrency = 'EUR';
+  gate.resolve();
+
+  await controller.whenIdle();
+
+  assert.deepEqual(published, [{ history: 'hub-a', currency: 'USD' }]);
+});

--- a/tests/electron/macWidgetSnapshotController.test.js
+++ b/tests/electron/macWidgetSnapshotController.test.js
@@ -72,7 +72,7 @@ test('queued stats cannot acquire a newer source owner before the lane starts', 
   const ownerA = harness.controller.captureProducerOwner();
 
   assert.equal(harness.controller.enqueue({ stats: { source: 'hub-a' }, producerOwner: ownerA }), true);
-  harness.controller.advanceSourceEpoch();
+  harness.controller.advanceProducerAndSourceEpoch();
   const ownerB = harness.controller.captureProducerOwner();
   assert.equal(harness.controller.enqueue({ stats: { source: 'hub-b' }, producerOwner: ownerB }), true);
 
@@ -83,10 +83,30 @@ test('queued stats cannot acquire a newer source owner before the lane starts', 
   assert.equal(harness.captures.length, 2);
 });
 
-test('a late producer callback is rejected instead of being relabeled with the current epoch', async () => {
+test('a source-only transition keeps the producer valid and captures the new source epoch', async () => {
+  const oldHistory = deferred();
+  const harness = createHarness({
+    resolveHistory(work) {
+      return work.stats.source === 'before' ? oldHistory.promise : history(work.stats.source);
+    }
+  });
+  const producer = harness.controller.captureProducerOwner();
+  assert.equal(harness.controller.enqueue({ stats: { source: 'before' }, producerOwner: producer }), true);
+  await nextTurn();
+
+  harness.controller.advanceSourceEpoch();
+  assert.equal(harness.controller.enqueue({ stats: { source: 'after' }, producerOwner: producer }), true);
+  oldHistory.resolve(history('stale-before'));
+  await harness.controller.whenIdle();
+
+  assert.deepEqual(harness.captures.map((capture) => capture.owner.epoch), [1, 2]);
+  assert.deepEqual(harness.published, [{ source: 'after', history: 'after' }]);
+});
+
+test('a late producer callback is rejected after a producer and source transition', async () => {
   const harness = createHarness();
   const ownerA = harness.controller.captureProducerOwner();
-  harness.controller.advanceSourceEpoch();
+  harness.controller.advanceProducerAndSourceEpoch();
 
   assert.equal(harness.controller.enqueue({ stats: { source: 'hub-a' }, producerOwner: ownerA }), false);
   await nextTurn();
@@ -104,20 +124,19 @@ test('an on-off-on source transition isolates old same-source history completion
       return historyCalls === 1 ? oldHistory.promise : history(`current-${work.owner.epoch}`);
     }
   });
-  const ownerOne = harness.controller.captureProducerOwner();
-  harness.controller.enqueue({ stats: { source: 'enabled' }, producerOwner: ownerOne });
+  const producer = harness.controller.captureProducerOwner();
+  harness.controller.enqueue({ stats: { source: 'enabled' }, producerOwner: producer });
   await nextTurn();
 
   harness.controller.advanceSourceEpoch();
   harness.controller.advanceSourceEpoch();
-  const ownerThree = harness.controller.captureProducerOwner();
-  harness.controller.enqueue({ stats: { source: 'enabled' }, producerOwner: ownerThree });
+  harness.controller.enqueue({ stats: { source: 'enabled' }, producerOwner: producer });
   oldHistory.resolve(history('stale-epoch-one'));
 
   await harness.controller.whenIdle();
 
   assert.equal(historyCalls, 2);
-  assert.deepEqual(harness.published, [{ source: 'enabled', history: `current-${ownerThree.epoch}` }]);
+  assert.deepEqual(harness.published, [{ source: 'enabled', history: 'current-3' }]);
 });
 
 test('latest work supersedes an active prepared snapshot and removes its temp file', async () => {

--- a/tests/electron/macWidgetSnapshotController.test.js
+++ b/tests/electron/macWidgetSnapshotController.test.js
@@ -161,6 +161,35 @@ test('latest work supersedes an active prepared snapshot and removes its temp fi
   assert.deepEqual(harness.published, [{ source: 'second', history: 'second' }]);
 });
 
+test('a committed snapshot still reloads when queued same-source work is unchanged', async () => {
+  const syncing = deferred();
+  const syncStarted = deferred();
+  let prepares = 0;
+  const harness = createHarness({
+    async prepareSnapshot(work, resolvedHistory) {
+      prepares += 1;
+      if (prepares === 2) return { ok: true, changed: false };
+      const value = { work, history: resolvedHistory, tempPath: `/tmp/${work.sequence}.tmp` };
+      harness.prepared.push(value);
+      return { ok: true, changed: true, prepared: value };
+    },
+    async syncSnapshot() {
+      syncStarted.resolve();
+      await syncing.promise;
+    }
+  });
+  const producer = harness.controller.captureProducerOwner();
+  harness.controller.enqueue({ stats: { source: 'same-source' }, producerOwner: producer });
+  await syncStarted.promise;
+
+  harness.controller.enqueue({ stats: { source: 'same-source' }, producerOwner: producer });
+  syncing.resolve();
+  await harness.controller.whenIdle();
+
+  assert.deepEqual(harness.published, [{ source: 'same-source', history: 'same-source' }]);
+  assert.deepEqual(harness.reloaded, ['same-source']);
+});
+
 test('a transition during post-commit directory sync suppresses the stale reload', async () => {
   const syncing = deferred();
   const syncStarted = deferred();

--- a/tests/electron/macWidgetSnapshotLane.test.js
+++ b/tests/electron/macWidgetSnapshotLane.test.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const mainSource = fs.readFileSync(path.join(__dirname, '../../src/electron/main.js'), 'utf8');
+
+function functionSource(name, nextName) {
+  const start = mainSource.indexOf(`function ${name}(`);
+  const end = mainSource.indexOf(`\nfunction ${nextName}(`, start);
+  assert.ok(start >= 0 && end > start, `${name} should precede ${nextName}`);
+  return mainSource.slice(start, end);
+}
+
+function history(label) {
+  return { daily: [], monthly: [], summary: { label } };
+}
+
+test('the history source key and fetch use one immutable resolver config', async () => {
+  let releaseFetch;
+  const fetchGate = new Promise((resolve) => { releaseFetch = resolve; });
+  let currentConfig = { source: 'hub-a' };
+  const context = vm.createContext({
+    completeHistorySource: () => 'remote',
+    historyResolverOptions: () => currentConfig,
+    hubModeGeneration: 1,
+    macWidgetHistorySourceKey: (config) => config.source,
+    resolveCompleteHistory: async (config) => config.source,
+    resolveMacWidgetHistory: async (options) => {
+      await fetchGate;
+      return options.fetchHistory();
+    }
+  });
+  vm.runInContext([
+    functionSource('getCompleteHistory', 'getMacWidgetHistory'),
+    functionSource('getMacWidgetHistory', 'scheduleMacWidgetSnapshot')
+  ].join('\n'), context);
+
+  const pending = vm.runInContext("getMacWidgetHistory({ historyRevision: 'r1' })", context);
+  currentConfig = { source: 'hub-b' };
+  releaseFetch();
+  const result = await pending;
+
+  assert.equal(result?.history ?? result, 'hub-a');
+  assert.equal(result.sourceToken.sourceKey, 'hub-a');
+});
+
+test('a superseded history result never publishes before the queued source', async () => {
+  let releaseHubA;
+  let markHubAStarted;
+  let markHubBPublished;
+  const hubAStarted = new Promise((resolve) => { markHubAStarted = resolve; });
+  const hubBPublished = new Promise((resolve) => { markHubBPublished = resolve; });
+  const published = [];
+  const context = vm.createContext({
+    compactNumbers: true,
+    console: { warn() {} },
+    effectiveRates: {},
+    getMacWidgetHistory: async (stats) => {
+      const sourceToken = { generation: context.hubModeGeneration };
+      if (stats.source === 'hub-a') {
+        markHubAStarted();
+        await new Promise((resolve) => { releaseHubA = resolve; });
+      }
+      return { history: history(stats.source), sourceToken };
+    },
+    macWidgetConfiguration: () => ({ snapshotPath: '/tmp/snapshot', widgetKind: 'TokenMonitorWidget' }),
+    macWidgetHistorySourceIsCurrent: (token) => token.generation === context.hubModeGeneration,
+    normalizeCurrency: (value) => value,
+    process: { platform: 'darwin' },
+    requestMacWidgetReload() {},
+    setImmediate,
+    settings: { currency: 'USD' },
+    updateMacWidgetSnapshot: async (_stats, options) => {
+      const value = options.snapshotOptions.history;
+      const label = value.summary?.label || value.history?.summary?.label;
+      published.push(label);
+      if (label === 'hub-b') markHubBPublished();
+      return { ok: true, changed: true };
+    }
+  });
+  vm.runInContext(`
+    let pendingMacWidgetStats = null;
+    let macWidgetWriteInFlight = false;
+    let hubModeGeneration = 1;
+    ${functionSource('scheduleMacWidgetSnapshot', 'sendPush')}
+  `, context);
+
+  vm.runInContext("scheduleMacWidgetSnapshot({ source: 'hub-a' })", context);
+  await hubAStarted;
+  vm.runInContext(`
+    hubModeGeneration = 2;
+    scheduleMacWidgetSnapshot({ source: 'hub-b' });
+  `, context);
+  context.hubModeGeneration = 2;
+  releaseHubA();
+  await hubBPublished;
+
+  assert.deepEqual(published, ['hub-b']);
+});

--- a/tests/electron/macWidgetSnapshotLane.test.js
+++ b/tests/electron/macWidgetSnapshotLane.test.js
@@ -91,7 +91,7 @@ test('a superseded history result cannot publish before queued current work', as
   const ownerA = controller.captureProducerOwner();
   controller.enqueue({ stats: { source: 'hub-a' }, producerOwner: ownerA });
   await new Promise((resolve) => setImmediate(resolve));
-  controller.advanceSourceEpoch();
+  controller.advanceProducerAndSourceEpoch();
   const ownerB = controller.captureProducerOwner();
   controller.enqueue({ stats: { source: 'hub-b' }, producerOwner: ownerB });
   oldHistory.resolve(history('hub-a'));

--- a/tests/electron/macWidgetSnapshotLane.test.js
+++ b/tests/electron/macWidgetSnapshotLane.test.js
@@ -19,8 +19,9 @@ function history(label) {
   return { daily: [], monthly: [], summary: { label } };
 }
 
-test('the history source key and fetch use one immutable resolver config', async () => {
+test('the history owner and fetch use one immutable resolver config', async () => {
   let releaseFetch;
+  let resolverGeneration;
   const fetchGate = new Promise((resolve) => { releaseFetch = resolve; });
   let currentConfig = { source: 'hub-a' };
   const context = vm.createContext({
@@ -30,6 +31,7 @@ test('the history source key and fetch use one immutable resolver config', async
     macWidgetHistorySourceKey: (config) => config.source,
     resolveCompleteHistory: async (config) => config.source,
     resolveMacWidgetHistory: async (options) => {
+      resolverGeneration = options.generation;
       await fetchGate;
       return options.fetchHistory();
     }
@@ -46,6 +48,7 @@ test('the history source key and fetch use one immutable resolver config', async
 
   assert.equal(result?.history ?? result, 'hub-a');
   assert.equal(result.sourceToken.sourceKey, 'hub-a');
+  assert.equal(resolverGeneration, 1);
 });
 
 test('a superseded history result never publishes before the queued source', async () => {

--- a/tests/electron/macWidgetSnapshotLane.test.js
+++ b/tests/electron/macWidgetSnapshotLane.test.js
@@ -1,106 +1,102 @@
 'use strict';
 
 const assert = require('node:assert/strict');
-const fs = require('node:fs');
-const path = require('node:path');
 const test = require('node:test');
-const vm = require('node:vm');
+const { createMacWidgetSnapshotController } = require('../../src/electron/macWidgetSnapshotController');
 
-const mainSource = fs.readFileSync(path.join(__dirname, '../../src/electron/main.js'), 'utf8');
-
-function functionSource(name, nextName) {
-  const start = mainSource.indexOf(`function ${name}(`);
-  const end = mainSource.indexOf(`\nfunction ${nextName}(`, start);
-  assert.ok(start >= 0 && end > start, `${name} should precede ${nextName}`);
-  return mainSource.slice(start, end);
+function deferred() {
+  let resolve;
+  const promise = new Promise((res) => { resolve = res; });
+  return { promise, resolve };
 }
 
 function history(label) {
   return { daily: [], monthly: [], summary: { label } };
 }
 
-test('the history owner and fetch use one immutable resolver config', async () => {
-  let releaseFetch;
-  let resolverGeneration;
-  const fetchGate = new Promise((resolve) => { releaseFetch = resolve; });
-  let currentConfig = { source: 'hub-a' };
-  const context = vm.createContext({
-    completeHistorySource: () => 'remote',
-    historyResolverOptions: () => currentConfig,
-    hubModeGeneration: 1,
-    macWidgetHistorySourceKey: (config) => config.source,
-    resolveCompleteHistory: async (config) => config.source,
-    resolveMacWidgetHistory: async (options) => {
-      resolverGeneration = options.generation;
-      await fetchGate;
-      return options.fetchHistory();
-    }
+test('the controller resolves and publishes from one immutable captured config', async () => {
+  const gate = deferred();
+  let liveSource = 'hub-a';
+  const published = [];
+  const controller = createMacWidgetSnapshotController({
+    captureWork({ stats, owner }) {
+      const resolverConfig = Object.freeze({ source: liveSource });
+      return {
+        stats,
+        owner: Object.freeze({ ...owner, sourceKey: resolverConfig.source }),
+        resolverConfig,
+        presentation: Object.freeze({ currencyCode: 'USD' }),
+        snapshotPath: '/tmp/snapshot.json',
+        widgetKind: 'TokenMonitorWidget'
+      };
+    },
+    async resolveHistory(work) {
+      await gate.promise;
+      return history(work.resolverConfig.source);
+    },
+    async prepareSnapshot(work, resolvedHistory) {
+      return { ok: true, changed: true, prepared: { work, resolvedHistory } };
+    },
+    commitSnapshot(value, options) {
+      if (!options.isCurrent()) return { ok: false, reason: 'superseded' };
+      published.push({ stats: value.work.stats.source, history: value.resolvedHistory.summary.label });
+      return { ok: true, changed: true };
+    },
+    async syncSnapshot() {},
+    async discardSnapshot() {},
+    reloadSnapshot() {},
+    logger() {}
   });
-  vm.runInContext([
-    functionSource('getCompleteHistory', 'getMacWidgetHistory'),
-    functionSource('getMacWidgetHistory', 'scheduleMacWidgetSnapshot')
-  ].join('\n'), context);
+  const producerOwner = controller.captureProducerOwner();
+  controller.enqueue({ stats: { source: 'stats-a' }, producerOwner });
+  liveSource = 'hub-b';
+  gate.resolve();
 
-  const pending = vm.runInContext("getMacWidgetHistory({ historyRevision: 'r1' })", context);
-  currentConfig = { source: 'hub-b' };
-  releaseFetch();
-  const result = await pending;
+  await controller.whenIdle();
 
-  assert.equal(result?.history ?? result, 'hub-a');
-  assert.equal(result.sourceToken.sourceKey, 'hub-a');
-  assert.equal(resolverGeneration, 1);
+  assert.deepEqual(published, [{ stats: 'stats-a', history: 'hub-a' }]);
 });
 
-test('a superseded history result never publishes before the queued source', async () => {
-  let releaseHubA;
-  let markHubAStarted;
-  let markHubBPublished;
-  const hubAStarted = new Promise((resolve) => { markHubAStarted = resolve; });
-  const hubBPublished = new Promise((resolve) => { markHubBPublished = resolve; });
+test('a superseded history result cannot publish before queued current work', async () => {
+  const oldHistory = deferred();
   const published = [];
-  const context = vm.createContext({
-    compactNumbers: true,
-    console: { warn() {} },
-    effectiveRates: {},
-    getMacWidgetHistory: async (stats) => {
-      const sourceToken = { generation: context.hubModeGeneration };
-      if (stats.source === 'hub-a') {
-        markHubAStarted();
-        await new Promise((resolve) => { releaseHubA = resolve; });
-      }
-      return { history: history(stats.source), sourceToken };
+  const controller = createMacWidgetSnapshotController({
+    captureWork({ stats, owner }) {
+      return {
+        stats,
+        owner: Object.freeze({ ...owner, sourceKey: stats.source }),
+        resolverConfig: Object.freeze({ source: stats.source }),
+        presentation: Object.freeze({}),
+        snapshotPath: '/tmp/snapshot.json',
+        widgetKind: 'TokenMonitorWidget'
+      };
     },
-    macWidgetConfiguration: () => ({ snapshotPath: '/tmp/snapshot', widgetKind: 'TokenMonitorWidget' }),
-    macWidgetHistorySourceIsCurrent: (token) => token.generation === context.hubModeGeneration,
-    normalizeCurrency: (value) => value,
-    process: { platform: 'darwin' },
-    requestMacWidgetReload() {},
-    setImmediate,
-    settings: { currency: 'USD' },
-    updateMacWidgetSnapshot: async (_stats, options) => {
-      const value = options.snapshotOptions.history;
-      const label = value.summary?.label || value.history?.summary?.label;
-      published.push(label);
-      if (label === 'hub-b') markHubBPublished();
+    resolveHistory(work) {
+      return work.stats.source === 'hub-a' ? oldHistory.promise : history('hub-b');
+    },
+    async prepareSnapshot(work, resolvedHistory) {
+      return { ok: true, changed: true, prepared: { work, resolvedHistory } };
+    },
+    commitSnapshot(value, options) {
+      if (!options.isCurrent()) return { ok: false, reason: 'superseded' };
+      published.push(value.resolvedHistory.summary.label);
       return { ok: true, changed: true };
-    }
+    },
+    async syncSnapshot() {},
+    async discardSnapshot() {},
+    reloadSnapshot() {},
+    logger() {}
   });
-  vm.runInContext(`
-    let pendingMacWidgetStats = null;
-    let macWidgetWriteInFlight = false;
-    let hubModeGeneration = 1;
-    ${functionSource('scheduleMacWidgetSnapshot', 'sendPush')}
-  `, context);
 
-  vm.runInContext("scheduleMacWidgetSnapshot({ source: 'hub-a' })", context);
-  await hubAStarted;
-  vm.runInContext(`
-    hubModeGeneration = 2;
-    scheduleMacWidgetSnapshot({ source: 'hub-b' });
-  `, context);
-  context.hubModeGeneration = 2;
-  releaseHubA();
-  await hubBPublished;
+  const ownerA = controller.captureProducerOwner();
+  controller.enqueue({ stats: { source: 'hub-a' }, producerOwner: ownerA });
+  await new Promise((resolve) => setImmediate(resolve));
+  controller.advanceSourceEpoch();
+  const ownerB = controller.captureProducerOwner();
+  controller.enqueue({ stats: { source: 'hub-b' }, producerOwner: ownerB });
+  oldHistory.resolve(history('hub-a'));
+
+  await controller.whenIdle();
 
   assert.deepEqual(published, ['hub-b']);
 });

--- a/tests/shared/macWidgetSnapshot.test.js
+++ b/tests/shared/macWidgetSnapshot.test.js
@@ -114,7 +114,7 @@ test('builds schema v6 overview, quota, models, activity, trend and presentation
   assert.equal(snapshot.trend.currentTokens, 1_200_000);
   assert.equal(snapshot.trend.peakTokens, 1_200_000);
   assert.deepEqual(snapshot.presentation, {
-    defaultPeriod: 'today', currencyCode: 'CNY', currencySymbol: '¥', currencyRate: 7.1,
+    currencyCode: 'CNY', currencySymbol: '¥', currencyRate: 7.1,
     numberStyle: 'compact', compactTokenUnits: 'localized', showCost: true, locale: 'zh-CN', theme: 'custom'
   });
   assert.equal(snapshot.status.noData, false);
@@ -255,14 +255,20 @@ test('preserves a zero balance and omits missing, non-finite, or unsupported bal
   }
 });
 
-test('chooses the configured period without duplicating aggregation logic', () => {
+test('pins the legacy top-level mirror to day and keeps every period addressable', () => {
+  // The app's own Today/Month/AllTime tab must not reach the snapshot: each
+  // widget picks its period through the AppIntent, so anything that tracked the
+  // app's tab would rewrite the file and spend a reload budget on a change no
+  // widget renders.
   const snapshot = buildSnapshot(sampleStats(), {
     now: NOW,
-    presentation: { defaultPeriod: 'month' }
+    presentation: { defaultPeriod: 'month', currencyCode: 'USD' }
   });
-  assert.equal(snapshot.overview.currentPeriod, 'month');
-  assert.equal(snapshot.overview.totalTokens, 9_000_000);
+  assert.equal(snapshot.overview.currentPeriod, 'today');
+  assert.equal(snapshot.overview.totalTokens, 1_200_000);
+  assert.equal(snapshot.presentation.defaultPeriod, undefined);
   assert.equal(snapshot.periods.day.overview.totalTokens, 1_200_000);
+  assert.equal(snapshot.periods.month.overview.totalTokens, 9_000_000);
   assert.equal(snapshot.periods.total.overview.totalTokens, 20_000_000);
 });
 
@@ -603,9 +609,18 @@ test('fingerprints business content while ignoring snapshot clock fields', () =>
 
   const presentationChange = buildSnapshot(stats, {
     now: NOW,
-    presentation: { defaultPeriod: 'month' }
+    presentation: { currencyCode: 'CNY', currencyRate: 7.1 }
   });
   assert.notEqual(macWidgetSnapshotFingerprint(first), macWidgetSnapshotFingerprint(presentationChange));
+
+  // The app's period tab is the one presentation input the widget cannot
+  // render, so it must not reach the fingerprint: every switch would otherwise
+  // rewrite the snapshot and spend a WidgetKit reload on nothing.
+  const periodTabChange = buildSnapshot(stats, {
+    now: NOW,
+    presentation: { defaultPeriod: 'month' }
+  });
+  assert.equal(macWidgetSnapshotFingerprint(first), macWidgetSnapshotFingerprint(periodTabChange));
 });
 
 // The snapshot re-declares the supported UI locales as a literal instead of


### PR DESCRIPTION
Follow-up to #194, aimed at the point where `TOKEN_MONITOR_WIDGET_ENABLED` flips to `1` and the extension reaches real machines. The release workflow still pins the flag to `0`, so no published build changes.

## Behaviour changes

**The complete history resolves behind a time floor.** Its cache key included `historyRevision`, a content hash of the whole history that moves on essentially every ingest from any device, so a remote client became a full `GET /api/history` per stats push where the payload had previously been fetched only when the dashboard opened. The revision is now a freshness signal the floor gates, with the source identity tracked separately so switching hubs still drops the cache immediately.

**Only the remote path pays that floor.** `resolveCompleteHistory` has four branches and just one is a network round trip, so the branch selection is now named by `completeHistorySource()` and the widget derives its throttling policy from it. Local and embedded-host history is an in-process aggregation, and throttling it would buy nothing while letting the Activity heatmap lag, so those pass `minIntervalMs: 0`. A guard test pins the classifier to the resolver so the cost model cannot drift from the branches it describes.

**A failed request no longer blanks the widget, and no longer spins.** The old `.catch` returned empty arrays straight into the snapshot and only cached on success for the current revision, so one unreachable hub emptied the Activity heatmap and the Trend page until some later revision happened to succeed; the last good copy is retained instead. That covers a warm cache, but a cold start whose first read failed has nothing to serve, and leaving that state unbounded let every push open another request against a hub that is down, each carrying a 15s timeout. It gets its own short bounded retry floor, kept independent of the freshness floor so a source that opts out of throttling still cannot spin on a failure. An in-flight request is joined ahead of both floors, since it is the answer rather than a stale stand-in for one.

**`presentation.defaultPeriod` is removed.** The extension decoded it and never read it, yet it tracked the app's own Today/Month/AllTime tab and fed the snapshot fingerprint, so switching tabs rewrote the file and spent a `WidgetCenter.reloadTimelines()` on a change no widget could render. Reload budgets are finite. Each widget picks its period through the AppIntent; the legacy top-level mirror is pinned to `day`, which is what every reader from schema version 2 on already took from `periods.day`.

**The gallery no longer previews an empty skeleton.** `snapshot(for:in:)` ignored `context.isPreview` and took the same real-I/O path as a placed widget, so a cold start drew the redacted placeholder. That reads as a broken widget rather than a loading one, at exactly the moment someone is deciding whether to add it. A preview now falls back to the sample snapshot; a placed widget still keeps `nil` rather than inventing numbers.

## Structure

The history cache moved into `src/electron/macWidgetHistory.js` so it can be unit tested at all, since `main.js` cannot be loaded outside Electron. `WidgetSnapshot.placeholder` moved to the model file because the test target compiles the model but not the timeline provider. The new Node test is added to the `mac-widget` job's hand-written test list, which is not a glob.

## Verification

`npm run verify`: 2677 passed, 1 skipped, lint clean. XCTest: 77 passed (74 existing plus 3 new). `npm run sync:worker`: no drift.

Also validated end to end on real hardware: built with `dist:mac:widget` under a real Developer ID certificate and confirmed the widget renders live data in all three families, with a Team-ID-prefixed App Group and `provisioningProfile=none`.

## Still blocking `TOKEN_MONITOR_WIDGET_ENABLED=1`

Neither is a defect in this diff, which strictly reduces cost against `main`. Both are tracked and want their own PR before the flag can flip.

**A runtime gate on actual widget demand.** `macWidgetConfiguration()` only proves the extension was packaged, not that any widget instance exists, so `scheduleMacWidgetSnapshot()` still reaches the pipeline on every push. This PR lowers that cost from per-push to at most a five-minute history read, but a user who never adds a widget should pay nothing. The `getCurrentConfigurations()` approach needs design work first: the query is itself a subprocess spawn, and any cache long enough to pay for itself leaves a newly added widget without a snapshot for that long, so it needs an activation path rather than only a gate.

**A stale LaunchServices registration from a pre-widget install.** When a release build and a widget-enabled build share the bundle id, `chronod` resolves the wrong host app and never delivers a timeline: widgets add successfully and stay permanently grey, while `pluginkit` still reports the correct `.appex` path. Every layer passes in isolation while the assembled system fails. Anyone upgrading from a pre-widget release can land in this state and cannot diagnose it from the UI.

Refs #169

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce widget network load and churn by throttling remote history reads and caching the last good copy. Linearize snapshot publishing with producer/source ownership so stale data can’t write or reload, keep producers valid across history-only changes, and preserve reloads for committed snapshots.

- **Bug Fixes**
  - Keep last good history on failures; add a short retry floor for cold failures, join in-flight requests, recover after clock rollbacks, and normalize trailing slashes in hub URLs.
  - Bound warm failures too, even when freshness is immediate, so in-process sources don’t spin.
  - Prevent stale history from publishing across hub/mode switches by isolating the cache by mode generation + source key and carrying ownership through a serial snapshot lane; recheck before serialization and in a non-yielding commit; preserve reloads for committed snapshots and drop throttled reloads when ownership expires; advance the producer epoch on mode changes and only the source epoch on history-policy changes; carry producer ownership through the single `sendPush` outlet.
  - Use sample data for the gallery preview only; placed widgets keep nil. Remove `presentation.defaultPeriod` and pin the top-level overview to day to avoid no-op reloads.

- **Refactors**
  - Derive throttling policy from `completeHistorySource()` so only the remote path pays the time floor; local/embedded paths skip it, with a guard test to keep the classifier in sync with the resolver.
  - Extract history caching to `src/electron/macWidgetHistory.js` and add a serial snapshot controller in `src/electron/macWidgetSnapshotController.js`; split snapshot writes into prepare/commit/sync with final `isCurrent` checks around an atomic rename, plus targeted tests.

<sup>Written for commit 01023688dfe5d6aad53512b523efa2e7c40774d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

