### PR TITLE
fix(codex): refresh plans and classify monthly quota

### DIFF
--- a/src/electron/renderer/accountIdentity.js
+++ b/src/electron/renderer/accountIdentity.js
@@ -156,6 +156,13 @@
     return (accounts || []).find((account) => codexAccountMatchesProvider(account, provider))?.id || '';
   }
 
+  function codexManagedAccountPlanLabel(account, providers = []) {
+    const provider = (providers || []).find((candidate) => (
+      candidate?.status === 'ok' && codexAccountMatchesProvider(account, candidate)
+    ));
+    return String(provider?.accountLabel || account?.accountLabel || '').trim();
+  }
+
   function isCodexLiveAccount(provider) {
     return String(provider?.provider || '').trim().toLowerCase() === 'codex'
       && String(provider?.status || '').trim() === 'ok'
@@ -183,6 +190,7 @@
     codexAccountDisplayLabel,
     codexAccountIdForProvider,
     codexAccountMatchesProvider,
+    codexManagedAccountPlanLabel,
     isCodexLiveAccount,
     localDeviceLimitsProviders,
     localLiveCodexProvider,

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -10662,6 +10662,7 @@ window.tokenMonitor.onTokscalePush?.((payload) => {
 
 function renderStatsUpdate() {
   render();
+  renderCodexAccounts();
   renderSettingsSummaries();
   renderLimitProviderCheckboxes();
   renderToolPreferences();
@@ -12017,6 +12018,7 @@ function renderCodexAccounts() {
     empty.textContent = t('settings.codex.empty');
     listEl.append(empty);
   } else {
+    const codexProviders = localProviderStatuses('codex');
     for (const account of accounts) {
       const enabled = account.enabled !== false;
       const row = document.createElement('div');
@@ -12056,7 +12058,11 @@ function renderCodexAccounts() {
         : account.workspaceLabel;
       const accountMetadata = [
         workspaceLabel,
-        enabled ? limitProviderPresentationApi.limitProviderDisplayLabel(account.accountLabel) : t('settings.codex.disabled')
+        enabled
+          ? limitProviderPresentationApi.limitProviderDisplayLabel(
+            accountIdentityApi.codexManagedAccountPlanLabel(account, codexProviders)
+          )
+          : t('settings.codex.disabled')
       ].filter((value, index, values) => value && values.indexOf(value) === index);
       info.textContent = accountMetadata.join(' · ');
       info.title = accountMetadata.join(' · ');

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -4378,15 +4378,21 @@ function renderProviderWindows(provider, color) {
   if (provider.provider === 'codex') {
     const session = windowForKind(provider, 'session');
     const weekly = windowForKind(provider, 'weekly');
+    const monthly = windowForKind(provider, 'billing');
     if (session) {
       const sessionNode = limitWindowNode(session.label || 'Session', session, color, 0.95);
-      if (!weekly) sessionNode.classList.add('limit-window-wide');
+      if (!weekly && !monthly) sessionNode.classList.add('limit-window-wide');
       windows.append(sessionNode);
     }
     if (weekly) {
       const weeklyNode = limitWindowNode(weekly.label || 'Weekly', weekly, color, 0.68);
-      if (!session) weeklyNode.classList.add('limit-window-wide');
+      if (!session && !monthly) weeklyNode.classList.add('limit-window-wide');
       windows.append(weeklyNode);
+    }
+    if (monthly) {
+      const monthlyNode = limitWindowNode(monthly.label || 'Monthly', monthly, color, 0.68);
+      monthlyNode.classList.add('limit-window-wide');
+      windows.append(monthlyNode);
     }
     const resetNode = codexResetCreditsNode(provider.resetCredits);
     if (resetNode) windows.append(resetNode);

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -1978,7 +1978,11 @@ async function touchClaudeAuthPath(deps = {}) {
 
 function codexWindowKind(name, window) {
   const mins = Number(window?.windowDurationMins || window?.window_duration_mins || 0);
-  if (mins >= 7 * 24 * 60) return 'weekly';
+  // Monthly quotas use the shared wire contract's billing lane. The display
+  // label below keeps the cadence explicit instead of presenting it as money.
+  if (mins === 30 * 24 * 60) return 'billing';
+  if (mins === 7 * 24 * 60) return 'weekly';
+  if (mins === 5 * 60) return 'session';
   if (String(name).toLowerCase() === 'secondary') return 'weekly';
   return 'session';
 }
@@ -2278,8 +2282,10 @@ function mapCodexRateLimitsToProvider(payload, meta = {}) {
   for (const key of ['primary', 'secondary']) {
     const window = rateLimits[key];
     if (!window) continue;
+    const kind = codexWindowKind(key, window);
     windows.push({
-      kind: codexWindowKind(key, window),
+      kind,
+      ...(kind === 'billing' ? { label: 'Monthly' } : {}),
       usedPercent: window.usedPercent ?? window.used_percent,
       resetsAt: window.resetsAt ?? window.resets_at,
       windowMinutes: window.windowDurationMins ?? window.window_duration_mins
@@ -2912,7 +2918,7 @@ async function fetchManagedCodexAccountLimits(account, _options = {}, deps = {})
     return mapCodexRateLimitsToProvider(payload, {
       accountKey: managedCodexAccountKey(account, authIdentity, email),
       accountEmail: email,
-      accountLabel: account.accountLabel || codexAccountLabel(payload),
+      accountLabel: codexAccountLabel(payload) || account.accountLabel,
       accountName: account.workspaceLabel,
       workspaceKind: account.workspaceKind,
       updatedAt: nowIso(nowMs),

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -1981,7 +1981,7 @@ function codexWindowKind(name, window) {
   // Monthly quotas use the shared wire contract's billing lane. The display
   // label below keeps the cadence explicit instead of presenting it as money.
   if (mins === 30 * 24 * 60) return 'billing';
-  if (mins === 7 * 24 * 60) return 'weekly';
+  if (mins >= 7 * 24 * 60) return 'weekly';
   if (mins === 5 * 60) return 'session';
   if (String(name).toLowerCase() === 'secondary') return 'weekly';
   return 'session';

--- a/tests/electron/accountIdentity.test.js
+++ b/tests/electron/accountIdentity.test.js
@@ -9,6 +9,7 @@ const {
   codexAccountDisplayLabel,
   codexAccountIdForProvider,
   codexAccountMatchesProvider,
+  codexManagedAccountPlanLabel,
   isCodexLiveAccount,
   localLiveCodexProvider,
   maskEmailAddress
@@ -125,6 +126,22 @@ test('Codex account identity matches by key or normalized email fields', () => {
     accountKey: 'account-2',
     accountEmail: 'shared@example.com'
   }), 'two');
+});
+
+test('managed Codex plan labels prefer a matching successful provider', () => {
+  const account = {
+    accountKey: 'account-1',
+    email: 'user@example.com',
+    accountLabel: 'plus'
+  };
+  assert.equal(codexManagedAccountPlanLabel(account, [
+    { provider: 'codex', status: 'error', accountKey: 'account-1', accountLabel: 'team' },
+    { provider: 'codex', status: 'ok', accountKey: 'account-2', accountLabel: 'pro' },
+    { provider: 'codex', status: 'ok', accountKey: 'account-1', accountLabel: 'free' }
+  ]), 'free');
+  assert.equal(codexManagedAccountPlanLabel(account, [
+    { provider: 'codex', status: 'error', accountKey: 'account-1', accountLabel: 'free' }
+  ]), 'plus');
 });
 
 test('live Codex provider selection uses local raw limits with a legacy aggregate fallback', () => {

--- a/tests/electron/cursorSettingsLayout.test.js
+++ b/tests/electron/cursorSettingsLayout.test.js
@@ -265,7 +265,9 @@ test('Codex account panel supports per-account enable toggles without showing ti
   assert.match(body, /account\.workspaceKind === 'personal'/);
   assert.match(body, /t\('settings\.codex\.personalWorkspace'\)/);
   assert.match(body, /account\.workspaceLabel/);
-  assert.match(body, /enabled \? limitProviderPresentationApi\.limitProviderDisplayLabel\(account\.accountLabel\) : t\('settings\.codex\.disabled'\)/);
+  assert.match(body, /const codexProviders = localProviderStatuses\('codex'\);/);
+  assert.match(body, /accountIdentityApi\.codexManagedAccountPlanLabel\(account, codexProviders\)/);
+  assert.match(body, /: t\('settings\.codex\.disabled'\)/);
   assert.match(body, /info\.textContent = accountMetadata\.join\(' · '\);/);
   assert.match(body, /right\.append\(info, remove\)/);
   assert.match(body, /row\.append\(input, main, right\)/);

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -858,7 +858,7 @@ test('Copilot renders monthly Premium and Chat quotas as billing windows', () =>
   assert.match(renderProviderWindows, /limitWindowNode\(billing\?\.label \|\| 'Monthly', billing, color, 0\.68\)/);
 });
 
-test('Codex renders manual reset credits below session and weekly windows', () => {
+test('Codex renders Monthly quota and manual reset credits below rolling windows', () => {
   const app = readRendererFile('app.js');
   const styles = readRendererFile('styles.css');
   const renderProviderWindows = functionBody(app, 'renderProviderWindows', 'renderLimitProviderRow');
@@ -875,8 +875,11 @@ test('Codex renders manual reset credits below session and weekly windows', () =
   const renderLimits = functionBody(app, 'renderLimits', 'serviceStatusLabel');
 
   assert.match(renderProviderWindows, /provider\.provider === 'codex'/);
-  assert.match(renderProviderWindows, /if \(!weekly\) sessionNode\.classList\.add\('limit-window-wide'\);/);
-  assert.match(renderProviderWindows, /if \(!session\) weeklyNode\.classList\.add\('limit-window-wide'\);/);
+  assert.match(renderProviderWindows, /const monthly = windowForKind\(provider, 'billing'\);/);
+  assert.match(renderProviderWindows, /if \(!weekly && !monthly\) sessionNode\.classList\.add\('limit-window-wide'\);/);
+  assert.match(renderProviderWindows, /if \(!session && !monthly\) weeklyNode\.classList\.add\('limit-window-wide'\);/);
+  assert.match(renderProviderWindows, /limitWindowNode\(monthly\.label \|\| 'Monthly', monthly, color, 0\.68\)/);
+  assert.match(renderProviderWindows, /monthlyNode\.classList\.add\('limit-window-wide'\);/);
   assert.match(renderProviderWindows, /const resetNode = codexResetCreditsNode\(provider\.resetCredits\);/);
   assert.doesNotMatch(renderProviderWindows, /limitWindowNode\('Reset credits'/);
   assert.match(resetCreditsValue, /if \(count <= 0\) return '';/);

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -1205,6 +1205,7 @@ test('settings provider status waits for stats and refreshes when stats arrive',
   assert.match(statsPush, /applyCodexActiveAccountFromStats\(\);/);
   assert.match(statsPush, /statsRenderScheduler\.request\(\);/);
   assert.match(statsRender, /renderLimitProviderCheckboxes\(\);/);
+  assert.match(statsRender, /renderCodexAccounts\(\);/);
   // Account cards read state.stats, so every path that refreshes stats must
   // re-render them. Grok is automatic and belongs only to the generic provider
   // list, so it must not retain a separate account-card renderer.

--- a/tests/shared/limitCollector.codex.test.js
+++ b/tests/shared/limitCollector.codex.test.js
@@ -339,6 +339,25 @@ test('Codex provider classifies a 30-day primary window as a Monthly billing lan
   assert.equal(provider.windows[0].windowMinutes, 30 * 24 * 60);
 });
 
+test('Codex provider keeps an unknown long primary window in the weekly lane', () => {
+  const provider = mapCodexRateLimitsToProvider({
+    rateLimits: {
+      primary: {
+        usedPercent: 25,
+        resetsAt: '2026-06-15T00:00:00Z',
+        windowDurationMins: 14 * 24 * 60
+      }
+    }
+  }, {
+    source: 'rpc',
+    sourceDetail: 'managed',
+    updatedAt: '2026-06-01T00:00:00Z'
+  });
+
+  assert.equal(provider.windows[0].kind, 'weekly');
+  assert.equal(provider.windows[0].windowMinutes, 14 * 24 * 60);
+});
+
 function codexPayload(email, sourceDetail) {
   return {
     account: { email, planType: 'plus' },

--- a/tests/shared/limitCollector.codex.test.js
+++ b/tests/shared/limitCollector.codex.test.js
@@ -317,6 +317,28 @@ test('Codex provider supports managed-account source detail', () => {
   assert.equal(provider.accountEmail, 'managed@example.com');
 });
 
+test('Codex provider classifies a 30-day primary window as a Monthly billing lane', () => {
+  const provider = mapCodexRateLimitsToProvider({
+    rateLimits: {
+      planType: 'free',
+      primary: {
+        usedPercent: 0,
+        resetsAt: '2026-07-01T00:00:00Z',
+        windowDurationMins: 30 * 24 * 60
+      }
+    }
+  }, {
+    source: 'rpc',
+    sourceDetail: 'managed',
+    updatedAt: '2026-06-01T00:00:00Z'
+  });
+
+  assert.equal(provider.accountLabel, 'Free');
+  assert.equal(provider.windows[0].kind, 'billing');
+  assert.equal(provider.windows[0].label, 'Monthly');
+  assert.equal(provider.windows[0].windowMinutes, 30 * 24 * 60);
+});
+
 function codexPayload(email, sourceDetail) {
   return {
     account: { email, planType: 'plus' },
@@ -354,6 +376,37 @@ function makeIdToken(payload) {
 
 // The live account's auth.json is never read in tests unless a test opts in.
 const noLiveAuth = { readFileSync: () => { throw new Error('no auth.json'); } };
+
+test('fetchCodexLimits replaces a saved managed plan with the latest RPC plan', async () => {
+  const providers = await fetchCodexLimits({
+    includeLiveCodexAccount: false,
+    codexManagedAccounts: [{
+      id: 'downgraded',
+      email: 'downgraded@example.com',
+      homePath: '/tmp/token-monitor-codex/downgraded',
+      accountLabel: 'plus'
+    }]
+  }, {
+    now: () => Date.parse('2026-06-01T00:00:00Z'),
+    env: { PATH: '/usr/bin' },
+    ...noLiveAuth,
+    readCodexRpc: async () => ({
+      rateLimits: {
+        planType: 'free',
+        primary: {
+          usedPercent: 0,
+          resetsAt: '2026-07-01T00:00:00Z',
+          windowDurationMins: 30 * 24 * 60
+        }
+      }
+    })
+  });
+
+  assert.equal(providers.length, 1);
+  assert.equal(providers[0].accountLabel, 'Free');
+  assert.equal(providers[0].windows[0].kind, 'billing');
+  assert.equal(providers[0].windows[0].label, 'Monthly');
+});
 
 test('fetchCodexLimits returns one provider per managed Codex account', async () => {
   const seenHomes = [];


### PR DESCRIPTION
## Summary

- Prefer the latest Codex RPC `planType` over a managed account's persisted plan label, while retaining the saved label as a fallback when fresh metadata is unavailable.
- Classify Codex quota windows using the standard cadences:
  - 300 minutes as Session
  - 10,080 minutes as Weekly
  - 43,200 minutes as Monthly
- Render the 30-day Codex quota as a full-width Monthly window.
- Resolve managed-account plan labels from the matching successful local provider and re-render the account list when fresh limits arrive.

This keeps the main Limits view and the Codex account settings consistent when an account changes plans, such as Plus to Free.

## Verification

- `npm run verify`
  - 2,826 passed
  - 1 skipped
  - 0 failed
- Manually verified that a downgraded Codex account displays `Free` and `Monthly` in both the main Limits view and the Codex account settings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh `codex` managed account plan labels from the latest RPC `planType`, classify quotas as Session, Weekly, or a full‑width Monthly, and keep the Limits view and Codex settings in sync. Only exact 30‑day windows map to Monthly; other long windows keep the Weekly fallback.

- **Bug Fixes**
  - Prefer RPC `planType` for managed accounts, with saved labels as a fallback when fresh metadata is missing.
  - Classify quotas: 300 mins → Session, 10,080 mins → Weekly, 43,200 mins → Monthly (`billing`, full‑width); preserve fallback so non‑30‑day long windows stay Weekly.
  - Re-render `codex` accounts on stats updates and resolve plan labels from matching successful local providers to keep views consistent.

<sup>Written for commit 517ef4e0db04a873c40b7b6c8411996c492ff7f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

