### PR TITLE
feat(star-history): publish charts from a pinned action

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,109 @@
+name: Star History
+
+on:
+  schedule:
+    # 03:17 in Hong Kong; a non-zero minute avoids GitHub's top-of-hour peak.
+    - cron: '17 19 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Generate and retain the validated artifact without publishing it
+        required: false
+        default: false
+        type: boolean
+
+permissions: {}
+
+concurrency:
+  group: star-history
+  cancel-in-progress: false
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Generate with the external read-only action
+        id: generate
+        uses: Javis603/star-history-action@7eedfe3bfa6f651dc0796cb06ff4271e8a4e789e
+        with:
+          repository: ${{ github.repository }}
+          token: ${{ github.token }}
+
+      - name: Upload generated assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: star-history-output
+          path: ${{ steps.generate.outputs.output-directory }}
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    if: github.event_name != 'workflow_dispatch' || inputs.dry_run != true
+    needs: generate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout trusted publisher
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download generated assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: star-history-output
+          path: ${{ runner.temp }}/star-history-output
+
+      - name: Validate generated assets
+        env:
+          GENERATED_DIRECTORY: ${{ runner.temp }}/star-history-output
+        run: >-
+          node scripts/validate-star-history-artifact.js
+          --directory "$GENERATED_DIRECTORY"
+          --repository "$GITHUB_REPOSITORY"
+          --renderer-commit bcddc9d532b10bac7e0187a741288bf9cab17616
+
+      - name: Publish generated assets to the orphan branch
+        env:
+          GENERATED_DIRECTORY: ${{ runner.temp }}/star-history-output
+          GITHUB_TOKEN: ${{ github.token }}
+          GIT_TERMINAL_PROMPT: '0'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          publish_dir="$(mktemp -d "$RUNNER_TEMP/star-history-publish.XXXXXX")"
+          git -C "$publish_dir" init --quiet
+          git -C "$publish_dir" config user.name 'github-actions[bot]'
+          git -C "$publish_dir" config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git -C "$publish_dir" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+
+          if git -C "$publish_dir" ls-remote --exit-code --heads origin star-history >/dev/null 2>&1; then
+            git -C "$publish_dir" fetch --depth=1 origin star-history
+            git -C "$publish_dir" checkout --quiet -B star-history FETCH_HEAD
+          else
+            git -C "$publish_dir" checkout --quiet --orphan star-history
+          fi
+
+          git -C "$publish_dir" clean -fdx
+          git -C "$publish_dir" rm -rf --ignore-unmatch .
+          install -m 0644 "$GENERATED_DIRECTORY/star-history.svg" "$publish_dir/star-history.svg"
+          install -m 0644 "$GENERATED_DIRECTORY/star-history-dark.svg" "$publish_dir/star-history-dark.svg"
+          install -m 0644 "$GENERATED_DIRECTORY/stars.json" "$publish_dir/stars.json"
+
+          git -C "$publish_dir" add star-history.svg star-history-dark.svg stars.json
+          if git -C "$publish_dir" diff --cached --quiet; then
+            echo 'Star History output is unchanged; no commit needed.'
+            exit 0
+          fi
+
+          git -C "$publish_dir" commit --quiet -m 'chore: update star history'
+          git -C "$publish_dir" \
+            -c credential.helper= \
+            -c 'credential.helper=!f() { echo username=x-access-token; echo "password=$GITHUB_TOKEN"; }; f' \
+            push origin HEAD:star-history

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -23,15 +23,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      artifact-id: ${{ steps.upload.outputs.artifact-id }}
     steps:
       - name: Generate with the external read-only action
         id: generate
-        uses: Javis603/star-history-action@6fa3ad0be57ee0010a5e48381d592a3437570ee6
+        uses: Javis603/star-history-action@bb3381bfc636969b3e635b2563ee2bcffe9f9044
         with:
           repository: ${{ github.repository }}
           token: ${{ github.token }}
 
       - name: Upload generated assets
+        id: upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: star-history-output
@@ -39,14 +42,17 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  publish:
-    if: github.event_name != 'workflow_dispatch' || inputs.dry_run != true
+  validate:
     needs: generate
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+    outputs:
+      light-sha256: ${{ steps.validate.outputs.light-sha256 }}
+      dark-sha256: ${{ steps.validate.outputs.dark-sha256 }}
+      snapshot-sha256: ${{ steps.validate.outputs.snapshot-sha256 }}
     steps:
-      - name: Checkout trusted publisher
+      - name: Checkout trusted validator
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.sha }}
@@ -56,17 +62,70 @@ jobs:
       - name: Download generated assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: star-history-output
+          artifact-ids: ${{ needs.generate.outputs.artifact-id }}
           path: ${{ runner.temp }}/star-history-output
+          merge-multiple: true
+          digest-mismatch: error
+
+      - name: Install the XML validator
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends libxml2-utils
 
       - name: Validate generated assets
+        id: validate
         env:
           GENERATED_DIRECTORY: ${{ runner.temp }}/star-history-output
