### PR TITLE
fix(widget): persist remote history fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           tests/electron/macWidgetBridge.test.js
           tests/electron/macWidgetDeepLink.test.js
           tests/electron/macWidgetHistory.test.js
+          tests/electron/macWidgetHistoryStore.test.js
           tests/electron/macWidgetSnapshotController.test.js
           tests/electron/macWidgetSnapshotLane.test.js
           tests/electron/macWidgetLaunchServicesRecovery.test.js

--- a/src/electron/macWidgetHistory.js
+++ b/src/electron/macWidgetHistory.js
@@ -68,9 +68,11 @@ function isHistoryDocument(value) {
   );
 }
 
-// The resolver configuration, without the revision. A change here means the
-// cached history describes a different source (another hub, history switched
-// off) and must not be served, however fresh it is.
+// The resolver configuration, without the revision or bearer secret. A change
+// here means the cached history describes a different source (another hub, or
+// history switched off) and must not be served, however fresh it is. The Hub
+// secret gates one shared data store; it does not select a tenant, and including
+// it would discard a valid last-good copy on routine credential rotation.
 function macWidgetHistorySourceKey(config = {}) {
   return [
     config.mode,

--- a/src/electron/macWidgetHistory.js
+++ b/src/electron/macWidgetHistory.js
@@ -16,7 +16,9 @@
 //     succeed, which reads as data loss rather than a transient network error.
 //
 // So the revision is treated as a freshness *signal* gated by a time floor, and
-// the last good history is retained across failures.
+// the last good history is retained across failures. A remote source also gets
+// a source-keyed persisted cache from the caller, because this module-level
+// cache disappears when Electron restarts.
 //
 // Two floors, because the two states are not the same risk. With a cached copy
 // to serve, the floor is about freshness and can be long. With none — a cold
@@ -44,6 +46,7 @@ let cachedRevision = '';
 let lastAttemptAt = null;
 let lastAttemptFailed = false;
 let inFlight = null;
+let persistedLoad = null;
 
 function log(logger, message) {
   try { logger?.(message); } catch (_) {}
@@ -51,6 +54,18 @@ function log(logger, message) {
 
 function emptyHistory() {
   return { daily: [], monthly: [], summary: {} };
+}
+
+function isHistoryDocument(value) {
+  return Boolean(
+    value
+    && typeof value === 'object'
+    && Array.isArray(value.daily)
+    && Array.isArray(value.monthly)
+    && value.summary
+    && typeof value.summary === 'object'
+    && !Array.isArray(value.summary)
+  );
 }
 
 // The resolver configuration, without the revision. A change here means the
@@ -70,6 +85,8 @@ async function resolveMacWidgetHistory(options = {}) {
   const sourceKey = String(options.sourceKey || '');
   const revision = String(options.revision || '').trim();
   const fetchHistory = options.fetchHistory;
+  const loadCachedHistory = options.loadCachedHistory;
+  const saveCachedHistory = options.saveCachedHistory;
   const logger = options.logger;
   const now = Number.isFinite(options.now) ? options.now : Date.now();
   const minIntervalMs = Number.isFinite(options.minIntervalMs)
@@ -94,6 +111,30 @@ async function resolveMacWidgetHistory(options = {}) {
     lastAttemptAt = null;
     lastAttemptFailed = false;
     inFlight = null;
+    persistedLoad = null;
+
+    if (typeof loadCachedHistory === 'function') {
+      let loadPromise;
+      loadPromise = Promise.resolve()
+        .then(() => loadCachedHistory())
+        .then((history) => {
+          if (generation !== activeGeneration || sourceKey !== activeSourceKey) return;
+          if (isHistoryDocument(history)) cachedHistory = history;
+        })
+        .catch((error) => {
+          log(logger, `[mac-widget] persisted history cache read failed: ${error?.message || error}`);
+        })
+        .finally(() => {
+          if (persistedLoad?.promise === loadPromise) persistedLoad = null;
+        });
+      persistedLoad = { generation, sourceKey, promise: loadPromise };
+    }
+  }
+
+  const activePersistedLoad = persistedLoad;
+  if (activePersistedLoad && activePersistedLoad.generation === generation && activePersistedLoad.sourceKey === sourceKey) {
+    await activePersistedLoad.promise;
+    if (generation !== activeGeneration || sourceKey !== activeSourceKey) return emptyHistory();
   }
 
   // An exact revision hit is served whatever the floors say: it is the answer,
@@ -125,7 +166,7 @@ async function resolveMacWidgetHistory(options = {}) {
 
   const promise = Promise.resolve()
     .then(() => fetchHistory())
-    .then((history) => {
+    .then(async (history) => {
       if (!history || typeof history !== 'object') throw new Error('history resolver returned no data');
       // An owner change while this was in flight makes the answer belong to a
       // mode lifetime nobody is asking about any more. It can neither populate
@@ -134,6 +175,13 @@ async function resolveMacWidgetHistory(options = {}) {
       cachedHistory = history;
       cachedRevision = revision;
       lastAttemptFailed = false;
+      if (typeof saveCachedHistory === 'function') {
+        try {
+          await saveCachedHistory(history);
+        } catch (error) {
+          log(logger, `[mac-widget] persisted history cache write failed: ${error?.message || error}`);
+        }
+      }
       return history;
     })
     .catch((error) => {
@@ -164,12 +212,14 @@ function resetMacWidgetHistoryCache() {
   lastAttemptAt = null;
   lastAttemptFailed = false;
   inFlight = null;
+  persistedLoad = null;
 }
 
 module.exports = {
   DEFAULT_MIN_INTERVAL_MS,
   DEFAULT_RETRY_INTERVAL_MS,
   EMPTY_HISTORY,
+  isHistoryDocument,
   macWidgetHistorySourceKey,
   resetMacWidgetHistoryCache,
   resolveMacWidgetHistory

--- a/src/electron/macWidgetHistoryStore.js
+++ b/src/electron/macWidgetHistoryStore.js
@@ -1,25 +1,65 @@
 'use strict';
 
+const { constants: fsConstants } = require('node:fs');
+const fs = require('node:fs/promises');
 const crypto = require('node:crypto');
 const path = require('node:path');
-const { coerceHistory } = require('../shared/history');
-const {
-  readRegularFileNoFollow,
-  writePrivateJsonAtomic
-} = require('../shared/credentialStore');
+const { MAC_WIDGET_ACTIVITY_DAYS } = require('../shared/macWidgetSnapshot');
 const { isHistoryDocument } = require('./macWidgetHistory');
 
-const MAC_WIDGET_HISTORY_CACHE_VERSION = 1;
-// History is bounded by day count but the lifetime monthly rollup is not. Keep
-// the persisted fallback large enough for normal long-lived hubs while making
-// a corrupt or hostile file unable to consume unbounded main-process memory.
-const MAX_MAC_WIDGET_HISTORY_CACHE_BYTES = 4 * 1024 * 1024;
+const MAC_WIDGET_HISTORY_CACHE_VERSION = 2;
+const MAX_MAC_WIDGET_HISTORY_CACHE_BYTES = 256 * 1024;
+const MAX_MAC_WIDGET_HISTORY_CACHE_ENTRIES = 8;
 const MAC_WIDGET_HISTORY_CACHE_DESCRIPTION = 'macOS Widget history cache';
+const CACHE_FILE_PATTERN = /^[a-f0-9]{64}\.json$/;
+
+function safeLog(logger, message) {
+  try { logger?.(message); } catch (_) {}
+}
 
 function maxCacheBytes(value) {
   return Number.isFinite(value)
     ? Math.max(0, Math.floor(value))
     : MAX_MAC_WIDGET_HISTORY_CACHE_BYTES;
+}
+
+function maxCacheEntries(value) {
+  return Number.isFinite(value)
+    ? Math.max(1, Math.floor(value))
+    : MAX_MAC_WIDGET_HISTORY_CACHE_ENTRIES;
+}
+
+function nonNegativeNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : 0;
+}
+
+function normalizedDay(value) {
+  const day = String(value || '');
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return '';
+  const timestamp = Date.parse(`${day}T00:00:00.000Z`);
+  if (!Number.isFinite(timestamp)) return '';
+  return new Date(timestamp).toISOString().slice(0, 10) === day ? day : '';
+}
+
+function projectMacWidgetHistory(history) {
+  const byDate = new Map();
+  for (const entry of (Array.isArray(history?.daily) ? history.daily : [])) {
+    const date = normalizedDay(entry?.date);
+    if (!date) continue;
+    byDate.set(date, {
+      date,
+      tokens: Math.round(nonNegativeNumber(entry?.tokens)),
+      cost: nonNegativeNumber(entry?.cost)
+    });
+  }
+  return {
+    daily: Array.from(byDate.values())
+      .sort((left, right) => left.date.localeCompare(right.date))
+      .slice(-MAC_WIDGET_ACTIVITY_DAYS),
+    monthly: [],
+    summary: {}
+  };
 }
 
 function macWidgetHistoryCacheFingerprint(sourceKey) {
@@ -40,55 +80,201 @@ function cacheDocument(sourceKey, history) {
   return {
     version: MAC_WIDGET_HISTORY_CACHE_VERSION,
     source: macWidgetHistoryCacheFingerprint(sourceKey),
-    history: coerceHistory(history)
+    daily: projectMacWidgetHistory(history).daily
   };
 }
 
-function cacheDocumentBytes(document) {
-  return Buffer.byteLength(`${JSON.stringify(document, null, 2)}\n`, 'utf8');
+function cacheHistory(document, sourceKey) {
+  if (
+    document?.version !== MAC_WIDGET_HISTORY_CACHE_VERSION
+    || document.source !== macWidgetHistoryCacheFingerprint(sourceKey)
+    || !Array.isArray(document.daily)
+    || document.daily.length > MAC_WIDGET_ACTIVITY_DAYS
+  ) return null;
+
+  const seen = new Set();
+  for (const day of document.daily) {
+    if (
+      normalizedDay(day?.date) !== day.date
+      || !Number.isInteger(day.tokens)
+      || day.tokens < 0
+      || typeof day.cost !== 'number'
+      || !Number.isFinite(day.cost)
+      || day.cost < 0
+      || seen.has(day.date)
+    ) return null;
+    seen.add(day.date);
+  }
+  return {
+    daily: document.daily
+      .map((day) => ({ date: day.date, tokens: day.tokens, cost: day.cost }))
+      .sort((left, right) => left.date.localeCompare(right.date)),
+    monthly: [],
+    summary: {}
+  };
 }
 
-function readMacWidgetHistoryCache(cachePath, sourceKey, options = {}) {
-  const readPrivateFile = options.readRegularFileNoFollow || readRegularFileNoFollow;
+async function readBoundedRegularFileNoFollow(filePath, options = {}) {
+  const fsApi = options.fs || fs;
+  const constants = options.constants || fsConstants;
+  const description = options.description || 'File';
+  const noFollow = constants.O_NOFOLLOW || 0;
+  const limit = maxCacheBytes(options.maxBytes);
+  const platform = options.platform || process.platform;
+  let handle = null;
+  let pathStat = null;
   try {
-    const raw = readPrivateFile(cachePath, {
-      ...(options.fs ? { fs: options.fs } : {}),
-      description: MAC_WIDGET_HISTORY_CACHE_DESCRIPTION,
-      encoding: 'utf8',
-      mode: 0o600,
-      maxBytes: maxCacheBytes(options.maxBytes)
+    if (!noFollow) {
+      pathStat = await fsApi.lstat(filePath);
+      if (!pathStat.isFile() || pathStat.isSymbolicLink()) {
+        throw new Error(`${description} must be a regular file`);
+      }
+    }
+    handle = await fsApi.open(filePath, constants.O_RDONLY | noFollow);
+    const descriptorStat = await handle.stat();
+    if (!descriptorStat.isFile()) throw new Error(`${description} must be a regular file`);
+    if (descriptorStat.size > limit) throw new Error(`${description} exceeds ${limit} bytes`);
+    if (pathStat && (pathStat.dev !== descriptorStat.dev || pathStat.ino !== descriptorStat.ino)) {
+      throw new Error(`${description} changed while it was being opened`);
+    }
+    if (options.mode !== undefined && platform !== 'win32') {
+      await handle.chmod(options.mode);
+    }
+
+    const expectedSize = descriptorStat.size;
+    const buffer = Buffer.allocUnsafe(Math.min(limit + 1, expectedSize + 1));
+    let offset = 0;
+    while (offset < buffer.length) {
+      const result = await handle.read(buffer, offset, buffer.length - offset, null);
+      if (result.bytesRead === 0) break;
+      offset += result.bytesRead;
+    }
+    if (offset > limit) throw new Error(`${description} exceeds ${limit} bytes`);
+    if (offset > expectedSize) throw new Error(`${description} changed while it was being read`);
+    return buffer.subarray(0, offset).toString('utf8');
+  } catch (error) {
+    if (error?.code === 'ELOOP') {
+      const symlinkError = new Error(`${description} must be a regular file`);
+      symlinkError.cause = error;
+      throw symlinkError;
+    }
+    throw error;
+  } finally {
+    try { await handle?.close(); } catch (_) {}
+  }
+}
+
+async function writePrivateBufferAtomic(filePath, serialized, options = {}) {
+  const fsApi = options.fs || fs;
+  const constants = options.constants || fsConstants;
+  const platform = options.platform || process.platform;
+  const directory = path.dirname(filePath);
+  const randomId = (options.randomUUID || crypto.randomUUID)();
+  const temporary = `${filePath}.${process.pid}.${randomId}.tmp`;
+  let handle = null;
+  let directoryHandle = null;
+  let renamed = false;
+  await fsApi.mkdir(directory, { recursive: true, mode: 0o700 });
+  if (platform !== 'win32') await fsApi.chmod(directory, 0o700);
+  try {
+    handle = await fsApi.open(temporary, 'wx', 0o600);
+    await handle.writeFile(serialized);
+    if (platform !== 'win32') await handle.chmod(0o600);
+    await handle.sync();
+    await handle.close();
+    handle = null;
+    await fsApi.rename(temporary, filePath);
+    renamed = true;
+    if (platform !== 'win32') {
+      directoryHandle = await fsApi.open(directory, constants.O_RDONLY);
+      await directoryHandle.sync();
+      await directoryHandle.close();
+      directoryHandle = null;
+    }
+  } catch (error) {
+    if (renamed) error.atomicWriteCommitted = true;
+    try { await handle?.close(); } catch (_) {}
+    try { await directoryHandle?.close(); } catch (_) {}
+    try { await fsApi.rm(temporary, { force: true }); } catch (_) {}
+    throw error;
+  }
+}
+
+async function pruneMacWidgetHistoryCaches(cachePath, options = {}) {
+  const fsApi = options.fs || fs;
+  const logger = options.logger;
+  const directory = path.dirname(cachePath);
+  try {
+    const entries = await fsApi.readdir(directory, { withFileTypes: true });
+    const candidates = [];
+    for (const entry of entries) {
+      if (!CACHE_FILE_PATTERN.test(entry.name)) continue;
+      const filePath = path.join(directory, entry.name);
+      try {
+        const stat = await fsApi.lstat(filePath);
+        if (!stat.isFile()) continue;
+        candidates.push({ filePath, mtimeMs: stat.mtimeMs });
+      } catch (error) {
+        if (error?.code !== 'ENOENT') throw error;
+      }
+    }
+    candidates.sort((left, right) => {
+      if (left.filePath === cachePath) return -1;
+      if (right.filePath === cachePath) return 1;
+      return right.mtimeMs - left.mtimeMs || left.filePath.localeCompare(right.filePath);
     });
-    const document = JSON.parse(raw);
-    if (
-      document?.version !== MAC_WIDGET_HISTORY_CACHE_VERSION
-      || document.source !== macWidgetHistoryCacheFingerprint(sourceKey)
-      || !isHistoryDocument(document.history)
-    ) return null;
-    return coerceHistory(document.history);
+    for (const candidate of candidates.slice(maxCacheEntries(options.maxEntries))) {
+      try {
+        await fsApi.unlink(candidate.filePath);
+      } catch (error) {
+        if (error?.code !== 'ENOENT') {
+          safeLog(logger, `[mac-widget] history cache cleanup failed: ${error?.message || error}`);
+        }
+      }
+    }
   } catch (error) {
     if (error?.code !== 'ENOENT') {
-      try { options.logger?.(`[mac-widget] history cache read failed: ${error?.message || error}`); } catch (_) {}
+      safeLog(logger, `[mac-widget] history cache cleanup failed: ${error?.message || error}`);
+    }
+  }
+}
+
+async function readMacWidgetHistoryCache(cachePath, sourceKey, options = {}) {
+  try {
+    const raw = await readBoundedRegularFileNoFollow(cachePath, {
+      ...options,
+      description: MAC_WIDGET_HISTORY_CACHE_DESCRIPTION,
+      mode: 0o600
+    });
+    return cacheHistory(JSON.parse(raw), sourceKey);
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      safeLog(options.logger, `[mac-widget] history cache read failed: ${error?.message || error}`);
     }
     return null;
   }
 }
 
-function writeMacWidgetHistoryCache(cachePath, sourceKey, history, options = {}) {
+async function writeMacWidgetHistoryCache(cachePath, sourceKey, history, options = {}) {
   if (!cachePath || !isHistoryDocument(history)) return;
   const document = cacheDocument(sourceKey, history);
+  const stringify = options.stringify || JSON.stringify;
+  const serialized = Buffer.from(`${stringify(document)}\n`, 'utf8');
   const limit = maxCacheBytes(options.maxBytes);
-  if (cacheDocumentBytes(document) > limit) {
+  if (serialized.byteLength > limit) {
     throw new Error(`${MAC_WIDGET_HISTORY_CACHE_DESCRIPTION} exceeds ${limit} bytes`);
   }
-  const writePrivateFile = options.writePrivateJsonAtomic || writePrivateJsonAtomic;
-  writePrivateFile(cachePath, document, options.fs ? { fs: options.fs } : {});
+  await writePrivateBufferAtomic(cachePath, serialized, options);
+  await pruneMacWidgetHistoryCaches(cachePath, options);
 }
 
 module.exports = {
   MAC_WIDGET_HISTORY_CACHE_VERSION,
   MAX_MAC_WIDGET_HISTORY_CACHE_BYTES,
+  MAX_MAC_WIDGET_HISTORY_CACHE_ENTRIES,
   macWidgetHistoryCacheFingerprint,
   macWidgetHistoryCachePath,
+  projectMacWidgetHistory,
   readMacWidgetHistoryCache,
   writeMacWidgetHistoryCache
 };

--- a/src/electron/macWidgetHistoryStore.js
+++ b/src/electron/macWidgetHistoryStore.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const path = require('node:path');
+const { coerceHistory } = require('../shared/history');
+const {
+  readRegularFileNoFollow,
+  writePrivateJsonAtomic
+} = require('../shared/credentialStore');
+const { isHistoryDocument } = require('./macWidgetHistory');
+
+const MAC_WIDGET_HISTORY_CACHE_VERSION = 1;
+// History is bounded by day count but the lifetime monthly rollup is not. Keep
+// the persisted fallback large enough for normal long-lived hubs while making
+// a corrupt or hostile file unable to consume unbounded main-process memory.
+const MAX_MAC_WIDGET_HISTORY_CACHE_BYTES = 4 * 1024 * 1024;
+const MAC_WIDGET_HISTORY_CACHE_DESCRIPTION = 'macOS Widget history cache';
+
+function maxCacheBytes(value) {
+  return Number.isFinite(value)
+    ? Math.max(0, Math.floor(value))
+    : MAX_MAC_WIDGET_HISTORY_CACHE_BYTES;
+}
+
+function macWidgetHistoryCacheFingerprint(sourceKey) {
+  return crypto.createHash('sha256').update(String(sourceKey || '')).digest('hex');
+}
+
+function macWidgetHistoryCachePath(userDataPath, sourceKey) {
+  const root = String(userDataPath || '').trim();
+  if (!root) return null;
+  return path.join(
+    root,
+    'mac-widget-history',
+    `${macWidgetHistoryCacheFingerprint(sourceKey)}.json`
+  );
+}
+
+function cacheDocument(sourceKey, history) {
+  return {
+    version: MAC_WIDGET_HISTORY_CACHE_VERSION,
+    source: macWidgetHistoryCacheFingerprint(sourceKey),
+    history: coerceHistory(history)
+  };
+}
+
+function cacheDocumentBytes(document) {
+  return Buffer.byteLength(`${JSON.stringify(document, null, 2)}\n`, 'utf8');
+}
+
+function readMacWidgetHistoryCache(cachePath, sourceKey, options = {}) {
+  const readPrivateFile = options.readRegularFileNoFollow || readRegularFileNoFollow;
+  try {
+    const raw = readPrivateFile(cachePath, {
+      ...(options.fs ? { fs: options.fs } : {}),
+      description: MAC_WIDGET_HISTORY_CACHE_DESCRIPTION,
+      encoding: 'utf8',
+      mode: 0o600,
+      maxBytes: maxCacheBytes(options.maxBytes)
+    });
+    const document = JSON.parse(raw);
+    if (
+      document?.version !== MAC_WIDGET_HISTORY_CACHE_VERSION
+      || document.source !== macWidgetHistoryCacheFingerprint(sourceKey)
+      || !isHistoryDocument(document.history)
+    ) return null;
+    return coerceHistory(document.history);
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      try { options.logger?.(`[mac-widget] history cache read failed: ${error?.message || error}`); } catch (_) {}
+    }
+    return null;
+  }
+}
+
+function writeMacWidgetHistoryCache(cachePath, sourceKey, history, options = {}) {
+  if (!cachePath || !isHistoryDocument(history)) return;
+  const document = cacheDocument(sourceKey, history);
+  const limit = maxCacheBytes(options.maxBytes);
+  if (cacheDocumentBytes(document) > limit) {
+    throw new Error(`${MAC_WIDGET_HISTORY_CACHE_DESCRIPTION} exceeds ${limit} bytes`);
+  }
+  const writePrivateFile = options.writePrivateJsonAtomic || writePrivateJsonAtomic;
+  writePrivateFile(cachePath, document, options.fs ? { fs: options.fs } : {});
+}
+
+module.exports = {
+  MAC_WIDGET_HISTORY_CACHE_VERSION,
+  MAX_MAC_WIDGET_HISTORY_CACHE_BYTES,
+  macWidgetHistoryCacheFingerprint,
+  macWidgetHistoryCachePath,
+  readMacWidgetHistoryCache,
+  writeMacWidgetHistoryCache
+};

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -3522,7 +3522,8 @@ function ensureMacWidgetSnapshotController() {
         saveCachedHistory: (history) => writeMacWidgetHistoryCache(
           work.historyCachePath,
           work.owner.sourceKey,
-          history
+          history,
+          { logger: (message) => console.warn(message) }
         )
       } : {}),
       minIntervalMs: completeHistorySource(work.resolverConfig) === 'remote' ? undefined : 0,

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -3481,7 +3481,11 @@ function ensureMacWidgetSnapshotController() {
       revision: work.stats?.historyRevision,
       fetchHistory: () => resolveCompleteHistory(work.resolverConfig),
       ...(work.historyCachePath ? {
-        loadCachedHistory: () => readMacWidgetHistoryCache(work.historyCachePath, work.owner.sourceKey),
+        loadCachedHistory: () => readMacWidgetHistoryCache(
+          work.historyCachePath,
+          work.owner.sourceKey,
+          { logger: (message) => console.warn(message) }
+        ),
         saveCachedHistory: (history) => writeMacWidgetHistoryCache(
           work.historyCachePath,
           work.owner.sourceKey,

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -147,7 +147,7 @@ const {
   fetchMimoLimits,
   normalizeMimoCookieHeader
 } = require('../shared/mimoLimits');
-const { coerceHistory, historyPreview, historyRevision } = require('../shared/history');
+const { historyPreview, historyRevision } = require('../shared/history');
 const { completeHistorySource, resolveCompleteHistory } = require('./historySource');
 const { readSessionDetailForPlatform } = require('../shared/sessionDetailResolver');
 const { startDiscordRpc, stopDiscordRpc, updateDiscordRpc } = require('./discordRpc');
@@ -159,7 +159,12 @@ const {
   syncMacWidgetSnapshotDirectory
 } = require('./macWidgetBridge');
 const { createMacWidgetSnapshotController } = require('./macWidgetSnapshotController');
-const { isHistoryDocument, macWidgetHistorySourceKey, resolveMacWidgetHistory } = require('./macWidgetHistory');
+const { macWidgetHistorySourceKey, resolveMacWidgetHistory } = require('./macWidgetHistory');
+const {
+  macWidgetHistoryCachePath,
+  readMacWidgetHistoryCache,
+  writeMacWidgetHistoryCache
+} = require('./macWidgetHistoryStore');
 const { parseMacWidgetDeepLink } = require('./macWidgetDeepLink');
 const { createMacWidgetLaunchServicesRecovery } = require('./macWidgetLaunchServicesRecovery');
 const { projectLimitStatsForDisplay } = require('./limitStatsPresentation');
@@ -3427,51 +3432,6 @@ function historyResolverOptions() {
   };
 }
 
-const MAC_WIDGET_HISTORY_CACHE_VERSION = 1;
-
-function macWidgetHistoryCacheFingerprint(sourceKey) {
-  return crypto.createHash('sha256').update(String(sourceKey || '')).digest('hex');
-}
-
-function macWidgetHistoryCachePath(sourceKey) {
-  return path.join(
-    app.getPath('userData'),
-    'mac-widget-history',
-    `${macWidgetHistoryCacheFingerprint(sourceKey)}.json`
-  );
-}
-
-function readMacWidgetHistoryCache(cachePath, sourceKey) {
-  try {
-    const raw = readRegularFileNoFollow(cachePath, {
-      description: 'macOS Widget history cache',
-      encoding: 'utf8',
-      mode: 0o600
-    });
-    const document = JSON.parse(raw);
-    if (
-      document?.version !== MAC_WIDGET_HISTORY_CACHE_VERSION
-      || document.source !== macWidgetHistoryCacheFingerprint(sourceKey)
-      || !isHistoryDocument(document.history)
-    ) return null;
-    return coerceHistory(document.history);
-  } catch (error) {
-    if (error?.code !== 'ENOENT') {
-      console.warn(`[mac-widget] history cache read failed: ${error?.message || error}`);
-    }
-    return null;
-  }
-}
-
-function writeMacWidgetHistoryCache(cachePath, sourceKey, history) {
-  if (!cachePath || !isHistoryDocument(history)) return;
-  writePrivateJsonAtomic(cachePath, {
-    version: MAC_WIDGET_HISTORY_CACHE_VERSION,
-    source: macWidgetHistoryCacheFingerprint(sourceKey),
-    history: coerceHistory(history)
-  });
-}
-
 function getCompleteHistory() {
   return resolveCompleteHistory(historyResolverOptions());
 }
@@ -3501,7 +3461,7 @@ function captureMacWidgetWork({ stats, owner }) {
     }),
     resolverConfig,
     historyCachePath: completeHistorySource(resolverConfig) === 'remote'
-      ? macWidgetHistoryCachePath(sourceKey)
+      ? macWidgetHistoryCachePath(app.getPath('userData'), sourceKey)
       : null,
     presentation: macWidgetPresentation(),
     snapshotPath: widget.snapshotPath,

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -147,7 +147,7 @@ const {
   fetchMimoLimits,
   normalizeMimoCookieHeader
 } = require('../shared/mimoLimits');
-const { historyPreview, historyRevision } = require('../shared/history');
+const { coerceHistory, historyPreview, historyRevision } = require('../shared/history');
 const { completeHistorySource, resolveCompleteHistory } = require('./historySource');
 const { readSessionDetailForPlatform } = require('../shared/sessionDetailResolver');
 const { startDiscordRpc, stopDiscordRpc, updateDiscordRpc } = require('./discordRpc');
@@ -159,7 +159,7 @@ const {
   syncMacWidgetSnapshotDirectory
 } = require('./macWidgetBridge');
 const { createMacWidgetSnapshotController } = require('./macWidgetSnapshotController');
-const { macWidgetHistorySourceKey, resolveMacWidgetHistory } = require('./macWidgetHistory');
+const { isHistoryDocument, macWidgetHistorySourceKey, resolveMacWidgetHistory } = require('./macWidgetHistory');
 const { parseMacWidgetDeepLink } = require('./macWidgetDeepLink');
 const { createMacWidgetLaunchServicesRecovery } = require('./macWidgetLaunchServicesRecovery');
 const { projectLimitStatsForDisplay } = require('./limitStatsPresentation');
@@ -3427,6 +3427,51 @@ function historyResolverOptions() {
   };
 }
 
+const MAC_WIDGET_HISTORY_CACHE_VERSION = 1;
+
+function macWidgetHistoryCacheFingerprint(sourceKey) {
+  return crypto.createHash('sha256').update(String(sourceKey || '')).digest('hex');
+}
+
+function macWidgetHistoryCachePath(sourceKey) {
+  return path.join(
+    app.getPath('userData'),
+    'mac-widget-history',
+    `${macWidgetHistoryCacheFingerprint(sourceKey)}.json`
+  );
+}
+
+function readMacWidgetHistoryCache(cachePath, sourceKey) {
+  try {
+    const raw = readRegularFileNoFollow(cachePath, {
+      description: 'macOS Widget history cache',
+      encoding: 'utf8',
+      mode: 0o600
+    });
+    const document = JSON.parse(raw);
+    if (
+      document?.version !== MAC_WIDGET_HISTORY_CACHE_VERSION
+      || document.source !== macWidgetHistoryCacheFingerprint(sourceKey)
+      || !isHistoryDocument(document.history)
+    ) return null;
+    return coerceHistory(document.history);
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      console.warn(`[mac-widget] history cache read failed: ${error?.message || error}`);
+    }
+    return null;
+  }
+}
+
+function writeMacWidgetHistoryCache(cachePath, sourceKey, history) {
+  if (!cachePath || !isHistoryDocument(history)) return;
+  writePrivateJsonAtomic(cachePath, {
+    version: MAC_WIDGET_HISTORY_CACHE_VERSION,
+    source: macWidgetHistoryCacheFingerprint(sourceKey),
+    history: coerceHistory(history)
+  });
+}
+
 function getCompleteHistory() {
   return resolveCompleteHistory(historyResolverOptions());
 }
@@ -3447,13 +3492,17 @@ function captureMacWidgetWork({ stats, owner }) {
   const widget = macWidgetConfiguration();
   if (!widget) return null;
   const resolverConfig = Object.freeze({ ...historyResolverOptions() });
+  const sourceKey = macWidgetHistorySourceKey(resolverConfig);
   return {
     stats,
     owner: Object.freeze({
       epoch: owner.epoch,
-      sourceKey: macWidgetHistorySourceKey(resolverConfig)
+      sourceKey
     }),
     resolverConfig,
+    historyCachePath: completeHistorySource(resolverConfig) === 'remote'
+      ? macWidgetHistoryCachePath(sourceKey)
+      : null,
     presentation: macWidgetPresentation(),
     snapshotPath: widget.snapshotPath,
     widgetKind: widget.widgetKind
@@ -3471,6 +3520,14 @@ function ensureMacWidgetSnapshotController() {
       sourceKey: work.owner.sourceKey,
       revision: work.stats?.historyRevision,
       fetchHistory: () => resolveCompleteHistory(work.resolverConfig),
+      ...(work.historyCachePath ? {
+        loadCachedHistory: () => readMacWidgetHistoryCache(work.historyCachePath, work.owner.sourceKey),
+        saveCachedHistory: (history) => writeMacWidgetHistoryCache(
+          work.historyCachePath,
+          work.owner.sourceKey,
+          history
+        )
+      } : {}),
       minIntervalMs: completeHistorySource(work.resolverConfig) === 'remote' ? undefined : 0,
       logger: (message) => console.warn(message)
     }),

--- a/src/shared/macWidgetSnapshot.js
+++ b/src/shared/macWidgetSnapshot.js
@@ -334,6 +334,7 @@ function normalizedDaily(history) {
   return Array.from(byDate.values()).sort((left, right) => left.date.localeCompare(right.date));
 }
 
+const MAC_WIDGET_ACTIVITY_DAYS = 182;
 const TREND_WINDOW_DAYS = 7;
 
 function localDayKey(date) {
@@ -349,7 +350,7 @@ function addCalendarDays(day, delta) {
 }
 
 function buildActivity(history, period) {
-  const daily = normalizedDaily(history).slice(-182);
+  const daily = normalizedDaily(history).slice(-MAC_WIDGET_ACTIVITY_DAYS);
   const peak = daily.reduce((max, day) => Math.max(max, day.totalTokens), 0);
   return {
     currentPeriod: period,
@@ -584,6 +585,7 @@ function serializeMacWidgetSnapshot(stats, options = {}) {
 }
 
 module.exports = {
+  MAC_WIDGET_ACTIVITY_DAYS,
   MAC_WIDGET_SCHEMA_VERSION,
   MAC_WIDGET_FRESHNESS_HEARTBEAT_MS,
   buildMacWidgetSnapshot,

--- a/tests/electron/macWidgetHistory.test.js
+++ b/tests/electron/macWidgetHistory.test.js
@@ -33,6 +33,14 @@ test('the source key ignores the revision so a moving hash cannot invalidate the
   );
 });
 
+test('the source key identifies the Hub data store, not its bearer secret', () => {
+  const config = { mode: 'client', hubMode: 'client', historyEnabled: true, hubUrl: 'http://hub' };
+  assert.equal(
+    macWidgetHistorySourceKey({ ...config, secret: 'old-secret' }),
+    macWidgetHistorySourceKey({ ...config, secret: 'rotated-secret' })
+  );
+});
+
 test('an unchanged revision is served from cache without refetching', async () => {
   let calls = 0;
   const fetchHistory = () => { calls += 1; return history('a'); };

--- a/tests/electron/macWidgetHistory.test.js
+++ b/tests/electron/macWidgetHistory.test.js
@@ -201,6 +201,63 @@ test('a warm-cache failure uses the retry floor even when freshness is immediate
   assert.equal(calls, 3, 'the bounded retry becomes due without discarding last-good history');
 });
 
+test('a cold start can serve source-keyed persisted history while the remote fetch fails', async () => {
+  let loads = 0;
+  let fetches = 0;
+  const persisted = history('persisted');
+  const result = await resolveMacWidgetHistory({
+    generation: 1,
+    sourceKey: 'hub-a',
+    revision: 'r1',
+    loadCachedHistory: () => {
+      loads += 1;
+      return persisted;
+    },
+    fetchHistory: () => {
+      fetches += 1;
+      throw new Error('hub unreachable');
+    },
+    now: 0,
+    logger: () => {}
+  });
+
+  assert.equal(loads, 1);
+  assert.equal(fetches, 1);
+  assert.equal(result.summary.label, 'persisted');
+  assert.equal(result.daily.length, 1);
+});
+
+test('successful history refreshes persist the new last-good value', async () => {
+  let saved = null;
+  const refreshed = history('refreshed');
+  const result = await resolveMacWidgetHistory({
+    sourceKey: 'hub-a',
+    revision: 'r1',
+    fetchHistory: () => refreshed,
+    saveCachedHistory: (value) => { saved = value; },
+    now: 0
+  });
+
+  assert.deepEqual(saved, refreshed);
+  assert.deepEqual(result, refreshed);
+});
+
+test('a persisted cache failure does not hide a successful remote refresh', async () => {
+  const warnings = [];
+  const refreshed = history('refreshed');
+  const result = await resolveMacWidgetHistory({
+    sourceKey: 'hub-a',
+    revision: 'r1',
+    fetchHistory: () => refreshed,
+    saveCachedHistory: () => { throw new Error('cache read-only'); },
+    logger: (message) => warnings.push(message),
+    now: 0
+  });
+
+  assert.deepEqual(result, refreshed);
+  assert.ok(warnings.some((message) => /persisted history cache write failed/.test(message)));
+});
+
 test('a stale source failure cannot return the active source cache', async () => {
   let rejectSourceA;
   let markSourceAStarted;

--- a/tests/electron/macWidgetHistory.test.js
+++ b/tests/electron/macWidgetHistory.test.js
@@ -242,7 +242,7 @@ test('successful history refreshes persist the new last-good value', async () =>
   assert.deepEqual(result, refreshed);
 });
 
-test('a persisted cache failure does not hide a successful remote refresh', async () => {
+test('a persisted cache write failure does not hide a successful remote refresh', async () => {
   const warnings = [];
   const refreshed = history('refreshed');
   const result = await resolveMacWidgetHistory({
@@ -256,6 +256,27 @@ test('a persisted cache failure does not hide a successful remote refresh', asyn
 
   assert.deepEqual(result, refreshed);
   assert.ok(warnings.some((message) => /persisted history cache write failed/.test(message)));
+});
+
+test('a persisted cache read failure does not hide a successful remote refresh', async () => {
+  let fetches = 0;
+  const warnings = [];
+  const refreshed = history('refreshed');
+  const result = await resolveMacWidgetHistory({
+    sourceKey: 'hub-a',
+    revision: 'r1',
+    loadCachedHistory: () => { throw new Error('cache corrupt'); },
+    fetchHistory: () => {
+      fetches += 1;
+      return refreshed;
+    },
+    logger: (message) => warnings.push(message),
+    now: 0
+  });
+
+  assert.equal(fetches, 1);
+  assert.deepEqual(result, refreshed);
+  assert.ok(warnings.some((message) => /persisted history cache read failed/.test(message)));
 });
 
 test('a stale source failure cannot return the active source cache', async () => {

--- a/tests/electron/macWidgetHistoryStore.test.js
+++ b/tests/electron/macWidgetHistoryStore.test.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const {
+  MAX_MAC_WIDGET_HISTORY_CACHE_BYTES,
+  macWidgetHistoryCachePath,
+  readMacWidgetHistoryCache,
+  writeMacWidgetHistoryCache
+} = require('../../src/electron/macWidgetHistoryStore');
+
+function history(label) {
+  return { daily: [{ date: '2026-08-09', totalTokens: 1, label }], monthly: [], summary: { label } };
+}
+
+function withTempRoot(callback) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'token-monitor-widget-history-'));
+  try {
+    return callback(root);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('history cache round-trips atomically with private permissions', () => {
+  withTempRoot((root) => {
+    const cachePath = macWidgetHistoryCachePath(root, 'hub-a');
+    const value = history('saved');
+
+    writeMacWidgetHistoryCache(cachePath, 'hub-a', value);
+
+    assert.deepEqual(readMacWidgetHistoryCache(cachePath, 'hub-a'), value);
+    if (process.platform !== 'win32') {
+      assert.equal(fs.statSync(cachePath).mode & 0o777, 0o600);
+      assert.equal(fs.statSync(path.dirname(cachePath)).mode & 0o777, 0o700);
+    }
+    assert.deepEqual(fs.readdirSync(path.dirname(cachePath)), [path.basename(cachePath)]);
+  });
+});
+
+test('history cache rejects a different source and schema version', () => {
+  withTempRoot((root) => {
+    const cachePath = macWidgetHistoryCachePath(root, 'hub-a');
+    writeMacWidgetHistoryCache(cachePath, 'hub-a', history('saved'));
+    assert.equal(readMacWidgetHistoryCache(cachePath, 'hub-b'), null);
+
+    fs.writeFileSync(cachePath, JSON.stringify({
+      version: 999,
+      source: 'anything',
+      history: history('wrong-version')
+    }));
+    assert.equal(readMacWidgetHistoryCache(cachePath, 'hub-a'), null);
+  });
+});
+
+test('history cache ignores malformed JSON', () => {
+  withTempRoot((root) => {
+    const cachePath = macWidgetHistoryCachePath(root, 'hub-a');
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    fs.writeFileSync(cachePath, '{broken');
+    assert.equal(readMacWidgetHistoryCache(cachePath, 'hub-a'), null);
+  });
+});
+
+test('history cache bounds reads before parsing', () => {
+  withTempRoot((root) => {
+    const cachePath = macWidgetHistoryCachePath(root, 'hub-a');
+    const warnings = [];
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    fs.writeFileSync(cachePath, 'x'.repeat(MAX_MAC_WIDGET_HISTORY_CACHE_BYTES + 1));
+
+    assert.equal(readMacWidgetHistoryCache(cachePath, 'hub-a', {
+      logger: (message) => warnings.push(message)
+    }), null);
+    assert.ok(warnings.some((message) => /exceeds/.test(message)));
+  });
+});
+
+test('history cache refuses an oversized write before creating a file', () => {
+  withTempRoot((root) => {
+    const cachePath = macWidgetHistoryCachePath(root, 'hub-a');
+    assert.throws(
+      () => writeMacWidgetHistoryCache(cachePath, 'hub-a', history('too-large'), { maxBytes: 32 }),
+      /exceeds 32 bytes/
+    );
+    assert.equal(fs.existsSync(cachePath), false);
+  });
+});
+
+test('history cache rejects non-regular files', () => {
+  withTempRoot((root) => {
+    const cachePath = macWidgetHistoryCachePath(root, 'hub-a');
+    fs.mkdirSync(cachePath, { recursive: true });
+    assert.equal(readMacWidgetHistoryCache(cachePath, 'hub-a'), null);
+  });
+});
+
+test('history cache rejects symlinks', { skip: process.platform === 'win32' }, () => {
+  withTempRoot((root) => {
+    const realPath = macWidgetHistoryCachePath(root, 'real');
+    const linkPath = macWidgetHistoryCachePath(root, 'hub-a');
+    writeMacWidgetHistoryCache(realPath, 'real', history('real'));
+    fs.symlinkSync(realPath, linkPath);
+    assert.equal(readMacWidgetHistoryCache(linkPath, 'hub-a'), null);
+  });
+});

--- a/tests/electron/macWidgetHistoryStore.test.js
+++ b/tests/electron/macWidgetHistoryStore.test.js
@@ -1,109 +1,225 @@
 'use strict';
 
 const assert = require('node:assert/strict');
-const fs = require('node:fs');
+const fsSync = require('node:fs');
+const fs = require('node:fs/promises');
 const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
+const { MAC_WIDGET_ACTIVITY_DAYS } = require('../../src/shared/macWidgetSnapshot');
 const {
+  MAC_WIDGET_HISTORY_CACHE_VERSION,
   MAX_MAC_WIDGET_HISTORY_CACHE_BYTES,
+  MAX_MAC_WIDGET_HISTORY_CACHE_ENTRIES,
   macWidgetHistoryCachePath,
+  projectMacWidgetHistory,
   readMacWidgetHistoryCache,
   writeMacWidgetHistoryCache
 } = require('../../src/electron/macWidgetHistoryStore');
 
-function history(label) {
-  return { daily: [{ date: '2026-08-09', totalTokens: 1, label }], monthly: [], summary: { label } };
+function history(label = 'saved', daily = null) {
+  return {
+    daily: daily || [{
+      date: '2026-08-09',
+      tokens: 123,
+      cost: 0.25,
+      messages: 4,
+      perClient: { codex: { tokens: 123, cost: 0.25 } },
+      perModel: { sensitiveModel: { tokens: 123, cost: 0.25 } },
+      label
+    }],
+    monthly: [{ month: '2026-08', tokens: 123, perClient: { codex: { tokens: 123 } } }],
+    summary: { favoriteModel: 'sensitiveModel', label }
+  };
 }
 
-function withTempRoot(callback) {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'token-monitor-widget-history-'));
+async function withTempRoot(callback) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'token-monitor-widget-history-'));
   try {
-    return callback(root);
+    return await callback(root);
   } finally {
-    fs.rmSync(root, { recursive: true, force: true });
+    await fs.rm(root, { recursive: true, force: true });
   }
 }
 
-test('history cache round-trips atomically with private permissions', () => {
-  withTempRoot((root) => {
+test('production history cache storage uses only asynchronous filesystem I/O', () => {
+  const source = fsSync.readFileSync(
+    path.join(__dirname, '..', '..', 'src', 'electron', 'macWidgetHistoryStore.js'),
+    'utf8'
+  );
+  assert.match(source, /require\('node:fs\/promises'\)/);
+  assert.doesNotMatch(source, /readRegularFileNoFollow|writePrivateJsonAtomic/);
+  assert.doesNotMatch(
+    source,
+    /\b(?:lstat|open|fstat|fchmod|read|readFile|write|writeFile|fsync|rename|mkdir|rm|close)Sync\b/
+  );
+});
+
+test('history cache round-trips a private Widget-only projection atomically', async () => {
+  await withTempRoot(async (root) => {
     const cachePath = macWidgetHistoryCachePath(root, 'hub-a');
-    const value = history('saved');
+    const value = history();
 
-    writeMacWidgetHistoryCache(cachePath, 'hub-a', value);
+    const writePromise = writeMacWidgetHistoryCache(cachePath, 'hub-a', value);
+    assert.equal(typeof writePromise?.then, 'function');
+    await writePromise;
 
-    assert.deepEqual(readMacWidgetHistoryCache(cachePath, 'hub-a'), value);
+    const readPromise = readMacWidgetHistoryCache(cachePath, 'hub-a');
+    assert.equal(typeof readPromise?.then, 'function');
+    assert.deepEqual(await readPromise, {
+      daily: [{ date: '2026-08-09', tokens: 123, cost: 0.25 }],
+      monthly: [],
+      summary: {}
+    });
     if (process.platform !== 'win32') {
-      assert.equal(fs.statSync(cachePath).mode & 0o777, 0o600);
-      assert.equal(fs.statSync(path.dirname(cachePath)).mode & 0o777, 0o700);
+      assert.equal((await fs.stat(cachePath)).mode & 0o777, 0o600);
+      assert.equal((await fs.stat(path.dirname(cachePath))).mode & 0o777, 0o700);
     }
-    assert.deepEqual(fs.readdirSync(path.dirname(cachePath)), [path.basename(cachePath)]);
+    assert.deepEqual(await fs.readdir(path.dirname(cachePath)), [path.basename(cachePath)]);
+
+    const raw = await fs.readFile(cachePath, 'utf8');
+    assert.doesNotMatch(raw, /sensitiveModel|perClient|perModel|monthly|summary|messages|label/);
   });
 });
 
-test('history cache rejects a different source and schema version', () => {
-  withTempRoot((root) => {
-    const cachePath = macWidgetHistoryCachePath(root, 'hub-a');
-    writeMacWidgetHistoryCache(cachePath, 'hub-a', history('saved'));
-    assert.equal(readMacWidgetHistoryCache(cachePath, 'hub-b'), null);
+test('Widget history projection keeps only the latest Activity window', () => {
+  const start = Date.UTC(2025, 0, 1);
+  const daily = Array.from({ length: MAC_WIDGET_ACTIVITY_DAYS + 18 }, (_value, index) => ({
+    date: new Date(start + index * 86_400_000).toISOString().slice(0, 10),
+    tokens: index + 0.6,
+    cost: index / 10,
+    perClient: { privateClient: { tokens: index } }
+  }));
 
-    fs.writeFileSync(cachePath, JSON.stringify({
+  const projected = projectMacWidgetHistory(history('full', daily));
+  assert.equal(projected.daily.length, MAC_WIDGET_ACTIVITY_DAYS);
+  assert.equal(projected.daily[0].date, daily[18].date);
+  assert.deepEqual(Object.keys(projected.daily[0]), ['date', 'tokens', 'cost']);
+  assert.equal(projected.daily[0].tokens, Math.round(daily[18].tokens));
+  assert.deepEqual(projected.monthly, []);
+  assert.deepEqual(projected.summary, {});
+});
+
+test('history cache serializes once and writes the same serialized payload', async () => {
+  await withTempRoot(async (root) => {
+    const cachePath = macWidgetHistoryCachePath(root, 'hub-a');
+    let calls = 0;
+    let expected = '';
+    await writeMacWidgetHistoryCache(cachePath, 'hub-a', history(), {
+      stringify: (document) => {
+        calls += 1;
+        expected = JSON.stringify(document);
+        return expected;
+      }
+    });
+
+    assert.equal(calls, 1);
+    assert.equal(await fs.readFile(cachePath, 'utf8'), `${expected}\n`);
+  });
+});
+
+test('history cache rejects a different source and schema version', async () => {
+  await withTempRoot(async (root) => {
+    const cachePath = macWidgetHistoryCachePath(root, 'hub-a');
+    await writeMacWidgetHistoryCache(cachePath, 'hub-a', history());
+    assert.equal(await readMacWidgetHistoryCache(cachePath, 'hub-b'), null);
+
+    await fs.writeFile(cachePath, JSON.stringify({
       version: 999,
       source: 'anything',
-      history: history('wrong-version')
+      daily: []
     }));
-    assert.equal(readMacWidgetHistoryCache(cachePath, 'hub-a'), null);
+    assert.equal(await readMacWidgetHistoryCache(cachePath, 'hub-a'), null);
   });
 });
 
-test('history cache ignores malformed JSON', () => {
-  withTempRoot((root) => {
+test('history cache ignores malformed or overlong projected documents', async () => {
+  await withTempRoot(async (root) => {
     const cachePath = macWidgetHistoryCachePath(root, 'hub-a');
-    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
-    fs.writeFileSync(cachePath, '{broken');
-    assert.equal(readMacWidgetHistoryCache(cachePath, 'hub-a'), null);
+    await fs.mkdir(path.dirname(cachePath), { recursive: true });
+    await fs.writeFile(cachePath, '{broken');
+    assert.equal(await readMacWidgetHistoryCache(cachePath, 'hub-a'), null);
+
+    const source = path.basename(cachePath, '.json');
+    await fs.writeFile(cachePath, JSON.stringify({
+      version: MAC_WIDGET_HISTORY_CACHE_VERSION,
+      source,
+      daily: Array.from({ length: MAC_WIDGET_ACTIVITY_DAYS + 1 }, (_value, index) => ({
+        date: `2026-01-${String(index + 1).padStart(2, '0')}`,
+        tokens: 1,
+        cost: 0
+      }))
+    }));
+    assert.equal(await readMacWidgetHistoryCache(cachePath, 'hub-a'), null);
   });
 });
 
-test('history cache bounds reads before parsing', () => {
-  withTempRoot((root) => {
+test('history cache bounds reads before parsing', async () => {
+  await withTempRoot(async (root) => {
     const cachePath = macWidgetHistoryCachePath(root, 'hub-a');
     const warnings = [];
-    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
-    fs.writeFileSync(cachePath, 'x'.repeat(MAX_MAC_WIDGET_HISTORY_CACHE_BYTES + 1));
+    await fs.mkdir(path.dirname(cachePath), { recursive: true });
+    await fs.writeFile(cachePath, 'x'.repeat(MAX_MAC_WIDGET_HISTORY_CACHE_BYTES + 1));
 
-    assert.equal(readMacWidgetHistoryCache(cachePath, 'hub-a', {
+    assert.equal(await readMacWidgetHistoryCache(cachePath, 'hub-a', {
       logger: (message) => warnings.push(message)
     }), null);
     assert.ok(warnings.some((message) => /exceeds/.test(message)));
   });
 });
 
-test('history cache refuses an oversized write before creating a file', () => {
-  withTempRoot((root) => {
+test('history cache refuses an oversized write before creating a file', async () => {
+  await withTempRoot(async (root) => {
     const cachePath = macWidgetHistoryCachePath(root, 'hub-a');
-    assert.throws(
-      () => writeMacWidgetHistoryCache(cachePath, 'hub-a', history('too-large'), { maxBytes: 32 }),
+    await assert.rejects(
+      writeMacWidgetHistoryCache(cachePath, 'hub-a', history(), { maxBytes: 32 }),
       /exceeds 32 bytes/
     );
-    assert.equal(fs.existsSync(cachePath), false);
+    assert.equal(fsSync.existsSync(cachePath), false);
   });
 });
 
-test('history cache rejects non-regular files', () => {
-  withTempRoot((root) => {
+test('history cache rejects non-regular files', async () => {
+  await withTempRoot(async (root) => {
     const cachePath = macWidgetHistoryCachePath(root, 'hub-a');
-    fs.mkdirSync(cachePath, { recursive: true });
-    assert.equal(readMacWidgetHistoryCache(cachePath, 'hub-a'), null);
+    await fs.mkdir(cachePath, { recursive: true });
+    assert.equal(await readMacWidgetHistoryCache(cachePath, 'hub-a'), null);
   });
 });
 
-test('history cache rejects symlinks', { skip: process.platform === 'win32' }, () => {
-  withTempRoot((root) => {
+test('history cache rejects symlinks', { skip: process.platform === 'win32' }, async () => {
+  await withTempRoot(async (root) => {
     const realPath = macWidgetHistoryCachePath(root, 'real');
     const linkPath = macWidgetHistoryCachePath(root, 'hub-a');
-    writeMacWidgetHistoryCache(realPath, 'real', history('real'));
-    fs.symlinkSync(realPath, linkPath);
-    assert.equal(readMacWidgetHistoryCache(linkPath, 'hub-a'), null);
+    await writeMacWidgetHistoryCache(realPath, 'real', history());
+    await fs.symlink(realPath, linkPath);
+    assert.equal(await readMacWidgetHistoryCache(linkPath, 'hub-a'), null);
+  });
+});
+
+test('history cache retains only the newest bounded source entries', async () => {
+  await withTempRoot(async (root) => {
+    const paths = [];
+    for (let index = 0; index < MAX_MAC_WIDGET_HISTORY_CACHE_ENTRIES; index += 1) {
+      const sourceKey = `hub-${index}`;
+      const cachePath = macWidgetHistoryCachePath(root, sourceKey);
+      paths.push(cachePath);
+      await writeMacWidgetHistoryCache(cachePath, sourceKey, history(String(index)));
+      const timestamp = new Date(1_000_000 + index * 1_000);
+      await fs.utimes(cachePath, timestamp, timestamp);
+    }
+
+    for (let index = MAX_MAC_WIDGET_HISTORY_CACHE_ENTRIES; index < MAX_MAC_WIDGET_HISTORY_CACHE_ENTRIES + 2; index += 1) {
+      const sourceKey = `hub-${index}`;
+      const cachePath = macWidgetHistoryCachePath(root, sourceKey);
+      paths.push(cachePath);
+      await writeMacWidgetHistoryCache(cachePath, sourceKey, history(String(index)));
+    }
+
+    const names = await fs.readdir(path.dirname(paths.at(-1)));
+    assert.equal(names.length, MAX_MAC_WIDGET_HISTORY_CACHE_ENTRIES);
+    assert.equal(fsSync.existsSync(paths[0]), false);
+    assert.equal(fsSync.existsSync(paths[1]), false);
+    assert.equal(fsSync.existsSync(paths.at(-1)), true);
   });
 });

--- a/tests/electron/macWidgetIntegration.test.js
+++ b/tests/electron/macWidgetIntegration.test.js
@@ -121,7 +121,7 @@ test('Widget ownership advances producer lifetime only for mode transitions', ()
   );
 });
 
-test('production persisted history reads forward store warnings to the main-process logger', () => {
+test('production persisted history I/O forwards store warnings to the main-process logger', () => {
   const start = mainSource.indexOf('resolveHistory: (work) => resolveMacWidgetHistory({');
   const end = mainSource.indexOf('\n    prepareSnapshot:', start);
   assert.ok(start >= 0 && end > start, 'Widget history resolver wiring should exist');
@@ -129,6 +129,10 @@ test('production persisted history reads forward store warnings to the main-proc
   assert.match(
     resolverSource,
     /loadCachedHistory: \(\) => readMacWidgetHistoryCache\(\s*work\.historyCachePath,\s*work\.owner\.sourceKey,\s*\{ logger: \(message\) => console\.warn\(message\) \}\s*\),/
+  );
+  assert.match(
+    resolverSource,
+    /saveCachedHistory: \(history\) => writeMacWidgetHistoryCache\(\s*work\.historyCachePath,\s*work\.owner\.sourceKey,\s*history,\s*\{ logger: \(message\) => console\.warn\(message\) \}\s*\)/
   );
 });
 

--- a/tests/electron/macWidgetIntegration.test.js
+++ b/tests/electron/macWidgetIntegration.test.js
@@ -121,6 +121,17 @@ test('Widget ownership advances producer lifetime only for mode transitions', ()
   );
 });
 
+test('production persisted history reads forward store warnings to the main-process logger', () => {
+  const start = mainSource.indexOf('resolveHistory: (work) => resolveMacWidgetHistory({');
+  const end = mainSource.indexOf('\n    prepareSnapshot:', start);
+  assert.ok(start >= 0 && end > start, 'Widget history resolver wiring should exist');
+  const resolverSource = mainSource.slice(start, end);
+  assert.match(
+    resolverSource,
+    /loadCachedHistory: \(\) => readMacWidgetHistoryCache\(\s*work\.historyCachePath,\s*work\.owner\.sourceKey,\s*\{ logger: \(message\) => console\.warn\(message\) \}\s*\),/
+  );
+});
+
 test('starts the runtime immediately and holds only Widget publication until host registration settles', () => {
   const readyStart = mainSource.indexOf('app.whenReady().then(() => {');
   const readyEnd = mainSource.indexOf("ipcMain.handle('settings:get'", readyStart);


### PR DESCRIPTION
Follow-up to #363.

## Summary

- Persist the last successful remote Widget history in a source-keyed private cache, so a cold start can still render the last known Activity and Trend data when the hub is temporarily unavailable.
- Load the persisted copy before the remote request and keep the bounded retry behavior; cache read and write failures remain fail-open and observable through the main-process logger.
- Keep local and embedded history in memory only, avoiding unnecessary disk writes.
- Use asynchronous no-follow reads and atomic durable writes so cache I/O does not block the Electron main thread; serialize the document once and reuse the same bytes for validation and writing.
- Persist a versioned Widget-only projection containing at most the latest 182 daily `{ date, tokens, cost }` points, omitting lifetime monthly, summary, client, and model breakdowns.
- Bound each cache file to 256 KiB and retain only the eight newest source entries, while preserving private `0600` files in a `0700` directory and rejecting malformed, mismatched, oversized, symlinked, or non-regular cache files.

## Verification

- `npm run verify`: 2823 passed, 1 skipped
- Focused Widget history/store/integration tests: 108 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the last successful remote Widget history to a source-keyed private cache so cold starts can still render Activity/Trend when the hub is unreachable. The cache loads before remote fetches, is hardened for safety, and now surfaces read, write, and cleanup warnings to the main-process logger.

- **Bug Fixes**
  - Added disk-backed per-source cache in userData/mac-widget-history/*.json; loaded before remote requests; local/embedded sources remain in-memory.
  - Hardened store: versioned JSON, SHA-256 source fingerprint, secret-agnostic source key, validation/coercion, bounded read/write sizes, 182-day Activity projection, and retention of only the 8 newest source entries.
  - I/O safety and integration: async no-follow reads; atomic 0600 writes in a 0700 dir; reject non-regular files/symlinks/malformed/oversized data; forward persisted read/write/cleanup warnings to the main-process logger; wired via `resolveMacWidgetHistory` load/save hooks; exported `isHistoryDocument`; added tests.

<sup>Written for commit a7b869aafb54e9fa19a3f75df620c617e6182e48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

