### PR TITLE
fix(star-history): isolate privileged stargazer fetch

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -19,19 +19,61 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  generate:
+  fetch:
     runs-on: ubuntu-latest
+    # GitHub's stargazer listing maps collaborator access to contents: write for
+    # GITHUB_TOKEN. Keep this job caller-owned and never run the generator here.
     permissions:
-      contents: read
+      contents: write
     outputs:
       artifact-id: ${{ steps.upload.outputs.artifact-id }}
     steps:
+      - name: Checkout trusted fetcher
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Fetch identity-free stargazer timestamps
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          INPUT_DIRECTORY: ${{ runner.temp }}/star-history-input
+        run: >-
+          node scripts/fetch-star-history-stargazers.js
+          --repository "$GITHUB_REPOSITORY"
+          --output "$INPUT_DIRECTORY/stargazers.json"
+
+      - name: Upload identity-free input
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: star-history-input
+          path: ${{ runner.temp }}/star-history-input/stargazers.json
+          if-no-files-found: error
+          retention-days: 1
+
+  generate:
+    needs: fetch
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      artifact-id: ${{ steps.upload.outputs.artifact-id }}
+    steps:
+      - name: Download identity-free input
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.fetch.outputs.artifact-id }}
+          path: ${{ runner.temp }}/star-history-input
+          merge-multiple: true
+          digest-mismatch: error
+
       - name: Generate with the external read-only action
         id: generate
-        uses: Javis603/star-history-action@bb3381bfc636969b3e635b2563ee2bcffe9f9044
+        uses: Javis603/star-history-action@cfeb3776e57b39f075dc824235e826b4c5ba343b
         with:
           repository: ${{ github.repository }}
-          token: ${{ github.token }}
+          stars-file: ${{ runner.temp }}/star-history-input/stargazers.json
 
       - name: Upload generated assets
         id: upload