-        run: >-
-          node scripts/validate-star-history-artifact.js
-          --directory "$GENERATED_DIRECTORY"
-          --repository "$GITHUB_REPOSITORY"
-          --renderer-commit bcddc9d532b10bac7e0187a741288bf9cab17616
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          node scripts/validate-star-history-artifact.js \
+            --directory "$GENERATED_DIRECTORY" \
+            --repository "$GITHUB_REPOSITORY" \
+            --renderer-commit bcddc9d532b10bac7e0187a741288bf9cab17616
+
+          light_digest="$(sha256sum "$GENERATED_DIRECTORY/star-history.svg")"
+          dark_digest="$(sha256sum "$GENERATED_DIRECTORY/star-history-dark.svg")"
+          snapshot_digest="$(sha256sum "$GENERATED_DIRECTORY/stars.json")"
+          echo "light-sha256=${light_digest%% *}" >> "$GITHUB_OUTPUT"
+          echo "dark-sha256=${dark_digest%% *}" >> "$GITHUB_OUTPUT"
+          echo "snapshot-sha256=${snapshot_digest%% *}" >> "$GITHUB_OUTPUT"
+
+  publish:
+    if: github.event_name != 'workflow_dispatch' || inputs.dry_run != true
+    needs: [generate, validate]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download validated assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.generate.outputs.artifact-id }}
+          path: ${{ runner.temp }}/star-history-output
+          merge-multiple: true
+          digest-mismatch: error
+
+      - name: Verify validated asset hashes
+        env:
+          GENERATED_DIRECTORY: ${{ runner.temp }}/star-history-output
+          LIGHT_SHA256: ${{ needs.validate.outputs.light-sha256 }}
+          DARK_SHA256: ${{ needs.validate.outputs.dark-sha256 }}
+          SNAPSHOT_SHA256: ${{ needs.validate.outputs.snapshot-sha256 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          [[ "$LIGHT_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$DARK_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$SNAPSHOT_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          cd "$GENERATED_DIRECTORY"
+          printf '%s  %s\n' \
+            "$LIGHT_SHA256" star-history.svg \
+            "$DARK_SHA256" star-history-dark.svg \
+            "$SNAPSHOT_SHA256" stars.json \
+            | sha256sum --check --strict
 
       - name: Publish generated assets to the orphan branch
         env:

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Generate with the external read-only action
         id: generate
-        uses: Javis603/star-history-action@7eedfe3bfa6f651dc0796cb06ff4271e8a4e789e
+        uses: Javis603/star-history-action@6fa3ad0be57ee0010a5e48381d592a3437570ee6
         with:
           repository: ${{ github.repository }}
           token: ${{ github.token }}

--- a/README.ja.md
+++ b/README.ja.md
@@ -267,11 +267,11 @@ Token Monitor は使用ログをローカルで処理し、プロジェクトの
 
 ## Star 履歴
 
-<a href="https://www.star-history.com/?repos=Javis603%2Ftoken-monitor&type=date&legend=top-left">
+<a href="https://github.com/Javis603/token-monitor/tree/star-history">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Javis603/token-monitor&type=date&theme=dark&legend=top-left&sealed_token=VEcaPQSNlH8coYjuILJy7eT6t-pGJrGDEjOAjVwP8WGwNBOeNXoLTcz-KVBaZ2Y8eSqG1tLEpWGF3-5eMvVhW5G8n1ckdYI_uMZ6UCBE7b_eANd6we__7g7yc4ShXemuWfi-8SRcxgJNLK12VZGgBIccY1ceI3T3xm7jBM1TJjTVQFWJ0MmX2e-7QBp9" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Javis603/token-monitor&type=date&legend=top-left&sealed_token=VEcaPQSNlH8coYjuILJy7eT6t-pGJrGDEjOAjVwP8WGwNBOeNXoLTcz-KVBaZ2Y8eSqG1tLEpWGF3-5eMvVhW5G8n1ckdYI_uMZ6UCBE7b_eANd6we__7g7yc4ShXemuWfi-8SRcxgJNLK12VZGgBIccY1ceI3T3xm7jBM1TJjTVQFWJ0MmX2e-7QBp9" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Javis603/token-monitor&type=date&legend=top-left&sealed_token=VEcaPQSNlH8coYjuILJy7eT6t-pGJrGDEjOAjVwP8WGwNBOeNXoLTcz-KVBaZ2Y8eSqG1tLEpWGF3-5eMvVhW5G8n1ckdYI_uMZ6UCBE7b_eANd6we__7g7yc4ShXemuWfi-8SRcxgJNLK12VZGgBIccY1ceI3T3xm7jBM1TJjTVQFWJ0MmX2e-7QBp9" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Javis603/token-monitor/star-history/star-history-dark.svg" />
+   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Javis603/token-monitor/star-history/star-history.svg" />
+   <img alt="Star History Chart" src="https://raw.githubusercontent.com/Javis603/token-monitor/star-history/star-history.svg" />
  </picture>
 </a>
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -267,11 +267,11 @@ Token Monitor는 사용 로그를 로컬에서 처리하며 프로젝트 관리�
 
 ## Star 기록
 
-<a href="https://www.star-history.com/?repos=Javis603%2Ftoken-monitor&type=date&legend=top-left">
+<a href="https://github.com/Javis603/token-monitor/tree/star-history">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Javis603/token-monitor&type=date&theme=dark&legend=top-left&sealed_token=VEcaPQSNlH8coYjuILJy7eT6t-pGJrGDEjOAjVwP8WGwNBOeNXoLTcz-KVBaZ2Y8eSqG1tLEpWGF3-5eMvVhW5G8n1ckdYI_uMZ6UCBE7b_eANd6we__7g7yc4ShXemuWfi-8SRcxgJNLK12VZGgBIccY1ceI3T3xm7jBM1TJjTVQFWJ0MmX2e-7QBp9" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Javis603/token-monitor&type=date&legend=top-left&sealed_token=VEcaPQSNlH8coYjuILJy7eT6t-pGJrGDEjOAjVwP8WGwNBOeNXoLTcz-KVBaZ2Y8eSqG1tLEpWGF3-5eMvVhW5G8n1ckdYI_uMZ6UCBE7b_eANd6we__7g7yc4ShXemuWfi-8SRcxgJNLK12VZGgBIccY1ceI3T3xm7jBM1TJjTVQFWJ0MmX2e-7QBp9" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Javis603/token-monitor&type=date&legend=top-left&sealed_token=VEcaPQSNlH8coYjuILJy7eT6t-pGJrGDEjOAjVwP8WGwNBOeNXoLTcz-KVBaZ2Y8eSqG1tLEpWGF3-5eMvVhW5G8n1ckdYI_uMZ6UCBE7b_eANd6we__7g7yc4ShXemuWfi-8SRcxgJNLK12VZGgBIccY1ceI3T3xm7jBM1TJjTVQFWJ0MmX2e-7QBp9" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Javis603/token-monitor/star-history/star-history-dark.svg" />
+   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Javis603/token-monitor/star-history/star-history.svg" />
+   <img alt="Star History Chart" src="https://raw.githubusercontent.com/Javis603/token-monitor/star-history/star-history.svg" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -267,11 +267,11 @@ Token Monitor processes usage logs locally and sends no analytics or telemetry t
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=Javis603%2Ftoken-monitor&type=date&legend=top-left">
+<a href="https://github.com/Javis603/token-monitor/tree/star-history">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Javis603/token-monitor&type=date&theme=dark&legend=top-left&sealed_token=VEcaPQSNlH8coYjuILJy7eT6t-pGJrGDEjOAjVwP8WGwNBOeNXoLTcz-KVBaZ2Y8eSqG1tLEpWGF3-5eMvVhW5G8n1ckdYI_uMZ6UCBE7b_eANd6we__7g7yc4ShXemuWfi-8SRcxgJNLK12VZGgBIccY1ceI3T3xm7jBM1TJjTVQFWJ0MmX2e-7QBp9" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Javis603/token-monitor&type=date&legend=top-left&sealed_token=VEcaPQSNlH8coYjuILJy7eT6t-pGJrGDEjOAjVwP8WGwNBOeNXoLTcz-KVBaZ2Y8eSqG1tLEpWGF3-5eMvVhW5G8n1ckdYI_uMZ6UCBE7b_eANd6we__7g7yc4ShXemuWfi-8SRcxgJNLK12VZGgBIccY1ceI3T3xm7jBM1TJjTVQFWJ0MmX2e-7QBp9" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Javis603/token-monitor&type=date&legend=top-left&sealed_token=VEcaPQSNlH8coYjuILJy7eT6t-pGJrGDEjOAjVwP8WGwNBOeNXoLTcz-KVBaZ2Y8eSqG1tLEpWGF3-5eMvVhW5G8n1ckdYI_uMZ6UCBE7b_eANd6we__7g7yc4ShXemuWfi-8SRcxgJNLK12VZGgBIccY1ceI3T3xm7jBM1TJjTVQFWJ0MmX2e-7QBp9" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Javis603/token-monitor/star-history/star-history-dark.svg" />
+   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Javis603/token-monitor/star-history/star-history.svg" />
+   <img alt="Star History Chart" src="https://raw.githubusercontent.com/Javis603/token-monitor/star-history/star-history.svg" />
  </picture>
 </a>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -267,11 +267,11 @@ Token Monitor 在本地处理使用日志，不会向项目维护者发送分析
 
 ## Star 历史
 
-<a href="https://www.star-history.com/?repos=Javis603%2Ftoken-monitor&type=date&legend=top-left">
+<a href="https://github.com/Javis603/token-monitor/tree/star-history">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Javis603/token-monitor&type=date&theme=dark&legend=top-left&sealed_token=VEcaPQSNlH8coYjuILJy7eT6t-pGJrGDEjOAjVwP8WGwNBOeNXoLTcz-KVBaZ2Y8eSqG1tLEpWGF3-5eMvVhW5G8n1ckdYI_uMZ6UCBE7b_eANd6we__7g7yc4ShXemuWfi-8SRcxgJNLK12VZGgBIccY1ceI3T3xm7jBM1TJjTVQFWJ0MmX2e-7QBp9" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Javis603/token-monitor&type=date&legend=top-left&sealed_token=VEcaPQSNlH8coYjuILJy7eT6t-pGJrGDEjOAjVwP8WGwNBOeNXoLTcz-KVBaZ2Y8eSqG1tLEpWGF3-5eMvVhW5G8n1ckdYI_uMZ6UCBE7b_eANd6we__7g7yc4ShXemuWfi-8SRcxgJNLK12VZGgBIccY1ceI3T3xm7jBM1TJjTVQFWJ0MmX2e-7QBp9" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Javis603/token-monitor&type=date&legend=top-left&sealed_token=VEcaPQSNlH8coYjuILJy7eT6t-pGJrGDEjOAjVwP8WGwNBOeNXoLTcz-KVBaZ2Y8eSqG1tLEpWGF3-5eMvVhW5G8n1ckdYI_uMZ6UCBE7b_eANd6we__7g7yc4ShXemuWfi-8SRcxgJNLK12VZGgBIccY1ceI3T3xm7jBM1TJjTVQFWJ0MmX2e-7QBp9" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Javis603/token-monitor/star-history/star-history-dark.svg" />
+   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Javis603/token-monitor/star-history/star-history.svg" />
+   <img alt="Star History Chart" src="https://raw.githubusercontent.com/Javis603/token-monitor/star-history/star-history.svg" />
  </picture>
 </a>
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -267,11 +267,11 @@ Token Monitor 會在本機處理使用紀錄，不會向專案維護者傳送分
 
 ## Star 歷史
 
-<a href="https://www.star-history.com/?repos=Javis603%2Ftoken-monitor&type=date&legend=top-left">
+<a href="https://github.com/Javis603/token-monitor/tree/star-history">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Javis603/token-monitor&type=date&theme=dark&legend=top-left&sealed_token=VEcaPQSNlH8coYjuILJy7eT6t-pGJrGDEjOAjVwP8WGwNBOeNXoLTcz-KVBaZ2Y8eSqG1tLEpWGF3-5eMvVhW5G8n1ckdYI_uMZ6UCBE7b_eANd6we__7g7yc4ShXemuWfi-8SRcxgJNLK12VZGgBIccY1ceI3T3xm7jBM1TJjTVQFWJ0MmX2e-7QBp9" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Javis603/token-monitor&type=date&legend=top-left&sealed_token=VEcaPQSNlH8coYjuILJy7eT6t-pGJrGDEjOAjVwP8WGwNBOeNXoLTcz-KVBaZ2Y8eSqG1tLEpWGF3-5eMvVhW5G8n1ckdYI_uMZ6UCBE7b_eANd6we__7g7yc4ShXemuWfi-8SRcxgJNLK12VZGgBIccY1ceI3T3xm7jBM1TJjTVQFWJ0MmX2e-7QBp9" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Javis603/token-monitor&type=date&legend=top-left&sealed_token=VEcaPQSNlH8coYjuILJy7eT6t-pGJrGDEjOAjVwP8WGwNBOeNXoLTcz-KVBaZ2Y8eSqG1tLEpWGF3-5eMvVhW5G8n1ckdYI_uMZ6UCBE7b_eANd6we__7g7yc4ShXemuWfi-8SRcxgJNLK12VZGgBIccY1ceI3T3xm7jBM1TJjTVQFWJ0MmX2e-7QBp9" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Javis603/token-monitor/star-history/star-history-dark.svg" />
+   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Javis603/token-monitor/star-history/star-history.svg" />
+   <img alt="Star History Chart" src="https://raw.githubusercontent.com/Javis603/token-monitor/star-history/star-history.svg" />
  </picture>
 </a>
 

--- a/scripts/validate-star-history-artifact.js
+++ b/scripts/validate-star-history-artifact.js
@@ -8,6 +8,28 @@ const EXPECTED_FILES = ['star-history-dark.svg', 'star-history.svg', 'stars.json
 const OFFICIAL_RENDERER_REPOSITORY = 'star-history/star-history';
 const MAX_SVG_BYTES = 2 * 1024 * 1024;
 const MAX_JSON_BYTES = 10 * 1024 * 1024;
+const XML_NAME_UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const XML_NAME_LOWER = 'abcdefghijklmnopqrstuvwxyz';
+const XML_POLICY_XPATH = `concat(
+  count(/*[local-name() = 'svg' and namespace-uri() = 'http://www.w3.org/2000/svg']),
+  '|',
+  count(//*[
+    translate(local-name(), '${XML_NAME_UPPER}', '${XML_NAME_LOWER}') = 'script' or
+    translate(local-name(), '${XML_NAME_UPPER}', '${XML_NAME_LOWER}') = 'foreignobject' or
+    translate(local-name(), '${XML_NAME_UPPER}', '${XML_NAME_LOWER}') = 'iframe' or
+    translate(local-name(), '${XML_NAME_UPPER}', '${XML_NAME_LOWER}') = 'object' or
+    translate(local-name(), '${XML_NAME_UPPER}', '${XML_NAME_LOWER}') = 'embed' or
+    translate(local-name(), '${XML_NAME_UPPER}', '${XML_NAME_LOWER}') = 'audio' or
+    translate(local-name(), '${XML_NAME_UPPER}', '${XML_NAME_LOWER}') = 'video'
+  ]),
+  '|',
+  count(//@*[starts-with(
+    translate(local-name(), '${XML_NAME_UPPER}', '${XML_NAME_LOWER}'),
+    'on'
+  )]),
+  '|',
+  count(//processing-instruction())
+)`.replace(/\s+/g, ' ');
 
 const fail = (message) => {
   throw new Error(`Invalid Star History artifact: ${message}`);
@@ -73,12 +95,21 @@ const validateSnapshot = (filename, { repository, rendererCommit }) => {
 };
 
 const validateXmlWithXmllint = (filename) => {
-  const result = spawnSync('xmllint', ['--noout', '--nonet', filename], {
+  const result = spawnSync('xmllint', ['--nonet', '--xpath', XML_POLICY_XPATH, filename], {
     encoding: 'utf8',
     windowsHide: true,
   });
   if (result.error) fail(`xmllint could not run: ${result.error.message}`);
   if (result.status !== 0) fail(`${path.basename(filename)} is not well-formed XML: ${(result.stderr || '').trim()}`);
+
+  const policy = (result.stdout || '').trim().split('|').map(Number);
+  if (policy.length !== 4 || policy.some((value) => !Number.isInteger(value) || value < 0)) {
+    fail(`${path.basename(filename)} produced an invalid XML policy result`);
+  }
+  if (policy[0] !== 1) fail(`${path.basename(filename)} does not have an SVG namespace root`);
+  if (policy[1] !== 0) fail(`${path.basename(filename)} contains active content`);
+  if (policy[2] !== 0) fail(`${path.basename(filename)} contains an event handler`);
+  if (policy[3] !== 0) fail(`${path.basename(filename)} contains a processing instruction`);
 };
 
 const validateSvg = (filename, { repository, validateXml = validateXmlWithXmllint }) => {
@@ -171,4 +202,5 @@ module.exports = {
   validateArtifact,
   validateSnapshot,
   validateSvg,
+  validateXmlWithXmllint,
 };

--- a/scripts/validate-star-history-artifact.js
+++ b/scripts/validate-star-history-artifact.js
@@ -1,0 +1,174 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const EXPECTED_FILES = ['star-history-dark.svg', 'star-history.svg', 'stars.json'];
+const OFFICIAL_RENDERER_REPOSITORY = 'star-history/star-history';
+const MAX_SVG_BYTES = 2 * 1024 * 1024;
+const MAX_JSON_BYTES = 10 * 1024 * 1024;
+
+const fail = (message) => {
+  throw new Error(`Invalid Star History artifact: ${message}`);
+};
+
+const exactKeys = (value, keys, context) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(`${context} must be an object`);
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    fail(`${context} has unexpected fields`);
+  }
+};
+
+const canonicalTimestamp = (value) => {
+  if (typeof value !== 'string') return false;
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString() === value;
+};
+
+const validateSnapshot = (filename, { repository, rendererCommit }) => {
+  const size = fs.statSync(filename).size;
+  if (size < 100 || size > MAX_JSON_BYTES) fail(`stars.json size ${size} is outside the allowed range`);
+
+  let snapshot;
+  try {
+    snapshot = JSON.parse(fs.readFileSync(filename, 'utf8'));
+  } catch (error) {
+    fail(`stars.json is not valid JSON: ${error.message}`);
+  }
+
+  exactKeys(snapshot, ['repository', 'renderer', 'stars'], 'stars.json');
+  if (snapshot.repository !== repository) fail(`stars.json repository is ${snapshot.repository}`);
+  exactKeys(snapshot.renderer, ['commit', 'repository'], 'stars.json renderer');
+  if (snapshot.renderer.repository !== OFFICIAL_RENDERER_REPOSITORY) {
+    fail(`stars.json renderer repository is ${snapshot.renderer.repository}`);
+  }
+  if (snapshot.renderer.commit !== rendererCommit) {
+    fail(`stars.json renderer commit is ${snapshot.renderer.commit}`);
+  }
+  if (!Array.isArray(snapshot.stars) || snapshot.stars.length === 0 || snapshot.stars.length > 100_000) {
+    fail('stars.json stars must be a non-empty bounded array');
+  }
+
+  let previousTime = -Infinity;
+  snapshot.stars.forEach((star, index) => {
+    exactKeys(star, ['count', 'starredAt'], `stars.json star ${index + 1}`);
+    if (!canonicalTimestamp(star.starredAt)) fail(`star ${index + 1} has a non-canonical timestamp`);
+    const timestamp = Date.parse(star.starredAt);
+    if (timestamp < previousTime) fail(`star ${index + 1} moves backwards in time`);
+
+    const isLast = index === snapshot.stars.length - 1;
+    const isAnchor = isLast && index > 0 && star.count === snapshot.stars[index - 1].count;
+    if (isAnchor && timestamp <= previousTime) fail('the current-day anchor must advance time');
+    const expectedCount = isAnchor ? index : index + 1;
+    if (!Number.isInteger(star.count) || star.count !== expectedCount) {
+      fail(`star ${index + 1} has invalid cumulative count ${star.count}`);
+    }
+    previousTime = timestamp;
+  });
+
+  return snapshot;
+};
+
+const validateXmlWithXmllint = (filename) => {
+  const result = spawnSync('xmllint', ['--noout', '--nonet', filename], {
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  if (result.error) fail(`xmllint could not run: ${result.error.message}`);
+  if (result.status !== 0) fail(`${path.basename(filename)} is not well-formed XML: ${(result.stderr || '').trim()}`);
+};
+
+const validateSvg = (filename, { repository, validateXml = validateXmlWithXmllint }) => {
+  const size = fs.statSync(filename).size;
+  if (size < 100 || size > MAX_SVG_BYTES) fail(`${path.basename(filename)} size ${size} is outside the allowed range`);
+  const svg = fs.readFileSync(filename, 'utf8');
+
+  if (!/^<svg\b[\s\S]*<\/svg>\s*$/.test(svg)) fail(`${path.basename(filename)} does not have one SVG document root`);
+  if (!svg.includes('Star History') || !svg.includes('GitHub Stars') || !svg.includes(repository)) {
+    fail(`${path.basename(filename)} is missing expected chart identity`);
+  }
+  if (/<!DOCTYPE|<!ENTITY/i.test(svg)) fail(`${path.basename(filename)} contains a document type or entity declaration`);
+  if (/<\/?(?:script|foreignObject|iframe|object|embed|audio|video)\b/i.test(svg)) {
+    fail(`${path.basename(filename)} contains active content`);
+  }
+  if (/\son[a-z][a-z0-9:_-]*\s*=/i.test(svg)) fail(`${path.basename(filename)} contains an event handler`);
+  if (/javascript\s*:|@import\b|expression\s*\(|-moz-binding\b/i.test(svg)) {
+    fail(`${path.basename(filename)} contains executable CSS or a javascript URL`);
+  }
+  if (/&#(?:x[0-9a-f]+|\d+);/i.test(svg)) fail(`${path.basename(filename)} contains encoded character references`);
+
+  for (const match of svg.matchAll(/\b(?:href|src)\s*=\s*(["'])(.*?)\1/gi)) {
+    const target = match[2];
+    if (target.startsWith('#')) continue;
+    if (/^data:image\/png;base64,[a-z0-9+/]+=*$/i.test(target)) continue;
+    fail(`${path.basename(filename)} contains a disallowed linked resource`);
+  }
+
+  for (const match of svg.matchAll(/url\(([^)]+)\)/gi)) {
+    const target = match[1].trim().replace(/^(["'])(.*)\1$/, '$2');
+    if (target.startsWith('#')) continue;
+    if (/^data:application\/font-woff;charset=utf-8;base64,[a-z0-9+/]+=*$/i.test(target)) continue;
+    fail(`${path.basename(filename)} contains a disallowed CSS resource`);
+  }
+
+  const externalUrls = svg.match(/https?:\/\/[^\s"')<]+/gi) || [];
+  if (externalUrls.some((url) => url !== 'http://www.w3.org/2000/svg')) {
+    fail(`${path.basename(filename)} contains an external URL`);
+  }
+
+  validateXml(filename);
+};
+
+const validateArtifact = (directory, expected, options = {}) => {
+  const resolved = path.resolve(directory);
+  const entries = fs.readdirSync(resolved, { withFileTypes: true });
+  const names = entries.map((entry) => entry.name).sort();
+  if (names.length !== EXPECTED_FILES.length || names.some((name, index) => name !== EXPECTED_FILES[index])) {
+    fail(`expected exactly ${EXPECTED_FILES.join(', ')}`);
+  }
+  if (entries.some((entry) => !entry.isFile() || entry.isSymbolicLink())) {
+    fail('all entries must be regular files');
+  }
+
+  const snapshot = validateSnapshot(path.join(resolved, 'stars.json'), expected);
+  validateSvg(path.join(resolved, 'star-history.svg'), { ...expected, ...options });
+  validateSvg(path.join(resolved, 'star-history-dark.svg'), { ...expected, ...options });
+  return { starCount: snapshot.stars.at(-1).count };
+};
+
+const parseCli = (args) => {
+  const options = { directory: '', repository: '', rendererCommit: '' };
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index + 1];
+    if (args[index] === '--directory') options.directory = value;
+    else if (args[index] === '--repository') options.repository = value;
+    else if (args[index] === '--renderer-commit') options.rendererCommit = value;
+    else fail(`unknown argument ${args[index]}`);
+    index += 1;
+  }
+  if (!options.directory || !options.repository || !/^[0-9a-f]{40}$/.test(options.rendererCommit)) {
+    fail('required arguments are --directory, --repository, and a full --renderer-commit SHA');
+  }
+  return options;
+};
+
+if (require.main === module) {
+  try {
+    const options = parseCli(process.argv.slice(2));
+    const result = validateArtifact(options.directory, options);
+    console.log(`Validated Star History artifact for ${result.starCount} stargazers.`);
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  EXPECTED_FILES,
+  validateArtifact,
+  validateSnapshot,
+  validateSvg,
+};

--- a/tests/scripts/starHistoryArtifact.test.js
+++ b/tests/scripts/starHistoryArtifact.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 const test = require('node:test');
 
 const { validateArtifact } = require('../../scripts/validate-star-history-artifact');
@@ -11,6 +12,10 @@ const { validateArtifact } = require('../../scripts/validate-star-history-artifa
 const REPOSITORY = 'Javis603/token-monitor';
 const RENDERER_COMMIT = 'bcddc9d532b10bac7e0187a741288bf9cab17616';
 const harmlessXmlCheck = () => {};
+const hasXmllint = spawnSync('xmllint', ['--version'], {
+  encoding: 'utf8',
+  windowsHide: true,
+}).status === 0;
 
 const snapshot = () => ({
   repository: REPOSITORY,
@@ -92,6 +97,37 @@ test('rejects active SVG content and external resources', () => {
   assert.throws(
     () => validate(fixture({ light: svg({ extra: '<path onclick="alert(1)"/>' }) })),
     /event handler/,
+  );
+});
+
+test('rejects namespaced active elements through the real XML policy', { skip: !hasXmllint }, () => {
+  const namespacedScript = '<x:script xmlns:x="http://www.w3.org/2000/svg">alert(1)</x:script>';
+  assert.throws(
+    () => validateArtifact(fixture({ light: svg({ extra: namespacedScript }) }), {
+      repository: REPOSITORY,
+      rendererCommit: RENDERER_COMMIT,
+    }),
+    /active content/,
+  );
+
+  const namespacedForeignObject = '<x:foreignObject xmlns:x="http://www.w3.org/2000/svg"/>';
+  assert.throws(
+    () => validateArtifact(fixture({ dark: svg({ extra: namespacedForeignObject }) }), {
+      repository: REPOSITORY,
+      rendererCommit: RENDERER_COMMIT,
+    }),
+    /active content/,
+  );
+});
+
+test('requires the SVG namespace through the real XML policy', { skip: !hasXmllint }, () => {
+  const wrongNamespace = svg().replace('http://www.w3.org/2000/svg', 'urn:not-svg');
+  assert.throws(
+    () => validateArtifact(fixture({ light: wrongNamespace }), {
+      repository: REPOSITORY,
+      rendererCommit: RENDERER_COMMIT,
+    }),
+    /SVG namespace root/,
   );
 });
 

--- a/tests/scripts/starHistoryArtifact.test.js
+++ b/tests/scripts/starHistoryArtifact.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const { validateArtifact } = require('../../scripts/validate-star-history-artifact');
+
+const REPOSITORY = 'Javis603/token-monitor';
+const RENDERER_COMMIT = 'bcddc9d532b10bac7e0187a741288bf9cab17616';
+const harmlessXmlCheck = () => {};
+
+const snapshot = () => ({
+  repository: REPOSITORY,
+  renderer: {
+    repository: 'star-history/star-history',
+    commit: RENDERER_COMMIT,
+  },
+  stars: [
+    { starredAt: '2026-08-01T12:00:00.000Z', count: 1 },
+    { starredAt: '2026-08-03T12:00:00.000Z', count: 2 },
+    { starredAt: '2026-08-09T00:00:00.000Z', count: 2 },
+  ],
+});
+
+const svg = ({ extra = '' } = {}) => `<svg xmlns="http://www.w3.org/2000/svg">
+  <text>Star History</text>
+  <text>GitHub Stars</text>
+  <text>${REPOSITORY}</text>
+  ${extra}
+</svg>\n`;
+
+const fixture = (changes = {}) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'star-history-artifact-'));
+  fs.writeFileSync(path.join(directory, 'star-history.svg'), changes.light ?? svg());
+  fs.writeFileSync(path.join(directory, 'star-history-dark.svg'), changes.dark ?? svg());
+  fs.writeFileSync(path.join(directory, 'stars.json'), `${JSON.stringify(changes.snapshot ?? snapshot())}\n`);
+  if (changes.extraFile) fs.writeFileSync(path.join(directory, changes.extraFile), 'unexpected');
+  return directory;
+};
+
+const validate = (directory) => validateArtifact(directory, {
+  repository: REPOSITORY,
+  rendererCommit: RENDERER_COMMIT,
+}, { validateXml: harmlessXmlCheck });
+
+test('accepts the exact generated file set and cumulative snapshot', () => {
+  const directory = fixture();
+  assert.deepEqual(validate(directory), { starCount: 2 });
+});
+
+test('rejects extra files before publication', () => {
+  const directory = fixture({ extraFile: 'README.md' });
+  assert.throws(() => validate(directory), /expected exactly/);
+});
+
+test('rejects repository or renderer substitution', () => {
+  const wrongRepository = snapshot();
+  wrongRepository.repository = 'attacker/repository';
+  assert.throws(() => validate(fixture({ snapshot: wrongRepository })), /repository is attacker/);
+
+  const wrongRenderer = snapshot();
+  wrongRenderer.renderer.commit = '0'.repeat(40);
+  assert.throws(() => validate(fixture({ snapshot: wrongRenderer })), /renderer commit/);
+});
+
+test('rejects identities and malformed cumulative history', () => {
+  const identity = snapshot();
+  identity.stars[0].login = 'private-user';
+  assert.throws(() => validate(fixture({ snapshot: identity })), /unexpected fields/);
+
+  const count = snapshot();
+  count.stars[1].count = 7;
+  assert.throws(() => validate(fixture({ snapshot: count })), /invalid cumulative count/);
+
+  const staleAnchor = snapshot();
+  staleAnchor.stars[2].starredAt = staleAnchor.stars[1].starredAt;
+  assert.throws(() => validate(fixture({ snapshot: staleAnchor })), /anchor must advance time/);
+});
+
+test('rejects active SVG content and external resources', () => {
+  assert.throws(
+    () => validate(fixture({ light: svg({ extra: '<script>alert(1)</script>' }) })),
+    /active content/,
+  );
+  assert.throws(
+    () => validate(fixture({ dark: svg({ extra: '<image href="https://example.com/pixel.png"/>' }) })),
+    /disallowed linked resource/,
+  );
+  assert.throws(
+    () => validate(fixture({ light: svg({ extra: '<path onclick="alert(1)"/>' }) })),
+    /event handler/,
+  );
+});
+
+test('allows only the official renderer data URI forms', () => {
+  const allowed = svg({
+    extra: '<style>@font-face{src:url(data:application/font-woff;charset=utf-8;base64,QUJD)}</style><image href="data:image/png;base64,QUJD"/>',
+  });
+  assert.doesNotThrow(() => validate(fixture({ light: allowed, dark: allowed })));
+  assert.throws(
+    () => validate(fixture({ light: svg({ extra: '<image href="data:image/svg+xml;base64,PHN2Zz4="/>' }) })),
+    /disallowed linked resource/,
+  );
+});

--- a/tests/scripts/starHistoryWorkflow.test.js
+++ b/tests/scripts/starHistoryWorkflow.test.js
@@ -22,20 +22,38 @@ test('external generation is SHA-pinned and read-only', () => {
     workflow,
     /uses: Javis603\/star-history-action@[0-9a-f]{40}/,
   );
-  const generate = workflow.slice(workflow.indexOf('  generate:'), workflow.indexOf('  publish:'));
+  const generate = workflow.slice(workflow.indexOf('  generate:'), workflow.indexOf('  validate:'));
   assert.match(generate, /permissions:\s+contents: read/);
   assert.doesNotMatch(generate, /contents: write/);
+  assert.match(generate, /artifact-id: \$\{\{ steps\.upload\.outputs\.artifact-id \}\}/);
   assert.match(generate, /retention-days: 1/);
   assert.doesNotMatch(workflow, /metadata: read/);
 });
 
-test('only the caller-owned publish job can write after validation', () => {
+test('validation parses artifacts without write permission', () => {
+  const validation = workflow.slice(workflow.indexOf('  validate:'), workflow.indexOf('  publish:'));
+  assert.match(validation, /permissions:\s+contents: read/);
+  assert.doesNotMatch(validation, /contents: write/);
+  assert.match(validation, /artifact-ids: \$\{\{ needs\.generate\.outputs\.artifact-id \}\}/);
+  assert.match(validation, /merge-multiple: true/);
+  assert.match(validation, /digest-mismatch: error/);
+  assert.match(validation, /libxml2-utils/);
+  assert.match(validation, /validate-star-history-artifact\.js/);
+  assert.match(validation, /light-sha256=/);
+  assert.match(validation, /dark-sha256=/);
+  assert.match(validation, /snapshot-sha256=/);
+});
+
+test('only the caller-owned publish job can write without parsing artifacts', () => {
   const publish = workflow.slice(workflow.indexOf('  publish:'));
   assert.match(publish, /permissions:\s+contents: write/);
-  assert.ok(
-    publish.indexOf('validate-star-history-artifact.js') < publish.indexOf('push origin HEAD:star-history'),
-    'artifact validation must precede the push',
-  );
+  assert.match(publish, /needs: \[generate, validate\]/);
+  assert.match(publish, /artifact-ids: \$\{\{ needs\.generate\.outputs\.artifact-id \}\}/);
+  assert.match(publish, /merge-multiple: true/);
+  assert.match(publish, /digest-mismatch: error/);
+  assert.match(publish, /sha256sum --check --strict/);
+  assert.doesNotMatch(publish, /validate-star-history-artifact\.js|xmllint|JSON\.parse/);
+  assert.doesNotMatch(publish, /actions\/checkout/);
   assert.match(publish, /install -m 0644 .*star-history\.svg/);
   assert.match(publish, /install -m 0644 .*star-history-dark\.svg/);
   assert.match(publish, /install -m 0644 .*stars\.json/);

--- a/tests/scripts/starHistoryWorkflow.test.js
+++ b/tests/scripts/starHistoryWorkflow.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const workflow = fs.readFileSync(
+  path.join(__dirname, '..', '..', '.github', 'workflows', 'star-history.yml'),
+  'utf8',
+);
+
+test('Star History runs daily and manually without per-star automation', () => {
+  assert.match(workflow, /cron: '17 19 \* \* \*'/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.doesNotMatch(workflow, /\bwatch:/);
+  assert.doesNotMatch(workflow, /\*\/6/);
+});
+
+test('external generation is SHA-pinned and read-only', () => {
+  assert.match(
+    workflow,
+    /uses: Javis603\/star-history-action@[0-9a-f]{40}/,
+  );
+  const generate = workflow.slice(workflow.indexOf('  generate:'), workflow.indexOf('  publish:'));
+  assert.match(generate, /permissions:\s+contents: read/);
+  assert.doesNotMatch(generate, /contents: write/);
+  assert.match(generate, /retention-days: 1/);
+  assert.doesNotMatch(workflow, /metadata: read/);
+});
+
+test('only the caller-owned publish job can write after validation', () => {
+  const publish = workflow.slice(workflow.indexOf('  publish:'));
+  assert.match(publish, /permissions:\s+contents: write/);
+  assert.ok(
+    publish.indexOf('validate-star-history-artifact.js') < publish.indexOf('push origin HEAD:star-history'),
+    'artifact validation must precede the push',
+  );
+  assert.match(publish, /install -m 0644 .*star-history\.svg/);
+  assert.match(publish, /install -m 0644 .*star-history-dark\.svg/);
+  assert.match(publish, /install -m 0644 .*stars\.json/);
+  assert.doesNotMatch(publish, /x-access-token:\$\{GITHUB_TOKEN\}@/);
+});


### PR DESCRIPTION
## Summary

- Generate light and dark Star History charts through [`Javis603/star-history-action`](https://github.com/Javis603/star-history-action/tree/bb3381bfc636969b3e635b2563ee2bcffe9f9044), pinned to its full commit SHA.
- Keep generation and artifact validation read-only, then publish only the validated files from a separate Token Monitor-owned job with narrowly scoped `contents: write` permission.
- Run once per day at 03:17 HKT, retain manual dry-run artifacts for one day, and update every README locale to use the assets-only `star-history` orphan branch.

## Security boundary

The custom action never receives `contents: write`, and its API token is exposed only to the generator invocation after dependency installation. A caller-owned read-only job accepts exactly `star-history.svg`, `star-history-dark.svg`, and `stars.json`; provisions `xmllint` explicitly; and verifies repository and renderer identity, cumulative JSON history, SVG namespace and structure, and active-content restrictions including namespace aliases. The write-only publisher does not parse generated content: it downloads the same immutable artifact by ID, verifies the three SHA-256 hashes produced by validation, and commits only when the output changes.

The generated snapshot contains timestamps and cumulative star counts, not stargazer usernames, profiles, credentials, tokens, cookies, or local paths. The orphan branch is intentionally not created by this PR; the first non-dry run after merge will create it from live GitHub API data.

## Verification

- `npm run verify` in Token Monitor: 2,679 tests, 2,678 passed, 1 skipped
- Focused Star History artifact and workflow tests: 12 passed
- `npm run verify` in `star-history-action`: 9 tests passed and `dist/` matches `src/`
- Pinned official-renderer fixture integration with pnpm 10.12.4
- Real generated artifact accepted by `scripts/validate-star-history-artifact.js`
