### PR TITLE
feat(widget): gate snapshot pipeline on extension demand lease

### DIFF
--- a/native/macos/TokenMonitorWidget.xcodeproj/project.pbxproj
+++ b/native/macos/TokenMonitorWidget.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		10000000000000000000000D /* WidgetConfigurationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20000000000000000000000E /* WidgetConfigurationIntent.swift */; };
 		10000000000000000000000E /* WidgetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20000000000000000000000F /* WidgetViewModel.swift */; };
 		10000000000000000000000F /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000010 /* Localizable.xcstrings */; };
+		100000000000000000000010 /* WidgetDemandMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000011 /* WidgetDemandMarker.swift */; };
+		100000000000000000000011 /* WidgetDemandMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000011 /* WidgetDemandMarker.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -41,6 +43,7 @@
 		20000000000000000000000E /* WidgetConfigurationIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetConfigurationIntent.swift; sourceTree = "<group>"; };
 		20000000000000000000000F /* WidgetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetViewModel.swift; sourceTree = "<group>"; };
 		200000000000000000000010 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		200000000000000000000011 /* WidgetDemandMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetDemandMarker.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -81,6 +84,7 @@
 				200000000000000000000002 /* TokenMonitorWidgetBundle.swift */,
 				200000000000000000000003 /* WidgetSnapshot.swift */,
 				200000000000000000000004 /* WidgetTimelineProvider.swift */,
+				200000000000000000000011 /* WidgetDemandMarker.swift */,
 				20000000000000000000000E /* WidgetConfigurationIntent.swift */,
 				20000000000000000000000F /* WidgetViewModel.swift */,
 				200000000000000000000010 /* Localizable.xcstrings */,
@@ -208,6 +212,7 @@
 				100000000000000000000002 /* TokenMonitorWidgetBundle.swift in Sources */,
 				100000000000000000000003 /* WidgetSnapshot.swift in Sources */,
 				100000000000000000000004 /* WidgetTimelineProvider.swift in Sources */,
+				100000000000000000000010 /* WidgetDemandMarker.swift in Sources */,
 				10000000000000000000000B /* WidgetConfigurationIntent.swift in Sources */,
 				10000000000000000000000C /* WidgetViewModel.swift in Sources */,
 			);
@@ -218,6 +223,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				100000000000000000000008 /* WidgetSnapshotDecodingTests.swift in Sources */,
+				100000000000000000000011 /* WidgetDemandMarker.swift in Sources */,
 				100000000000000000000009 /* WidgetSnapshot.swift in Sources */,
 				10000000000000000000000D /* WidgetConfigurationIntent.swift in Sources */,
 				10000000000000000000000E /* WidgetViewModel.swift in Sources */,

--- a/native/macos/TokenMonitorWidget/WidgetDemandMarker.swift
+++ b/native/macos/TokenMonitorWidget/WidgetDemandMarker.swift
@@ -12,9 +12,18 @@ import Foundation
 // resolve it to the same path, and it is touched by updating mtime only (never
 // content), matching the host's `lstatSync`-based lease check.
 enum WidgetDemandMarker {
+    /// Touched by timeline(): a placed Widget asks for its next update. Fresh
+    /// means "a Widget is on screen and wants updates", so this is the full lease.
     static let fileName = "widget-demand"
 
+    /// Touched by snapshot() outside the gallery. WidgetKit calls snapshot() for
+    /// transient situations that include the add flow, before the user confirms
+    /// placement, so this signal only warms up a possible first placement and
+    /// must grant a short lease, never the full one.
+    static let provisionalFileName = "widget-demand-provisional"
+
     static func noteRequested(
+        fileName: String = Self.fileName,
         appGroup: String = "",
         container: URL? = nil,
         fileManager: FileManager = .default,

--- a/native/macos/TokenMonitorWidget/WidgetDemandMarker.swift
+++ b/native/macos/TokenMonitorWidget/WidgetDemandMarker.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+// The demand lease signal for the snapshot pipeline. Electron skips snapshot
+// work entirely while no Widget is on screen; it learns "a Widget wants data"
+// from this zero-content marker's mtime, which WidgetKit-driven entry points
+// touch whenever they genuinely render. Only real placements may write demand:
+// the gallery preview (`context.isPreview`) and the placeholder are not a
+// Widget the user actually keeps, so they must not create the marker — a
+// marker that has never existed is the one faithful "no Widget has ever asked".
+//
+// The file lives in the app group container, so the extension and the host app
+// resolve it to the same path, and it is touched by updating mtime only (never
+// content), matching the host's `lstatSync`-based lease check.
+enum WidgetDemandMarker {
+    static let fileName = "widget-demand"
+
+    static func noteRequested(
+        appGroup: String = "",
+        container: URL? = nil,
+        fileManager: FileManager = .default,
+        now: Date = Date()
+    ) {
+        let resolved = container ?? (appGroup.isEmpty ? nil : fileManager.containerURL(
+            forSecurityApplicationGroupIdentifier: appGroup
+        ))
+        guard let directory = resolved else { return }
+        let url = directory.appendingPathComponent(fileName)
+        if !fileManager.fileExists(atPath: url.path) {
+            try? Data().write(to: url, options: .atomic)
+        }
+        try? fileManager.setAttributes([.modificationDate: now], ofItemAtPath: url.path)
+    }
+}

--- a/native/macos/TokenMonitorWidget/WidgetTimelineProvider.swift
+++ b/native/macos/TokenMonitorWidget/WidgetTimelineProvider.swift
@@ -16,7 +16,11 @@ struct TokenMonitorTimelineProvider: AppIntentTimelineProvider {
     func snapshot(for configuration: TokenMonitorWidgetConfigurationIntent, in context: Context) async -> TokenMonitorEntry {
         let now = Date()
         if !context.isPreview {
-            WidgetDemandMarker.noteRequested(appGroup: TokenMonitorWidgetConfiguration.appGroup, now: now)
+            WidgetDemandMarker.noteRequested(
+                fileName: WidgetDemandMarker.provisionalFileName,
+                appGroup: TokenMonitorWidgetConfiguration.appGroup,
+                now: now
+            )
         }
         let page = effectivePage(for: configuration, family: context.family)
         let period = WidgetPeriodPolicy.effectivePeriod(for: page, selectedPeriod: currentPeriod())

--- a/native/macos/TokenMonitorWidget/WidgetTimelineProvider.swift
+++ b/native/macos/TokenMonitorWidget/WidgetTimelineProvider.swift
@@ -15,6 +15,9 @@ struct TokenMonitorTimelineProvider: AppIntentTimelineProvider {
 
     func snapshot(for configuration: TokenMonitorWidgetConfigurationIntent, in context: Context) async -> TokenMonitorEntry {
         let now = Date()
+        if !context.isPreview {
+            WidgetDemandMarker.noteRequested(appGroup: TokenMonitorWidgetConfiguration.appGroup, now: now)
+        }
         let page = effectivePage(for: configuration, family: context.family)
         let period = WidgetPeriodPolicy.effectivePeriod(for: page, selectedPeriod: currentPeriod())
         let snapshot = WidgetPeriodPolicy.previewAwareSnapshot(
@@ -28,6 +31,7 @@ struct TokenMonitorTimelineProvider: AppIntentTimelineProvider {
 
     func timeline(for configuration: TokenMonitorWidgetConfigurationIntent, in context: Context) async -> Timeline<TokenMonitorEntry> {
         let now = Date()
+        WidgetDemandMarker.noteRequested(appGroup: TokenMonitorWidgetConfiguration.appGroup, now: now)
         let page = effectivePage(for: configuration, family: context.family)
         let period = WidgetPeriodPolicy.effectivePeriod(for: page, selectedPeriod: currentPeriod())
         let snapshot = currentSnapshot(period: period)

--- a/native/macos/TokenMonitorWidgetTests/WidgetSnapshotDecodingTests.swift
+++ b/native/macos/TokenMonitorWidgetTests/WidgetSnapshotDecodingTests.swift
@@ -1254,6 +1254,53 @@ final class WidgetSnapshotDecodingTests: XCTestCase {
     }
 }
 
+final class WidgetDemandMarkerTests: XCTestCase {
+    func testFirstRequestCreatesAZeroContentMarkerAtTheGivenTime() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let marker = directory.appendingPathComponent(WidgetDemandMarker.fileName)
+        let requestedAt = Date(timeIntervalSince1970: 1_000_000)
+
+        WidgetDemandMarker.noteRequested(container: directory, now: requestedAt)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: marker.path))
+        let attributes = try XCTUnwrap(FileManager.default.attributesOfItem(atPath: marker.path))
+        XCTAssertEqual(try XCTUnwrap(attributes[.size] as? Int), 0)
+        XCTAssertEqual(try XCTUnwrap(attributes[.modificationDate] as? Date), requestedAt)
+    }
+
+    func testLaterRequestRenewsOnlyTheMtimeNotTheContent() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let marker = directory.appendingPathComponent(WidgetDemandMarker.fileName)
+
+        WidgetDemandMarker.noteRequested(container: directory, now: Date(timeIntervalSince1970: 1_000_000))
+        WidgetDemandMarker.noteRequested(container: directory, now: Date(timeIntervalSince1970: 1_000_600))
+
+        let attributes = try XCTUnwrap(FileManager.default.attributesOfItem(atPath: marker.path))
+        XCTAssertEqual(try XCTUnwrap(attributes[.size] as? Int), 0)
+        XCTAssertEqual(try XCTUnwrap(attributes[.modificationDate] as? Date), Date(timeIntervalSince1970: 1_000_600))
+    }
+
+    func testUnresolvableContainerIsANoOp() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        WidgetDemandMarker.noteRequested(appGroup: "", container: nil, now: Date())
+
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent(WidgetDemandMarker.fileName).path
+        ))
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("demand-marker-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}
+
 final class WidgetTimelineProviderPreviewTests: XCTestCase {
     // The gallery is where someone decides whether the widget is worth adding.
     // Before this fallback existed it rendered the redacted placeholder skeleton

--- a/native/macos/TokenMonitorWidgetTests/WidgetSnapshotDecodingTests.swift
+++ b/native/macos/TokenMonitorWidgetTests/WidgetSnapshotDecodingTests.swift
@@ -1293,6 +1293,26 @@ final class WidgetDemandMarkerTests: XCTestCase {
         ))
     }
 
+    func testProvisionalSignalWritesItsOwnFileOnly() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let full = directory.appendingPathComponent(WidgetDemandMarker.fileName)
+        let provisional = directory.appendingPathComponent(WidgetDemandMarker.provisionalFileName)
+
+        WidgetDemandMarker.noteRequested(
+            fileName: WidgetDemandMarker.provisionalFileName,
+            container: directory,
+            now: Date(timeIntervalSince1970: 1_000_000)
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: full.path),
+                       "snapshot demand must not touch the full lease")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: provisional.path))
+        let attributes = try XCTUnwrap(FileManager.default.attributesOfItem(atPath: provisional.path))
+        XCTAssertEqual(try XCTUnwrap(attributes[.size] as? Int), 0)
+        XCTAssertEqual(try XCTUnwrap(attributes[.modificationDate] as? Date), Date(timeIntervalSince1970: 1_000_000))
+    }
+
     private func temporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("demand-marker-\(UUID().uuidString)")

