### PR TITLE
fix(collector): keep Kiro globalStorage off live watcher

### DIFF
--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1131,8 +1131,9 @@ function hasCopilotChatSessions(workspaceRoot) {
 }
 
 // Per-client data-dir candidates, keyed by client. Drives the detection-status
-// derivation and (minus the self-synced clients below) the chokidar watch list;
-// Antigravity's read-only source roots are added back explicitly below.
+// derivation and, after the interval-only/self-synced projections below, the
+// chokidar watch list; Antigravity's read-only source roots are added back
+// explicitly below.
 // The watched roots, each tagged with a stable id for its *kind*. One id may
 // cover several paths: Copilot's workspaceStorage has a variant per platform and
 // Kiro's IDE globalStorage has four, but "the VS Code workspace storage is
@@ -1299,9 +1300,10 @@ function clientSourceRoots(clientsCsv) {
   // Kiro (AWS): tokscale reads home-relative roots — the sessions tree used by
   // both CLI and IDE, the Kiro IDE globalStorage root (native macOS / Linux /
   // Windows), and the kiro-cli sqlite dir. None falls back to a host-absolute
-  // path under --home
-  // (unlike Zed), so all are safe to watch cross-platform for seconds-level
-  // refresh and a correct waiting/missing status.
+  // path under --home (unlike Zed), so every root remains a valid source and
+  // presence signal. The globalStorage kind is deliberately interval-only in
+  // clientWatchCandidates() because real trees can contain tens of thousands of
+  // files; the sessions and sqlite roots retain seconds-level refresh.
   //
   // Note the deliberate Kiro-vs-kiro casing asymmetry below (do not "fix" it to
   // list both cases everywhere): tokscale scans both `Kiro` and `kiro` cased
@@ -1339,6 +1341,15 @@ function clientSourceRoots(clientsCsv) {
   return byClient;
 }
 
+// Sources that remain part of collection, health, and diagnostics but are too
+// broad for a persistent recursive watcher. Kiro globalStorage accepts every
+// `.chat`, `.json`, and extensionless file at any depth in tokscale, so a real
+// tree can require thousands of native directory watches; after descriptor
+// exhaustion the same tree becomes an even more expensive 2-second polling
+// watch. Regular interval ticks (five minutes by default), manual refreshes, and
+// hourly full reconciliation still scan it through the unchanged Kiro client.
+const INTERVAL_ONLY_SOURCE_CHECK_IDS = new Set(['kiro-ide-globalstorage']);
+
 // The watcher only ever wants paths, so it keeps its original shape rather than
 // learning about check ids it would immediately discard.
 function clientWatchCandidates(clientsCsv) {
@@ -1349,7 +1360,10 @@ function clientWatchCandidates(clientsCsv) {
     // hand both nested paths to chokidar or it may install two native watches
     // over the same tree.
     byClient[client] = roots
-      .filter((root) => !(client === 'copilot' && root.id === 'copilot-otel'))
+      .filter((root) => (
+        !(client === 'copilot' && root.id === 'copilot-otel')
+        && !INTERVAL_ONLY_SOURCE_CHECK_IDS.has(root.id)
+      ))
       .map((root) => root.dir);
   }
   return byClient;

--- a/tests/shared/clientHealth.test.js
+++ b/tests/shared/clientHealth.test.js
@@ -335,7 +335,10 @@ test('labelling roots keeps diagnostics separate from watcher roots', () => {
   assert.deepEqual(Object.keys(candidates).sort(), Object.keys(roots).sort());
   for (const [client, dirs] of Object.entries(candidates)) {
     const expected = roots[client]
-      .filter((root) => !(client === 'copilot' && root.id === 'copilot-otel'))
+      .filter((root) => (
+        !(client === 'copilot' && root.id === 'copilot-otel')
+        && root.id !== 'kiro-ide-globalstorage'
+      ))
       .map((root) => root.dir);
     assert.deepEqual(dirs, expected);
   }

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -1746,7 +1746,7 @@ test('clientDataDirPresence requires an actual VS Code Copilot chat source', () 
   }
 });
 
-test('watchPathsForClients watches Pi (incl. Oh My Pi), Zed (incl. native macOS), Kilo Code (only tokscale-scanned roots), and Kiro (CLI + IDE + kiro-cli roots)', () => {
+test('watchPathsForClients keeps bounded tool roots but leaves Kiro IDE globalStorage to interval scans', () => {
   const tmp = withTmpHome([
     path.join('.pi', 'agent', 'sessions'),
     path.join('.omp', 'agent', 'sessions'),
@@ -1779,11 +1779,11 @@ test('watchPathsForClients watches Pi (incl. Oh My Pi), Zed (incl. native macOS)
     assert.ok(!dirs.includes(path.join(tmp, 'Library', 'Application Support', 'Code', 'User', 'globalStorage', 'kilocode.kilo-code', 'tasks')));
     assert.ok(dirs.includes(path.join(tmp, '.local', 'share', 'mimocode')));
     assert.ok(dirs.includes(path.join(tmp, '.zcode', 'projects')));
-    // Kiro: tokscale reads the sessions tree for both CLI and IDE, the Kiro IDE
-    // globalStorage root, and the kiro-cli sqlite dir — all home-relative, so we
-    // watch each.
+    // Kiro sessions and the bounded kiro-cli database keep seconds-level
+    // refresh. The unbounded IDE globalStorage source remains present and
+    // collectable, but never enters chokidar's native or 2-second polling tree.
     assert.ok(dirs.includes(path.join(tmp, '.kiro', 'sessions')));
-    assert.ok(dirs.includes(path.join(tmp, 'Library', 'Application Support', 'Kiro', 'User', 'globalStorage', 'kiro.kiroagent')));
+    assert.ok(!dirs.includes(path.join(tmp, 'Library', 'Application Support', 'Kiro', 'User', 'globalStorage', 'kiro.kiroagent')));
     assert.ok(dirs.includes(path.join(tmp, '.local', 'share', 'kiro-cli')));
     // CodeBuddy/WorkBuddy: assert the platform-agnostic roots. CodeBuddy's
     // extension-log root is process.platform-specific, so it's covered by the
@@ -1793,6 +1793,26 @@ test('watchPathsForClients watches Pi (incl. Oh My Pi), Zed (incl. native macOS)
     assert.deepEqual(clientDataDirPresence('pi,zed,kilocode,micode,zcode,kiro,codebuddy,workbuddy'), {
       pi: true, zed: true, kilocode: true, micode: true, zcode: true, kiro: true, codebuddy: true, workbuddy: true
     });
+  } finally {
+    os.homedir = originalHomedir;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('Kiro IDE globalStorage stays a health source when it is the only Kiro root', () => {
+  const globalStorage = path.join('Library', 'Application Support', 'Kiro', 'User', 'globalStorage', 'kiro.kiroagent');
+  const tmp = withTmpHome([globalStorage]);
+  const originalHomedir = os.homedir;
+  os.homedir = () => tmp;
+  try {
+    const { clientDataDirPresence, clientSourceChecks, watchPathsForClients } = freshCollector();
+    assert.deepEqual(watchPathsForClients('kiro'), []);
+    assert.deepEqual(clientDataDirPresence('kiro'), { kiro: true });
+    assert.deepEqual(
+      clientSourceChecks('kiro').kiro.find((check) => check.id === 'kiro-ide-globalstorage'),
+      { id: 'kiro-ide-globalstorage', exists: true }
+    );
   } finally {
     os.homedir = originalHomedir;
     delete require.cache[collectorPath];


### PR DESCRIPTION
## Summary

- Keep Kiro IDE `globalStorage` available to tokscale collection, source health, and diagnostics.
- Exclude the unbounded `kiro.kiroagent` directory from native and polling-based recursive watchers.
- Preserve live refresh for Kiro sessions and the bounded Kiro CLI SQLite source.
- Add regression coverage for the separation between collection sources and watcher roots.

## Context

In #325, the reporter's Kiro IDE `globalStorage` directory had grown to approximately 3.4 GB across 18,656 files.

With Kiro enabled, the recursive watcher hit `EMFILE`, fell back to 2-second polling, and the Electron main process reached approximately 1.9 GB. Disabling Kiro removed the watcher fallback and collection failure, while main-process memory dropped to 136 MB.

Because disabling Kiro also removes it from tokscale scans, this comparison does not prove that the watcher is the sole source of the memory increase. It does establish Kiro as the common trigger and makes the unbounded persistent watcher the first load boundary to remove.

This change keeps Kiro usage collection intact while moving its IDE `globalStorage` source to regular interval scans. Manual refresh continues to scan it immediately.

## Before and after

| Behavior | Before | After |
| --- | --- | --- |
| Kiro IDE `globalStorage` collected by tokscale | Yes | Yes |
| Included in source health and diagnostics | Yes | Yes |
| Recursively watched with native file events | Yes | No |
| Included in the 2-second polling tree after watcher fallback | Yes | No |
| Collected by the regular interval tick | Yes | Yes |
| Collected by manual refresh | Yes | Yes |
| Kiro `~/.kiro/sessions` live refresh | Yes | Yes |
| Kiro CLI SQLite live refresh | Yes | Yes |
| Expected `globalStorage` freshness | Seconds | Up to the configured interval, 5 minutes by default |
| Existing usage and history data | Unchanged | Unchanged |

## Testing

- `npm run verify`
  - 2,829 tests
  - 2,828 passed
  - 1 skipped
  - 0 failed

Refs #325


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude Kiro IDE globalStorage from the live file watcher to avoid EMFILE fallbacks and memory spikes, while keeping it in collection, health, and manual refresh. Live refresh remains for Kiro sessions and the CLI SQLite source.

- **Bug Fixes**
  - Keep `kiro-ide-globalstorage` in collection, source health, and diagnostics, but scan it on the regular interval and manual refresh only.
  - Remove `kiro-ide-globalstorage` from `chokidar` candidates to avoid native and 2s polling watchers.
  - Preserve live refresh for `~/.kiro/sessions` and the bounded Kiro CLI SQLite source.
  - Add regression tests to enforce the separation between collection sources and watcher roots.

<sup>Written for commit 5bb81a129eaa9ccf939ab9d955ad77bc77b80942. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

