### PR TITLE
fix(star-history): refine generated chart styling

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -70,10 +70,11 @@ jobs:
 
       - name: Generate with the external read-only action
         id: generate
-        uses: Javis603/star-history-action@cfeb3776e57b39f075dc824235e826b4c5ba343b
+        uses: Javis603/star-history-action@c6ca634f7bad7354b05bf3d70c1c8a065374c7e1
         with:
           repository: ${{ github.repository }}
           stars-file: ${{ runner.temp }}/star-history-input/stargazers.json
+          logo-url: ${{ github.server_url }}/${{ github.repository_owner }}.png?size=22
 
       - name: Upload generated assets
         id: upload

--- a/scripts/validate-star-history-artifact.js
+++ b/scripts/validate-star-history-artifact.js
@@ -28,7 +28,9 @@ const XML_POLICY_XPATH = `concat(
     'on'
   )]),
   '|',
-  count(//processing-instruction())
+  count(//processing-instruction()),
+  '|',
+  count(//*[local-name() = 'text' and normalize-space(.) = 'star-history.com'])
 )`.replace(/\s+/g, ' ');
 
 const fail = (message) => {
@@ -103,13 +105,14 @@ const validateXmlWithXmllint = (filename) => {
   if (result.status !== 0) fail(`${path.basename(filename)} is not well-formed XML: ${(result.stderr || '').trim()}`);
 
   const policy = (result.stdout || '').trim().split('|').map(Number);
-  if (policy.length !== 4 || policy.some((value) => !Number.isInteger(value) || value < 0)) {
+  if (policy.length !== 5 || policy.some((value) => !Number.isInteger(value) || value < 0)) {
     fail(`${path.basename(filename)} produced an invalid XML policy result`);
   }
   if (policy[0] !== 1) fail(`${path.basename(filename)} does not have an SVG namespace root`);
   if (policy[1] !== 0) fail(`${path.basename(filename)} contains active content`);
   if (policy[2] !== 0) fail(`${path.basename(filename)} contains an event handler`);
   if (policy[3] !== 0) fail(`${path.basename(filename)} contains a processing instruction`);
+  if (policy[4] !== 0) fail(`${path.basename(filename)} contains the renderer watermark`);
 };
 
 const validateSvg = (filename, { repository, validateXml = validateXmlWithXmllint }) => {
@@ -148,6 +151,28 @@ const validateSvg = (filename, { repository, validateXml = validateXmlWithXmllin
   const externalUrls = svg.match(/https?:\/\/[^\s"')<]+/gi) || [];
   if (externalUrls.some((url) => url !== 'http://www.w3.org/2000/svg')) {
     fail(`${path.basename(filename)} contains an external URL`);
+  }
+
+  const embeddedImages = [...svg.matchAll(/<image\b[^>]*>/gi)];
+  const titleLogos = embeddedImages.filter((match) => {
+    const element = match[0];
+    const attribute = (name) => element.match(new RegExp('\\b' + name + '="([^"]*)"', 'i'))?.[1];
+    return attribute('width') === '22'
+      && attribute('height') === '22'
+      && attribute('y') === '12'
+      && attribute('clip-path') === 'url(#clip-circle-title)'
+      && /^data:image\/png;base64,[a-z0-9+/]+=*$/i.test(attribute('href') || '');
+  });
+  if (titleLogos.length !== 1) {
+    fail(path.basename(filename) + ' must contain exactly one embedded owner title icon');
+  }
+  if (embeddedImages.length !== 1) {
+    fail(`${path.basename(filename)} must not contain the renderer watermark`);
+  }
+
+  const renderedDots = (svg.match(/class="chart-tooltip-dot"/g) || []).length;
+  if (renderedDots !== 0) {
+    fail(`${path.basename(filename)} must not contain rendered chart dots`);
   }
 
   validateXml(filename);

--- a/tests/scripts/starHistoryArtifact.test.js
+++ b/tests/scripts/starHistoryArtifact.test.js
@@ -34,6 +34,7 @@ const svg = ({ extra = '' } = {}) => `<svg xmlns="http://www.w3.org/2000/svg">
   <text>Star History</text>
   <text>GitHub Stars</text>
   <text>${REPOSITORY}</text>
+  <image width="22" height="22" x="316" y="12" clip-path="url(#clip-circle-title)" href="data:image/png;base64,QUJD"/>
   ${extra}
 </svg>\n`;
 
@@ -100,6 +101,47 @@ test('rejects active SVG content and external resources', () => {
   );
 });
 
+test('requires one embedded owner icon beside the chart title', () => {
+  const withoutIcon = svg().replace(/ {2}<image[^>]+>\n/, '');
+  assert.throws(
+    () => validate(fixture({ light: withoutIcon })),
+    /exactly one embedded owner title icon/,
+  );
+
+  const duplicateIcon = svg().replace('</svg>', '<image width="22" height="22" y="12" clip-path="url(#clip-circle-title)" href="data:image/png;base64,QUJD"/></svg>');
+  assert.throws(
+    () => validate(fixture({ dark: duplicateIcon })),
+    /exactly one embedded owner title icon/,
+  );
+});
+
+test('rejects rendered chart dots', () => {
+  const withDot = svg({ extra: '<circle class="chart-tooltip-dot"/>' });
+  assert.throws(
+    () => validate(fixture({ dark: withDot })),
+    /must not contain rendered chart dots/,
+  );
+});
+
+test('rejects the renderer watermark while retaining the owner title icon', () => {
+  const watermark = '<text>star-history.com</text><image width="20" height="20" href="data:image/png;base64,QUJD"/>';
+  assert.throws(
+    () => validate(fixture({ light: svg({ extra: watermark }) })),
+    /must not contain the renderer watermark/,
+  );
+});
+
+test('rejects a text-only renderer watermark through the XML policy', { skip: !hasXmllint }, () => {
+  const watermark = '<text><tspan>star-history.com</tspan></text>';
+  assert.throws(
+    () => validateArtifact(fixture({ light: svg({ extra: watermark }) }), {
+      repository: REPOSITORY,
+      rendererCommit: RENDERER_COMMIT,
+    }),
+    /contains the renderer watermark/,
+  );
+});
+
 test('rejects namespaced active elements through the real XML policy', { skip: !hasXmllint }, () => {
   const namespacedScript = '<x:script xmlns:x="http://www.w3.org/2000/svg">alert(1)</x:script>';
   assert.throws(
@@ -133,7 +175,7 @@ test('requires the SVG namespace through the real XML policy', { skip: !hasXmlli
 
 test('allows only the official renderer data URI forms', () => {
   const allowed = svg({
-    extra: '<style>@font-face{src:url(data:application/font-woff;charset=utf-8;base64,QUJD)}</style><image href="data:image/png;base64,QUJD"/>',
+    extra: '<style>@font-face{src:url(data:application/font-woff;charset=utf-8;base64,QUJD)}</style>',
   });
   assert.doesNotThrow(() => validate(fixture({ light: allowed, dark: allowed })));
   assert.throws(

--- a/tests/scripts/starHistoryWorkflow.test.js
+++ b/tests/scripts/starHistoryWorkflow.test.js
@@ -36,6 +36,7 @@ test('external generation is SHA-pinned, tokenless, and has no repository permis
   assert.match(generate, /permissions: \{\}/);
   assert.match(generate, /artifact-ids: \$\{\{ needs\.fetch\.outputs\.artifact-id \}\}/);
   assert.match(generate, /stars-file: \$\{\{ runner\.temp \}\}\/star-history-input\/stargazers\.json/);
+  assert.match(generate, /logo-url: \$\{\{ github\.server_url \}\}\/\$\{\{ github\.repository_owner \}\}\.png\?size=22/);
   assert.doesNotMatch(generate, /token:|contents: (?:read|write)/);
   assert.match(generate, /artifact-id: \$\{\{ steps\.upload\.outputs\.artifact-id \}\}/);
   assert.match(generate, /retention-days: 1/);


### PR DESCRIPTION
## Summary

- keep the complete timestamp history in `stars.json` while rendering a dot-free line capped at 12 underlying points
- restore the public repository owner avatar beside the chart title with optical spacing
- remove the lower-right renderer watermark while preserving Star History attribution and its MIT notice in the pinned action repository
- pin `Javis603/star-history-action` to merged commit `c6ca634f7bad7354b05bf3d70c1c8a065374c7e1`
- validate that published SVGs contain exactly one embedded owner image, no chart dots, no watermark, and no external URL

The daily schedule and assets-only orphan publication model are unchanged. The owner avatar is public and embedded as a PNG data URI; no stargazer identities, profile URLs, tokens, sensitive data, or private personal records are added.

## Verification

- `npm run lint`
- `node --test tests/scripts/starHistoryArtifact.test.js tests/scripts/starHistoryWorkflow.test.js`
- complete Token Monitor test suite with `node --test --test-reporter=dot 'tests/**/*.test.js'`
- rendered and validated light/dark SVGs using the complete 1,248-record production snapshot

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines the Star History chart by restoring the owner avatar beside the title, removing the watermark and dots, and keeping the chart clean while preserving full stargazer history. Pins the external action and tightens SVG validation to block watermark text and enforce a single embedded logo.

- **New Features**
  - Embed the public repo owner avatar (22px) next to the title via `logo-url` (inlined, clipped PNG).
  - Render a dot-free line chart capped at 12 underlying points; keep full timestamps in `stars.json`.
  - Enforce strict SVG rules: exactly one embedded owner image (data URI at the title), no dots, no watermark (including text-only), no external URLs.

- **Dependencies**
  - Pin `Javis603/star-history-action` to a specific merged commit.

<sup>Written for commit b8460e0108dd9b9e211cfed8376f36df9eb66768. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