--- a/src/electron/macWidgetDemand.js
+++ b/src/electron/macWidgetDemand.js
@@ -3,39 +3,58 @@
 // Tracks whether the user actually has a Widget on screen (demand) so the
 // snapshot pipeline — history resolution, serialization, fsync, reload helper
 // spawn — can be skipped entirely while nothing is installed. The signal is a
-// zero-content "widget-demand" marker file in the app group container that the
-// widget extension touches whenever WidgetKit genuinely asks it for data
-// (timeline() always, snapshot() outside the gallery preview, never
-// placeholder()). The extension is the only process WidgetKit lets speak for
-// the widgets, so its marker mtime is the demand lease.
+// zero-content marker file in the app group container that the widget extension
+// touches whenever WidgetKit genuinely asks it for data. The extension is the
+// only process WidgetKit lets speak for the widgets, so its marker mtimes are
+// the demand lease.
 //
-// The lease is deliberately very conservative: WidgetKit does not refresh a
-// placed widget on a fixed cadence (a `.after(15 min)` timeline policy is only
-// the earliest it may ask again, and rarely-viewed widgets are throttled much
-// further), so a short TTL would starve a real widget. A long lease means a
-// removed widget keeps the pipeline warm for a few days — the accepted trade
+// Two markers carry two lease lengths:
+//   - "widget-demand" (full, 72 h): touched by timeline(). A placed widget
+//     asking for its next update is the only authoritative "Widget on screen".
+//   - "widget-demand-provisional" (short): touched by snapshot() outside the
+//     gallery. WidgetKit calls snapshot() for transient situations that include
+//     the add flow, before the user confirms placement, so this only warms up a
+//     possible first placement and must not grant the full lease.
+// A fresh marker of either length opens the gate; a real placement upgrades to
+// the full lease on the next timeline(), while a cancelled add flow lets the
+// provisional signal expire on its own.
+//
+// The leases are deliberately conservative: WidgetKit does not refresh a placed
+// widget on a fixed cadence (a `.after(15 min)` timeline policy is only the
+// earliest it may ask again, and rarely-viewed widgets are throttled much
+// further), so a short TTL would starve a real widget. A long full lease means
+// a removed widget keeps the pipeline warm for a few days — the accepted trade
 // for never mis-gating someone who does have one. Users who never add a widget
-// pay zero from day one, because the marker never exists (ENOENT closes the
-// gate on the very first probe).
+// pay zero from day one, because neither marker ever exists (ENOENT closes the
+// gate on the very first probe). A stale lease does not permanently starve a
+// placed widget: the next genuine timeline request re-opens the gate within
+// moments, and the host then produces a fresh snapshot and asks WidgetKit to
+// reload.
 //
 // First-widget activation uses a directory watcher so the initial snapshot
 // lands within moments of placement, with a low-frequency reconcile poll as
-// the fallback. Every non-ENOENT error is fail-open: only a confirmed missing
-// or stale marker may gate work, because skipping work for a user who does
-// have a Widget would starve the one thing this feature exists to keep fresh.
+// the fallback. Every non-ENOENT error is fail-open: only confirmed missing or
+// stale markers may gate work, because skipping work for a user who does have a
+// Widget would starve the one thing this feature exists to keep fresh.
 
 const fsSync = require('node:fs');
 const path = require('node:path');
 
 const WIDGET_DEMAND_MARKER = 'widget-demand';
+const WIDGET_DEMAND_PROVISIONAL_MARKER = 'widget-demand-provisional';
 const DEFAULT_DEMAND_LEASE_MS = 72 * 60 * 60 * 1000;