--- a/scripts/fetch-star-history-stargazers.js
+++ b/scripts/fetch-star-history-stargazers.js
@@ -1,0 +1,168 @@
+'use strict';
+
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const PAGE_SIZE = 100;
+const MAX_PAGES = 10_000;
+const REQUEST_TIMEOUT_MS = 30_000;
+const GITHUB_API_VERSION = '2026-03-10';
+
+const fail = (message) => {
+  throw new Error(`Star History stargazer fetch failed: ${message}`);
+};
+
+const assertRepository = (repository) => {
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,38})\/[a-z0-9._-]+$/i.test(repository)) {
+    fail(`invalid repository name: ${repository}`);
+  }
+};
+
+const apiEndpoint = (apiUrl, pathname) => {
+  const base = String(apiUrl || '').trim().replace(/\/+$/, '');
+  if (!/^https?:\/\//i.test(base)) fail(`invalid GITHUB_API_URL: ${apiUrl}`);
+  return `${base}${pathname}`;
+};
+
+const responseHeader = (headers, name) => {
+  if (headers?.get) return headers.get(name) || headers.get(name.toLowerCase()) || '';
+  return headers?.[name] || headers?.[name.toLowerCase()] || '';
+};
+
+const requestHeaders = (token) => ({
+  Accept: 'application/vnd.github.star+json',
+  Authorization: `Bearer ${token}`,
+  'X-GitHub-Api-Version': GITHUB_API_VERSION,
+  'User-Agent': 'token-monitor-star-history',
+});
+
+const fetchJson = async (url, token, fetchImpl) => {
+  const response = await fetchImpl(url, {
+    headers: requestHeaders(token),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const body = await response.text();
+  if (!response.ok) {
+    const accepted = responseHeader(response.headers, 'x-accepted-github-permissions');
+    const hint = accepted ? `; accepted permissions: ${accepted}` : '';
+    fail(`GitHub API returned ${response.status} ${response.statusText || 'unknown status'}${hint}`);
+  }
+  try {
+    return { data: JSON.parse(body), headers: response.headers };
+  } catch {
+    fail('GitHub API returned invalid JSON');
+  }
+};
+
+const parseNextPage = (linkHeader) => {
+  if (!linkHeader) return null;
+  const next = linkHeader
+    .split(',')
+    .map((part) => part.trim())
+    .find((part) => /;\s*rel="next"(?:\s|$)/i.test(part));
+  if (!next) return null;
+  const match = next.match(/<([^>]+)>/);
+  const page = match ? new URL(match[1]).searchParams.get('page') : '';
+  if (!/^\d+$/.test(page) || Number(page) < 1) fail('GitHub returned an invalid next-page link');
+  return Number(page);
+};
+
+const normalizePage = (entries, offset) => {
+  if (!Array.isArray(entries)) fail('GitHub stargazer response was not an array');
+  return entries.map((entry, index) => {
+    const parsed = new Date(entry?.starred_at);
+    if (typeof entry?.starred_at !== 'string' || !Number.isFinite(parsed.getTime())) {
+      fail(`stargazer entry ${offset + index + 1} has no valid starred_at timestamp`);
+    }
+    return { starredAt: parsed.toISOString(), sourceIndex: offset + index };
+  });
+};
+
+const fetchSanitizedStargazers = async ({
+  repository,
+  token,
+  apiUrl = process.env.GITHUB_API_URL || 'https://api.github.com',
+  fetchImpl = globalThis.fetch,
+} = {}) => {
+  assertRepository(repository);
+  if (!token) fail('GITHUB_TOKEN is required');
+  if (typeof fetchImpl !== 'function') fail('this Node runtime does not provide fetch');
+
+  const stars = [];
+  let page = 1;
+  for (;;) {
+    if (page > MAX_PAGES) fail(`pagination exceeded ${MAX_PAGES} pages`);
+    const url = new URL(apiEndpoint(apiUrl, `/repos/${repository}/stargazers`));
+    url.searchParams.set('per_page', String(PAGE_SIZE));
+    url.searchParams.set('page', String(page));
+    const response = await fetchJson(url, token, fetchImpl);
+    if (response.data.length === 0) {
+      if (page === 1) fail('GitHub returned no timestamped stargazers');
+      break;
+    }
+    stars.push(...normalizePage(response.data, stars.length));
+
+    const nextPage = parseNextPage(responseHeader(response.headers, 'link'));
+    if (nextPage !== null) {
+      if (nextPage <= page) fail(`pagination moved backwards from page ${page}`);
+      page = nextPage;
+    } else if (response.data.length === PAGE_SIZE) {
+      page += 1;
+    } else {
+      break;
+    }
+  }
+
+  const metadata = await fetchJson(apiEndpoint(apiUrl, `/repos/${repository}`), token, fetchImpl);
+  const expectedCount = metadata.data?.stargazers_count;
+  if (!Number.isInteger(expectedCount) || expectedCount < 1) {
+    fail('repository metadata has no positive stargazers_count');
+  }
+  if (stars.length !== expectedCount) {
+    fail(`fetched ${stars.length} timestamps but repository metadata reports ${expectedCount}`);
+  }
+
+  stars.sort((left, right) => {
+    const delta = Date.parse(left.starredAt) - Date.parse(right.starredAt);
+    return delta || left.sourceIndex - right.sourceIndex;
+  });
+  return stars.map(({ starredAt }) => ({ starredAt }));
+};
+
+const parseCli = (args) => {
+  const options = { repository: '', output: '' };
+  for (let index = 0; index < args.length; index += 2) {
+    const name = args[index];
+    const value = args[index + 1];
+    if (!value || value.startsWith('--')) fail(`${name || 'argument'} requires a value`);
+    if (name === '--repository') options.repository = value;
+    else if (name === '--output') options.output = value;
+    else fail(`unknown argument ${name}`);
+  }
+  if (!options.repository || !options.output) fail('required arguments are --repository and --output');
+  return options;
+};
+
+const main = async () => {
+  const options = parseCli(process.argv.slice(2));
+  const stars = await fetchSanitizedStargazers({
+    repository: options.repository,
+    token: process.env.GITHUB_TOKEN,
+  });
+  const output = path.resolve(options.output);
+  await fs.mkdir(path.dirname(output), { recursive: true });
+  await fs.writeFile(output, `${JSON.stringify(stars, null, 2)}\n`, { mode: 0o600 });
+  console.log(`Prepared ${stars.length} identity-free stargazer timestamps.`);
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  fetchSanitizedStargazers,
+  parseNextPage,
+};

--- a/tests/scripts/starHistoryFetch.test.js
+++ b/tests/scripts/starHistoryFetch.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { fetchSanitizedStargazers } = require('../../scripts/fetch-star-history-stargazers');
+
+const response = (data, { status = 200, headers = {} } = {}) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  statusText: status === 200 ? 'OK' : 'Forbidden',
+  headers: new Headers(headers),
+  text: async () => JSON.stringify(data),
+});
+
+test('fetches timestamped stargazers and strips every identity field', async () => {
+  const requests = [];
+  const fetchImpl = async (url, options) => {
+    requests.push({ url: String(url), options });
+    if (String(url).endsWith('/repos/Javis603/token-monitor')) {
+      return response({ stargazers_count: 2, owner: { login: 'Javis603' } });
+    }
+    return response([
+      { starred_at: '2026-08-03T12:00:00Z', user: { login: 'newest-user' } },
+      { starred_at: '2026-08-01T12:00:00Z', user: { login: 'oldest-user' } },
+    ]);
+  };
+
+  const stars = await fetchSanitizedStargazers({
+    repository: 'Javis603/token-monitor',
+    token: 'secret-token',
+    fetchImpl,
+  });
+
+  assert.deepEqual(stars, [
+    { starredAt: '2026-08-01T12:00:00.000Z' },
+    { starredAt: '2026-08-03T12:00:00.000Z' },
+  ]);
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0].options.headers.Authorization, 'Bearer secret-token');
+  assert.equal(requests[0].options.headers.Accept, 'application/vnd.github.star+json');
+  assert.doesNotMatch(JSON.stringify(stars), /login|user|Javis603/);
+});
+
+test('rejects incomplete pagination instead of publishing a partial chart', async () => {
+  const fetchImpl = async (url) => String(url).endsWith('/repos/Javis603/token-monitor')
+    ? response({ stargazers_count: 2 })
+    : response([{ starred_at: '2026-08-01T12:00:00Z' }]);
+
+  await assert.rejects(
+    fetchSanitizedStargazers({
+      repository: 'Javis603/token-monitor',
+      token: 'secret-token',
+      fetchImpl,
+    }),
+    /fetched 1 timestamps.*reports 2/,
+  );
+});
+
+test('reports the GitHub accepted-permissions hint without response data', async () => {
+  const fetchImpl = async () => response(
+    { message: 'Resource not accessible by integration', private: 'do not echo me' },
+    { status: 403, headers: { 'x-accepted-github-permissions': 'metadata=read; contents=write' } },
+  );
+
+  await assert.rejects(
+    fetchSanitizedStargazers({
+      repository: 'Javis603/token-monitor',
+      token: 'secret-token',
+      fetchImpl,
+    }),
+    (error) => {
+      assert.match(error.message, /403 Forbidden; accepted permissions: metadata=read; contents=write/);
+      assert.doesNotMatch(error.message, /do not echo me|secret-token/);
+      return true;
+    },
+  );
+});