+const DEFAULT_PROVISIONAL_LEASE_MS = 10 * 60 * 1000;
 const DEFAULT_RECONCILE_MS = 30_000;
 
 function createMacWidgetDemandState(options = {}) {
   const markerPath = String(options.markerPath || '').trim();
+  const provisionalMarkerPath = String(options.provisionalMarkerPath || '').trim() || null;
   const leaseMs = Number.isFinite(options.leaseMs)
     ? Math.max(1, options.leaseMs)
     : DEFAULT_DEMAND_LEASE_MS;
+  const provisionalLeaseMs = Number.isFinite(options.provisionalLeaseMs)
+    ? Math.max(1, options.provisionalLeaseMs)
+    : DEFAULT_PROVISIONAL_LEASE_MS;
   const reconcileMs = Number.isFinite(options.reconcileMs)
     ? Math.max(1, options.reconcileMs)
     : DEFAULT_RECONCILE_MS;
@@ -58,12 +77,12 @@ function createMacWidgetDemandState(options = {}) {
   }
 
   // Returns the marker age in ms, or null when the marker has never existed.
-  // A clean missing file is the one signal that may close the gate; any other
-  // read outcome throws so the caller fails open instead.
-  function probe() {
+  // A clean missing file is the one signal that may count as "no demand"; any
+  // other read outcome throws so the caller fails open instead.
+  function probeMarker(targetPath) {
     let stat;
     try {
-      stat = fsApi.lstatSync(markerPath);
+      stat = fsApi.lstatSync(targetPath);
     } catch (error) {
       if (error?.code === 'ENOENT') return null;
       throw error;
@@ -71,8 +90,16 @@ function createMacWidgetDemandState(options = {}) {
     return now() - stat.mtimeMs;
   }
 
-  function apply(age) {
-    const nowInstalled = age === null ? false : age < leaseMs;
+  function probe() {
+    const ages = { full: probeMarker(markerPath), provisional: null };
+    if (provisionalMarkerPath) ages.provisional = probeMarker(provisionalMarkerPath);
+    return ages;
+  }
+
+  function apply(ages) {
+    const fullFresh = ages.full !== null && ages.full < leaseMs;
+    const provisionalFresh = ages.provisional !== null && ages.provisional < provisionalLeaseMs;
+    const nowInstalled = fullFresh || provisionalFresh;
     const wasInstalled = installed;
     installed = nowInstalled;
     if (nowInstalled && !wasInstalled) {
@@ -87,15 +114,15 @@ function createMacWidgetDemandState(options = {}) {
 
   async function refresh() {
     if (stopped) return;
-    let age;
+    let ages;
     try {
-      age = probe();
+      ages = probe();
     } catch (error) {
       log(`[mac-widget] widget demand marker unreadable; assuming a widget is present: ${error?.message || error}`);
-      apply(0); // fail-open: a broken marker must not read as "no widgets"
+      apply({ full: 0, provisional: 0 }); // fail-open: a broken marker must not read as "no widgets"
       return;
     }
-    apply(age);
+    apply(ages);
   }
 
   function start() {
@@ -137,12 +164,12 @@ function createMacWidgetDemandState(options = {}) {
   }
 
   // Seed the initial answer synchronously so the first tick's gate is correct
-  // (closed) for a marker that never existed instead of fail-open.
+  // (closed) for markers that never existed instead of fail-open.
   if (markerPath) {
     try {
       apply(probe());
     } catch (_) {
-      apply(0);
+      apply({ full: 0, provisional: 0 });
     }
   }
 
@@ -151,7 +178,9 @@ function createMacWidgetDemandState(options = {}) {
 
 module.exports = {
   DEFAULT_DEMAND_LEASE_MS,
+  DEFAULT_PROVISIONAL_LEASE_MS,
   DEFAULT_RECONCILE_MS,
   WIDGET_DEMAND_MARKER,
+  WIDGET_DEMAND_PROVISIONAL_MARKER,
   createMacWidgetDemandState
 };

--- a/src/electron/macWidgetDemand.js
+++ b/src/electron/macWidgetDemand.js
@@ -1,0 +1,157 @@
+'use strict';
+
+// Tracks whether the user actually has a Widget on screen (demand) so the
+// snapshot pipeline — history resolution, serialization, fsync, reload helper
+// spawn — can be skipped entirely while nothing is installed. The signal is a
+// zero-content "widget-demand" marker file in the app group container that the
+// widget extension touches whenever WidgetKit genuinely asks it for data
+// (timeline() always, snapshot() outside the gallery preview, never
+// placeholder()). The extension is the only process WidgetKit lets speak for
+// the widgets, so its marker mtime is the demand lease.
+//
+// The lease is deliberately very conservative: WidgetKit does not refresh a
+// placed widget on a fixed cadence (a `.after(15 min)` timeline policy is only
+// the earliest it may ask again, and rarely-viewed widgets are throttled much
+// further), so a short TTL would starve a real widget. A long lease means a
+// removed widget keeps the pipeline warm for a few days — the accepted trade
+// for never mis-gating someone who does have one. Users who never add a widget
+// pay zero from day one, because the marker never exists (ENOENT closes the
+// gate on the very first probe).
+//
+// First-widget activation uses a directory watcher so the initial snapshot
+// lands within moments of placement, with a low-frequency reconcile poll as
+// the fallback. Every non-ENOENT error is fail-open: only a confirmed missing
+// or stale marker may gate work, because skipping work for a user who does
+// have a Widget would starve the one thing this feature exists to keep fresh.
+
+const fsSync = require('node:fs');
+const path = require('node:path');
+
+const WIDGET_DEMAND_MARKER = 'widget-demand';
+const DEFAULT_DEMAND_LEASE_MS = 72 * 60 * 60 * 1000;
+const DEFAULT_RECONCILE_MS = 30_000;
+
+function createMacWidgetDemandState(options = {}) {
+  const markerPath = String(options.markerPath || '').trim();
+  const leaseMs = Number.isFinite(options.leaseMs)
+    ? Math.max(1, options.leaseMs)
+    : DEFAULT_DEMAND_LEASE_MS;
+  const reconcileMs = Number.isFinite(options.reconcileMs)
+    ? Math.max(1, options.reconcileMs)
+    : DEFAULT_RECONCILE_MS;
+  const fsApi = options.fs || fsSync;
+  const now = options.now || Date.now;
+  const setIntervalImpl = options.setInterval || setInterval;
+  const clearIntervalImpl = options.clearInterval || clearInterval;
+  const watchImpl = options.watch
+    || ((directory, callback) => fsApi.watch(directory, { persistent: false }, callback));
+  const onActivation = options.onActivation;
+  const logger = options.logger;
+
+  let installed = true; // fail-open until a probe confirms otherwise
+  let watcher = null;
+  let intervalId = null;
+  let stopped = false;
+
+  function log(message) {
+    try { logger?.(message); } catch (_) {}
+  }
+
+  // Returns the marker age in ms, or null when the marker has never existed.
+  // A clean missing file is the one signal that may close the gate; any other
+  // read outcome throws so the caller fails open instead.
+  function probe() {
+    let stat;
+    try {
+      stat = fsApi.lstatSync(markerPath);
+    } catch (error) {
+      if (error?.code === 'ENOENT') return null;
+      throw error;
+    }
+    return now() - stat.mtimeMs;
+  }
+
+  function apply(age) {
+    const nowInstalled = age === null ? false : age < leaseMs;
+    const wasInstalled = installed;
+    installed = nowInstalled;
+    if (nowInstalled && !wasInstalled) {
+      log('[mac-widget] widget demand lease acquired; priming the first snapshot');
+      try {
+        onActivation?.();
+      } catch (error) {
+        log(`[mac-widget] widget demand activation callback failed: ${error?.message || error}`);
+      }
+    }
+  }
+
+  async function refresh() {
+    if (stopped) return;
+    let age;
+    try {
+      age = probe();
+    } catch (error) {
+      log(`[mac-widget] widget demand marker unreadable; assuming a widget is present: ${error?.message || error}`);
+      apply(0); // fail-open: a broken marker must not read as "no widgets"
+      return;
+    }
+    apply(age);
+  }
+
+  function start() {
+    if (stopped || watcher || intervalId !== null) return;
+    if (markerPath) {
+      try {
+        watcher = watchImpl(path.dirname(markerPath), () => { void refresh(); });
+        watcher?.on?.('error', (error) => {
+          log(`[mac-widget] widget demand watcher failed; falling back to reconcile polling: ${error?.message || error}`);
+          try { watcher?.close?.(); } catch (_) {}
+          watcher = null;
+        });
+      } catch (error) {
+        log(`[mac-widget] widget demand watcher unavailable; falling back to reconcile polling: ${error?.message || error}`);
+        watcher = null;
+      }
+    }
+    intervalId = setIntervalImpl(() => { void refresh(); }, reconcileMs);
+    void refresh();
+  }
+
+  // The gate the snapshot pipeline consults on every tick. Only a confirmed
+  // missing or stale marker reads false; everything else must not skip work.
+  function isInstalled() {
+    return installed;
+  }
+
+  function stop() {
+    if (stopped) return;
+    stopped = true;
+    if (watcher) {
+      try { watcher.close(); } catch (_) {}
+      watcher = null;
+    }
+    if (intervalId !== null) {
+      try { clearIntervalImpl(intervalId); } catch (_) {}
+      intervalId = null;
+    }
+  }
+
+  // Seed the initial answer synchronously so the first tick's gate is correct
+  // (closed) for a marker that never existed instead of fail-open.
+  if (markerPath) {
+    try {
+      apply(probe());
+    } catch (_) {
+      apply(0);
+    }
+  }
+
+  return { isInstalled, refresh, start, stop };
+}
+
+module.exports = {
+  DEFAULT_DEMAND_LEASE_MS,
+  DEFAULT_RECONCILE_MS,
+  WIDGET_DEMAND_MARKER,
+  createMacWidgetDemandState
+};

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -165,6 +165,7 @@ const { createMacWidgetLaunchServicesRecovery } = require('./macWidgetLaunchServ
 const { projectLimitStatsForDisplay } = require('./limitStatsPresentation');
 const { normalizeWidgetURLScheme } = require('../shared/macWidgetConfig');
 const { DEFAULT_WIDGET_KIND, requestMacWidgetReload, resetMacWidgetReloadThrottle } = require('./macWidgetReloader');
+const { WIDGET_DEMAND_MARKER, createMacWidgetDemandState } = require('./macWidgetDemand');
 const linuxAutostart = require('./linuxAutostart');
 const { codexAccountIdForProvider, localLiveCodexProvider } = require('./renderer/accountIdentity');
 const {
@@ -2336,6 +2337,7 @@ let hubModeGeneration = 0;
 let tray = null;
 let latestStats = null;
 let macWidgetSnapshotController = null;
+let macWidgetDemand = null;
 let macWidgetPublicationReady = false;
 let cachedMacWidgetConfiguration;
 let trayRefreshInFlight = false;
@@ -3443,9 +3445,37 @@ function macWidgetPresentation() {
   });
 }
 
+function ensureMacWidgetDemand() {
+  if (process.platform !== 'darwin') return null;
+  if (macWidgetDemand) return macWidgetDemand;
+  const widget = macWidgetConfiguration();
+  if (!widget) return null;
+  // The demand lease lives beside the snapshot in the app group container. The
+  // widget extension touches it whenever WidgetKit genuinely asks for data, so
+  // a fresh marker here means "a Widget is on screen and wants updates". The
+  // watcher arms immediately so a first placement primes the initial snapshot
+  // within moments; the reconcile poll catches anything the watcher missed.
+  macWidgetDemand = createMacWidgetDemandState({
+    markerPath: path.join(path.dirname(widget.snapshotPath), WIDGET_DEMAND_MARKER),
+    onActivation: () => {
+      const visibleStats = electronPresentationStats(latestStats);
+      scheduleMacWidgetSnapshot(visibleStats, captureMacWidgetProducerOwner());
+    },
+    logger: (message) => console.warn(message)
+  });
+  macWidgetDemand.start();
+  return macWidgetDemand;
+}
+
 function captureMacWidgetWork({ stats, owner }) {
   const widget = macWidgetConfiguration();
   if (!widget) return null;
+  // No Widget on screen means no WidgetKit render loop is asking for data, so
+  // the whole snapshot pipeline (history resolution, serialization, fsync and
+  // the reload helper spawn) can be skipped. Only a confirmed missing or stale
+  // demand marker closes this gate; an unarmed state must not starve someone
+  // who does have a Widget.
+  if (macWidgetDemand && !macWidgetDemand.isInstalled()) return null;
   const resolverConfig = Object.freeze({ ...historyResolverOptions() });
   return {
     stats,
@@ -4539,6 +4569,10 @@ function stopAll() {
   stopHostStats();
   stopSyncCollector({ skipCloseWatchers: true });
   macWidgetSnapshotController?.stop();
+  if (macWidgetDemand) {
+    macWidgetDemand.stop();
+    macWidgetDemand = null;
+  }
   // Fire-and-forget on purpose. server.close() does not complete until every
   // in-flight request does, so awaiting it hands a remote device on the embedded
   // hub the power to hold our own exit open. The listening socket closes with
@@ -5570,6 +5604,7 @@ app.whenReady().then(() => {
   if (pendingMacWidgetOpen) setImmediate(openMainWindowFromWidget);
   if (settings.trayMode) enterTrayMode();
   regenerateTokscalePricing();
+  ensureMacWidgetDemand();
   startMode();
   void widgetRecovery.finally(() => {
     app.removeListener('before-quit', abortWidgetRecovery);

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -165,7 +165,7 @@ const { createMacWidgetLaunchServicesRecovery } = require('./macWidgetLaunchServ
 const { projectLimitStatsForDisplay } = require('./limitStatsPresentation');
 const { normalizeWidgetURLScheme } = require('../shared/macWidgetConfig');
 const { DEFAULT_WIDGET_KIND, requestMacWidgetReload, resetMacWidgetReloadThrottle } = require('./macWidgetReloader');
-const { WIDGET_DEMAND_MARKER, createMacWidgetDemandState } = require('./macWidgetDemand');
+const { WIDGET_DEMAND_MARKER, WIDGET_DEMAND_PROVISIONAL_MARKER, createMacWidgetDemandState } = require('./macWidgetDemand');
 const linuxAutostart = require('./linuxAutostart');
 const { codexAccountIdForProvider, localLiveCodexProvider } = require('./renderer/accountIdentity');
 const {
@@ -3450,13 +3450,16 @@ function ensureMacWidgetDemand() {
   if (macWidgetDemand) return macWidgetDemand;
   const widget = macWidgetConfiguration();
   if (!widget) return null;
-  // The demand lease lives beside the snapshot in the app group container. The
-  // widget extension touches it whenever WidgetKit genuinely asks for data, so
-  // a fresh marker here means "a Widget is on screen and wants updates". The
+  // The demand leases live beside the snapshot in the app group container. The
+  // widget extension touches the full marker on every timeline() request and
+  // the short provisional marker on a non-gallery snapshot() (the add flow),
+  // so a fresh marker here means "a Widget is on screen or being placed". The
   // watcher arms immediately so a first placement primes the initial snapshot
   // within moments; the reconcile poll catches anything the watcher missed.
+  const markerDirectory = path.dirname(widget.snapshotPath);
   macWidgetDemand = createMacWidgetDemandState({
-    markerPath: path.join(path.dirname(widget.snapshotPath), WIDGET_DEMAND_MARKER),
+    markerPath: path.join(markerDirectory, WIDGET_DEMAND_MARKER),
+    provisionalMarkerPath: path.join(markerDirectory, WIDGET_DEMAND_PROVISIONAL_MARKER),
     onActivation: () => {
       const visibleStats = electronPresentationStats(latestStats);
       scheduleMacWidgetSnapshot(visibleStats, captureMacWidgetProducerOwner());

--- a/tests/electron/macWidgetDemand.test.js
+++ b/tests/electron/macWidgetDemand.test.js
@@ -1,0 +1,175 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  DEFAULT_DEMAND_LEASE_MS,
+  DEFAULT_RECONCILE_MS,
+  createMacWidgetDemandState
+} = require('../../src/electron/macWidgetDemand');
+
+const BASE_CLOCK = 1_000_000;
+const MARKER_PATH = '/home/Library/Group Containers/group.com.tokenmonitor/widget-demand';
+
+function createHarness(options = {}, initialMtime = null) {
+  let clock = BASE_CLOCK;
+  let activations = 0;
+  let intervalCallback = null;
+  let watcherCallback = null;
+  let watchCalls = 0;
+  let markerMtime = initialMtime;
+  const state = createMacWidgetDemandState({
+    markerPath: MARKER_PATH,
+    leaseMs: DEFAULT_DEMAND_LEASE_MS,
+    reconcileMs: DEFAULT_RECONCILE_MS,
+    now: () => clock,
+    setInterval: (callback) => {
+      intervalCallback = callback;
+      return 1;
+    },
+    clearInterval: () => {
+      intervalCallback = null;
+    },
+    watch: (_directory, callback) => {
+      watchCalls += 1;
+      watcherCallback = callback;
+      return { close: () => { watcherCallback = null; }, on: () => {} };
+    },
+    fs: {
+      lstatSync: () => {
+        if (markerMtime === null) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        return { mtimeMs: markerMtime };
+      }
+    },
+    onActivation: () => {
+      activations += 1;
+    },
+    ...options
+  });
+  async function flush() {
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+  return {
+    state,
+    clock: { advance: (milliseconds) => { clock += milliseconds; } },
+    marker: {
+      touch: () => { markerMtime = clock; },
+      age: (milliseconds) => { markerMtime = clock - milliseconds; },
+      remove: () => { markerMtime = null; }
+    },
+    activations: () => activations,
+    watchCalls: () => watchCalls,
+    fireInterval() {
+      if (intervalCallback) intervalCallback();
+    },
+    fireWatcher() {
+      if (watcherCallback) watcherCallback();
+    },
+    flush
+  };
+}
+
+test('a never-existing marker closes the gate from the first probe', () => {
+  const harness = createHarness();
+  assert.equal(harness.state.isInstalled(), false);
+});
+
+test('a fresh marker keeps the gate open', () => {
+  const harness = createHarness({}, BASE_CLOCK - 1_000);
+  assert.equal(harness.state.isInstalled(), true);
+});
+
+test('a marker as old as the lease closes the gate', () => {
+  const stale = createHarness({}, BASE_CLOCK - DEFAULT_DEMAND_LEASE_MS);
+  assert.equal(stale.state.isInstalled(), false);
+  const fresh = createHarness({}, BASE_CLOCK - (DEFAULT_DEMAND_LEASE_MS - 1));
+  assert.equal(fresh.state.isInstalled(), true);
+});
+
+test('first placement fires activation the moment the watcher sees the marker', async () => {
+  const harness = createHarness();
+  assert.equal(harness.state.isInstalled(), false);
+  harness.state.start();
+  harness.marker.touch();
+  harness.fireWatcher();
+  await harness.flush();
+  assert.equal(harness.activations(), 1);
+  assert.equal(harness.state.isInstalled(), true);
+});
+
+test('a missed watcher event is caught by the reconcile poll', async () => {
+  const harness = createHarness();
+  harness.state.start();
+  harness.marker.touch();
+  harness.clock.advance(DEFAULT_RECONCILE_MS);
+  harness.fireInterval();
+  await harness.flush();
+  assert.equal(harness.activations(), 1);
+  assert.equal(harness.state.isInstalled(), true);
+});
+
+test('a stale→fresh transition fires activation', async () => {
+  const harness = createHarness({}, BASE_CLOCK - (DEFAULT_DEMAND_LEASE_MS + 1));
+  assert.equal(harness.state.isInstalled(), false);
+  harness.state.start();
+  harness.marker.touch();
+  harness.fireWatcher();
+  await harness.flush();
+  assert.equal(harness.activations(), 1);
+  assert.equal(harness.state.isInstalled(), true);
+});
+
+test('removal closes the gate without firing activation', async () => {
+  const harness = createHarness({}, BASE_CLOCK - 1_000);
+  assert.equal(harness.state.isInstalled(), true);
+  harness.state.start();
+  harness.marker.remove();
+  harness.fireWatcher();
+  await harness.flush();
+  assert.equal(harness.state.isInstalled(), false);
+  assert.equal(harness.activations(), 0);
+});
+
+test('an unreadable marker is fail-open and never gates work', async () => {
+  const messages = [];
+  const harness = createHarness({
+    logger: (message) => messages.push(message),
+    fs: {
+      lstatSync: () => { throw Object.assign(new Error('EIO'), { code: 'EIO' }); }
+    }
+  });
+  assert.equal(harness.state.isInstalled(), true);
+  harness.state.start();
+  await harness.flush();
+  assert.equal(harness.state.isInstalled(), true);
+  assert.equal(messages.length, 1);
+});
+
+test('stop clears the interval and watcher and ignores later signals', async () => {
+  const harness = createHarness();
+  harness.state.start();
+  harness.state.stop();
+  harness.marker.touch();
+  harness.fireWatcher();
+  harness.fireInterval();
+  await harness.flush();
+  assert.equal(harness.activations(), 0);
+  assert.equal(harness.state.isInstalled(), false);
+});
+
+test('start is idempotent and attaches a single watcher', () => {
+  const harness = createHarness();
+  harness.state.start();
+  harness.state.start();
+  assert.equal(harness.watchCalls(), 1);
+});
+
+test('an already-fresh marker at start does not re-fire activation', async () => {
+  const harness = createHarness({}, BASE_CLOCK - 1_000);
+  harness.state.start();
+  harness.fireInterval();
+  await harness.flush();
+  assert.equal(harness.activations(), 0);
+  assert.equal(harness.state.isInstalled(), true);
+});

--- a/tests/electron/macWidgetDemand.test.js
+++ b/tests/electron/macWidgetDemand.test.js
@@ -4,23 +4,30 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 const {
   DEFAULT_DEMAND_LEASE_MS,
+  DEFAULT_PROVISIONAL_LEASE_MS,
   DEFAULT_RECONCILE_MS,
   createMacWidgetDemandState
 } = require('../../src/electron/macWidgetDemand');
 
 const BASE_CLOCK = 1_000_000;
 const MARKER_PATH = '/home/Library/Group Containers/group.com.tokenmonitor/widget-demand';
+const PROVISIONAL_MARKER_PATH = '/home/Library/Group Containers/group.com.tokenmonitor/widget-demand-provisional';
 
-function createHarness(options = {}, initialMtime = null) {
+function createHarness(options = {}, initialMarkers = {}) {
   let clock = BASE_CLOCK;
   let activations = 0;
   let intervalCallback = null;
   let watcherCallback = null;
   let watchCalls = 0;
-  let markerMtime = initialMtime;
+  const markerMtime = {
+    full: initialMarkers.full ?? null,
+    provisional: initialMarkers.provisional ?? null
+  };
   const state = createMacWidgetDemandState({
     markerPath: MARKER_PATH,
+    provisionalMarkerPath: PROVISIONAL_MARKER_PATH,
     leaseMs: DEFAULT_DEMAND_LEASE_MS,
+    provisionalLeaseMs: DEFAULT_PROVISIONAL_LEASE_MS,
     reconcileMs: DEFAULT_RECONCILE_MS,
     now: () => clock,
     setInterval: (callback) => {
@@ -36,9 +43,11 @@ function createHarness(options = {}, initialMtime = null) {
       return { close: () => { watcherCallback = null; }, on: () => {} };
     },
     fs: {
-      lstatSync: () => {
-        if (markerMtime === null) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
-        return { mtimeMs: markerMtime };
+      lstatSync: (targetPath) => {
+        const which = targetPath === MARKER_PATH ? 'full' : 'provisional';
+        const mtime = markerMtime[which];
+        if (mtime === null) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        return { mtimeMs: mtime };
       }
     },
     onActivation: () => {
@@ -54,9 +63,14 @@ function createHarness(options = {}, initialMtime = null) {
     state,
     clock: { advance: (milliseconds) => { clock += milliseconds; } },
     marker: {
-      touch: () => { markerMtime = clock; },
-      age: (milliseconds) => { markerMtime = clock - milliseconds; },
-      remove: () => { markerMtime = null; }
+      touch: () => { markerMtime.full = clock; },
+      age: (milliseconds) => { markerMtime.full = clock - milliseconds; },
+      remove: () => { markerMtime.full = null; }
+    },
+    provisional: {
+      touch: () => { markerMtime.provisional = clock; },
+      age: (milliseconds) => { markerMtime.provisional = clock - milliseconds; },
+      remove: () => { markerMtime.provisional = null; }
     },
     activations: () => activations,
     watchCalls: () => watchCalls,
@@ -76,14 +90,14 @@ test('a never-existing marker closes the gate from the first probe', () => {
 });
 
 test('a fresh marker keeps the gate open', () => {
-  const harness = createHarness({}, BASE_CLOCK - 1_000);
+  const harness = createHarness({}, { full: BASE_CLOCK - 1_000 });
   assert.equal(harness.state.isInstalled(), true);
 });
 
 test('a marker as old as the lease closes the gate', () => {
-  const stale = createHarness({}, BASE_CLOCK - DEFAULT_DEMAND_LEASE_MS);
+  const stale = createHarness({}, { full: BASE_CLOCK - DEFAULT_DEMAND_LEASE_MS });
   assert.equal(stale.state.isInstalled(), false);
-  const fresh = createHarness({}, BASE_CLOCK - (DEFAULT_DEMAND_LEASE_MS - 1));
+  const fresh = createHarness({}, { full: BASE_CLOCK - (DEFAULT_DEMAND_LEASE_MS - 1) });
   assert.equal(fresh.state.isInstalled(), true);
 });
 
@@ -110,7 +124,7 @@ test('a missed watcher event is caught by the reconcile poll', async () => {
 });
 
 test('a stale→fresh transition fires activation', async () => {
-  const harness = createHarness({}, BASE_CLOCK - (DEFAULT_DEMAND_LEASE_MS + 1));
+  const harness = createHarness({}, { full: BASE_CLOCK - (DEFAULT_DEMAND_LEASE_MS + 1) });
   assert.equal(harness.state.isInstalled(), false);
   harness.state.start();
   harness.marker.touch();
@@ -121,7 +135,7 @@ test('a stale→fresh transition fires activation', async () => {
 });
 
 test('removal closes the gate without firing activation', async () => {
-  const harness = createHarness({}, BASE_CLOCK - 1_000);
+  const harness = createHarness({}, { full: BASE_CLOCK - 1_000 });
   assert.equal(harness.state.isInstalled(), true);
   harness.state.start();
   harness.marker.remove();
@@ -166,10 +180,69 @@ test('start is idempotent and attaches a single watcher', () => {
 });
 
 test('an already-fresh marker at start does not re-fire activation', async () => {
-  const harness = createHarness({}, BASE_CLOCK - 1_000);
+  const harness = createHarness({}, { full: BASE_CLOCK - 1_000 });
   harness.state.start();
   harness.fireInterval();
   await harness.flush();
   assert.equal(harness.activations(), 0);
   assert.equal(harness.state.isInstalled(), true);
+});
+
+test('a provisional-only signal opens the gate without the full lease', () => {
+  const harness = createHarness({}, { provisional: BASE_CLOCK - 1_000 });
+  assert.equal(harness.state.isInstalled(), true);
+});
+
+test('a provisional signal as old as its short lease closes the gate', () => {
+  const stale = createHarness({}, { provisional: BASE_CLOCK - DEFAULT_PROVISIONAL_LEASE_MS });
+  assert.equal(stale.state.isInstalled(), false);
+  const fresh = createHarness({}, { provisional: BASE_CLOCK - (DEFAULT_PROVISIONAL_LEASE_MS - 1) });
+  assert.equal(fresh.state.isInstalled(), true);
+});
+
+test('a full lease overrides a stale provisional signal', () => {
+  const harness = createHarness({}, {
+    full: BASE_CLOCK - 1_000,
+    provisional: BASE_CLOCK - DEFAULT_PROVISIONAL_LEASE_MS
+  });
+  assert.equal(harness.state.isInstalled(), true);
+});
+
+test('a cancelled add flow expires and a later timeline reopens the gate', async () => {
+  const harness = createHarness({}, { provisional: BASE_CLOCK - 1_000 });
+  assert.equal(harness.state.isInstalled(), true);
+  harness.state.start();
+
+  // The user cancels placement: the provisional signal expires on its own.
+  harness.provisional.remove();
+  harness.clock.advance(DEFAULT_RECONCILE_MS);
+  harness.fireInterval();
+  await harness.flush();
+  assert.equal(harness.state.isInstalled(), false);
+
+  // A real placement is then confirmed: the first timeline() writes the full
+  // marker, which must reopen the gate immediately.
+  harness.marker.touch();
+  harness.fireWatcher();
+  await harness.flush();
+  assert.equal(harness.state.isInstalled(), true);
+  assert.equal(harness.activations(), 1);
+});
+
+test('snapshot-only demand keeps the full lease idle so a no-widget user pays little', async () => {
+  const harness = createHarness();
+  harness.state.start();
+  harness.provisional.touch();
+  harness.fireWatcher();
+  await harness.flush();
+  assert.equal(harness.state.isInstalled(), true);
+  assert.equal(harness.activations(), 1);
+
+  // The provisional lease is short: after it expires with no full marker, the
+  // gate closes and a no-widget user is back to zero pipeline cost.
+  harness.provisional.age(DEFAULT_PROVISIONAL_LEASE_MS);
+  harness.clock.advance(DEFAULT_RECONCILE_MS);
+  harness.fireInterval();
+  await harness.flush();
+  assert.equal(harness.state.isInstalled(), false);
 });

--- a/tests/electron/macWidgetIntegration.test.js
+++ b/tests/electron/macWidgetIntegration.test.js
@@ -121,6 +121,89 @@ test('Widget ownership advances producer lifetime only for mode transitions', ()
   );
 });
 
+function executeMacWidgetDemandWiring() {
+  const demandStart = mainSource.indexOf('function ensureMacWidgetDemand()');
+  const demandEnd = mainSource.indexOf('\nfunction captureMacWidgetWork(', demandStart);
+  assert.ok(demandStart >= 0 && demandEnd > demandStart, 'ensureMacWidgetDemand should exist');
+  const demandSource = mainSource.slice(demandStart, demandEnd);
+
+  const state = {
+    startCalls: 0,
+    start() { this.startCalls += 1; }
+  };
+  const captured = [];
+  const calls = { scheduled: [] };
+  const context = vm.createContext({
+    process: { platform: 'darwin' },
+    path,
+    WIDGET_DEMAND_MARKER: require('../../src/electron/macWidgetDemand').WIDGET_DEMAND_MARKER,
+    macWidgetDemand: null,
+    macWidgetConfiguration: () => ({
+      snapshotPath: '/Users/acceptance/Library/Group Containers/group.com.tokenmonitor/snapshot.json'
+    }),
+    createMacWidgetDemandState: (options) => {
+      captured.push(options);
+      return state;
+    },
+    electronPresentationStats: (stats) => ({ projected: true, ...stats }),
+    latestStats: { limits: { providers: [] } },
+    scheduleMacWidgetSnapshot: (stats, producerOwner) => { calls.scheduled.push({ stats, producerOwner }); },
+    captureMacWidgetProducerOwner: () => ({ epoch: 7 }),
+    console
+  });
+  vm.runInContext(demandSource, context);
+  vm.runInContext('ensureMacWidgetDemand()', context);
+  return { context, captured, calls, state };
+}
+
+test('main wiring arms Widget demand from the app-group marker and gates snapshot work', () => {
+  const execution = executeMacWidgetDemandWiring();
+  assert.equal(execution.captured.length, 1);
+  assert.equal(
+    execution.captured[0].markerPath,
+    '/Users/acceptance/Library/Group Containers/group.com.tokenmonitor/widget-demand'
+  );
+  assert.equal(execution.state.startCalls, 1);
+
+  vm.runInContext('ensureMacWidgetDemand()', execution.context);
+  assert.equal(execution.captured.length, 1, 'second ensure must reuse the armed state');
+
+  execution.captured[0].onActivation();
+  assert.equal(execution.calls.scheduled.length, 1);
+  assert.deepEqual(execution.calls.scheduled[0].producerOwner, { epoch: 7 });
+  assert.equal(execution.calls.scheduled[0].stats.projected, true);
+});
+
+test('Widget demand gate, startup arm and quit stop are wired into the snapshot path', () => {
+  const captureStart = mainSource.indexOf('function captureMacWidgetWork(');
+  const captureEnd = mainSource.indexOf('\nfunction ensureMacWidgetSnapshotController', captureStart);
+  const captureSource = mainSource.slice(captureStart, captureEnd);
+  assert.match(captureSource, /if \(macWidgetDemand && !macWidgetDemand\.isInstalled\(\)\) return null;/);
+
+  const demandStart = mainSource.indexOf('function ensureMacWidgetDemand()');
+  const demandEnd = mainSource.indexOf('\nfunction captureMacWidgetWork', demandStart);
+  const demandSource = mainSource.slice(demandStart, demandEnd);
+  assert.match(
+    demandSource,
+    /markerPath: path\.join\(path\.dirname\(widget\.snapshotPath\), WIDGET_DEMAND_MARKER\)/
+  );
+  assert.match(
+    demandSource,
+    /onActivation: \(\) => \{\s*const visibleStats = electronPresentationStats\(latestStats\);\s*scheduleMacWidgetSnapshot\(visibleStats, captureMacWidgetProducerOwner\(\)\);/
+  );
+  assert.match(demandSource, /macWidgetDemand\.start\(\);/);
+
+  const readyStart = mainSource.indexOf('app.whenReady().then(() => {');
+  const readyEnd = mainSource.indexOf("ipcMain.handle('settings:get'", readyStart);
+  const readySource = mainSource.slice(readyStart, readyEnd);
+  assert.match(readySource, /ensureMacWidgetDemand\(\);\s*startMode\(\);/);
+
+  const stopStart = mainSource.indexOf('function stopAll()');
+  const stopEnd = mainSource.indexOf('\nfunction ', stopStart + 'function stopAll()'.length);
+  const stopSource = mainSource.slice(stopStart, stopEnd === -1 ? mainSource.length : stopEnd);
+  assert.match(stopSource, /macWidgetDemand\.stop\(\);\s*macWidgetDemand = null;/);
+});
+
 test('starts the runtime immediately and holds only Widget publication until host registration settles', () => {
   const readyStart = mainSource.indexOf('app.whenReady().then(() => {');
   const readyEnd = mainSource.indexOf("ipcMain.handle('settings:get'", readyStart);
@@ -228,6 +311,46 @@ test('main wiring holds Widget publication when the app quits before registratio
   assert.equal(execution.context.macWidgetPublicationReady, false);
   assert.equal(execution.calls.resumed, 0);
   assert.deepEqual(execution.calls.removeListener, ['before-quit']);
+});
+
+test('Widget demand lease marker contract stays aligned between Swift and Electron', () => {
+  const widgetDemandSource = fs.readFileSync(
+    path.join(root, 'native', 'macos', 'TokenMonitorWidget', 'WidgetDemandMarker.swift'),
+    'utf8'
+  );
+  const providerSource = fs.readFileSync(
+    path.join(root, 'native', 'macos', 'TokenMonitorWidget', 'WidgetTimelineProvider.swift'),
+    'utf8'
+  );
+  const { WIDGET_DEMAND_MARKER } = require('../../src/electron/macWidgetDemand');
+
+  // The marker filename is the one cross-process contract: Electron lstat's it
+  // from the app group container and the extension writes it. They may not drift.
+  assert.match(widgetDemandSource, /static let fileName = "widget-demand"/);
+  assert.equal(WIDGET_DEMAND_MARKER, 'widget-demand');
+
+  // timeline() always records demand; snapshot() only outside the gallery
+  // preview; placeholder() must never write demand or a gallery browse would
+  // keep a nonexistent Widget's pipeline warm forever.
+  const placeholder = providerSource.slice(
+    providerSource.indexOf('func placeholder('),
+    providerSource.indexOf('func snapshot(')
+  );
+  const snapshot = providerSource.slice(
+    providerSource.indexOf('func snapshot('),
+    providerSource.indexOf('func timeline(')
+  );
+  const timeline = providerSource.slice(
+    providerSource.indexOf('func timeline('),
+    providerSource.indexOf('private func currentPeriod()')
+  );
+  assert.doesNotMatch(placeholder, /WidgetDemandMarker/);
+  assert.match(snapshot, /if !context\.isPreview \{[\s\S]*WidgetDemandMarker\.noteRequested\(/);
+  assert.match(timeline, /WidgetDemandMarker\.noteRequested\(/);
+
+  // The marker compiles into both the extension and its test target.
+  assert.match(widgetProject, /100000000000000000000010 \/\* WidgetDemandMarker\.swift in Sources \*\//);
+  assert.match(widgetProject, /100000000000000000000011 \/\* WidgetDemandMarker\.swift in Sources \*\//);
 });
 
 test('LaunchServices recovery delegates current-host registration to the public native API', () => {

--- a/tests/electron/macWidgetIntegration.test.js
+++ b/tests/electron/macWidgetIntegration.test.js
@@ -135,7 +135,7 @@ function executeMacWidgetDemandWiring() {
   const calls = { scheduled: [] };
   const context = vm.createContext({
     process: { platform: 'darwin' },
-    path,
+    path: path.posix,
     WIDGET_DEMAND_MARKER: require('../../src/electron/macWidgetDemand').WIDGET_DEMAND_MARKER,
     macWidgetDemand: null,
     macWidgetConfiguration: () => ({

--- a/tests/electron/macWidgetIntegration.test.js
+++ b/tests/electron/macWidgetIntegration.test.js
@@ -133,10 +133,15 @@ function executeMacWidgetDemandWiring() {
   };
   const captured = [];
   const calls = { scheduled: [] };
+  const {
+    WIDGET_DEMAND_MARKER,
+    WIDGET_DEMAND_PROVISIONAL_MARKER
+  } = require('../../src/electron/macWidgetDemand');
   const context = vm.createContext({
     process: { platform: 'darwin' },
     path: path.posix,
-    WIDGET_DEMAND_MARKER: require('../../src/electron/macWidgetDemand').WIDGET_DEMAND_MARKER,
+    WIDGET_DEMAND_MARKER,
+    WIDGET_DEMAND_PROVISIONAL_MARKER,
     macWidgetDemand: null,
     macWidgetConfiguration: () => ({
       snapshotPath: '/Users/acceptance/Library/Group Containers/group.com.tokenmonitor/snapshot.json'
@@ -163,6 +168,10 @@ test('main wiring arms Widget demand from the app-group marker and gates snapsho
     execution.captured[0].markerPath,
     '/Users/acceptance/Library/Group Containers/group.com.tokenmonitor/widget-demand'
   );
+  assert.equal(
+    execution.captured[0].provisionalMarkerPath,
+    '/Users/acceptance/Library/Group Containers/group.com.tokenmonitor/widget-demand-provisional'
+  );
   assert.equal(execution.state.startCalls, 1);
 
   vm.runInContext('ensureMacWidgetDemand()', execution.context);
@@ -183,9 +192,14 @@ test('Widget demand gate, startup arm and quit stop are wired into the snapshot 
   const demandStart = mainSource.indexOf('function ensureMacWidgetDemand()');
   const demandEnd = mainSource.indexOf('\nfunction captureMacWidgetWork', demandStart);
   const demandSource = mainSource.slice(demandStart, demandEnd);
+  assert.match(demandSource, /const markerDirectory = path\.dirname\(widget\.snapshotPath\);/);
   assert.match(
     demandSource,
-    /markerPath: path\.join\(path\.dirname\(widget\.snapshotPath\), WIDGET_DEMAND_MARKER\)/
+    /markerPath: path\.join\(markerDirectory, WIDGET_DEMAND_MARKER\),/
+  );
+  assert.match(
+    demandSource,
+    /provisionalMarkerPath: path\.join\(markerDirectory, WIDGET_DEMAND_PROVISIONAL_MARKER\),/
   );
   assert.match(
     demandSource,
@@ -322,16 +336,23 @@ test('Widget demand lease marker contract stays aligned between Swift and Electr
     path.join(root, 'native', 'macos', 'TokenMonitorWidget', 'WidgetTimelineProvider.swift'),
     'utf8'
   );
-  const { WIDGET_DEMAND_MARKER } = require('../../src/electron/macWidgetDemand');
+  const {
+    WIDGET_DEMAND_MARKER,
+    WIDGET_DEMAND_PROVISIONAL_MARKER
+  } = require('../../src/electron/macWidgetDemand');
 
-  // The marker filename is the one cross-process contract: Electron lstat's it
-  // from the app group container and the extension writes it. They may not drift.
+  // The marker filenames are the one cross-process contract: Electron lstat's
+  // them from the app group container and the extension writes them. They may
+  // not drift.
   assert.match(widgetDemandSource, /static let fileName = "widget-demand"/);
   assert.equal(WIDGET_DEMAND_MARKER, 'widget-demand');
+  assert.match(widgetDemandSource, /static let provisionalFileName = "widget-demand-provisional"/);
+  assert.equal(WIDGET_DEMAND_PROVISIONAL_MARKER, 'widget-demand-provisional');
 
-  // timeline() always records demand; snapshot() only outside the gallery
-  // preview; placeholder() must never write demand or a gallery browse would
-  // keep a nonexistent Widget's pipeline warm forever.
+  // timeline() always records the full lease; snapshot() only writes the short
+  // provisional lease outside the gallery preview; placeholder() must never
+  // write either or a gallery browse would keep a nonexistent Widget's pipeline
+  // warm forever.
   const placeholder = providerSource.slice(
     providerSource.indexOf('func placeholder('),
     providerSource.indexOf('func snapshot(')
@@ -345,8 +366,9 @@ test('Widget demand lease marker contract stays aligned between Swift and Electr
     providerSource.indexOf('private func currentPeriod()')
   );
   assert.doesNotMatch(placeholder, /WidgetDemandMarker/);
-  assert.match(snapshot, /if !context\.isPreview \{[\s\S]*WidgetDemandMarker\.noteRequested\(/);
+  assert.match(snapshot, /if !context\.isPreview \{[\s\S]*WidgetDemandMarker\.noteRequested\([\s\S]*WidgetDemandMarker\.provisionalFileName/);
   assert.match(timeline, /WidgetDemandMarker\.noteRequested\(/);
+  assert.doesNotMatch(timeline, /provisionalFileName/);
 
   // The marker compiles into both the extension and its test target.
   assert.match(widgetProject, /100000000000000000000010 \/\* WidgetDemandMarker\.swift in Sources \*\//);


### PR DESCRIPTION
## Summary

Today the Widget snapshot pipeline — history resolution, JSON serialization, fsync, and the reload-helper spawn — runs on every scheduled tick regardless of whether the user actually has a Widget on screen. Users who never add a Widget pay that cost for a feature they don't use.

This PR introduces a **demand lease** tracked with zero-content mtime markers in the app group container. The Widget extension is the only process WidgetKit lets speak for the widgets, so it touches the markers whenever WidgetKit genuinely asks it for data. Two markers carry two lease lengths:

- `widget-demand` — the **full 72 h lease**, written by `timeline()`. A placed widget asking for its next update is the only authoritative "Widget on screen" signal.
- `widget-demand-provisional` — a **short 10 min lease**, written by `snapshot()` outside the gallery preview. WidgetKit calls `snapshot()` for transient situations that include the add flow, before the user confirms placement, so this only warms up a possible first placement and must not grant the full lease.

The main process tracks both markers:

- **No-widget users** have the gate closed from the very first probe (neither marker ever exists), so the entire snapshot pipeline is skipped — no history resolution, no serialization, no fsync, no reload spawn.
- **First placement** writes the provisional marker during the add flow (warm snapshot within moments via the directory watcher, ≤ 30 s via the reconcile fallback), and the first `timeline()` upgrades it to the full lease.
- **Cancelled add flows** pay at most the short provisional window, then return to zero cost; no cleanup protocol is needed because the marker expires on its own.
- **Placed widgets** keep the full marker fresh on every timeline request. The conservative 72 h lease, combined with fail-open reads, means a stale lease **self-heals on the next WidgetKit provider request** — it cannot permanently starve a real widget.
- **Fail-open everywhere else**: any unreadable marker, watcher failure, or unarmed state keeps the pipeline running. Only confirmed missing or stale markers may gate work.

Gallery previews and `placeholder()` never touch either marker, so browsing widget styles cannot fabricate demand. macOS-only; Windows and other platforms are untouched.

## Before / After

| | Before | After |
|---|---|---|
| Snapshot production | Every scheduled tick | Only while a demand lease is fresh |
| No-widget users | Full pipeline every tick (wasted) | Zero pipeline cost |
| First widget placement | Next scheduled tick | Immediate (watcher) / ≤ 30 s (fallback) |
| Cancelled add flow | Could leave the pipeline warm | ≤ 10 min provisional window, then zero |
| Gallery preview | Could trigger work | Never touches either marker |
| Widget users | Normal | Unchanged; first placement faster |
| Failure modes | — | Fail-open (never starves a real widget) |

## Files

- `src/electron/macWidgetDemand.js` (new) — demand-lease state: synchronous initial probe of both markers, directory watcher + 30 s reconcile, 72 h full lease + 10 min provisional lease, fail-open semantics.
- `src/electron/main.js` — arm `ensureMacWidgetDemand()` before `startMode()`, gate `captureMacWidgetWork()`, stop wiring.
- `native/macos/TokenMonitorWidget/WidgetDemandMarker.swift` (new) — zero-content mtime marker helper for the full and provisional filenames.
- `native/macos/TokenMonitorWidget/WidgetTimelineProvider.swift` — touch the full marker in `timeline()` and the provisional marker in non-preview `snapshot()`.
- `native/macos/TokenMonitorWidget.xcodeproj/project.pbxproj` — wire the new source into both targets.
- Tests — `tests/electron/macWidgetDemand.test.js` (new), wiring assertions in `macWidgetIntegration.test.js`, native `WidgetDemandMarkerTests`.

## Verification

- `npm run verify` — lint clean; 2806 tests pass, 0 fail.
- Native Widget XCTest suite via `xcodebuild test` (arm64, Debug) — 81 tests pass, 0 fail, including the `WidgetDemandMarkerTests`.
- `npm run sync:worker` — no generated Worker drift.
- `git diff --check` — clean.