--- a/tests/scripts/starHistoryWorkflow.test.js
+++ b/tests/scripts/starHistoryWorkflow.test.js
@@ -17,14 +17,26 @@ test('Star History runs daily and manually without per-star automation', () => {
   assert.doesNotMatch(workflow, /\*\/6/);
 });
 
-test('external generation is SHA-pinned and read-only', () => {
+test('privileged stargazer fetch is caller-owned and uploads identity-free input', () => {
+  const fetchJob = workflow.slice(workflow.indexOf('  fetch:'), workflow.indexOf('  generate:'));
+  assert.match(fetchJob, /permissions:\s+contents: write/);
+  assert.match(fetchJob, /persist-credentials: false/);
+  assert.match(fetchJob, /fetch-star-history-stargazers\.js/);
+  assert.match(fetchJob, /star-history-input\/stargazers\.json/);
+  assert.match(fetchJob, /artifact-id: \$\{\{ steps\.upload\.outputs\.artifact-id \}\}/);
+  assert.doesNotMatch(fetchJob, /Javis603\/star-history-action/);
+});
+
+test('external generation is SHA-pinned, tokenless, and has no repository permission', () => {
   assert.match(
     workflow,
     /uses: Javis603\/star-history-action@[0-9a-f]{40}/,
   );
   const generate = workflow.slice(workflow.indexOf('  generate:'), workflow.indexOf('  validate:'));
-  assert.match(generate, /permissions:\s+contents: read/);
-  assert.doesNotMatch(generate, /contents: write/);
+  assert.match(generate, /permissions: \{\}/);
+  assert.match(generate, /artifact-ids: \$\{\{ needs\.fetch\.outputs\.artifact-id \}\}/);
+  assert.match(generate, /stars-file: \$\{\{ runner\.temp \}\}\/star-history-input\/stargazers\.json/);
+  assert.doesNotMatch(generate, /token:|contents: (?:read|write)/);
   assert.match(generate, /artifact-id: \$\{\{ steps\.upload\.outputs\.artifact-id \}\}/);
   assert.match(generate, /retention-days: 1/);
   assert.doesNotMatch(workflow, /metadata: read/);
@@ -44,7 +56,7 @@ test('validation parses artifacts without write permission', () => {
   assert.match(validation, /snapshot-sha256=/);
 });
 
-test('only the caller-owned publish job can write without parsing artifacts', () => {
+test('caller-owned publisher writes without parsing artifacts', () => {
   const publish = workflow.slice(workflow.indexOf('  publish:'));
   assert.match(publish, /permissions:\s+contents: write/);
   assert.match(publish, /needs: \[generate, validate\]/);


### PR DESCRIPTION
## Summary

- Fetch timestamped stargazers in caller-owned code with the `contents: write` permission now required by GitHub's listing endpoint.
- Strip usernames, profiles, and every other identity field before uploading a one-day intermediate artifact containing only canonical `starredAt` timestamps.
- Run the external Star History generator without a token and with `permissions: {}`, then keep the existing read-only validation and hash-bound publication flow.

## Why

The first production run after #366 failed with `403 Resource not accessible by integration`; GitHub reported that the stargazer listing accepts `metadata=read; contents=write`, while `metadata` is not a valid workflow permission key. Granting `contents: write` directly to the external generator would break the intended trust boundary, so the privileged API call now lives in a small caller-owned fetcher instead.

Failed acceptance run: https://github.com/Javis603/token-monitor/actions/runs/31313162226

## Security and privacy

The write-enabled fetch job checks out only the merged caller commit with persisted credentials disabled, does not run the external generator, never logs the API response, and writes only `{ "starredAt": "..." }` records. The external action receives neither `github.token` nor repository permissions. Publication remains caller-owned and accepts only the three validated, hash-matched output files.

## Verification

- `npm run verify`: 2,683 tests, 2,682 passed, 1 skipped
- Focused Star History fetch, artifact, and workflow tests: 16 passed
- Workflow YAML parsed successfully
- `npm run verify` in `star-history-action`: 10 tests passed and `dist/` matches `src/`
- [Branch acceptance workflow](https://github.com/Javis603/token-monitor/actions/runs/31313717210): fetch, tokenless generation, validation, hash verification, and publication passed
- Published orphan root `4ed3b1123ae80e5a1ee1fe624516010fcaf3e8c2` contains exactly the two SVGs and `stars.json`; schema and sensitive-data audit found no identity fields, credentials, cookies, emails, or local paths
