### PR TITLE
feat(limits): Ollama multi-account support

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -1045,6 +1045,147 @@ function setMimoManagedAccountEnabled(id, enabled) {
   return { ok: true, accounts: mimoAccountsForRenderer() };
 }
 
+
+function ollamaAccountsForRenderer() {
+  return normalizeOllamaManagedAccounts(settings?.ollamaManagedAccounts).map(({
+    id, accountKey, accountEmail, accountLabel, addedAt, updatedAt, enabled
+  }) => ({ id, accountKey, accountEmail, accountLabel, addedAt, updatedAt, enabled }));
+}
+
+function ollamaManagedAccountsForCollector() {
+  const guiAccounts = normalizeOllamaManagedAccounts(settings?.ollamaManagedAccounts).map((account) => ({
+    ...account,
+    cookieHeader: readOllamaCredential(account.id)
+  })).filter((account) => account.cookieHeader);
+
+  // If a cookie was configured via env / ollamaCookie setting, inject it as a
+  // synthetic read-only account so it is not silently dropped when GUI accounts
+  // also exist (the multi-account path in fetchOllamaLimits only fans out over
+  // managed accounts and never falls back to the single-cookie path when the
+  // managed list is non-empty).
+  // Use createOllamaManagedAccount to derive a proper accountKey — an empty key
+  // would be dropped by normalizeOllamaManagedAccounts before the fetch.
+  const envCookie = ollamaSessionCookie(process.env, { ollamaCookie: settings?.ollamaCookie || '' });
+  if (envCookie && !guiAccounts.some((a) => a.cookieHeader === envCookie)) {
+    const envResult = createOllamaManagedAccount(envCookie, guiAccounts);
+    if (envResult.ok) {
+      guiAccounts.unshift({ ...envResult.account, id: '__env__', readOnly: true });
+    }
+  }
+
+  return guiAccounts;
+}
+
+function writeOllamaCredential(id, value) {
+  const cookieHeader = String(value || '').trim();
+  if (!cookieHeader) return false;
+  try {
+    return ensureCredentialStore().writeOllamaCredential(id, cookieHeader);
+  } catch (_) {
+    return false;
+  }
+}
+
+function readOllamaCredential(id) {
+  try {
+    return String(ensureCredentialStore().readOllamaCredential(id) || '').trim();
+  } catch (_) {
+    return '';
+  }
+}
+
+function removeOllamaCredential(id) {
+  try {
+    return ensureCredentialStore().removeOllamaCredential(id);
+  } catch (_) {
+    return false;
+  }
+}
+
+async function addOllamaManagedAccount(cookieValue) {
+  const accounts = normalizeOllamaManagedAccounts(settings?.ollamaManagedAccounts);
+  const result = createOllamaManagedAccount(cookieValue, accounts);
+  if (!result.ok) return result;
+  const [validation] = await fetchOllamaLimits({ ollamaManagedAccounts: [result.account] });
+  if (validation?.status !== 'ok') {
+    const errorCode = validation?.status === 'unauthorized'
+      ? 'invalidCookie'
+      : validation?.status === 'sourceRateLimited' ? 'validationRateLimited' : 'validationUnavailable';
+    return { ok: false, errorCode };
+  }
+  result.account.accountEmail = String(validation.accountEmail || '').trim().slice(0, 254);
+  result.account.accountLabel = String(validation.accountLabel || '').trim();
+  const previousCookie = readOllamaCredential(result.account.id);
+  const credentialStored = writeOllamaCredential(result.account.id, result.account.cookieHeader);
+  delete result.account.cookieHeader;
+  if (!credentialStored) return { ok: false, errorCode: 'credentialStorageUnavailable' };
+  settings.ollamaManagedAccounts = normalizeOllamaManagedAccounts([
+    ...accounts.filter((account) => account.accountKey !== result.account.accountKey),
+    result.account
+  ]);
+  try {
+    saveSettings({ throwOnError: true });
+  } catch (_) {
+    if (previousCookie) writeOllamaCredential(result.account.id, previousCookie);
+    else removeOllamaCredential(result.account.id);
+    return { ok: false, errorCode: 'credentialStorageUnavailable' };
+  }
+  pushSettingsToRenderer();
+  sendOllamaAccountsPush();
+  void queueLimitInvalidation({
+    provider: 'ollama',
+    accountId: result.account.id,
+    accountKey: result.account.accountKey
+  }, 'account-added');
+  return { ok: true, accounts: ollamaAccountsForRenderer() };
+}
+
+async function removeOllamaManagedAccount(id) {
+  const accountId = String(id || '').trim();
+  const accounts = normalizeOllamaManagedAccounts(settings.ollamaManagedAccounts);
+  const account = accounts.find((entry) => entry.id === accountId);
+  if (!account) return { ok: false, error: 'Account not found' };
+  const previousCookie = readOllamaCredential(accountId);
+  if (!removeOllamaCredential(accountId)) return { ok: false, error: 'Could not remove stored credential' };
+  settings.ollamaManagedAccounts = accounts.filter((entry) => entry.id !== accountId);
+  try {
+    saveSettings({ throwOnError: true });
+  } catch (_) {
+    if (previousCookie) writeOllamaCredential(accountId, previousCookie);
+    return { ok: false, error: 'Could not persist account removal' };
+  }
+  pushSettingsToRenderer();
+  sendOllamaAccountsPush();
+  void queueLimitInvalidation({ provider: 'ollama', accountId, accountKey: account.accountKey }, 'account-removed', {
+    clear: true,
+    refresh: false
+  });
+  return { ok: true, accounts: ollamaAccountsForRenderer() };
+}
+
+function setOllamaManagedAccountEnabled(id, enabled) {
+  const accountId = String(id || '').trim();
+  const accounts = normalizeOllamaManagedAccounts(settings.ollamaManagedAccounts);
+  const account = accounts.find((entry) => entry.id === accountId);
+  if (!account) return { ok: false, error: 'Account not found' };
+  account.enabled = Boolean(enabled);
+  account.updatedAt = new Date().toISOString();
+  settings.ollamaManagedAccounts = accounts;
+  try {
+    saveSettings({ throwOnError: true });
+  } catch (_) {
+    return { ok: false, error: 'Could not persist account state' };
+  }
+  pushSettingsToRenderer();
+  sendOllamaAccountsPush();
+  void queueLimitInvalidation({ provider: 'ollama', accountId, accountKey: account.accountKey }, 'account-state', {
+    clear: !account.enabled,
+    refresh: account.enabled
+  });
+  return { ok: true, accounts: ollamaAccountsForRenderer() };
+}
+
+
 function codexManagedRoot() {
   return path.join(app.getPath('userData'), 'managed-codex-homes');
 }

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -2,11 +2,10 @@
 
 const fs = require('node:fs');
 const crypto = require('node:crypto');
-const os = require('node:os');
 const path = require('node:path');
 const { app, BrowserWindow, clipboard, dialog, globalShortcut, ipcMain, nativeImage, net, Notification, screen, session, shell } = require('electron');
 const { autoUpdater } = require('electron-updater');
-const { defaultDeviceId, generateHubSecret, lanIpv4Addresses, loadDotEnv, pidFilePath, readJson, sharedDataDir } = require('../shared/config');
+const { defaultDeviceId, generateHubSecret, lanIpv4Addresses, loadDotEnv, pidFilePath, sharedDataDir } = require('../shared/config');
 const {
   CredentialStore,
   credentialSettingsForRenderer,
@@ -41,18 +40,14 @@ const {
 installSafeStdout();
 const electronClaudeWebFetch = createClaudeWebFetch(net);
 const { DEFAULT_CLIENTS, KNOWN_CLIENTS, clientsCsvForSetting } = require('../shared/clientTracking');
-const { clientDiagnosticRoots, lookupModelPricing, normalizeHistoryIntervalMs, visibleDiagnosticRoots } = require('../shared/collector');
-const { deviceRecordFromAnchor } = require('../shared/anchorSeed');
-const { sendWhenRendererReady } = require('./deferredWindowSend');
+const { lookupModelPricing, normalizeHistoryIntervalMs } = require('../shared/collector');
 const { createDeviceRuntime } = require('../shared/deviceRuntime');
-const { createDiagnosticJournal } = require('../shared/diagnosticJournal');
-const { createDiagnosticReportGenerator } = require('./diagnostics');
-const { createDiagnosticSnapshotBuilder, diagnosticStreamDetailCode, selectLocalDeviceRecord } = require('./diagnosticSnapshot');
 const { customPricingPath } = require('../shared/tokscaleConfig');
 const { applyCustomPricing, normalizeCustomPricingSetting } = require('../shared/tokscaleCustomPricing');
 const { createHub } = require('../hub/server');
 const { claudeWebCookie, deepseekToken, fetchClaudeLimits, normalizeClaudeWebCookieInput, normalizeLimitsRefreshMs, parseBoolean, parseLimitProviders, runCodexLogin, minimaxToken, copilotToken, zaiToken, zaiRegion, zaiTeamToken, volcengineCredentials, qoderCookie, kimiToken, kimiWebToken, ollamaSessionCookie } = require('../shared/limitCollector');
-const { fetchOllamaLimits, rememberOllamaValidation } = require('../shared/ollamaLimits');
+const { fetchOllamaLimits, rememberOllamaValidation, normalizeOllamaManagedAccounts, createOllamaManagedAccount } = require('../shared/ollamaLimits');
+const { DEFAULT_PORT: FREELLM_DEFAULT_PORT, DEFAULT_THRESHOLD_PERCENT: FREELLM_DEFAULT_THRESHOLD_PERCENT, createFreeLlmRouter, normalizePort: normalizeFreeLlmPort, clampThreshold: normalizeFreeLlmThreshold } = require('../shared/freellmRouter');
 const { copilotLoginErrorMessage, isAllowedVerificationUrl, runCopilotDeviceFlowLogin } = require('../shared/copilotDeviceFlow');
 const {
   codexAuthIdentity,
@@ -99,18 +94,13 @@ const {
 } = require('../shared/tokscaleUpdater');
 const {
   appUpdateInstallSupport,
-  classifyAppUpdateError,
   checkLatestRelease,
   deriveAppUpdateAvailability,
   downloadedAppUpdateMatchesLatest,
-  installFailureErrorKind,
-  latestFromUpdaterInfo,
+  GITHUB_REPO,
   mergeLatestReleaseMetadata,
-  providerUpdateCheckAvailability,
-  resolveAppUpdateCheckError,
   shouldDownloadAutomaticAppUpdate,
-  shouldSkipAppUpdateCheck,
-  updateInstallQuitPolicy
+  shouldSkipAppUpdateCheck
 } = require('../shared/appUpdater');
 const cursorAuth = require('../shared/cursorAuth');
 const cursorProbe = require('../shared/cursorProbe');
@@ -118,6 +108,7 @@ const opencodeWeb = require('../shared/opencodeWeb');
 const openrouterLimits = require('../shared/openrouterLimits');
 const thirdPartyLimits = require('../shared/thirdPartyLimits');
 const subscriptionDisplay = require('../shared/subscriptionDisplay');
+const semver = require('semver');
 const { normalizeCurrency, resolveEffectiveRates, configureRates } = require('../shared/currency');
 const { normalizeCompactTokenUnits } = require('../shared/compactTokens');
 const { fetchRates, isCacheStale } = require('../shared/exchangeRates');
@@ -133,7 +124,6 @@ const {
   clearSessionUsageArchive,
   normalizeSessionUsageArchive,
   readSessionUsageArchive,
-  sessionUsageArchivePath,
   sessionUsageArchiveDate,
   writeSessionUsageArchive
 } = require('../shared/sessionUsageArchive');
@@ -148,29 +138,8 @@ const {
   normalizeMimoCookieHeader
 } = require('../shared/mimoLimits');
 const { historyPreview, historyRevision } = require('../shared/history');
-const { completeHistorySource, resolveCompleteHistory } = require('./historySource');
 const { readSessionDetailForPlatform } = require('../shared/sessionDetailResolver');
 const { startDiscordRpc, stopDiscordRpc, updateDiscordRpc } = require('./discordRpc');
-const {
-  commitMacWidgetSnapshot,
-  discardMacWidgetSnapshot,
-  prepareMacWidgetSnapshotUpdate,
-  resolveMacWidgetSnapshotPath,
-  syncMacWidgetSnapshotDirectory
-} = require('./macWidgetBridge');
-const { createMacWidgetSnapshotController } = require('./macWidgetSnapshotController');
-const { macWidgetHistorySourceKey, resolveMacWidgetHistory } = require('./macWidgetHistory');
-const {
-  macWidgetHistoryCachePath,
-  readMacWidgetHistoryCache,
-  writeMacWidgetHistoryCache
-} = require('./macWidgetHistoryStore');
-const { parseMacWidgetDeepLink } = require('./macWidgetDeepLink');
-const { createMacWidgetLaunchServicesRecovery } = require('./macWidgetLaunchServicesRecovery');
-const { projectLimitStatsForDisplay } = require('./limitStatsPresentation');
-const { normalizeWidgetURLScheme } = require('../shared/macWidgetConfig');
-const { DEFAULT_WIDGET_KIND, requestMacWidgetReload, resetMacWidgetReloadThrottle } = require('./macWidgetReloader');
-const { WIDGET_DEMAND_MARKER, WIDGET_DEMAND_PROVISIONAL_MARKER, createMacWidgetDemandState } = require('./macWidgetDemand');
 const linuxAutostart = require('./linuxAutostart');
 const { codexAccountIdForProvider, localLiveCodexProvider } = require('./renderer/accountIdentity');
 const {
@@ -193,20 +162,16 @@ const {
   trayToggleAction
 } = require('./trayModeSettings');
 const { SERVICE_STATUS_PROVIDERS, createServiceStatusClient } = require('./serviceStatus');
-const { createUpdateInstallQuitGuard, observeUpdateInstallHandoff } = require('./updateInstallQuit');
 const { classifyStreamFailure } = require('./syncConnection');
 const { composeLocalSyncStats } = require('./syncDisplayStats');
 const { createSyncUploadScheduler, normalizeSyncUploadIntervalMs } = require('./syncUploadScheduler');
 const {
   classifySettingsChange,
-  diagnosticConfigurationFromSettings,
   envelopeFromSettings,
   limitsConfigFromSettings,
   usageConfigFromSettings
 } = require('./runtimeConfig');
 const {
-  canRefreshUsageRuntime,
-  drainPendingUsageClientRefreshes: drainPendingUsageClientRefreshQueue,
   runLimitInvalidation,
   runManualDeviceRefresh,
   settingsLimitInvalidationPlan
@@ -288,17 +253,12 @@ let claudeWebCookieMutationRevision = 0;
 let persistedSettingsSnapshot = null;
 let credentialStore = null;
 let credentialStorageErrorShown = false;
+let freeLlmRouter = null;
+let freeLlmRouterQueue = Promise.resolve();
 let sessionUsageArchive = null;
-let lastSessionUsageArchiveUpdate = {
-  at: null,
-  durationMs: null,
-  failureCode: null
-};
 let rendererViewState = normalizeInitialRendererViewState();
 const serviceStatusClient = createServiceStatusClient();
 const STATUS_PAGE_HOSTS = new Set(SERVICE_STATUS_PROVIDERS.map((provider) => new URL(provider.pageUrl).hostname));
-const diagnosticJournal = createDiagnosticJournal();
-const recoverMacWidgetLaunchServicesRegistration = createMacWidgetLaunchServicesRecovery();
 
 app.setName(APP_NAME);
 if (process.platform === 'win32') app.setAppUserModelId('com.javis.tokenmonitor');
@@ -314,16 +274,6 @@ function normalizeHomeLimitAccountCount(value) {
   if (!Number.isFinite(count)) return HOME_LIMIT_ACCOUNT_COUNT_DEFAULT;
   return Math.max(1, Math.min(HOME_LIMIT_ACCOUNT_COUNT_MAX, count));
 }
-
-let pendingMacWidgetOpen = null;
-app.on('open-url', (event, url) => {
-  const urlScheme = macWidgetConfiguration()?.urlScheme || 'token-monitor';
-  const destination = parseMacWidgetDeepLink(url, urlScheme);
-  if (!destination) return;
-  event.preventDefault();
-  pendingMacWidgetOpen = destination;
-  if (app.isReady()) setImmediate(openMainWindowFromWidget);
-});
 
 function defaultSettings() {
   const envHubUrl = process.env.TOKEN_MONITOR_HUB_URL || '';
@@ -402,7 +352,6 @@ function defaultSettings() {
     showLimitSource: parseBoolean(process.env.TOKEN_MONITOR_SHOW_LIMIT_SOURCE, false),
     maskLimitAccountEmails: false,
     claudePrepaidBalanceEnabled: parseBoolean(process.env.TOKEN_MONITOR_CLAUDE_PREPAID_BALANCE, true),
-    opencodeLocalLimitsEnabled: false,
     showLimitUsed: parseBoolean(process.env.TOKEN_MONITOR_SHOW_LIMIT_USED, false),
     // Manual subscription metadata. Plain preferences, not credentials, so they
     // live in settings.json and cross to the renderer unredacted.
@@ -452,6 +401,11 @@ function defaultSettings() {
     ollamaCookie: '',
     codexManagedAccounts: [],
     mimoManagedAccounts: [],
+    ollamaManagedAccounts: [],
+    freeLlmRoutingEnabled: false,
+    freeLlmRoutingPort: FREELLM_DEFAULT_PORT,
+    freeLlmRoutingThresholdPercent: FREELLM_DEFAULT_THRESHOLD_PERCENT,
+    freeLlmRoutingKeys: [],
     appUpdate: {
       lastCheckedAt: null,
       lastKnownLatest: null,
@@ -548,7 +502,8 @@ function electronLimitsConfig() {
     env: process.env,
     defaultLimitProviders: defaultLimitProviders(),
     codexManagedAccounts: codexManagedAccountsForCollector(),
-    mimoManagedAccounts: mimoManagedAccountsForCollector()
+    mimoManagedAccounts: mimoManagedAccountsForCollector(),
+    ollamaManagedAccounts: ollamaManagedAccountsForCollector()
   });
 }
 
@@ -1045,7 +1000,6 @@ function setMimoManagedAccountEnabled(id, enabled) {
   return { ok: true, accounts: mimoAccountsForRenderer() };
 }
 
-
 function ollamaAccountsForRenderer() {
   return normalizeOllamaManagedAccounts(settings?.ollamaManagedAccounts).map(({
     id, accountKey, accountEmail, accountLabel, addedAt, updatedAt, enabled
@@ -1100,6 +1054,142 @@ function removeOllamaCredential(id) {
   } catch (_) {
     return false;
   }
+}
+
+function normalizeFreeLlmRoutingKeys(value) {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set();
+  return value.flatMap((entry) => {
+    const id = String(entry?.id || '').trim();
+    const ollamaAccountId = String(entry?.ollamaAccountId || '').trim();
+    if (!id || !ollamaAccountId || seen.has(id)) return [];
+    seen.add(id);
+    return [{
+      id,
+      ollamaAccountId,
+      label: String(entry?.label || '').trim().slice(0, 80),
+      enabled: entry?.enabled !== false,
+      addedAt: entry?.addedAt || new Date().toISOString(),
+      updatedAt: entry?.updatedAt || entry?.addedAt || new Date().toISOString()
+    }];
+  });
+}
+
+function readFreeLlmRoutingKey(id) {
+  try { return ensureCredentialStore().readFreeLlmRoutingKey(id); } catch (_) { return ''; }
+}
+
+function writeFreeLlmRoutingKey(id, apiKey) {
+  try { return ensureCredentialStore().writeFreeLlmRoutingKey(id, apiKey); } catch (_) { return false; }
+}
+
+function removeFreeLlmRoutingKey(id) {
+  try { return ensureCredentialStore().removeFreeLlmRoutingKey(id); } catch (_) { return false; }
+}
+
+function freeLlmRoutingKeysForRenderer() {
+  return normalizeFreeLlmRoutingKeys(settings?.freeLlmRoutingKeys).map((key) => ({ ...key }));
+}
+
+function freeLlmRoutingKeysForRuntime() {
+  const accounts = new Map(normalizeOllamaManagedAccounts(settings?.ollamaManagedAccounts).map((account) => [account.id, account]));
+  return normalizeFreeLlmRoutingKeys(settings?.freeLlmRoutingKeys).flatMap((key) => {
+    const account = accounts.get(key.ollamaAccountId);
+    const apiKey = readFreeLlmRoutingKey(key.id);
+    return account?.enabled !== false && apiKey ? [{ ...key, apiKey, accountKey: account.accountKey }] : [];
+  });
+}
+
+function freeLlmQuotaSnapshot() {
+  const providers = deviceRuntimeHandle?.getSnapshot?.()?.limits?.providers || [];
+  const accountIds = new Map(normalizeOllamaManagedAccounts(settings?.ollamaManagedAccounts).map((account) => [account.accountKey, account.id]));
+  return providers.filter((provider) => provider?.provider === 'ollama').flatMap((provider) => {
+    const accountId = accountIds.get(String(provider.accountKey || '').trim());
+    return accountId ? [{ ...provider, accountId }] : [];
+  });
+}
+
+function freeLlmRoutingConfig() {
+  return {
+    port: normalizeFreeLlmPort(settings?.freeLlmRoutingPort),
+    thresholdPercent: normalizeFreeLlmThreshold(settings?.freeLlmRoutingThresholdPercent)
+  };
+}
+
+function freeLlmRouterStatus() {
+  return freeLlmRouter?.getStatus?.() || { running: false, port: null, error: '', activeKeyId: '', blockedKeyIds: [] };
+}
+
+function reconcileFreeLlmRouter() {
+  freeLlmRouterQueue = freeLlmRouterQueue.then(async () => {
+    if (freeLlmRouter) {
+      await freeLlmRouter.stop();
+      freeLlmRouter = null;
+    }
+    if (!settings?.freeLlmRoutingEnabled) return freeLlmRouterStatus();
+    freeLlmRouter = createFreeLlmRouter({
+      getConfig: freeLlmRoutingConfig,
+      getKeys: freeLlmRoutingKeysForRuntime,
+      getQuotas: freeLlmQuotaSnapshot
+    });
+    try {
+      return await freeLlmRouter.start();
+    } catch (error) {
+      console.warn(`[freellm] Router could not start: ${error.message}`);
+      return freeLlmRouterStatus();
+    } finally {
+      pushSettingsToRenderer();
+    }
+  }).catch((error) => {
+    console.warn(`[freellm] Router reconciliation failed: ${error.message}`);
+    return freeLlmRouterStatus();
+  });
+  return freeLlmRouterQueue;
+}
+
+async function addFreeLlmRoutingKey(input) {
+  const apiKey = String(input?.apiKey || '').trim();
+  const ollamaAccountId = String(input?.ollamaAccountId || '').trim();
+  if (!apiKey) return { ok: false, error: 'Enter an Ollama API key.' };
+  const account = normalizeOllamaManagedAccounts(settings?.ollamaManagedAccounts).find((entry) => entry.id === ollamaAccountId);
+  if (!account || account.enabled === false) return { ok: false, error: 'Choose an enabled monitored Ollama account.' };
+  const record = { id: crypto.randomUUID(), ollamaAccountId, label: String(input?.label || '').trim().slice(0, 80), enabled: true, addedAt: new Date().toISOString(), updatedAt: new Date().toISOString() };
+  if (!writeFreeLlmRoutingKey(record.id, apiKey)) return { ok: false, error: 'Could not securely save the API key.' };
+  settings.freeLlmRoutingKeys = [...normalizeFreeLlmRoutingKeys(settings.freeLlmRoutingKeys), record];
+  try { saveSettings({ throwOnError: true }); } catch (_) {
+    removeFreeLlmRoutingKey(record.id);
+    return { ok: false, error: 'Could not save the routing key configuration.' };
+  }
+  await reconcileFreeLlmRouter();
+  void queueLimitInvalidation({ provider: 'ollama' }, 'freellm-routing', { refresh: true });
+  return { ok: true, keys: freeLlmRoutingKeysForRenderer(), status: freeLlmRouterStatus() };
+}
+
+async function removeFreeLlmRoutingKeyRecord(id) {
+  const keyId = String(id || '').trim();
+  const keys = normalizeFreeLlmRoutingKeys(settings?.freeLlmRoutingKeys);
+  if (!keys.some((key) => key.id === keyId)) return { ok: false, error: 'Routing key not found.' };
+  const apiKey = readFreeLlmRoutingKey(keyId);
+  if (!removeFreeLlmRoutingKey(keyId)) return { ok: false, error: 'Could not remove the API key.' };
+  settings.freeLlmRoutingKeys = keys.filter((key) => key.id !== keyId);
+  try { saveSettings({ throwOnError: true }); } catch (_) {
+    if (apiKey) writeFreeLlmRoutingKey(keyId, apiKey);
+    return { ok: false, error: 'Could not save the routing key configuration.' };
+  }
+  await reconcileFreeLlmRouter();
+  return { ok: true, keys: freeLlmRoutingKeysForRenderer(), status: freeLlmRouterStatus() };
+}
+
+async function setFreeLlmRoutingKeyEnabled(id, enabled) {
+  const keys = normalizeFreeLlmRoutingKeys(settings?.freeLlmRoutingKeys);
+  const key = keys.find((entry) => entry.id === String(id || '').trim());
+  if (!key) return { ok: false, error: 'Routing key not found.' };
+  key.enabled = Boolean(enabled);
+  key.updatedAt = new Date().toISOString();
+  settings.freeLlmRoutingKeys = keys;
+  try { saveSettings({ throwOnError: true }); } catch (_) { return { ok: false, error: 'Could not save the routing key configuration.' }; }
+  await reconcileFreeLlmRouter();
+  return { ok: true, keys: freeLlmRoutingKeysForRenderer(), status: freeLlmRouterStatus() };
 }
 
 async function addOllamaManagedAccount(cookieValue) {
@@ -1184,7 +1274,6 @@ function setOllamaManagedAccountEnabled(id, enabled) {
   });
   return { ok: true, accounts: ollamaAccountsForRenderer() };
 }
-
 
 function codexManagedRoot() {
   return path.join(app.getPath('userData'), 'managed-codex-homes');
@@ -2148,7 +2237,6 @@ function readSettings() {
     }
     merged.showHomeLimitBars = parseBoolean(merged.showHomeLimitBars, false);
     merged.showHomeLimitProviderNames = parseBoolean(merged.showHomeLimitProviderNames, false);
-    merged.opencodeLocalLimitsEnabled = parseBoolean(merged.opencodeLocalLimitsEnabled, false);
     merged.windowMaximized = parseBoolean(merged.windowMaximized, false);
     merged.automaticAppUpdates = parseBoolean(merged.automaticAppUpdates, false);
     if (saved.homeLimitProviderOrder !== undefined) {
@@ -2189,6 +2277,10 @@ function readSettings() {
     }
     merged.codexManagedAccounts = normalizeCodexManagedAccounts(merged.codexManagedAccounts);
     merged.mimoManagedAccounts = normalizeMimoManagedAccounts(merged.mimoManagedAccounts);
+    merged.freeLlmRoutingEnabled = parseBoolean(merged.freeLlmRoutingEnabled, false);
+    merged.freeLlmRoutingPort = normalizeFreeLlmPort(merged.freeLlmRoutingPort);
+    merged.freeLlmRoutingThresholdPercent = normalizeFreeLlmThreshold(merged.freeLlmRoutingThresholdPercent);
+    merged.freeLlmRoutingKeys = normalizeFreeLlmRoutingKeys(merged.freeLlmRoutingKeys);
     if (saved.windowBehavior === undefined && saved.alwaysOnTop !== undefined) {
       merged.windowBehavior = saved.alwaysOnTop ? 'floating' : 'normal';
     }
@@ -2289,14 +2381,10 @@ function removedTrackedClients(previousClients, nextClients) {
 }
 
 function localArchiveSourceDevice() {
-  return selectLocalDeviceRecord({
-    deviceId: settings?.deviceId || defaultDeviceId(),
-    externalAgentActive: isExternalAgentActive(),
-    lastCollectedDevice,
-    localDevice,
-    latestHubStats: currentHubStatsCache(),
-    latestStats
-  });
+  const deviceId = settings?.deviceId || defaultDeviceId();
+  if (lastCollectedDevice?.deviceId === deviceId) return lastCollectedDevice;
+  if (localDevice?.deviceId === deviceId) return localDevice;
+  return (latestStats?.devices || []).find((device) => device?.deviceId === deviceId) || null;
 }
 
 function updateArchivedClientUsage(previousClients, nextClients) {
@@ -2320,56 +2408,36 @@ function ensureSessionUsageArchiveLoaded() {
 }
 
 function updateSessionUsageArchive(summary, now) {
-  const startedAt = Date.now();
-  const finish = (failureCode = null) => {
-    lastSessionUsageArchiveUpdate = {
-      at: new Date().toISOString(),
-      durationMs: Math.max(0, Date.now() - startedAt),
-      failureCode
-    };
-  };
   const previous = ensureSessionUsageArchiveLoaded();
   const next = captureSessionUsageArchive(previous, summary, now);
-  if (JSON.stringify(next) === JSON.stringify(previous)) {
-    finish();
-    return previous;
-  }
+  if (JSON.stringify(next) === JSON.stringify(previous)) return previous;
   try {
     writeSessionUsageArchive(next);
     sessionUsageArchive = next;
   } catch (error) {
-    finish('archive-write-failed');
-    diagnosticJournal.record({ subsystem: 'storage', code: 'storage-archive-update-failed' });
     console.log(`[session-archive] write failed: ${error.message}`);
-    return next;
   }
-  finish();
   return next;
-}
-
-// Read-only projection of both archives onto a summary. Un-tracked clients and
-// retained sessions add to the period totals, not just to the breakdowns, so
-// anything rendered without this reads low. Takes the session archive as an
-// argument because capturing into it is a separate decision, see below.
-function summaryWithArchivesApplied(summary, sessionArchive, now) {
-  const withArchivedClients = applyArchivedClientUsage(summary, settings?.archivedClientUsage, {
-    activeClients: settings?.clients,
-    now
-  });
-  const visibleSummary = settings?.sessionUsageArchiveEnabled === false
-    ? withArchivedClients
-    : applySessionUsageArchive(withArchivedClients, sessionArchive, { now });
-  return settings?.projectsEnabled === false ? visibleSummary : applyProjectRollups(visibleSummary);
 }
 
 function summaryWithArchivedClientUsage(summary) {
   const now = sessionUsageArchiveDate(summary);
-  if (settings?.sessionUsageArchiveEnabled === false) return summaryWithArchivesApplied(summary, null, now);
+  const withArchivedClients = applyArchivedClientUsage(summary, settings?.archivedClientUsage, {
+    activeClients: settings?.clients,
+    now
+  });
+  let visibleSummary = withArchivedClients;
+  if (settings?.sessionUsageArchiveEnabled === false) {
+    return settings?.projectsEnabled === false ? visibleSummary : applyProjectRollups(visibleSummary);
+  }
   if (isExternalAgentActive()) {
     sessionUsageArchive = null;
-    return summaryWithArchivesApplied(summary, ensureSessionUsageArchiveLoaded(), now);
+    visibleSummary = applySessionUsageArchive(withArchivedClients, ensureSessionUsageArchiveLoaded(), { now });
+  } else {
+    const sessionArchive = updateSessionUsageArchive(summary, now);
+    visibleSummary = applySessionUsageArchive(withArchivedClients, sessionArchive, { now });
   }
-  return summaryWithArchivesApplied(summary, updateSessionUsageArchive(summary, now), now);
+  return settings?.projectsEnabled === false ? visibleSummary : applyProjectRollups(visibleSummary);
 }
 
 function applyMacActivationPolicy(state = {}) {
@@ -2475,28 +2543,11 @@ let streamConnected = false;
 let streamFailure = null;
 let lastCollectedDevice = null;
 let latestHubStats = null;
-let latestHubStatsReceivedAt = null;
-let latestHubStatsSource = 'none';
-let latestHubStatsGeneration = null;
-let latestHubStatsIdentity = null;
-let hubModeGeneration = 0;
 let tray = null;
 let latestStats = null;
-let macWidgetSnapshotController = null;
-let macWidgetDemand = null;
-let macWidgetPublicationReady = false;
-let cachedMacWidgetConfiguration;
 let trayRefreshInFlight = false;
 let trayCodexActiveAccountId = '';
 let trayCodexPendingAccountId = '';
-
-function electronPresentationStats(stats) {
-  return projectLimitStatsForDisplay(stats, {
-    localDeviceId: settings?.deviceId,
-    syncActive: mode === 'sync' || Boolean(String(settings?.hubUrl || '').trim()),
-    opencodeLocalLimitsEnabled: settings?.opencodeLocalLimitsEnabled === true
-  });
-}
 let trayCodexPendingSince = 0;
 let trayCodexSwitchInFlight = false;
 const DEFAULT_EXPORT_INTERVAL_MS = 60 * 1000;
@@ -2526,121 +2577,6 @@ let embeddedHubUnsub = null;
 let modeQueue = Promise.resolve();
 const pendingLimitInvalidations = new Map();
 const pendingUsageClientRefreshes = new Map();
-
-function hubModeRequestIsCurrent(generation, expectedMode, expectedIdentity = null) {
-  return generation === hubModeGeneration
-    && settings?.hubMode === expectedMode
-    && (expectedIdentity === null || currentHubStatsIdentity(expectedMode) === expectedIdentity);
-}
-
-function currentHubStatsIdentity(expectedMode = settings?.hubMode) {
-  const { url } = effectiveHubConfig();
-  return `${String(expectedMode || 'none')}|${String(url || 'none').replace(/\/$/, '')}`;
-}
-
-function currentHubStatsCache() {
-  const hubMode = settings?.hubMode || 'local';
-  const expectedSource = hubMode === 'host'
-    ? 'host'
-    : hubMode === 'client'
-      ? 'client'
-      : 'none';
-  if (!latestHubStats
-    || latestHubStatsSource !== expectedSource
-    || latestHubStatsGeneration !== hubModeGeneration
-    || latestHubStatsIdentity !== currentHubStatsIdentity(hubMode)) {
-    return null;
-  }
-  return latestHubStats;
-}
-
-function clearLatestHubStatsCache() {
-  latestHubStats = null;
-  latestHubStatsReceivedAt = null;
-  latestHubStatsSource = 'none';
-  latestHubStatsGeneration = null;
-  latestHubStatsIdentity = null;
-}
-
-function setLatestHubStatsCache(stats, source, generation, identity) {
-  latestHubStats = stats;
-  latestHubStatsReceivedAt = new Date().toISOString();
-  latestHubStatsSource = source;
-  latestHubStatsGeneration = generation;
-  latestHubStatsIdentity = identity;
-}
-
-const diagnosticSnapshotBuilder = createDiagnosticSnapshotBuilder({
-  getSettings: () => settings,
-  getMode: () => mode,
-  getEffectiveHubConfig: effectiveHubConfig,
-  getExternalAgentActive: isExternalAgentActive,
-  getDeviceRuntime: () => deviceRuntimeHandle,
-  getEmbeddedHub: () => embeddedHub,
-  getStreamState: () => ({ connected: streamConnected, failure: streamFailure }),
-  getLatestHubStats: () => latestHubStats,
-  getLatestHubStatsReceivedAt: () => latestHubStatsReceivedAt,
-  getLatestHubStatsSource: () => latestHubStatsSource,
-  getLatestHubStatsGeneration: () => latestHubStatsGeneration,
-  getLatestHubStatsIdentity: () => latestHubStatsIdentity,
-  getHubModeGeneration: () => hubModeGeneration,
-  getCurrentHubStatsIdentity: (hubMode) => currentHubStatsIdentity(hubMode),
-  getLocalRecord: localArchiveSourceDevice,
-  getTokscaleStatus,
-  getConfiguration: () => diagnosticConfigurationFromSettings(settings || {}, {
-    usage: {
-      agentVersion: appVersion(),
-      agentRuntime: 'electron-widget',
-      commandTimeoutMs: 120 * 1000,
-      defaultDeviceId: defaultDeviceId(),
-      intervalMs: collectorIntervalMs(),
-      historyIntervalMs: normalizeHistoryIntervalMs(settings?.historyIntervalMs)
-    },
-    limits: {
-      env: process.env,
-      defaultLimitProviders: defaultLimitProviders()
-    },
-    syncUploadIntervalMs: syncUploadIntervalMs()
-  }),
-  getJournalSnapshot: () => diagnosticJournal.getSnapshot(),
-  getArchiveState: () => {
-    const enabled = settings?.sessionUsageArchiveEnabled !== false;
-    const loaded = sessionUsageArchive !== null;
-    return {
-      enabled,
-      loaded,
-      sessionCount: loaded ? Object.keys(sessionUsageArchive?.sessions || {}).length : null,
-      countSource: loaded ? 'loaded-memory' : enabled ? 'not-loaded' : 'not-enabled',
-      lastUpdate: lastSessionUsageArchiveUpdate
-    };
-  },
-  getAppVersion: appVersion,
-  getDefaultDeviceId: defaultDeviceId,
-  canRefreshUsageRuntime,
-  getAppState: () => ({
-    packaged: app.isPackaged,
-    preferredLanguages: typeof app.getPreferredSystemLanguages === 'function'
-      ? app.getPreferredSystemLanguages()
-      : [app.getLocale?.() || 'en'],
-    locale: app.getLocale?.() || 'en'
-  })
-});
-
-const diagnosticReportGenerator = createDiagnosticReportGenerator({
-  getAppMetrics: () => app.getAppMetrics(),
-  getSystemMemory: () => ({ total: os.totalmem(), free: os.freemem() }),
-  privateMemorySupported: process.platform === 'win32',
-  getSnapshot: ({ generatedAt }) => diagnosticSnapshotBuilder.build(generatedAt),
-  getArchiveFileStat: async () => {
-    if (settings?.sessionUsageArchiveEnabled === false) return { ok: false, code: 'archive-not-enabled' };
-    try {
-      const stat = await fs.promises.stat(sessionUsageArchivePath());
-      return { ok: true, stat };
-    } catch (error) {
-      return { ok: false, code: error?.code === 'ENOENT' ? 'archive-not-present' : 'archive-stat-failed' };
-    }
-  }
-});
 
 function limitInvalidationKey(scope) {
   const provider = String(scope?.provider || '').trim().toLowerCase();
@@ -2691,10 +2627,6 @@ function drainPendingLimitInvalidations(runtime) {
 
 function refreshUsageClient(clientId, options = {}) {
   const client = String(clientId || '').trim().toLowerCase();
-  const tracked = trackedClientSet(clientsCsvForSetting(settings?.clients));
-  if (!client || !KNOWN_CLIENTS.split(',').includes(client) || !tracked.has(client)) {
-    throw new TypeError(`Unsupported targeted usage client: ${client || '(empty)'}`);
-  }
   if (!deviceRuntimeHandle) {
     pendingUsageClientRefreshes.set(client, { clientId: client, options: { ...options } });
     return Promise.resolve({ queued: true });
@@ -2702,31 +2634,14 @@ function refreshUsageClient(clientId, options = {}) {
   return Promise.resolve(deviceRuntimeHandle.refreshClient(client, options));
 }
 
-function bestEffortTrackedUsageRefresh(clientId, options = {}) {
-  const client = String(clientId || '').trim().toLowerCase();
-  const tracked = trackedClientSet(clientsCsvForSetting(settings?.clients));
-  if (
-    !tracked.has(client)
-    || !canRefreshUsageRuntime(mode, isExternalAgentActive)
-  ) return;
-  try {
-    void refreshUsageClient(client, options).catch((error) => {
-      console.log(`[usage-runtime] credential refresh failed: ${error.message}`);
-    });
-  } catch (error) {
-    console.log(`[usage-runtime] credential refresh failed: ${error.message}`);
-  }
-}
-
 function drainPendingUsageClientRefreshes(runtime) {
-  drainPendingUsageClientRefreshQueue(
-    pendingUsageClientRefreshes,
-    runtime,
-    (error) => {
+  const pending = [...pendingUsageClientRefreshes.values()];
+  pendingUsageClientRefreshes.clear();
+  for (const entry of pending) {
+    void Promise.resolve(runtime.refreshClient(entry.clientId, entry.options)).catch((error) => {
       console.log(`[usage-runtime] pending client refresh failed: ${error.message}`);
-    },
-    { enabled: canRefreshUsageRuntime(mode, isExternalAgentActive) }
-  );
+    });
+  }
 }
 
 function drainPendingRuntimeActions(runtime) {
@@ -2816,13 +2731,6 @@ function isExternalAgentActive() {
     process.kill(pid, 0);
     return true;
   } catch (_) { return false; }
-}
-
-function ownsUsageRuntime() {
-  return Boolean(
-    deviceRuntimeHandle
-    && canRefreshUsageRuntime(mode, isExternalAgentActive)
-  );
 }
 
 async function deleteDeviceFromHub(deviceId) {
@@ -3364,17 +3272,14 @@ async function saveSubscriptions(list, base) {
   return settingsForRenderer();
 }
 
-// `options` is forwarded verbatim to the runtime; the quit path passes
-// `skipCloseWatchers` (see stopAll).
-function stopSyncCollector(options = {}) {
-  if (deviceRuntimeHandle) { try { deviceRuntimeHandle.stop(options); } catch (_) {} }
+function stopSyncCollector() {
+  if (deviceRuntimeHandle) { try { deviceRuntimeHandle.stop(); } catch (_) {} }
   deviceRuntimeHandle = null;
 }
 
 function startSyncCollector() {
   stopSyncCollector();
   if (!effectiveHubConfig().url) return;
-  const widgetProducerOwner = captureMacWidgetProducerOwner();
   const syncUploadScheduler = createSyncUploadScheduler({
     intervalMs: syncUploadIntervalMs(),
     upload: postToHub,
@@ -3391,7 +3296,7 @@ function startSyncCollector() {
       const displayStats = composeLocalSyncStats(latestHubStats, lastCollectedDevice);
       if (displayStats) {
         updateDiscordRpcDisplay(displayStats);
-        sendPush({ event: 'stats', data: { type: 'stats', reason: 'local', stats: displayStats, at: new Date().toISOString() } }, { widgetProducerOwner });
+        sendPush({ event: 'stats', data: { type: 'stats', reason: 'local', stats: displayStats, at: new Date().toISOString() } });
       }
       await syncUploadScheduler.enqueue(visibleSummary, revision);
     },
@@ -3405,7 +3310,6 @@ function startSyncCollector() {
     transformUsage: summaryWithArchivedClientUsage,
     usageOptions: electronUsageConfig('sync-collector'),
     sink,
-    onDiagnosticEvent: recordDiagnosticEvent,
     onError: (error, reason) => console.log(`[sync-collector] ${reason}: ${error.message}`)
   }, {
     limitsDeps: electronLimitsDeps()
@@ -3450,7 +3354,6 @@ function startHostCollector() {
     transformUsage: summaryWithArchivedClientUsage,
     usageOptions: electronUsageConfig('host-collector'),
     sink,
-    onDiagnosticEvent: recordDiagnosticEvent,
     onError: (error, reason) => console.log(`[host-collector] ${reason}: ${error.message}`)
   }, {
     limitsDeps: electronLimitsDeps()
@@ -3466,19 +3369,14 @@ function stopHostStats() {
 function startHostStats() {
   stopHostStats();
   if (!embeddedHub) return;
-  const generation = hubModeGeneration;
-  const widgetProducerOwner = captureMacWidgetProducerOwner();
-  const cacheIdentity = currentHubStatsIdentity('host');
   // Host mode presents the same multi-device hub aggregate as connecting to a
   // remote hub, so it reuses the renderer's 'sync' status path (Live / synced
   // data). The in-process vs loopback distinction is internal to fetchStats.
   mode = 'sync';
   sendStatus(true);
   const emit = (stats, reason = 'hub') => {
-    if (!hubModeRequestIsCurrent(generation, 'host', cacheIdentity)) return;
-    setLatestHubStatsCache(stats, 'host', generation, cacheIdentity);
     updateDiscordRpcDisplay(stats);
-    sendPush({ event: 'stats', data: { type: 'stats', reason, stats, at: new Date().toISOString() } }, { widgetProducerOwner });
+    sendPush({ event: 'stats', data: { type: 'stats', reason, stats, at: new Date().toISOString() } });
   };
   embeddedHubUnsub = embeddedHub.hub.onStats((stats, reason) => emit(stats, reason || 'hub'));
   // Prime the renderer with the current snapshot so it isn't blank until the
@@ -3487,17 +3385,16 @@ function startHostStats() {
 }
 
 // Detection status is about this machine's local files, so stamp the freshly
-// collected local clientStatus, clientHealth AND wslStatus onto the local device
-// in whatever stats we hand the renderer. This keeps the 采集 tags + WSL panel
-// correct in sync/host mode without depending on the hub (or a remote Worker)
-// being redeployed to preserve these fields.
+// collected local clientStatus AND wslStatus onto the local device in whatever
+// stats we hand the renderer. This keeps the 采集 tags + WSL panel correct in
+// sync/host mode without depending on the hub (or a remote Worker) being
+// redeployed to preserve these fields.
 function injectLocalDeviceStatus(stats) {
   if (!stats || !Array.isArray(stats.devices)) return stats;
   if (lastCollectedDevice) {
     const device = stats.devices.find((entry) => entry.deviceId === lastCollectedDevice.deviceId);
     if (device) {
       if (lastCollectedDevice.clientStatus) device.clientStatus = lastCollectedDevice.clientStatus;
-      if (lastCollectedDevice.clientHealth) device.clientHealth = lastCollectedDevice.clientHealth;
       if (lastCollectedDevice.wslStatus) device.wslStatus = lastCollectedDevice.wslStatus;
     }
   }
@@ -3517,244 +3414,21 @@ function injectLocalDeviceStatus(stats) {
   return stats;
 }
 
-function macWidgetConfiguration() {
-  if (process.platform !== 'darwin') return null;
-  if (cachedMacWidgetConfiguration !== undefined) return cachedMacWidgetConfiguration;
-
-  let appGroup = String(process.env.TOKEN_MONITOR_APP_GROUP || '').trim();
-  let urlScheme = String(process.env.TOKEN_MONITOR_WIDGET_URL_SCHEME || 'token-monitor').trim();
-  let snapshotFileName = 'snapshot.json';
-  let widgetKind = DEFAULT_WIDGET_KIND;
-  const configCandidates = [
-    path.join(process.resourcesPath, 'token-monitor-widget.json'),
-    path.resolve(__dirname, '..', '..', 'build', 'macos-widget', 'widget-config.json')
-  ];
-  if (!appGroup) {
-    for (const configPath of configCandidates) {
-      try {
-        const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-        appGroup = String(config.appGroup || '').trim();
-        urlScheme = String(config.urlScheme || urlScheme).trim();
-        widgetKind = String(config.widgetKind || widgetKind).trim();
-        snapshotFileName = String(config.snapshotFileName || snapshotFileName).trim();
-        if (appGroup) break;
-      } catch (_) {}
-    }
-  }
-  const snapshotPath = resolveMacWidgetSnapshotPath({
-    appGroup,
-    home: app.getPath('home'),
-    snapshotFileName
-  });
-  if (!snapshotPath) {
-    cachedMacWidgetConfiguration = null;
-    return cachedMacWidgetConfiguration;
-  }
-  cachedMacWidgetConfiguration = {
-    appGroup,
-    snapshotPath,
-    widgetKind,
-    urlScheme: (() => {
-      try { return normalizeWidgetURLScheme(urlScheme); } catch (_) { return 'token-monitor'; }
-    })()
-  };
-  return cachedMacWidgetConfiguration;
-}
-
-function historyResolverOptions() {
-  const { url: hubUrl, secret } = effectiveHubConfig();
-  return {
-    aggregateHistory,
-    embeddedHub,
-    historyEnabled: settings?.historyEnabled !== false,
-    hubMode: settings?.hubMode,
-    hubUrl,
-    localDevice,
-    mode,
-    secret
-  };
-}
-
-function getCompleteHistory() {
-  return resolveCompleteHistory(historyResolverOptions());
-}
-
-function macWidgetPresentation() {
-  return Object.freeze({
-    currencyCode: settings?.currency,
-    currencyRate: effectiveRates?.[normalizeCurrency(settings?.currency)] || 1,
-    compactNumbers: settings?.showCompactTotalTokens !== false,
-    compactTokenUnits: settings?.compactTokenUnits,
-    showCost: true,
-    locale: settings?.language,
-    theme: Object.keys(settings?.themeColors || {}).length ? 'custom' : 'system'
-  });
-}
-
-function ensureMacWidgetDemand() {
-  if (process.platform !== 'darwin') return null;
-  if (macWidgetDemand) return macWidgetDemand;
-  const widget = macWidgetConfiguration();
-  if (!widget) return null;
-  // The demand leases live beside the snapshot in the app group container. The
-  // widget extension touches the full marker on every timeline() request and
-  // the short provisional marker on a non-gallery snapshot() (the add flow),
-  // so a fresh marker here means "a Widget is on screen or being placed". The
-  // watcher arms immediately so a first placement primes the initial snapshot
-  // within moments; the reconcile poll catches anything the watcher missed.
-  const markerDirectory = path.dirname(widget.snapshotPath);
-  macWidgetDemand = createMacWidgetDemandState({
-    markerPath: path.join(markerDirectory, WIDGET_DEMAND_MARKER),
-    provisionalMarkerPath: path.join(markerDirectory, WIDGET_DEMAND_PROVISIONAL_MARKER),
-    onActivation: () => {
-      const visibleStats = electronPresentationStats(latestStats);
-      scheduleMacWidgetSnapshot(visibleStats, captureMacWidgetProducerOwner());
-    },
-    logger: (message) => console.warn(message)
-  });
-  macWidgetDemand.start();
-  return macWidgetDemand;
-}
-
-function captureMacWidgetWork({ stats, owner }) {
-  const widget = macWidgetConfiguration();
-  if (!widget) return null;
-  // No Widget on screen means no WidgetKit render loop is asking for data, so
-  // the whole snapshot pipeline (history resolution, serialization, fsync and
-  // the reload helper spawn) can be skipped. Only a confirmed missing or stale
-  // demand marker closes this gate; an unarmed state must not starve someone
-  // who does have a Widget.
-  if (macWidgetDemand && !macWidgetDemand.isInstalled()) return null;
-  const resolverConfig = Object.freeze({ ...historyResolverOptions() });
-  const sourceKey = macWidgetHistorySourceKey(resolverConfig);
-  return {
-    stats,
-    owner: Object.freeze({
-      epoch: owner.epoch,
-      sourceKey
-    }),
-    resolverConfig,
-    historyCachePath: completeHistorySource(resolverConfig) === 'remote'
-      ? macWidgetHistoryCachePath(app.getPath('userData'), sourceKey)
-      : null,
-    presentation: macWidgetPresentation(),
-    snapshotPath: widget.snapshotPath,
-    widgetKind: widget.widgetKind
-  };
-}
-
-function ensureMacWidgetSnapshotController() {
-  if (process.platform !== 'darwin') return null;
-  if (macWidgetSnapshotController) return macWidgetSnapshotController;
-  macWidgetSnapshotController = createMacWidgetSnapshotController({
-    startPaused: !macWidgetPublicationReady,
-    captureWork: captureMacWidgetWork,
-    resolveHistory: (work) => resolveMacWidgetHistory({
-      generation: work.owner.epoch,
-      sourceKey: work.owner.sourceKey,
-      revision: work.stats?.historyRevision,
-      fetchHistory: () => resolveCompleteHistory(work.resolverConfig),
-      ...(work.historyCachePath ? {
-        loadCachedHistory: () => readMacWidgetHistoryCache(
-          work.historyCachePath,
-          work.owner.sourceKey,
-          { logger: (message) => console.warn(message) }
-        ),
-        saveCachedHistory: (history) => writeMacWidgetHistoryCache(
-          work.historyCachePath,
-          work.owner.sourceKey,
-          history,
-          { logger: (message) => console.warn(message) }
-        )
-      } : {}),
-      minIntervalMs: completeHistorySource(work.resolverConfig) === 'remote' ? undefined : 0,
-      logger: (message) => console.warn(message)
-    }),
-    prepareSnapshot: (work, history) => prepareMacWidgetSnapshotUpdate(work.stats, {
-      snapshotPath: work.snapshotPath,
-      snapshotOptions: {
-        presentation: work.presentation,
-        history
-      },
-      logger: (message) => console.warn(message)
-    }),
-    commitSnapshot: (prepared, options) => commitMacWidgetSnapshot(prepared, {
-      isCurrent: options.isCurrent,
-      logger: (message) => console.warn(message)
-    }),
-    syncSnapshot: (_work, committed, prepared) => syncMacWidgetSnapshotDirectory({
-      ...committed,
-      fs: prepared?.fs
-    }),
-    discardSnapshot: discardMacWidgetSnapshot,
-    reloadSnapshot: (work, options) => requestMacWidgetReload({
-      widgetKind: work.widgetKind,
-      isCurrent: options.isCurrent,
-      logger: (message) => console.warn(message)
-    }),
-    logger: (message) => console.warn(message)
-  });
-  return macWidgetSnapshotController;
-}
-
-function captureMacWidgetProducerOwner() {
-  return ensureMacWidgetSnapshotController()?.captureProducerOwner() || null;
-}
-
-function advanceMacWidgetProducerAndSourceEpoch() {
-  ensureMacWidgetSnapshotController()?.advanceProducerAndSourceEpoch();
-}
-
-function advanceMacWidgetSourceEpoch() {
-  ensureMacWidgetSnapshotController()?.advanceSourceEpoch();
-}
-
-function refreshMacWidgetHistorySource() {
-  advanceMacWidgetSourceEpoch();
-  const visibleStats = electronPresentationStats(latestStats);
-  scheduleMacWidgetSnapshot(visibleStats, captureMacWidgetProducerOwner());
-}
-
-function scheduleMacWidgetSnapshot(stats, producerOwner) {
-  if (process.platform !== 'darwin' || !stats) return false;
-  return ensureMacWidgetSnapshotController()?.enqueue({ stats, producerOwner }) || false;
-}
-
-// Two options, both for the cold-start seed and neither for live stats.
-// `skipExport` keeps a republished snapshot from spending the auto-export
-// interval that this run's first real scan needs. `deferToRenderer` waits for
-// the renderer to finish loading, and is deliberately not the default: a live
-// push that lands mid-load is already covered by the refreshStats() the renderer
-// runs on init, so deferring every one of them would only queue a listener per
-// frame against a slow load and then replay a burst of superseded stats.
-function sendPush(payload, options = {}) {
+function sendPush(payload) {
   const previousHistoryRevision = statsHistoryRevision(latestStats);
-  let rendererPayload = payload;
   if (payload?.data?.stats) {
     injectLocalDeviceStatus(payload.data.stats);
     latestStats = payload.data.stats;
-    const visibleStats = electronPresentationStats(latestStats);
-    rendererPayload = {
-      ...payload,
-      data: { ...payload.data, stats: visibleStats }
-    };
-    scheduleMacWidgetSnapshot(visibleStats, options.widgetProducerOwner);
     syncTrayCodexActiveAccount();
     updateTrayDisplay();
-    if (!options.skipExport && settings.exportAutoEnabled && settings.exportDir && Date.now() - lastExportAt >= exportIntervalMs()) {
+    if (settings.exportAutoEnabled && settings.exportDir && Date.now() - lastExportAt >= exportIntervalMs()) {
       lastExportAt = Date.now();
       writeExportTo(settings.exportDir, payload.data.stats.periods, { skipUnchanged: true })
         .catch((err) => console.warn(`[export] auto-export failed: ${err.message}`));
     }
   }
-  if (options.deferToRenderer) {
-    // Only while it is still the newest thing published. A slow load can outlast
-    // the first real collection, and delivering the queued snapshot then would
-    // walk the numbers backwards until the next push.
-    const deferred = payload?.data?.stats;
-    sendMainWindowEvent('stats:push', rendererPayload, () => !deferred || latestStats === deferred);
-  } else if (mainWindow && !mainWindow.isDestroyed()) {
-    try { mainWindow.webContents.send('stats:push', rendererPayload); } catch (_) {}
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    try { mainWindow.webContents.send('stats:push', payload); } catch (_) {}
   }
   if (payload?.data?.stats) {
     const nextHistoryRevision = statsHistoryRevision(payload.data.stats);
@@ -3824,11 +3498,10 @@ function updateDiscordRpcDisplay(stats) {
 
 function updateTrayDisplay() {
   if (!tray || tray.isDestroyed()) return;
-  const visibleStats = electronPresentationStats(latestStats);
   const mode = settings?.trayContent || 'tokens';
   const currency = normalizeCurrency(settings?.currency);
   const compactOptions = compactTokenDisplayOptions();
-  const limitText = formatTrayText(visibleStats, mode, currency, {
+  const limitText = formatTrayText(latestStats, mode, currency, {
     limitProviderOrder: settings?.limitProviderOrder,
     limitProviders: settings?.limitProviders,
     showLimitUsed: settings?.showLimitUsed,
@@ -3843,115 +3516,42 @@ function updateTrayDisplay() {
   const text = trayImageMode || customImageMode ? '' : limitText;
   if (trayShowsTitle(process.platform)) tray.setTitle(text);
   // Tooltip always shows a useful summary, even in icon-only mode where setTitle is blank.
-  const tip = formatTrayText(visibleStats, 'both', currency, compactOptions);
+  const tip = formatTrayText(latestStats, 'both', currency, compactOptions);
   tray.setToolTip(`Token Monitor - ${tip}`);
   // Icon: rendered bars image in bar modes, otherwise the app icon.
   let icon = null;
   if (barsImageMode || trayImageMode || customImageMode) {
     icon = providerTrayIcons[mode];
   } else {
-    const usageIconId = pickUsageTrayIconId(visibleStats, mode, Object.keys(providerTrayIcons));
+    const usageIconId = pickUsageTrayIconId(latestStats, mode, Object.keys(providerTrayIcons));
     if (usageIconId) icon = providerTrayIcons[usageIconId];
   }
   tray.setImage(icon || getDefaultTrayIcon());
 }
 
-function recordDiagnosticEvent(event) {
-  diagnosticJournal.record({
-    ...event,
-    modeAtEvent: settings?.hubMode || 'local'
-  });
-}
-
 function sendStatus(connected, extra) {
-  const previous = streamConnected;
   streamConnected = Boolean(connected);
   streamFailure = streamConnected ? null : ((extra && extra.reason) ? { reason: extra.reason, detail: extra.detail ?? null } : streamFailure);
-  if (mode === 'sync') {
-    if (streamConnected && !previous) {
-      recordDiagnosticEvent({ subsystem: 'stream', code: 'stream-reconnected' });
-    } else if (!streamConnected && (previous || extra?.reason)) {
-      recordDiagnosticEvent({
-        subsystem: 'stream',
-        code: 'stream-disconnected',
-        detailCode: diagnosticStreamDetailCode(extra || streamFailure || {})
-      });
-    }
-  }
   sendPush({ event: 'status', data: { connected: streamConnected, mode, ...(extra || {}) } });
 }
 
-// `options` is forwarded verbatim to the runtime; the quit path passes
-// `skipCloseWatchers` (see stopAll).
-function stopLocalCollector(options = {}) {
-  if (deviceRuntimeHandle) { try { deviceRuntimeHandle.stop(options); } catch (_) {} }
+function stopLocalCollector() {
+  if (deviceRuntimeHandle) { try { deviceRuntimeHandle.stop(); } catch (_) {} }
   deviceRuntimeHandle = null;
   localDevice = null;
   localStats = null;
 }
 
-// Show the last full scan's totals while the first one of this run is still
-// going, instead of zeros for the tens of seconds it takes. deviceRecordFromAnchor
-// owns the trust rules; anything it rejects leaves the renderer on its normal
-// wait-for-real-data path.
-function primeLocalStatsFromAnchor(usageOptions, widgetProducerOwner) {
-  // Cold start only. startMode() re-enters here on structural settings changes
-  // as well, and there the numbers already collected are newer than any anchor.
-  if (lastCollectedDevice) return;
-  const deviceRecord = deviceRecordFromAnchor(
-    readJson(path.join(sharedDataDir(), 'collector-anchor.json'), null),
-    {
-      envelope: electronDeviceEnvelope(),
-      clients: usageOptions.clients,
-      allTimeSince: usageOptions.allTimeSince,
-      projectsEnabled: usageOptions.projectsEnabled,
-      wslScanEnabled: usageOptions.wslScanEnabled,
-      wslSupported: process.platform === 'win32',
-      hostname: os.hostname(),
-      platform: `${process.platform}-${process.arch}`
-    }
-  );
-  if (!deviceRecord) return;
-  // The anchor holds raw collector output, while everything the renderer is ever
-  // shown has been through the archives first. Project the same way or the seed
-  // reads low for anyone with an un-tracked client or retained sessions, and then
-  // jumps when the first scan lands. Read-only on purpose: the capture step
-  // records a fresh observation, and an anchor from hours ago is not one.
-  const visible = summaryWithArchivesApplied(
-    deviceRecord,
-    settings?.sessionUsageArchiveEnabled === false ? null : ensureSessionUsageArchiveLoaded(),
-    sessionUsageArchiveDate(deviceRecord)
-  );
-  localDevice = visible;
-  localStats = withHistoryPreview(aggregateDevices([visible], 0), [visible]);
-  // Through the normal publisher, not straight to the renderer: the tray reads
-  // what sendPush sets, and in tray mode the window is hidden, so a seed that
-  // only reached the renderer would leave the one visible surface on zero.
-  // This one waits for the renderer: it is the only stats push whose whole point
-  // is to be on screen before the first scan, so it cannot be left to the
-  // refreshStats() that covers the rest. It must also not spend the export
-  // interval this run's first live scan needs on a snapshot it is republishing.
-  sendPush({
-    event: 'stats',
-    data: { type: 'stats', reason: 'anchor', stats: localStats, at: deviceRecord.receivedAt }
-  }, { skipExport: true, deferToRenderer: true, widgetProducerOwner });
-}
-
 function startLocalCollector() {
   stopLocalCollector();
-  const widgetProducerOwner = captureMacWidgetProducerOwner();
   mode = 'local';
   sendStatus(false, { reason: 'collecting' });
-  // One config object for both, so the fingerprint the seed validates against
-  // cannot drift from the one the collector will compute.
-  const usageOptions = electronUsageConfig('collector');
-  primeLocalStatsFromAnchor(usageOptions, widgetProducerOwner);
   deviceRuntimeHandle = createDeviceRuntime({
     envelope: electronDeviceEnvelope(),
     initialLimits: lastCollectedDevice?.limits,
     limitsOptions: electronLimitsConfig(),
     transformUsage: summaryWithArchivedClientUsage,
-    usageOptions,
+    usageOptions: electronUsageConfig('collector'),
     progressive: true,
     onRecord: (summary, meta) => {
       const reason = meta.reason;
@@ -3960,10 +3560,9 @@ function startLocalCollector() {
       lastCollectedDevice = localDevice;
       localStats = withHistoryPreview(aggregateDevices([localDevice], 0), [localDevice]);
       updateDiscordRpcDisplay(localStats);
-      sendPush({ event: 'stats', data: { type: 'stats', reason, stats: localStats, at: new Date().toISOString() } }, { widgetProducerOwner });
+      sendPush({ event: 'stats', data: { type: 'stats', reason, stats: localStats, at: new Date().toISOString() } });
       sendStatus(true, { reason });
     },
-    onDiagnosticEvent: recordDiagnosticEvent,
     onError: (error, reason) => sendStatus(false, { reason: `${reason}:${error.message}` })
   }, {
     limitsDeps: electronLimitsDeps()
@@ -3996,13 +3595,7 @@ function parseSseChunk(chunk) {
 
 async function startStatsStream(options = {}) {
   stopStatsStream();
-  const generation = hubModeGeneration;
-  const widgetProducerOwner = captureMacWidgetProducerOwner();
-  if (settings?.hubMode !== 'client') return;
-  const cacheIdentity = currentHubStatsIdentity('client');
-  if (options.resetSnapshot) {
-    clearLatestHubStatsCache();
-  }
+  if (options.resetSnapshot) latestHubStats = null;
   const { url: hubUrl, secret } = effectiveHubConfig();
   if (!hubUrl) return;
   mode = 'sync';
@@ -4014,7 +3607,6 @@ async function startStatsStream(options = {}) {
       headers: { accept: 'text/event-stream', ...(secret ? { authorization: `Bearer ${secret}` } : {}) },
       signal: controller.signal
     });
-    if (!hubModeRequestIsCurrent(generation, 'client', cacheIdentity)) return;
     if (!response.ok || !response.body) {
       sendStatus(false, classifyStreamFailure({ status: response.status }));
       scheduleStreamRetry();
@@ -4025,9 +3617,7 @@ async function startStatsStream(options = {}) {
     const decoder = new TextDecoder();
     let buffer = '';
     for (;;) {
-      if (!hubModeRequestIsCurrent(generation, 'client', cacheIdentity)) return;
       const { value, done } = await reader.read();
-      if (!hubModeRequestIsCurrent(generation, 'client', cacheIdentity)) return;
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
       let idx;
@@ -4037,20 +3627,19 @@ async function startStatsStream(options = {}) {
         let parsed = parseSseChunk(chunk);
         if (parsed) {
           if (parsed.event === 'stats' && parsed.data?.stats) {
-            setLatestHubStatsCache(parsed.data.stats, 'client', generation, cacheIdentity);
+            latestHubStats = parsed.data.stats;
             const displayStats = composeLocalSyncStats(latestHubStats, lastCollectedDevice);
             parsed = { ...parsed, data: { ...parsed.data, stats: displayStats } };
             updateDiscordRpcDisplay(displayStats);
           }
-          sendPush(parsed, { widgetProducerOwner });
+          sendPush(parsed);
         }
       }
     }
-    if (!hubModeRequestIsCurrent(generation, 'client', cacheIdentity)) return;
     sendStatus(false, classifyStreamFailure({ eof: true }));
     scheduleStreamRetry();
   } catch (error) {
-    if (controller.signal.aborted || !hubModeRequestIsCurrent(generation, 'client', cacheIdentity)) return;
+    if (controller.signal.aborted) return;
     sendStatus(false, classifyStreamFailure({ errorCode: error?.cause?.code || error?.code, message: error?.message }));
     scheduleStreamRetry();
   }
@@ -4070,37 +3659,6 @@ function showPopover() {
   // case where macOS fires blur immediately after show because the click that
   // opened us still has the menu bar as the focused element.
   setTimeout(() => { suppressNextBlurHide = false; }, 250);
-}
-
-function openMainWindowFromWidget() {
-  if (!app.isReady()) return;
-  const destination = pendingMacWidgetOpen || { page: 'overview', view: 'home', settings: false };
-  pendingMacWidgetOpen = null;
-  updateRendererViewState({ breakdown: destination.view });
-  applyMacActivationPolicy({ mainWindowVisible: true });
-  // Closing the window with the tray icon off destroys it while macOS keeps the
-  // app alive, so a widget click has to be able to build one again — the same
-  // recovery focusExistingWindow() performs for the dock and the shortcut.
-  // Bailing out instead consumed the open-url event and left the widget dead
-  // for the rest of the session, since nothing else reads pendingMacWidgetOpen.
-  if (!mainWindow || mainWindow.isDestroyed()) createWindow();
-  if (!mainWindow || mainWindow.isDestroyed()) return;
-  const sendDestination = () => {
-    if (!mainWindow || mainWindow.isDestroyed()) return;
-    if (destination.settings) mainWindow.webContents.send('settings:open');
-    else mainWindow.webContents.send('view:open', destination.view);
-  };
-  if (mainWindow.webContents.isLoadingMainFrame()) mainWindow.webContents.once('did-finish-load', sendDestination);
-  else sendDestination();
-  if (settings?.trayMode && tray) {
-    showPopover();
-    return;
-  }
-  if (mainWindow.isMinimized()) mainWindow.restore();
-  applyMacSpaceBehavior(false);
-  // A collapsed bubble would otherwise swallow the navigation we just sent.
-  if (floatingBubbleState.collapsed) expandFloatingBubble();
-  else mainWindow.show();
 }
 
 function hidePopover() {
@@ -4288,6 +3846,9 @@ function settingsForRenderer() {
     thirdPartyEnvConfigured: thirdPartyLimits.configuredAccounts({}, { env: process.env }).length > 0,
     codexManagedAccounts: codexAccountsForRenderer(),
     mimoManagedAccounts: mimoAccountsForRenderer(),
+    ollamaManagedAccounts: ollamaAccountsForRenderer(),
+    freeLlmRoutingKeys: freeLlmRoutingKeysForRenderer(),
+    freeLlmRoutingStatus: freeLlmRouterStatus(),
     claudeWebCookieConfigured: Boolean(currentClaudeWebCookie()),
     claudeWebCookieSource,
     deepseekApiKeyConfigured: Boolean(currentDeepSeekApiKey()),
@@ -4332,24 +3893,14 @@ function pushSettingsToRenderer() {
   }
 }
 
-function refreshLimitStatsPresentation() {
-  if (!latestStats) return;
-  const visibleStats = electronPresentationStats(latestStats);
-  scheduleMacWidgetSnapshot(visibleStats, captureMacWidgetProducerOwner());
-  updateTrayDisplay();
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    try {
-      mainWindow.webContents.send('stats:push', {
-        event: 'stats',
-        data: { type: 'stats', reason: 'presentation', mode, stats: visibleStats }
-      });
-    } catch (_) {}
-  }
-}
-
 function sendMimoAccountsPush() {
   if (!mainWindow || mainWindow.isDestroyed()) return;
   try { mainWindow.webContents.send('mimo:accounts', mimoAccountsForRenderer()); } catch (_) {}
+}
+
+function sendOllamaAccountsPush() {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  try { mainWindow.webContents.send('ollama:accounts', ollamaAccountsForRenderer()); } catch (_) {}
 }
 
 function unregisterWindowToggleShortcut() {
@@ -4387,16 +3938,18 @@ function trayMenuLocale() {
   return resolveLocale(settings?.language || 'auto', preferredLanguages);
 }
 
-// `isStillCurrent`, when given, is re-checked after the wait: see
-// deferredWindowSend.js.
-function sendMainWindowEvent(channel, payload, isStillCurrent) {
+function sendMainWindowEvent(channel, payload) {
   if (!mainWindow || mainWindow.isDestroyed()) return;
-  sendWhenRendererReady(mainWindow.webContents, channel, payload, isStillCurrent);
+  const send = () => {
+    if (!mainWindow || mainWindow.isDestroyed()) return;
+    try { mainWindow.webContents.send(channel, payload); } catch (_) {}
+  };
+  if (mainWindow.webContents.isLoading()) mainWindow.webContents.once('did-finish-load', send);
+  else send();
 }
 
 async function refreshFromTray() {
   if (trayRefreshInFlight) return;
-  const widgetProducerOwner = captureMacWidgetProducerOwner();
   trayRefreshInFlight = true;
   try {
     const stats = await fetchStats({ force: true });
@@ -4404,7 +3957,7 @@ async function refreshFromTray() {
     // result when fetchStats returned a different object (for example, a remote hub
     // fetch while an external headless agent owns collection).
     if (stats && stats !== latestStats) {
-      sendPush({ event: 'stats', data: { stats, mode, reason: 'manual' } }, { widgetProducerOwner });
+      sendPush({ event: 'stats', data: { stats, mode, reason: 'manual' } });
     }
   } catch (error) {
     console.warn(`[tray] refresh failed: ${error.message}`);
@@ -4638,9 +4191,6 @@ function exitTrayMode() {
 }
 
 function startMode() {
-  hubModeGeneration += 1;
-  advanceMacWidgetProducerAndSourceEpoch();
-  clearLatestHubStatsCache();
   // Tear down collectors synchronously so they can't double-run while the
   // async reconciliation below is queued.
   stopLocalCollector();
@@ -4719,30 +4269,12 @@ function restartDeviceRuntimeForMode() {
   else startLocalCollector();
 }
 
-// Quit-path teardown. Every step here must be synchronous, because performQuit
-// exits on the next line and anything awaited in between is a chance to never
-// get there. `skipCloseWatchers` is what buys that: chokidar's close() returns a
-// promise, but not before an O(N) synchronous pass over every watched entry, and
-// on a tree the size of ~/.claude/projects that pass alone blocks the main
-// thread long enough to look like a hang. The descriptors go with the process.
-// Mode switches deliberately do NOT come through here: they keep the default
-// stopLocalCollector() / stopSyncCollector() behaviour so the old watcher is
-// really gone before a new one starts on the same paths.
 function stopAll() {
   stopPersistBoundsTimer();
-  stopLocalCollector({ skipCloseWatchers: true });
+  stopLocalCollector();
   stopStatsStream();
   stopHostStats();
-  stopSyncCollector({ skipCloseWatchers: true });
-  macWidgetSnapshotController?.stop();
-  if (macWidgetDemand) {
-    macWidgetDemand.stop();
-    macWidgetDemand = null;
-  }
-  // Fire-and-forget on purpose. server.close() does not complete until every
-  // in-flight request does, so awaiting it hands a remote device on the embedded
-  // hub the power to hold our own exit open. The listening socket closes with
-  // the process, and a graceful hub close buys nothing on the way out.
+  stopSyncCollector();
   void stopEmbeddedHub();
   stopDiscordRpc();
   if (tray && !tray.isDestroyed()) tray.destroy();
@@ -4750,64 +4282,12 @@ function stopAll() {
 }
 
 let quitRequested = false;
-let quitInProgress = false;
-// Owned by the update-install guard below and by nothing else: electron-updater
-// restarts the process itself, so the exit has to stand down or the install
-// never runs.
-let skipForcedQuit = false;
-
-// An install request stands the forced exit down, and quitAndInstall() never
-// reports back whether the installer actually took over. The guard owns that
-// unconfirmed window; these two flags are all it touches here. See
-// updateInstallQuit.js for why the claim expires and what promotes it.
-// Set once the hand-off listener is actually attached; see the guard's watchdog.
-let updateHandoffObserved = false;
-
-const updateInstallQuit = createUpdateInstallQuitGuard({
-  ...updateInstallQuitPolicy(),
-  watchdogEnabled: () => updateHandoffObserved,
-  claim: () => { quitRequested = true; skipForcedQuit = true; },
-  release: () => { quitRequested = false; skipForcedQuit = false; },
-  onStalled: () => {
-    // The bound is far enough out that reaching it means the install genuinely
-    // stalled, which is exactly what the user is looking at: they pressed Install
-    // and the app neither restarted nor complained. What to do about it depends on
-    // whether the attempt survived: where the guard handed it back the update is
-    // still one press away, and only where it did not is a restart the way out.
-    setNativeAppUpdateState({
-      phase: 'error',
-      progress: null,
-      error: 'Update installer did not start',
-      errorKind: installFailureErrorKind({ spent: updateInstallQuit.isSpent(), stalled: true })
-    });
-  },
-  onHandoff: (afterStalledReport) => {
-    // The bound is a decision to stop waiting, not proof the installer is dead, so
-    // a hand-off that turns up later withdraws the report rather than leaving the
-    // app advising a restart it is about to perform itself.
-    if (!afterStalledReport) return;
-    setNativeAppUpdateState({ phase: 'downloaded', progress: 100, error: null });
-  }
-});
-
-// The single quit path. Teardown above is what used to hang, so it runs
-// synchronously and cheaply, and then app.exit() ends the process without
-// another trip through Electron's shutdown events.
-function performQuit() {
-  if (quitInProgress) return;
-  quitInProgress = true;
-  try {
-    stopAll();
-  } catch (error) {
-    console.log(`[quit] stopAll failed: ${error?.message || error}`);
-  }
-  app.exit(0);
-}
-
 function requestAppQuit() {
   if (quitRequested) return;
   quitRequested = true;
-  performQuit();
+  stopAll();
+  if (app.isReady()) app.quit();
+  else app.exit(0);
 }
 
 // Write the export file set (JSON + CSVs) into `dir`, atomically (temp + rename)
@@ -4860,15 +4340,14 @@ async function writeExportTo(dir, periods, options = {}) {
 }
 
 async function fetchStats(options = {}) {
-  const requestGeneration = hubModeGeneration;
-  const requestHubIdentity = currentHubStatsIdentity('client');
   const force = Boolean(options?.force);
   // forceHistory and forceSelfSync stay independent of `force` on purpose: tool
   // settings, account sign-ins and limits actions all refresh with { force: true },
   // so folding them in would spawn the expensive `tokscale graph` — and the Cursor
   // and Antigravity sync subprocesses — on every one of them. Only the manual
   // refresh button opts in.
-  if (force && ownsUsageRuntime()) {
+  const canRefreshRuntime = mode === 'local' || !isExternalAgentActive();
+  if (force && deviceRuntimeHandle && canRefreshRuntime) {
     await runManualDeviceRefresh(deviceRuntimeHandle, {
       forceHistory: Boolean(options?.forceHistory),
       forceSelfSync: Boolean(options?.forceSelfSync),
@@ -4887,22 +4366,8 @@ async function fetchStats(options = {}) {
   const url = `${hubUrl.replace(/\/$/, '')}/api/stats`;
   const response = await fetch(url, { headers: secret ? { authorization: `Bearer ${secret}` } : {} });
   if (!response.ok) throw new Error(`Hub ${response.status}: ${(await response.text()).slice(0, 200)}`);
-  const stats = await response.json();
-  if (!hubModeRequestIsCurrent(requestGeneration, 'client', requestHubIdentity)) {
-    // The response belongs to a mode that is no longer active. Wait for the
-    // queued mode reconciliation before re-reading: Client -> Host may still
-    // be binding the embedded hub, and an immediate retry would hit its
-    // loopback URL before it is listening.
-    await modeQueue;
-    return fetchStats({
-      ...options,
-      force: false,
-      forceHistory: false,
-      forceSelfSync: false
-    });
-  }
-  setLatestHubStatsCache(stats, 'client', requestGeneration, requestHubIdentity);
-  return injectLocalDeviceStatus(composeLocalSyncStats(stats, lastCollectedDevice));
+  latestHubStats = await response.json();
+  return injectLocalDeviceStatus(composeLocalSyncStats(latestHubStats, lastCollectedDevice));
 }
 
 function managedPricingSidecarPath() {
@@ -4922,7 +4387,7 @@ function regenerateTokscalePricing() {
 
 async function refreshAfterPricingChange() {
   try {
-    if (ownsUsageRuntime()) {
+    if (deviceRuntimeHandle && (mode === 'local' || !isExternalAgentActive())) {
       await deviceRuntimeHandle.tick('manual', {});
     }
   } catch (error) {
@@ -4980,7 +4445,6 @@ async function downloadTokscaleFromNpm() {
 let appUpdateCheckInFlight = false;
 let appUpdateCheckPromise = null;
 let appUpdateLastError = null;
-let appUpdateLastAttemptAt = null;
 let appUpdateBackgroundTimer = null;
 let appUpdateNativeBusy = false;
 let appUpdateNativeConfigured = false;
@@ -4988,33 +4452,36 @@ let appUpdateNativeState = {
   phase: 'idle',
   version: null,
   progress: null,
-  error: null,
-  errorKind: null
+  error: null
 };
 
-function rememberSuccessfulAppUpdateCheck(latest, checkedAt = new Date().toISOString(), { clearLatest = false } = {}) {
-  if (!latest && !clearLatest) return null;
-  const remembered = latest
-    ? mergeLatestReleaseMetadata(settings?.appUpdate?.lastKnownLatest, latest)
-    : null;
+function latestFromUpdaterInfo(info) {
+  if (!info || typeof info !== 'object') return null;
+  const version = semver.valid(info.version);
+  if (!version) return null;
+  return {
+    version,
+    tag: `v${version}`,
+    name: (typeof info.releaseName === 'string' && info.releaseName.trim()) ? info.releaseName : `v${version}`,
+    htmlUrl: `https://github.com/${GITHUB_REPO}/releases/tag/v${version}`,
+    publishedAt: typeof info.releaseDate === 'string' ? info.releaseDate : ''
+  };
+}
+
+function rememberLatestAppUpdate(latest, checkedAt = new Date().toISOString()) {
+  if (!latest) return null;
+  const merged = mergeLatestReleaseMetadata(settings?.appUpdate?.lastKnownLatest, latest);
   settings.appUpdate = {
     ...(settings.appUpdate || {}),
     lastCheckedAt: checkedAt,
-    lastKnownLatest: remembered
+    lastKnownLatest: merged
   };
   saveSettings();
-  appUpdateLastAttemptAt = checkedAt;
-  appUpdateLastError = null;
-  return remembered;
+  return merged;
 }
 
 function setNativeAppUpdateState(patch = {}) {
-  const next = { ...appUpdateNativeState, ...patch };
-  // A kind belongs to the error it arrived with and must never outlive it, so any
-  // patch that touches `error` without naming one clears it. That keeps the
-  // ordinary updater failures generic without every call site restating it.
-  if ('error' in patch && !('errorKind' in patch)) next.errorKind = null;
-  appUpdateNativeState = next;
+  appUpdateNativeState = { ...appUpdateNativeState, ...patch };
   sendAppUpdatePush();
 }
 
@@ -5024,6 +4491,18 @@ function configureNativeAppUpdater() {
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = false;
   autoUpdater.logger = console;
+  autoUpdater.on('checking-for-update', () => {
+    setNativeAppUpdateState({ phase: 'checking', progress: null, error: null });
+  });
+  autoUpdater.on('update-available', (info) => {
+    const latest = rememberLatestAppUpdate(latestFromUpdaterInfo(info));
+    setNativeAppUpdateState({ phase: 'available', version: latest?.version || info?.version || null, progress: null, error: null });
+  });
+  autoUpdater.on('update-not-available', (info) => {
+    appUpdateNativeBusy = false;
+    const latest = rememberLatestAppUpdate(latestFromUpdaterInfo(info));
+    setNativeAppUpdateState({ phase: 'idle', version: latest?.version || null, progress: null, error: null });
+  });
   autoUpdater.on('download-progress', (progress) => {
     setNativeAppUpdateState({
       phase: 'downloading',
@@ -5036,74 +4515,10 @@ function configureNativeAppUpdater() {
     const latest = latestFromUpdaterInfo(info);
     setNativeAppUpdateState({ phase: 'downloaded', version: latest?.version || info?.version || appUpdateNativeState.version || null, progress: 100, error: null });
   });
-  // The hand-off is emitted on Electron's own autoUpdater, not electron-updater's:
-  // BaseUpdater re-emits it there to mimic what Squirrel does natively. Losing it
-  // is not merely losing a confirmation, so the flag records a verified
-  // registration and nothing weaker: without the listener nothing could re-claim
-  // the flags after the grace period, and the guard would expire into a state a
-  // late hand-off could not recover from. It stops arming the watchdog instead.
-  try {
-    updateHandoffObserved = observeUpdateInstallHandoff(
-      require('electron').autoUpdater,
-      () => updateInstallQuit.noteHandoff()
-    );
-  } catch (error) {
-    updateHandoffObserved = false;
-    console.log(`[update] cannot observe the install hand-off: ${error?.message || error}`);
-  }
-  if (!updateHandoffObserved) console.log('[update] no install hand-off signal; quit recovery disabled');
   autoUpdater.on('error', (error) => {
-    // Released before the busy guard below, deliberately: update-downloaded has
-    // already cleared appUpdateNativeBusy by the time an install can fail, so a
-    // rollback behind that guard would never run and the quit flags would stay
-    // stuck for the rest of the session.
-    const wasInstalling = updateInstallQuit.abort();
-    // Availability checks use the same provider but report through
-    // appUpdateLastError. Only a real download or install attempt owns installError.
-    if (!appUpdateNativeBusy && !wasInstalling) return;
     appUpdateNativeBusy = false;
-    setNativeAppUpdateState({
-      phase: 'error',
-      progress: null,
-      error: error?.message || String(error || 'Update failed'),
-      // Where the attempt was single-use, a failed install also closed the in-app
-      // path: the controls below now offer the release page instead of a retry, and
-      // a generic "couldn't install" leaves that looking like the end of the road.
-      // A restart is what brings the retry back, so the message has to say so.
-      // `wasInstalling` is the part the helper cannot know: without it a check
-      // failure arriving after an earlier spent attempt borrows its explanation.
-      errorKind: wasInstalling
-        ? installFailureErrorKind({ spent: updateInstallQuit.isSpent() })
-        : null
-    });
+    setNativeAppUpdateState({ phase: 'error', progress: null, error: error?.message || String(error || 'Update failed') });
   });
-}
-
-async function checkAppUpdateProvider() {
-  if (!app.isPackaged) return checkLatestRelease(app.getVersion());
-  const checkedAt = new Date().toISOString();
-  configureNativeAppUpdater();
-  const result = await autoUpdater.checkForUpdates();
-  const availability = providerUpdateCheckAvailability(result, app.getVersion());
-  if (!availability.valid) {
-    return {
-      ok: false,
-      newer: false,
-      latest: null,
-      error: 'Update metadata missing or invalid',
-      errorKind: 'metadata',
-      checkedAt
-    };
-  }
-  return {
-    ok: true,
-    newer: availability.newer,
-    latest: availability.latest,
-    clearLatest: availability.clearLatest,
-    error: null,
-    errorKind: null,
-    checkedAt
-  };
 }
 
 function deriveAppUpdateState() {
@@ -5126,32 +4541,16 @@ function deriveAppUpdateState() {
     showUpdateNotice: availability.showUpdateNotice,
     dismissedVersion,
     lastCheckedAt: block.lastCheckedAt || null,
-    lastAttemptAt: appUpdateLastAttemptAt,
     checking: appUpdateCheckInFlight,
-    lastError: appUpdateLastError?.message || null,
-    lastErrorKind: appUpdateLastError?.kind || null,
+    lastError: appUpdateLastError,
     installSupported: installSupport.supported,
     installSupportReason: installSupport.reason,
     installPhase: appUpdateNativeState.phase,
     installProgress: appUpdateNativeState.progress,
     installVersion: appUpdateNativeState.version,
     installError: appUpdateNativeState.error,
-    installErrorKind: appUpdateNativeState.errorKind || null,
     downloaded: availability.downloaded,
-    // The hand-off window, straight from the state machine rather than inferred
-    // from a pair of booleans downstream: between the press and the installer
-    // taking over there is nothing else to tell the user.
-    installStarting: updateInstallQuit.isInstalling(),
-    // No further attempt is possible until a restart, so the action policy and the
-    // automatic downloader both have to stop offering one.
-    installRetryBlocked: updateInstallQuit.isSpent(),
-    // An install the guard is still trying to complete counts as busy: on macOS
-    // Squirrel can take tens of seconds, and leaving the control live for that long
-    // invites a second press the guard can only refuse.
-    installBusy: appUpdateNativeBusy
-      || updateInstallQuit.isInstalling()
-      || appUpdateNativeState.phase === 'checking'
-      || appUpdateNativeState.phase === 'downloading'
+    installBusy: appUpdateNativeBusy || appUpdateNativeState.phase === 'checking' || appUpdateNativeState.phase === 'downloading'
   };
 }
 
@@ -5172,31 +4571,15 @@ function sendAppUpdatePush() {
 }
 
 async function runAppUpdateCheck({ force = false, bypassCooldown = false } = {}) {
-  // An outstanding install owns the updater until the guard is idle again.
-  // electron-updater reports a failed check by emitting on the same global 'error'
-  // event an install failure arrives on -- checkForUpdates() emits there and
-  // rethrows -- and the handler below has nothing to tell them apart. Treating a
-  // check's failure as the install's would tear down the install, which is what the
-  // hourly check made an ordinary overlap on macOS, where an install is outstanding
-  // for as long as minutes.
-  //
-  // `isOutstanding` rather than `isInstalling`, so this covers a spent attempt too.
-  // Spent is not terminal: the bound is only where we stopped waiting, and a late
-  // hand-off still promotes it back to `handoff` and re-claims the flags. A check
-  // allowed to start in the meantime would then be in flight during a genuine
-  // hand-off, and its failure would release `skipForcedQuit` with the installer
-  // owning the exit -- the one outcome this whole path exists to prevent. Checking
-  // is worth less than that: after a spent attempt it can only find a version this
-  // process is already refusing to download.
-  if (updateInstallQuit.isOutstanding()) return deriveAppUpdateState();
   if (appUpdateCheckPromise) {
     if (force) sendAppUpdatePush();
     const activeResult = await appUpdateCheckPromise;
     if (force) {
-      appUpdateLastAttemptAt = activeResult?.checkedAt || new Date().toISOString();
-      appUpdateLastError = resolveAppUpdateCheckError(appUpdateLastError, activeResult, { force: true });
       if (activeResult?.ok) {
         if (activeResult.newer) restoreDismissedAppUpdate(activeResult.latest?.version);
+        appUpdateLastError = null;
+      } else {
+        appUpdateLastError = activeResult?.error || 'Update check failed';
       }
       sendAppUpdatePush();
     }
@@ -5214,35 +4597,24 @@ async function runAppUpdateCheck({ force = false, bypassCooldown = false } = {})
   }
   const checkTask = (async () => {
     appUpdateCheckInFlight = true;
-    appUpdateLastAttemptAt = new Date().toISOString();
+    appUpdateLastError = null;
     if (force) sendAppUpdatePush();
     let result;
     try {
-      result = await checkAppUpdateProvider();
-      appUpdateLastAttemptAt = result.checkedAt || appUpdateLastAttemptAt;
+      result = await checkLatestRelease(app.getVersion());
       if (result.ok) {
-        rememberSuccessfulAppUpdateCheck(result.latest, result.checkedAt, { clearLatest: result.clearLatest });
+        rememberLatestAppUpdate(result.latest, result.checkedAt);
         if (force && result.newer) restoreDismissedAppUpdate(result.latest?.version);
+        appUpdateLastError = null;
       } else {
-        appUpdateLastError = resolveAppUpdateCheckError(appUpdateLastError, result, { force });
+        appUpdateLastError = force ? (result.error || 'Update check failed') : null;
         if (!force) console.warn('App update check failed:', result.error);
       }
     } catch (error) {
-      const classified = classifyAppUpdateError(error);
-      appUpdateLastError = resolveAppUpdateCheckError(appUpdateLastError, {
-        ok: false,
-        error: classified.message,
-        errorKind: classified.kind
-      }, { force });
+      const message = error.message || String(error);
+      appUpdateLastError = force ? message : null;
       if (!force) console.warn('App update check threw:', error);
-      return {
-        ok: false,
-        newer: false,
-        latest: null,
-        error: classified.message,
-        errorKind: classified.kind,
-        checkedAt: appUpdateLastAttemptAt
-      };
+      return { ok: false, newer: false, latest: null, error: message };
     } finally {
       appUpdateCheckInFlight = false;
       sendAppUpdatePush();
@@ -5293,18 +4665,6 @@ async function downloadAndPrepareAppUpdate() {
     setNativeAppUpdateState({ phase: 'error', error: support.reason || 'unsupported-platform', progress: null });
     return deriveAppUpdateState();
   }
-  // Same ownership rule as the check path, and one more: a spent attempt can never
-  // be installed by this process either, so re-entering the download lifecycle
-  // rebuilds MacUpdater's local proxy while the listener the first quitAndInstall()
-  // attached is still on the native updater. The renderer stops offering this and
-  // the automatic downloader stands down, but neither of those is the boundary --
-  // this is, and an IPC action queued before the attempt ended still arrives here.
-  //
-  // Every entry point uses the same rule, for the same reason (see
-  // runAppUpdateCheck): while the guard holds anything, nothing else drives the
-  // updater.
-  if (updateInstallQuit.isOutstanding()) return deriveAppUpdateState();
-  if (appUpdateCheckPromise) await appUpdateCheckPromise;
   if (appUpdateNativeBusy) return deriveAppUpdateState();
   const latest = settings?.appUpdate?.lastKnownLatest || null;
   if (downloadedAppUpdateMatchesLatest({
@@ -5312,26 +4672,19 @@ async function downloadAndPrepareAppUpdate() {
     downloadedVersion: appUpdateNativeState.version,
     latest
   })) return deriveAppUpdateState();
+  restoreDismissedAppUpdate(latest?.version);
   configureNativeAppUpdater();
   appUpdateNativeBusy = true;
   setNativeAppUpdateState({ phase: 'checking', progress: null, error: null });
   try {
     const result = await autoUpdater.checkForUpdates();
-    const availability = providerUpdateCheckAvailability(result, app.getVersion());
-    if (!availability.valid) throw new Error('Update metadata missing or invalid');
-    const checkedAt = new Date().toISOString();
-    const latestFromCheck = rememberSuccessfulAppUpdateCheck(
-      availability.latest,
-      checkedAt,
-      { clearLatest: availability.clearLatest }
-    );
-    const version = latestFromCheck?.version || null;
-    if (!availability.newer || !version) {
+    const info = result?.updateInfo || null;
+    const version = semver.valid(info?.version) || null;
+    if (!version || !semver.gt(version, app.getVersion())) {
       appUpdateNativeBusy = false;
       setNativeAppUpdateState({ phase: 'idle', version, progress: null, error: null });
       return deriveAppUpdateState();
     }
-    restoreDismissedAppUpdate(version);
     setNativeAppUpdateState({ phase: 'downloading', version, progress: 0, error: null });
     await autoUpdater.downloadUpdate();
   } catch (error) {
@@ -5341,52 +4694,17 @@ async function downloadAndPrepareAppUpdate() {
   return deriveAppUpdateState();
 }
 
-async function installDownloadedAppUpdate() {
-  // The other half of the same rule. Refusing new operations during the install
-  // only holds the boundary if nothing was already running when it started, and a
-  // check begun a moment earlier would still be reporting on the shared event.
-  // Waiting rather than refusing, since this one is a button press: the checks
-  // below are read afterwards, when the update it is about to install is settled.
-  if (appUpdateCheckPromise) await appUpdateCheckPromise;
+function installDownloadedAppUpdate() {
   const latest = settings?.appUpdate?.lastKnownLatest || null;
   if (!downloadedAppUpdateMatchesLatest({
     phase: appUpdateNativeState.phase,
     downloadedVersion: appUpdateNativeState.version,
     latest
   })) return deriveAppUpdateState();
-  // quitAndInstall goes through before-quit, and electron-updater owns the
-  // restart from there. Stand the forced exit down or the installer never runs.
-  // Refused while an earlier request is still outstanding, and permanently once an
-  // attempt is spent, so a second press can never stack install attempts.
-  if (!updateInstallQuit.request()) {
-    // Say so rather than leave a button that quietly does nothing: a spent attempt
-    // cannot be retried in this process at all.
-    if (updateInstallQuit.phase() === 'spent') {
-      setNativeAppUpdateState({
-        phase: 'error',
-        progress: null,
-        error: 'Update install was already attempted',
-        errorKind: 'attempt-spent'
-      });
-    }
-    return deriveAppUpdateState();
-  }
-  try {
-    // isSilent: skip the NSIS installer UI on Windows so the update feels seamless
-    // (per-user install needs no elevation); isForceRunAfter relaunches the app.
-    autoUpdater.quitAndInstall(true, true);
-  } catch (error) {
-    // The abort above ended the attempt this call had just made, so unlike the
-    // updater's own error handler there is nothing else this failure could belong
-    // to, and the same recovery applies.
-    updateInstallQuit.abort();
-    setNativeAppUpdateState({
-      phase: 'error',
-      progress: null,
-      error: error?.message || String(error || 'Update failed'),
-      errorKind: installFailureErrorKind({ spent: updateInstallQuit.isSpent() })
-    });
-  }
+  quitRequested = true;
+  // isSilent: skip the NSIS installer UI on Windows so the update feels seamless
+  // (per-user install needs no elevation); isForceRunAfter relaunches the app.
+  autoUpdater.quitAndInstall(true, true);
   return deriveAppUpdateState();
 }
 
@@ -5699,7 +5017,35 @@ function createDashboardWindow() {
 }
 
 async function getDashboardHistory() {
-  return getCompleteHistory();
+  if (settings?.historyEnabled === false) return aggregateHistory([]);
+  if (mode === 'local') {
+    // The local collector keeps localDevice.history current (watch + interval
+    // ticks, with carry-forward), so read it directly — exactly as the hub
+    // branch reads /api/history. Forcing a full collection tick here made the
+    // fetch take seconds; on a quick close/reopen the response outlived the
+    // renderer and was dropped, stranding the dashboard on its empty state.
+    return aggregateHistory(localDevice ? [localDevice] : []);
+  }
+  if (settings.hubMode === 'host' && embeddedHub) {
+    // Host mode reads its own hub store in-process, so the dashboard history
+    // doesn't depend on a loopback fetch the local firewall/proxy might block.
+    return embeddedHub.hub.getHistory();
+  }
+  const { url: hubUrl, secret } = effectiveHubConfig();
+  if (!hubUrl) return aggregateHistory([]);
+  const url = `${hubUrl.replace(/\/$/, '')}/api/history`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15000);
+  try {
+    const response = await fetch(url, {
+      headers: secret ? { authorization: `Bearer ${secret}` } : {},
+      signal: controller.signal
+    });
+    if (!response.ok) throw new Error(`Hub ${response.status}: ${(await response.text()).slice(0, 200)}`);
+    return response.json();
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 let cursorStatusCache = { value: null, at: 0 };
@@ -5742,17 +5088,6 @@ function rebuildWindow() {
 app.whenReady().then(() => {
   if (process.platform === 'darwin' && app.dock) app.dock.setIcon(APP_ICON_PATH);
   ensureSettingsLoaded();
-  const widgetRecoveryAbort = new AbortController();
-  const abortWidgetRecovery = () => widgetRecoveryAbort.abort();
-  app.once('before-quit', abortWidgetRecovery);
-  const widgetRecovery = recoverMacWidgetLaunchServicesRegistration({
-    platform: process.platform,
-    isPackaged: app.isPackaged,
-    resourcesPath: process.resourcesPath,
-    userDataPath: app.getPath('userData'),
-    signal: widgetRecoveryAbort.signal,
-    logger: (message) => console.warn(message)
-  });
   session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
     callback({
       responseHeaders: {
@@ -5767,18 +5102,10 @@ app.whenReady().then(() => {
   configureWindowToggleShortcut();
   cleanupStaleStaging().catch((error) => console.log(`[tokscale] staging cleanup failed: ${error.message}`));
   ensureTray();
-  if (pendingMacWidgetOpen) setImmediate(openMainWindowFromWidget);
   if (settings.trayMode) enterTrayMode();
   regenerateTokscalePricing();
-  ensureMacWidgetDemand();
   startMode();
-  void widgetRecovery.finally(() => {
-    app.removeListener('before-quit', abortWidgetRecovery);
-    if (!widgetRecoveryAbort.signal.aborted) {
-      macWidgetPublicationReady = true;
-      macWidgetSnapshotController?.resume();
-    }
-  });
+  void reconcileFreeLlmRouter();
   void hydrateCodexManagedWorkspaceLabels();
   if (settings.discordRpcEnabled) startDiscordRpc();
   rateCache = readRateCache();
@@ -5843,7 +5170,6 @@ app.whenReady().then(() => {
     const previousTrayCustomLayout = JSON.stringify(settings.trayCustomLayout || {});
     const previousFloatingBubbleCustomLayout = JSON.stringify(settings.floatingBubbleCustomLayout || {});
     const previousShowTrayProviderBadge = settings.showTrayProviderBadge;
-    const previousOpenCodeLocalLimitsEnabled = settings.opencodeLocalLimitsEnabled === true;
     const previousCurrency = settings.currency;
     const previousCompactTokenUnits = settings.compactTokenUnits;
     const previousLanguage = settings.language;
@@ -5964,7 +5290,6 @@ app.whenReady().then(() => {
       showLimitSource: parseBoolean(patch.showLimitSource ?? settings.showLimitSource, false),
       maskLimitAccountEmails: parseBoolean(patch.maskLimitAccountEmails ?? settings.maskLimitAccountEmails, false),
       claudePrepaidBalanceEnabled: parseBoolean(patch.claudePrepaidBalanceEnabled ?? settings.claudePrepaidBalanceEnabled, true),
-      opencodeLocalLimitsEnabled: parseBoolean(patch.opencodeLocalLimitsEnabled ?? settings.opencodeLocalLimitsEnabled, false),
       showLimitUsed: parseBoolean(patch.showLimitUsed ?? settings.showLimitUsed, false),
       windowMaximized: parseBoolean(settings.windowMaximized, false),
       zoomFactor: clampZoom(patch.zoomFactor ?? settings.zoomFactor),
@@ -6049,10 +5374,6 @@ app.whenReady().then(() => {
       applyNativeMaterial();
     }
     const runtimeChange = classifySettingsChange(previousRuntimeSettings, settings);
-    const widgetHistorySourceChanged = previousRuntimeSettings.historyEnabled !== settings.historyEnabled;
-    if (widgetHistorySourceChanged && !runtimeChange.modeStructural) {
-      refreshMacWidgetHistorySource();
-    }
     const limitInvalidations = settingsLimitInvalidationPlan(runtimeChange);
     if (runtimeChange.modeStructural) {
       for (const { scope, reason, options } of limitInvalidations) {
@@ -6097,11 +5418,6 @@ app.whenReady().then(() => {
       updateTrayDisplay();
       if (settings.discordRpcEnabled && latestStats) updateDiscordRpcDisplay(latestStats);
       refreshExchangeRates();              // async: fetch if stale, then re-push
-    }
-    if ((settings.opencodeLocalLimitsEnabled === true) !== previousOpenCodeLocalLimitsEnabled) {
-      // Re-project the cached aggregate immediately. The Hub can be offline and
-      // therefore may not send another frame after this local-only setting changes.
-      refreshLimitStatsPresentation();
     }
     pushSettingsToRenderer();
     return settingsForRenderer();
@@ -6217,7 +5533,7 @@ app.whenReady().then(() => {
     // The stream normally carries the stamp, but it is precisely when the stream
     // is down that this read is the only thing still arriving from the hub.
     maybeAdoptSharedSubscriptionRevision(stats);
-    return electronPresentationStats(stats);
+    return stats;
   });
   ipcMain.handle('export:now', async () => {
     const result = await dialog.showOpenDialog({
@@ -6261,87 +5577,10 @@ app.whenReady().then(() => {
     osRelease: require('os').release(),
     isPackaged: app.isPackaged,
     userData: app.getPath('userData'),
-    // So the diagnostics panel can print ~/… instead of the user's account name.
-    homeDir: require('os').homedir(),
     sharedDataDir: sharedDataDir(),
     loginItemSupported: loginItemEnabledHere(),
     loginItemOpenAtLogin: currentLoginItemState()
   }));
-  ipcMain.handle('diagnostics:generate', async () => {
-    const report = await diagnosticReportGenerator.generate();
-    return {
-      generatedAt: report.generatedAt,
-      completeness: report.completeness,
-      text: report.text,
-      bytes: report.bytes,
-      truncated: report.truncated,
-      includedClientCount: report.includedClientCount,
-      omittedClientCount: report.omittedClientCount,
-      includedLimitProviderCount: report.includedLimitProviderCount,
-      omittedLimitProviderCount: report.omittedLimitProviderCount,
-      includedRemoteGroupCount: report.includedRemoteGroupCount,
-      omittedRemoteGroupCount: report.omittedRemoteGroupCount,
-      includedJournalEventCount: report.includedJournalEventCount,
-      journalOmittedCount: report.journalOmittedCount
-    };
-  });
-  // Where each tracked tool's data is read from on THIS machine. The absolute
-  // paths stay local by design — they carry the user's home directory and never
-  // go on the wire — so the renderer asks the main process for them instead.
-  //
-  // Probe only the client whose detail panel is open. The renderer caches the
-  // result for the current health snapshot, avoiding both eager filesystem work
-  // and path flicker when a stats tick rebuilds the panel.
-  ipcMain.handle('usage:clientSources', (_event, clientId) => {
-    const client = String(clientId || '').trim().toLowerCase();
-    const tracked = trackedClientSet(clientsCsvForSetting(settings?.clients));
-    if (!KNOWN_CLIENTS.split(',').includes(client) || !tracked.has(client)) return null;
-    try {
-      const seen = new Set();
-      const all = (visibleDiagnosticRoots(client)[client] || [])
-        .filter((root) => {
-          const key = `${root.id}\0${root.dir}`;
-          return !seen.has(key) && seen.add(key);
-        })
-        .map((root) => ({ id: root.id, dir: root.dir, exists: root.exists === true }));
-      const sources = all.slice(0, 32);
-      return { sources, omittedCount: all.length - sources.length };
-    } catch (_) {
-      return null;
-    }
-  });
-  // Reveals one of those paths. The renderer sends a client id, never a path:
-  // anything it could send would otherwise become an arbitrary filesystem open.
-  ipcMain.handle('usage:revealClientSource', async (_event, clientId) => {
-    const client = String(clientId || '').trim().toLowerCase();
-    const tracked = trackedClientSet(clientsCsvForSetting(settings?.clients));
-    if (!KNOWN_CLIENTS.split(',').includes(client) || !tracked.has(client)) return false;
-    try {
-      const roots = clientDiagnosticRoots(client)[client] || [];
-      const target = roots.find((root) => root.exists);
-      if (!target) return false;
-      // An exact-file source would otherwise be handed to openPath, which opens
-      // the file in whatever app claims .db/.jsonl. Select it in its folder
-      // instead — the user asked where the data lives, not to open it.
-      if (target.sourcePath) {
-        shell.showItemInFolder(target.sourcePath);
-        return true;
-      }
-      return await shell.openPath(target.dir) === '';
-    } catch (_) {
-      return false;
-    }
-  });
-  ipcMain.handle('usage:rescanClient', async (_event, clientId) => {
-    const client = String(clientId || '').trim().toLowerCase();
-    if (!client || !ownsUsageRuntime()) return false;
-    try {
-      return await refreshUsageClient(client, { forceSync: true }) === true;
-    } catch (error) {
-      console.log(`[usage-runtime] rescan failed: ${error.message}`);
-      return false;
-    }
-  });
   ipcMain.handle('clipboard:write', (_event, text) => {
     clipboard.writeText(String(text || ''));
     return true;
@@ -6360,6 +5599,21 @@ app.whenReady().then(() => {
     .catch((error) => ({ ok: false, error: error.message })));
   ipcMain.handle('mimo:setAccountEnabled', (_event, id, enabled) => setMimoManagedAccountEnabled(id, enabled));
   ipcMain.handle('mimo:removeAccount', async (_event, id) => removeMimoManagedAccount(id));
+  ipcMain.handle('ollama:addAccount', async (_event, raw) => addOllamaManagedAccount(raw));
+  ipcMain.handle('ollama:removeAccount', async (_event, id) => removeOllamaManagedAccount(id));
+  ipcMain.handle('ollama:setAccountEnabled', (_event, id, enabled) => setOllamaManagedAccountEnabled(id, enabled));
+  ipcMain.handle('ollama:accounts', () => ollamaAccountsForRenderer());
+  ipcMain.handle('freellm:status', () => freeLlmRouterStatus());
+  ipcMain.handle('freellm:setEnabled', async (_event, enabled) => {
+    settings.freeLlmRoutingEnabled = Boolean(enabled);
+    try { saveSettings({ throwOnError: true }); } catch (_) { return { ok: false, error: 'Could not save routing settings.' }; }
+    if (settings.freeLlmRoutingEnabled) void queueLimitInvalidation({ provider: 'ollama' }, 'freellm-routing', { refresh: true });
+    const status = await reconcileFreeLlmRouter();
+    return { ok: Boolean(!settings.freeLlmRoutingEnabled || status.running), status };
+  });
+  ipcMain.handle('freellm:addKey', async (_event, input) => addFreeLlmRoutingKey(input));
+  ipcMain.handle('freellm:removeKey', async (_event, id) => removeFreeLlmRoutingKeyRecord(id));
+  ipcMain.handle('freellm:setKeyEnabled', async (_event, id, enabled) => setFreeLlmRoutingKeyEnabled(id, enabled));
   ipcMain.handle('tokscale:getStatus', () => getTokscaleStatus());
   ipcMain.handle('tokscale:checkNpm', () => checkTokscaleNpm());
   ipcMain.handle('tokscale:downloadFromNpm', () => downloadTokscaleFromNpm());
@@ -6383,7 +5637,7 @@ app.whenReady().then(() => {
       await cursorAuth.runCursorLogin(token);
       cursorStatusCache = { value: null, at: 0 };
       void queueLimitInvalidation({ provider: 'cursor' }, 'login', { clear: true });
-      bestEffortTrackedUsageRefresh('cursor', { forceSync: true });
+      void refreshUsageClient('cursor', { forceSync: true });
       return { ok: true, email: probeResult.user.email };
     } catch (err) {
       return { ok: false, error: err.message };
@@ -6494,7 +5748,7 @@ app.whenReady().then(() => {
       await cursorAuth.runCursorLogout();
       cursorStatusCache = { value: null, at: 0 };
       void queueLimitInvalidation({ provider: 'cursor' }, 'logout', { clear: true });
-      bestEffortTrackedUsageRefresh('cursor', { forceSync: true });
+      void refreshUsageClient('cursor', { forceSync: true });
       return { ok: true };
     } catch (err) {
       return { ok: false, error: err.message };
@@ -7059,19 +6313,7 @@ app.whenReady().then(() => {
 
 app.on('second-instance', focusExistingWindow);
 app.on('window-all-closed', () => { if (process.platform !== 'darwin') app.quit(); });
-// Every quit route (Cmd+Q, last window closed, system shutdown) lands here.
-// performQuit is synchronous through to the exit, so there is nothing to wait
-// for and deliberately no preventDefault: taking the quit over would cancel an
-// OS-initiated logout or restart on macOS.
-app.on('before-quit', () => {
-  quitRequested = true;
-  resetMacWidgetReloadThrottle();
-  if (rateRefreshTimer) clearInterval(rateRefreshTimer);
-  if (appUpdateBackgroundTimer) clearInterval(appUpdateBackgroundTimer);
-  unregisterWindowToggleShortcut();
-  if (skipForcedQuit) return;
-  performQuit();
-});
+app.on('before-quit', () => { quitRequested = true; if (rateRefreshTimer) clearInterval(rateRefreshTimer); if (appUpdateBackgroundTimer) clearInterval(appUpdateBackgroundTimer); unregisterWindowToggleShortcut(); stopAll(); });
 for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
   process.once(signal, requestAppQuit);
 }

--- a/src/electron/preload.js
+++ b/src/electron/preload.js
@@ -123,6 +123,13 @@ contextBridge.exposeInMainWorld('tokenMonitor', {
   ollama: {
     validateCookie: (cookie) => ipcRenderer.invoke('ollama:validateCookie', cookie)
   },
+  freellm: {
+    status: () => ipcRenderer.invoke('freellm:status'),
+    setEnabled: (enabled) => ipcRenderer.invoke('freellm:setEnabled', enabled),
+    addKey: (input) => ipcRenderer.invoke('freellm:addKey', input),
+    removeKey: (id) => ipcRenderer.invoke('freellm:removeKey', id),
+    setKeyEnabled: (id, enabled) => ipcRenderer.invoke('freellm:setKeyEnabled', id, enabled)
+  },
   opencode: {
     saveCookie: (cookie) => ipcRenderer.invoke('opencode:saveCookie', cookie),
     logout: () => ipcRenderer.invoke('opencode:logout'),

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -12,7 +12,7 @@ const { tokenRatePerSecond, tokenBurnPerMinute } = tokenRateApi;
 const reducedMotionMedia = window.matchMedia?.('(prefers-reduced-motion: reduce)');
 const clientsWithIcon = new Set([
   'claude', 'codex', 'gemini', 'cursor', 'opencode', 'openclaw', 'hermes', 'antigravity', 'cline', 'kimi', 'qwen', 'grok', 'copilot', 'pi', 'zed', 'kilocode', 'micode', 'zcode', 'kiro', 'codebuddy', 'workbuddy', 'proma',
-  'xai', 'openrouter', 'deepseek', 'meta', 'mistral', 'qwen', 'moonshot', 'zai', 'zaiteam', 'cohere', 'xiaomi', 'mimo', 'minimax', 'doubao', 'volcengine', 'qoder', 'ollama', 'thirdparty', 'hunyuan'
+  'xai', 'openrouter', 'deepseek', 'meta', 'mistral', 'qwen', 'moonshot', 'zai', 'zaiteam', 'cohere', 'xiaomi', 'mimo', 'minimax', 'doubao', 'volcengine', 'qoder', 'ollama', 'thirdparty'
 ]);
 
 function osIconFor(platform) {
@@ -156,16 +156,12 @@ const limitProviderPresentationApi = window.TokenMonitorLimitProviderPresentatio
 const appUpdatePresentationApi = window.TokenMonitorAppUpdatePresentation;
 const accountIdentityApi = window.TokenMonitorAccountIdentity;
 const clientStatusPresentationApi = window.TokenMonitorClientStatusPresentation;
-const clientHealthPresentationApi = window.TokenMonitorClientHealthPresentation;
-const clientSourceCacheApi = window.TokenMonitorClientSourceCache;
-const clientRescanStateApi = window.TokenMonitorClientRescanState;
 const serviceStatusPresentationApi = window.TokenMonitorServiceStatusPresentation;
 const clientDisplayPreferencesApi = window.TokenMonitorClientDisplayPreferences;
 const customPricingFormApi = window.TokenMonitorCustomPricingForm;
 const viewDisplayPreferencesApi = window.TokenMonitorViewDisplayPreferences;
 const preferenceDragSortApi = window.TokenMonitorPreferenceDragSort;
 const verticalDragSortApi = window.TokenMonitorVerticalDragSort;
-const rowDragControllerApi = window.TokenMonitorRowDragController;
 const homeOverviewApi = window.TokenMonitorHomeOverview;
 const homeModulePreferencesApi = window.TokenMonitorHomeModulePreferences;
 const { limitFillPercent, limitModeSuffix } = window.TokenMonitorLimitDisplayMode;
@@ -281,7 +277,7 @@ const TOKEN_MONITOR_ISSUES_URL = `${TOKEN_MONITOR_REPOSITORY_URL}/issues/new/cho
 const TOKEN_MONITOR_WEBSITE_URL = 'https://javis-ai.com/token-monitor/';
 const TOKEN_MONITOR_WSL_SQLITE_GUIDE_URL = `${TOKEN_MONITOR_REPOSITORY_URL}/blob/main/docs/wsl-sqlite-setup.md`;
 const serviceStatusProviderPreferencesApi = window.TokenMonitorServiceStatusProviderPreferences;
-const SETTINGS_SECTION_IDS = ['general', 'main', 'window', 'appearance', 'tools', 'limits', 'subscriptions', 'sync'];
+const SETTINGS_SECTION_IDS = ['general', 'main', 'window', 'appearance', 'tools', 'limits', 'subscriptions', 'routing', 'sync'];
 const REFRESH_BUTTON_FEEDBACK_MS = 700;
 const CODEX_PENDING_ACTIVE_GRACE_MS = 30000;
 const initialFloatingBubble = window.__TOKEN_MONITOR_INITIAL_FLOATING_BUBBLE__ || { collapsed: false, side: null };
@@ -293,18 +289,7 @@ function normalizeInitialViewValue(value, allowed, fallback) {
   return allowed.has(raw) ? raw : fallback;
 }
 
-const state = { period: normalizeInitialViewValue(initialViewState.period, viewPeriodValues, 'today'), appUpdate: null, breakdown: normalizeInitialViewValue(initialViewState.breakdown, viewBreakdownValues, 'home'), viewSwitcherOpen: false, viewSwitcherHasOpened: false, limitDetailTooltipHasOpened: false, limitDetailTooltipActive: false, limitDetailTooltipRenderPending: false, settings: null, stats: null, homeHistory: null, homeHistoryBusy: false, homeHistoryRequested: false, homeHistorySignature: '', homeHistoryRetries: 0, homeHistoryRetryTimer: null, homeActivityScrollLeft: null, homeActivityFollowEnd: true, homeActivityResizeObserver: null, serviceStatus: null, serviceStatusBusy: false, serviceProvidersExpanded: false, trendSettingsExpanded: false, trendsActivating: false, homeSettingsExpanded: false, homeLimitSettingsExpanded: false, limitProviderSettingsExpanded: '', clientHealthExpanded: '', clientSources: clientSourceCacheApi.createClientSourceCache(), clientSourcesKey: '', clientSourcesRequest: 0, subscriptionEditingId: '', subscriptionTopUps: [], subscriptionFormBase: null, subscriptionEditorTransitionId: 0, serviceStatusTicker: null, refreshTimer: null, refreshBusy: false, refreshFeedbackTimer: null, currentTotal: 0, rowSignature: '', streamConnected: false, streamFailure: null, mode: 'idle', appInfo: null, tokscaleStatus: null, tokscaleCheck: null, tokscaleBusy: false, hubInfo: null, cursorAccount: { status: null, error: '' }, cursorAccountExpanded: false, codexAccountExpanded: false, codexAccountError: '', codexSignInBusy: false, codexSignInFlowId: '', codexLoginUrl: '', codexLoginStatus: '', codexLoginOutput: '', codexWorkspaceChoices: [], codexWorkspaceId: '', codexActiveAccount: null, codexPendingActiveAccount: null, codexPendingActiveAccountUntil: 0, codexPendingActiveAccountTimer: null, codexSystemSwitchingAccountId: '', codexSystemSwitchErrorAccountId: '', codexSystemSwitchError: '', codexSwitchPopoverHasOpened: false, codexSwitchPopoverActive: false, codexSwitchPopoverRenderPending: false, customPricingExpanded: false, claudeAccountExpanded: false, claudePendingCheckSince: 0, opencodeProfileCount: 0, opencodeCookieExpanded: false, openrouterProfileCount: 0, openrouterAccountExpanded: false, thirdPartyProfileCount: 0, thirdPartyAccountExpanded: false, deepseekAccountExpanded: false, deepseekPendingCheckSince: 0, minimaxAccountExpanded: false, minimaxPendingCheckSince: 0, zaiAccountExpanded: false, zaiPendingCheckSince: 0, zaiteamAccountExpanded: false, zaiteamPendingCheckSince: 0, volcengineAccountExpanded: false, volcenginePendingCheckSince: 0, qoderAccountExpanded: false, qoderPendingCheckSince: 0, kimiAccountExpanded: false, kimiPendingCheckSince: 0, ollamaAccountExpanded: false, ollamaPendingCheckSince: 0, mimoAccountExpanded: false, mimoAccountError: '', copilotAccountExpanded: false, copilotManualExpanded: false, copilotPendingCheckSince: 0, copilotSignInBusy: false, copilotSignInCancelable: false, copilotSignInFlowId: '', copilotAuthorizeMessage: '', copilotLoginStatus: '', copilotErrorMessage: '', floatingBubble: initialFloatingBubble, suppressInitialNumberAnimation: window.__TOKEN_MONITOR_SUPPRESS_INITIAL_NUMBER_ANIMATION__ === true, openSession: null, detailSort: 'time', recordingWindowShortcut: false, windowShortcutInvalid: false };
-state.clientRescans = clientRescanStateApi.createClientRescanState({
-  onChange: (clientId) => {
-    if (state.clientHealthExpanded === clientId) refillOpenClientHealthPanel();
-  }
-});
-state.toolPreferenceRenderSignature = '';
-state.toolPreferenceDetailSignature = '';
-state.toolPreferenceSourceSignature = '';
-state.limitProviderRenderSignature = '';
-state.limitPanelRenderSignature = '';
-state.settingsPushRevision = 0;
+const state = { period: normalizeInitialViewValue(initialViewState.period, viewPeriodValues, 'today'), appUpdate: null, breakdown: normalizeInitialViewValue(initialViewState.breakdown, viewBreakdownValues, 'home'), viewSwitcherOpen: false, viewSwitcherHasOpened: false, limitDetailTooltipHasOpened: false, limitDetailTooltipActive: false, limitDetailTooltipRenderPending: false, settings: null, stats: null, homeHistory: null, homeHistoryBusy: false, homeHistoryRequested: false, homeHistorySignature: '', homeHistoryRetries: 0, homeHistoryRetryTimer: null, homeActivityScrollLeft: null, homeActivityFollowEnd: true, homeActivityResizeObserver: null, serviceStatus: null, serviceStatusBusy: false, serviceProvidersExpanded: false, trendSettingsExpanded: false, trendsActivating: false, homeSettingsExpanded: false, homeLimitSettingsExpanded: false, limitProviderSettingsExpanded: '', subscriptionEditingId: '', subscriptionTopUps: [], subscriptionFormBase: null, subscriptionEditorTransitionId: 0, serviceStatusTicker: null, refreshTimer: null, refreshBusy: false, refreshFeedbackTimer: null, currentTotal: 0, rowSignature: '', streamConnected: false, streamFailure: null, mode: 'idle', appInfo: null, tokscaleStatus: null, tokscaleCheck: null, tokscaleBusy: false, hubInfo: null, cursorAccount: { status: null, error: '' }, cursorAccountExpanded: false, codexAccountExpanded: false, codexAccountError: '', codexSignInBusy: false, codexSignInFlowId: '', codexLoginUrl: '', codexLoginStatus: '', codexLoginOutput: '', codexWorkspaceChoices: [], codexWorkspaceId: '', codexActiveAccount: null, codexPendingActiveAccount: null, codexPendingActiveAccountUntil: 0, codexPendingActiveAccountTimer: null, codexSystemSwitchingAccountId: '', codexSystemSwitchErrorAccountId: '', codexSystemSwitchError: '', codexSwitchPopoverHasOpened: false, codexSwitchPopoverActive: false, codexSwitchPopoverRenderPending: false, customPricingExpanded: false, claudeAccountExpanded: false, claudePendingCheckSince: 0, opencodeProfileCount: 0, opencodeCookieExpanded: false, openrouterProfileCount: 0, openrouterAccountExpanded: false, thirdPartyProfileCount: 0, thirdPartyAccountExpanded: false, deepseekAccountExpanded: false, deepseekPendingCheckSince: 0, minimaxAccountExpanded: false, minimaxPendingCheckSince: 0, zaiAccountExpanded: false, zaiPendingCheckSince: 0, zaiteamAccountExpanded: false, zaiteamPendingCheckSince: 0, volcengineAccountExpanded: false, volcenginePendingCheckSince: 0, qoderAccountExpanded: false, qoderPendingCheckSince: 0, kimiAccountExpanded: false, kimiPendingCheckSince: 0, ollamaAccountExpanded: false, ollamaPendingCheckSince: 0, mimoAccountExpanded: false, mimoAccountError: '', copilotAccountExpanded: false, copilotManualExpanded: false, copilotPendingCheckSince: 0, copilotSignInBusy: false, copilotSignInCancelable: false, copilotSignInFlowId: '', copilotAuthorizeMessage: '', copilotLoginStatus: '', copilotErrorMessage: '', floatingBubble: initialFloatingBubble, suppressInitialNumberAnimation: window.__TOKEN_MONITOR_SUPPRESS_INITIAL_NUMBER_ANIMATION__ === true, openSession: null, detailSort: 'time', recordingWindowShortcut: false, windowShortcutInvalid: false };
 state.homeHistoryLoadedSignature = '';
 state.homeHistoryRetrySignature = '';
 state.homeReturnVisible = false;
@@ -514,12 +499,6 @@ function t(key, params) {
   return i18n.translate(currentLocale(), key, params);
 }
 
-const diagnosticsPanel = window.TokenMonitorDiagnosticsPanel?.createDiagnosticsPanel({
-  api: window.tokenMonitor,
-  translate: t,
-  getLocale: currentLocale
-});
-
 function translatedLimitCapabilityTag(label) {
   const key = LIMIT_CAPABILITY_TAG_KEYS[label];
   return key ? t(key) : label;
@@ -535,7 +514,6 @@ function applySettingsTranslations() {
   i18n.applyTranslations(document, currentLocale());
   setThirdPartyAdapterFields();
   setSubscriptionFormMode();
-  diagnosticsPanel?.render();
 }
 
 function applySettingsSectionDom(id, open) {
@@ -652,11 +630,6 @@ function settingsSectionSummary(section) {
     return t('settings.sync.localOnly');
   }
   if (section === 'tools') {
-    const counts = clientHealthPresentationApi.clientHealthCountsForTracked(
-      localClientHealth(),
-      enabledClientSet()
-    );
-    if (counts) return t('settings.summary.toolsHealth', counts);
     return t('settings.summary.tools', {
       tracked: enabledClientSet().size,
       visible: KNOWN_CLIENTS.length - hiddenClientSet().size,
@@ -683,6 +656,11 @@ function settingsSectionSummary(section) {
       count: active.length,
       total: formatCost(subscriptionApi.monthlyTotalUsd(active, currencyApi))
     });
+  }
+  if (section === 'routing') {
+    const status = state.settings.freeLlmRoutingStatus || {};
+    if (state.settings.freeLlmRoutingEnabled && status.running) return `Running · :${status.port}`;
+    return state.settings.freeLlmRoutingEnabled ? 'Needs attention' : 'Off';
   }
   if (section === 'main') {
     return viewsSummary();
@@ -922,6 +900,13 @@ function formatUpdatedAge(value) {
 function versionText(value) {
   return value ? `v${value}` : 'unknown';
 }
+function appUpdateActionMode(s) {
+  if (!s) return '';
+  if (s.downloaded) return 'install';
+  if (!s.hasUpdate) return '';
+  if (s.installSupported) return 'download';
+  return s.latest?.htmlUrl ? 'release' : '';
+}
 function setAppUpdatePillDisclosure(available) {
   const action = els.appUpdatePillAction;
   if (available) {
@@ -938,7 +923,7 @@ function renderAppUpdatePill() {
   const s = state.appUpdate;
   const pill = els.appUpdatePill;
   if (!pill) return;
-  const mode = appUpdatePresentationApi.appUpdateActionMode(s);
+  const mode = appUpdateActionMode(s);
   const version = s?.latest?.version || s?.installVersion || '';
   if (!s || !mode || !version || !s.showUpdateNotice) {
     pill.classList.add('hidden');
@@ -1006,7 +991,7 @@ function buildAppUpdateNoteGroupNodes(groups) {
 function renderAppUpdatePopover(s) {
   const version = s?.latest?.version || '';
   const groups = releaseNoteGroupsForCurrentLocale(s?.latest);
-  const mode = appUpdatePresentationApi.appUpdateActionMode(s);
+  const mode = appUpdateActionMode(s);
   if (!version || groups.length === 0 || !mode) {
     if (els.appUpdatePopover.matches(':popover-open')) els.appUpdatePopover.hidePopover();
     els.appUpdatePopoverTitle.textContent = '';
@@ -1069,14 +1054,12 @@ function renderSettingsAppUpdateRow() {
     return;
   }
   els.appUpdateInstalled.textContent = `v${s.currentVersion}`;
-  const presentation = appUpdatePresentationApi.appUpdateStatusPresentation(s);
-  const displayVersion = presentation.displayVersion;
+  const displayVersion = s.latest?.version || s.installVersion || '';
   if (displayVersion) {
-    const status = presentation.latestStatusKey ? t(presentation.latestStatusKey) : '';
-    els.appUpdateLatest.textContent = status
-      ? t('settings.appUpdate.latestWithStatus', { version: displayVersion, status })
+    els.appUpdateLatest.textContent = !s.hasUpdate && semverLikeEqual(displayVersion, s.currentVersion)
+      ? t('settings.appUpdate.latestWithStatus', { version: displayVersion, status: t('settings.appUpdate.upToDateShort') })
       : `v${displayVersion}`;
-    const actionMode = appUpdatePresentationApi.appUpdateActionMode(s);
+    const actionMode = appUpdateActionMode(s);
     els.appUpdateViewReleaseButton.classList.toggle('hidden', !actionMode);
     els.appUpdateViewReleaseButton.disabled = Boolean(s.installBusy);
     els.appUpdateViewReleaseButton.textContent = actionMode === 'install'
@@ -1085,39 +1068,24 @@ function renderSettingsAppUpdateRow() {
         ? t('settings.appUpdate.download')
         : t('settings.appUpdate.viewRelease');
   } else {
-    els.appUpdateLatest.textContent = s.lastError
-      ? t('settings.appUpdate.unavailable')
-      : s.lastCheckedAt
-        ? t('settings.appUpdate.upToDate')
-        : t('settings.common.notChecked');
+    els.appUpdateLatest.textContent = s.lastCheckedAt ? t('settings.appUpdate.upToDate') : t('settings.common.notChecked');
     els.appUpdateViewReleaseButton.classList.add('hidden');
   }
-  // installRetryBlocked as well as busy: the main process stops running checks once
-  // an attempt is spent, so without this the button would sit live and do nothing.
-  // It is not folded into installBusy, which would disable View release along with
-  // it and take away the one path a spent attempt leaves working.
-  els.appUpdateCheckButton.disabled = Boolean(s.checking || s.installBusy || s.installRetryBlocked);
+  els.appUpdateCheckButton.disabled = Boolean(s.checking || s.installBusy);
   els.appUpdateCheckButton.textContent = s.checking ? t('settings.appUpdate.checking') : t('settings.appUpdate.check');
   renderAppUpdateNotes(s);
   if (s.installPhase === 'downloading') {
     const percent = Number.isFinite(s.installProgress) ? Math.round(s.installProgress) : 0;
     els.appUpdateMessage.textContent = t('settings.appUpdate.downloading', { percent });
     els.appUpdateMessage.classList.remove('error');
-  } else if (s.installStarting) {
-    els.appUpdateMessage.textContent = t('settings.appUpdate.installStarting');
-    els.appUpdateMessage.classList.remove('error');
   } else if (s.downloaded) {
     els.appUpdateMessage.textContent = t('settings.appUpdate.ready');
     els.appUpdateMessage.classList.remove('error');
   } else if (s.installError) {
-    els.appUpdateMessage.textContent = t(appUpdatePresentationApi.appUpdateInstallErrorMessageKey(s.installErrorKind));
+    els.appUpdateMessage.textContent = t('settings.appUpdate.installError');
     els.appUpdateMessage.classList.add('error');
   } else if (s.lastError) {
-    const error = t(presentation.errorKey);
-    const age = compactAge(presentation.lastSuccessfulCheckAt);
-    els.appUpdateMessage.textContent = age
-      ? t('settings.appUpdate.errorWithLastSuccess', { error, age })
-      : error;
+    els.appUpdateMessage.textContent = t('settings.appUpdate.githubError');
     els.appUpdateMessage.classList.add('error');
   } else {
     els.appUpdateMessage.textContent = '';
@@ -1139,6 +1107,9 @@ function renderAutomaticAppUpdateControl() {
   }
 }
 
+function semverLikeEqual(a, b) {
+  return typeof a === 'string' && typeof b === 'string' && a === b;
+}
 function compactAge(value) {
   const date = value ? new Date(value) : null;
   if (!date || Number.isNaN(date.getTime())) return '';
@@ -2180,7 +2151,7 @@ function subscriptionAccountChoices() {
 }
 
 function subscriptionAccountValue(provider) {
-  return [provider?.provider || '', provider?.accountKey || '', provider?.accountName || ''].join('\0');
+  return [provider?.provider || '', provider?.accountKey || '', provider?.accountName || ''].join(' ');
 }
 
 // The plan the account already reports ("Pro", "Plus") is nearly always what the
@@ -4378,21 +4349,15 @@ function renderProviderWindows(provider, color) {
   if (provider.provider === 'codex') {
     const session = windowForKind(provider, 'session');
     const weekly = windowForKind(provider, 'weekly');
-    const monthly = windowForKind(provider, 'billing');
     if (session) {
       const sessionNode = limitWindowNode(session.label || 'Session', session, color, 0.95);
-      if (!weekly && !monthly) sessionNode.classList.add('limit-window-wide');
+      if (!weekly) sessionNode.classList.add('limit-window-wide');
       windows.append(sessionNode);
     }
     if (weekly) {
       const weeklyNode = limitWindowNode(weekly.label || 'Weekly', weekly, color, 0.68);
-      if (!session && !monthly) weeklyNode.classList.add('limit-window-wide');
+      if (!session) weeklyNode.classList.add('limit-window-wide');
       windows.append(weeklyNode);
-    }
-    if (monthly) {
-      const monthlyNode = limitWindowNode(monthly.label || 'Monthly', monthly, color, 0.68);
-      monthlyNode.classList.add('limit-window-wide');
-      windows.append(monthlyNode);
     }
     const resetNode = codexResetCreditsNode(provider.resetCredits);
     if (resetNode) windows.append(resetNode);
@@ -4868,6 +4833,31 @@ function mimoSettingsAccountTitle(account, index) {
   return String(account?.accountEmail || '').trim() || `Account ${index + 1}`;
 }
 
+function ollamaSettingsAccountTitle(account, index) {
+  return String(account?.accountEmail || account?.accountLabel || '').trim() || `Account ${index + 1}`;
+}
+
+function renderOllamaAccountGroup(label, providers, color) {
+  const row = document.createElement('div');
+  row.className = `limit-row limit-row-group${providers.some((provider) => provider.stale) ? ' stale' : ''}`;
+  const groupProvider = { provider: 'ollama', status: 'ok', windows: [], accountGroup: true };
+  const head = renderLimitProviderHead('ollama', label, groupProvider, color, {
+    planText: t('settings.ollama.nAccounts', { count: providers.length }),
+    hideMeta: true
+  });
+  const accountList = document.createElement('div');
+  accountList.className = 'limit-account-list';
+  providers.forEach((provider, index) => {
+    accountList.append(renderLimitProviderRow('ollama', limitAccountTitle('ollama', provider, index, providers), provider, color, {
+      accountRow: true,
+      accountTitle: true,
+      showIcon: false
+    }));
+  });
+  row.append(head, accountList);
+  return row;
+}
+
 function renderMimoAccountGroup(label, providers, color) {
   const row = document.createElement('div');
   row.className = `limit-row limit-row-group${providers.some((provider) => provider.stale) ? ' stale' : ''}`;
@@ -4997,54 +4987,22 @@ function renderLimits() {
   const limitsEnabled = state.settings?.limitsEnabled !== false;
   const enabled = enabledLimitProviderSet();
   const providers = providersByLimitProviderId(state.stats?.limits?.providers || []);
-  const orderedProviders = limitProviderOrderApi
+  const nodes = [];
+  const rows = limitProviderOrderApi
     .orderedLimitProviders(LIMIT_PROVIDERS, state.settings?.limitProviderOrder)
     .filter(({ id }) => limitsEnabled && enabled.has(id));
-  const visibleProviderEntries = new Map(orderedProviders.map(({ id }) => {
-    const providerEntries = limitsEnabled && enabled.has(id)
-      ? (providers.get(id) || [{ provider: id, status: state.stats ? missingLimitProviderStatus() : 'unavailable', windows: [] }])
-      : [{ provider: id, status: 'disabled', windows: [] }];
-    return [id, providerEntries];
-  }));
-  const renderSignature = JSON.stringify({
-    locale: currentLocale(),
-    minute: Math.floor(Date.now() / 60000),
-    mode: state.mode,
-    hubUrl: state.settings?.hubUrl || '',
-    deviceId: state.settings?.deviceId || '',
-    settings: [
-      state.settings?.showLimitSource === true,
-      state.settings?.maskLimitAccountEmails === true,
-      state.settings?.showLimitUsed === true,
-      state.settings?.showToolIcons !== false,
-      state.settings?.claudePrepaidBalanceEnabled !== false,
-      state.settings?.currency || '',
-      state.settings?.currencyRatesEffective || null,
-      state.settings?.subscriptions || [],
-      state.settings?.codexManagedAccounts || [],
-      state.codexActiveAccount || null,
-      state.codexSystemSwitchingAccountId || '',
-      state.codexSystemSwitchErrorAccountId || '',
-      state.codexSystemSwitchError || ''
-    ],
-    providerOrder: orderedProviders.map(({ id }) => id),
-    providers: [...visibleProviderEntries.entries()]
-  });
-  if (
-    state.limitPanelRenderSignature === renderSignature
-    && els.limitsPanel.children.length === orderedProviders.length
-  ) {
-    return;
-  }
-  state.limitPanelRenderSignature = renderSignature;
-  const nodes = [];
-  const rows = orderedProviders;
   if (rows.length === 0) {
     els.limitsPanel.replaceChildren();
     return;
   }
   for (const { id, label } of rows) {
-    const visibleProviders = visibleProviderEntries.get(id) || [{ provider: id, status: 'disabled', windows: [] }];
+    const providerEnabled = limitsEnabled && enabled.has(id);
+    const providerEntries = providerEnabled
+      ? (providers.get(id) || [{ provider: id, status: state.stats ? missingLimitProviderStatus() : 'unavailable', windows: [] }])
+      : [{ provider: id, status: 'disabled', windows: [] }];
+    const visibleProviders = providerEntries.length > 0
+      ? providerEntries
+      : { provider: id, status: 'disabled', windows: [] };
     const color = id === 'mimo' ? clientColors.xiaomi : (clientColors[id] || clientColors.default);
     if (id === 'claude' && Array.isArray(visibleProviders) && visibleProviders.length > 1) {
       nodes.push(renderClaudeAccountGroup(label, visibleProviders, color));
@@ -5064,6 +5022,10 @@ function renderLimits() {
     }
     if (id === 'thirdparty' && Array.isArray(visibleProviders) && visibleProviders.length > 1) {
       nodes.push(renderThirdPartyAccountGroup(label, visibleProviders, color));
+      continue;
+    }
+    if (id === 'ollama' && Array.isArray(visibleProviders) && visibleProviders.length > 1) {
+      nodes.push(renderOllamaAccountGroup(label, visibleProviders, color));
       continue;
     }
     if (id === 'mimo' && Array.isArray(visibleProviders) && visibleProviders.length > 1) {
@@ -5410,7 +5372,7 @@ function renderTrends() {
 
   const model = charts.sparklinePreview(finalPoints, { width: 300, height: 120, gap: 0.3, metric });
   const titles = finalPoints.map((p) => `${trendShortLabel(p[labelKey], labelKey)} · ${formatCompact(p[metric])}`);
-  const svg = charts.sparklineSvg(model, { titles, showZeroMarkers: state.period === 'today' });
+  const svg = charts.sparklineSvg(model, { titles });
 
   const summary = preview.summary || {};
   const rangeLabel = state.period === 'allTime' ? t('trends.range.year')
@@ -7652,6 +7614,7 @@ function renderSessionUsageArchiveStatus() {
 
 function syncSettingsForm() {
   applySettingsTranslations();
+  renderFreeLlmRouting();
   applyInitialBreakdownPreference();
   syncPeriodTabs();
   syncHubModeUi();
@@ -7967,12 +7930,12 @@ function onPreferencePointerMove(event) {
 function onPreferencePointerUp(event) {
   if (!preferenceDrag || preferenceDrag.pointerId !== event.pointerId) return;
   event.preventDefault();
-  const { kind } = preferenceDrag;
+  const { kind, id } = preferenceDrag;
   const order = applyPreferenceLiveOrder(kind, event.clientY) || preferenceDrag.order;
   const changed = preferenceDrag.changed;
   releasePreferencePointer(event.pointerId);
   finishPreferenceDrag();
-  if (changed) void onPreferenceOrderCommit(kind, order);
+  if (changed) void onPreferenceOrderCommit(kind, order, id);
 }
 
 function onPreferencePointerCancel(event) {
@@ -7987,13 +7950,17 @@ function createPreferenceOrderHandle({ kind, id, label, count }) {
   handle.type = 'button';
   handle.className = 'preference-order-handle';
   handle.dataset.preferenceOrderHandle = kind;
-  const titleKey = kind === 'view'
-    ? 'settings.views.reorderView'
-    : kind === 'statusProvider'
-      ? 'serviceStatus.reorderProvider'
-      : kind === 'homeModule'
-        ? 'settings.home.reorderModule'
-        : 'settings.home.reorderProvider';
+  const titleKey = kind === 'client'
+    ? 'settings.tools.reorderClient'
+    : kind === 'view'
+      ? 'settings.views.reorderView'
+      : kind === 'statusProvider'
+        ? 'serviceStatus.reorderProvider'
+        : kind === 'homeModule'
+          ? 'settings.home.reorderModule'
+          : kind === 'homeLimitProvider'
+            ? 'settings.home.reorderProvider'
+            : 'settings.limits.reorderProvider';
   handle.title = t(titleKey, { name: label });
   handle.setAttribute('aria-label', handle.title);
   handle.setAttribute('aria-keyshortcuts', 'ArrowUp ArrowDown Home End');
@@ -8003,32 +7970,268 @@ function createPreferenceOrderHandle({ kind, id, label, count }) {
   return handle;
 }
 
-// The limit provider list drags from the whole row instead of a handle. The
-// gesture itself is generic and lives in `rowDragController.js`; what stays
-// here is the wiring to this list's DOM, ordering setting, and accordion.
-//
+// The limit provider list drags from the whole row instead of a handle: the
+// pointer must travel this far vertically before the gesture counts as a drag
+// rather than a click. Same threshold the tray composer uses horizontally.
+const LIMIT_PROVIDER_DRAG_THRESHOLD = 4;
+let limitProviderDrag = null;
+
+// Rows are measured in the settings panel's content space (client Y plus its
+// scrollTop) so edge auto-scrolling never invalidates the snapshot: when the
+// panel scrolls the pointer's content Y advances on its own, with no
+// compensation term anywhere else.
+function limitProviderContentY(clientY) {
+  const panel = els.settingsPanel;
+  if (!panel) return clientY;
+  return clientY - panel.getBoundingClientRect().top + panel.scrollTop;
+}
+
+function limitProviderRowElements() {
+  return Array.from(els.limitProviderCheckboxes?.querySelectorAll('.limit-provider-row[data-provider]') || []);
+}
+
+function limitProviderContentTop(el) {
+  const panel = els.settingsPanel;
+  const panelTop = panel ? panel.getBoundingClientRect().top - panel.scrollTop : 0;
+  return el.getBoundingClientRect().top - panelTop;
+}
+
+function limitProviderDragRows() {
+  const panel = els.settingsPanel;
+  const panelTop = panel ? panel.getBoundingClientRect().top - panel.scrollTop : 0;
+  return limitProviderRowElements().map((el) => {
+    const rect = el.getBoundingClientRect();
+    return { el, id: el.dataset.provider, top: rect.top - panelTop, height: rect.height };
+  });
+}
+
 // The checkbox, nested controls, and options panel own their clicks. The main
 // disclosure button is deliberately the drag surface too: below the threshold
 // it clicks, above it the drag suppresses that click.
 const LIMIT_PROVIDER_DRAG_EXCLUDED = 'button:not(.limit-provider-main), input, select, textarea, a, .accordion-animated-container';
 
-const limitProviderRowDrag = rowDragControllerApi.createRowDragController({
-  dragSort: verticalDragSortApi,
-  getList: () => els.limitProviderCheckboxes,
-  getScrollPanel: () => els.settingsPanel,
-  rowSelector: '.limit-provider-row[data-provider]',
-  idKey: 'provider',
-  dragExcluded: LIMIT_PROVIDER_DRAG_EXCLUDED,
-  getExpanded: () => state.limitProviderSettingsExpanded,
-  setExpanded: setLimitProviderSettingsExpanded,
-  applyOrder: (order) => applyPreferenceOrder('provider', order),
-  preserveScroll: preserveSettingsPanelScroll,
-  mirrorOrder: (order) => { state.settings = { ...state.settings, limitProviderOrder: order.join(',') }; },
-  // Saved directly rather than through `onPreferenceOrderCommit`, whose no-op
-  // guard compares against the value `mirrorOrder` just wrote and would drop it.
-  persistOrder: (order) => void saveSettings({ limitProviderOrder: order.join(',') }),
-  requestRender: () => renderLimitProviderCheckboxes()
-});
+function startLimitProviderRowDrag(event, id) {
+  if (event.button !== 0) return;
+  const rowEl = event.currentTarget;
+  // Scoped to the row on purpose: `closest` keeps walking past it, and the
+  // whole settings section is itself an `.accordion-animated-container`, so an
+  // unscoped match excludes every row and no drag ever starts.
+  const excluded = event.target?.closest?.(LIMIT_PROVIDER_DRAG_EXCLUDED);
+  if (excluded && rowEl.contains(excluded)) return;
+  if (limitProviderDrag) finishLimitProviderDrag(false);
+  if (limitProviderRowElements().length <= 1) return;
+  const pressY = limitProviderContentY(event.clientY);
+  limitProviderDrag = {
+    id,
+    pointerId: event.pointerId,
+    // Where in the row the pointer landed. The origin is rebuilt from this once
+    // the rows are measured, so a collapse between press and measurement cannot
+    // leave the row hanging off the cursor.
+    grabOffset: pressY - limitProviderContentTop(rowEl),
+    pressY,
+    lastClientY: event.clientY,
+    started: false,
+    changed: false,
+    expandedBefore: state.limitProviderSettingsExpanded,
+    captureEl: rowEl,
+    rows: [],
+    snapshot: null,
+    order: null,
+    scrollFrame: 0,
+    renderPending: false
+  };
+  setLimitProviderDragListeners(true);
+}
+
+function setLimitProviderDragListeners(active) {
+  const method = active ? 'addEventListener' : 'removeEventListener';
+  window[method]('pointermove', onLimitProviderPointerMove, true);
+  window[method]('pointerup', onLimitProviderPointerUp, true);
+  window[method]('pointercancel', onLimitProviderDragAbort, true);
+  window[method]('keydown', onLimitProviderDragKeydown, true);
+  // Deliberately not capture. `blur` does not bubble, so a capture listener on
+  // `window` is the standard way to observe *every* element's blur — including
+  // the one the press itself causes when focus leaves whatever the user last
+  // clicked. That cancelled the drag before it could start. Without capture only
+  // the window's own blur arrives, which is the case worth aborting on.
+  window[method]('blur', onLimitProviderDragAbort);
+}
+
+// Order matters: freeze the accordion, collapse, and only then measure. With
+// the transition disabled the collapse lands synchronously, so the snapshot
+// sees settled geometry instead of a mid-animation height.
+function beginLimitProviderDrag() {
+  const drag = limitProviderDrag;
+  const list = els.limitProviderCheckboxes;
+  drag.started = true;
+  list?.classList.add('is-reordering');
+  if (drag.expandedBefore) setLimitProviderSettingsExpanded('');
+  drag.rows = limitProviderDragRows();
+  drag.snapshot = verticalDragSortApi.createVerticalDragSnapshot(
+    drag.rows.map(({ id, top, height }) => ({ id, top, height })),
+    drag.id,
+    drag.grabOffset
+  );
+  if (drag.snapshot.sourceIndex < 0) {
+    finishLimitProviderDrag(false);
+    return false;
+  }
+  drag.rows[drag.snapshot.sourceIndex].el.classList.add('dragging');
+  list?.classList.add('drag-active');
+  startLimitProviderDragScroll();
+  return true;
+}
+
+function updateLimitProviderDragPositions() {
+  const drag = limitProviderDrag;
+  if (!drag?.started) return;
+  const offsetY = limitProviderContentY(drag.lastClientY) - drag.snapshot.originY;
+  const resolved = verticalDragSortApi.resolveVerticalDrag(drag.snapshot, offsetY);
+  drag.order = resolved.order;
+  drag.changed = resolved.targetIndex !== drag.snapshot.sourceIndex;
+  for (const [index, { el }] of drag.rows.entries()) {
+    if (index === drag.snapshot.sourceIndex) el.style.setProperty('--drag-y', `${offsetY}px`);
+    else el.style.setProperty('--drag-shift', `${resolved.shifts[index]}px`);
+  }
+}
+
+function startLimitProviderDragScroll() {
+  const step = () => {
+    const drag = limitProviderDrag;
+    const panel = els.settingsPanel;
+    if (!drag?.started || !panel) return;
+    const rect = panel.getBoundingClientRect();
+    const delta = verticalDragSortApi.edgeScrollDelta({
+      pointerY: drag.lastClientY,
+      top: rect.top,
+      bottom: rect.bottom
+    });
+    if (delta) {
+      panel.scrollTop += delta;
+      updateLimitProviderDragPositions();
+    }
+    drag.scrollFrame = requestAnimationFrame(step);
+  };
+  limitProviderDrag.scrollFrame = requestAnimationFrame(step);
+}
+
+function onLimitProviderPointerMove(event) {
+  const drag = limitProviderDrag;
+  if (!drag || drag.pointerId !== event.pointerId) return;
+  drag.lastClientY = event.clientY;
+  if (!drag.started) {
+    if (Math.abs(limitProviderContentY(event.clientY) - drag.pressY) < LIMIT_PROVIDER_DRAG_THRESHOLD) return;
+    // Capture only after the gesture crosses the drag threshold. Capturing on
+    // pointerdown retargets the eventual click from the nested disclosure
+    // button to the outer row, so an ordinary press can no longer expand it.
+    // Once dragging, capture still guarantees that an outside-window release
+    // reaches cleanup instead of leaving the repaint gate stuck.
+    drag.captureEl?.addEventListener('lostpointercapture', onLimitProviderDragAbort);
+    try { drag.captureEl?.setPointerCapture?.(event.pointerId); } catch (_) {}
+    if (!beginLimitProviderDrag()) return;
+  }
+  event.preventDefault();
+  updateLimitProviderDragPositions();
+}
+
+function onLimitProviderPointerUp(event) {
+  const drag = limitProviderDrag;
+  if (!drag || drag.pointerId !== event.pointerId) return;
+  const { started, changed, order } = drag;
+  if (!started || !changed || !order?.length) {
+    finishLimitProviderDrag(true);
+    return;
+  }
+  // Mirror the new order locally before anything can repaint. A stats update
+  // held back during the drag is flushed on drop, and every repaint sorts from
+  // `state.settings` — which the deferred save has not written yet, so without
+  // this the list rebuilds into the old order and flips again a frame later.
+  const value = order.join(',');
+  state.settings = { ...state.settings, limitProviderOrder: value };
+  finishLimitProviderDrag(true);
+  // The drop itself is already in the DOM. Persisting re-renders the whole
+  // settings form, which on a populated install is a long task — run it only
+  // once the browser has painted the landed row, or that paint gets swallowed
+  // and the drop reads as a freeze. rAF fires before paint, so the timeout
+  // inside it is what lands after. Saved directly rather than through
+  // `onPreferenceOrderCommit`, whose no-op guard compares against the value we
+  // just mirrored and would drop the write.
+  requestAnimationFrame(() => {
+    setTimeout(() => void saveSettings({ limitProviderOrder: value }), 0);
+  });
+}
+
+function onLimitProviderDragAbort(event) {
+  if (!limitProviderDrag) return;
+  if (event?.pointerId != null && event.pointerId !== limitProviderDrag.pointerId) return;
+  finishLimitProviderDrag(false);
+}
+
+function onLimitProviderDragKeydown(event) {
+  if (event.key !== 'Escape' || !limitProviderDrag) return;
+  event.preventDefault();
+  finishLimitProviderDrag(false);
+}
+
+function releaseLimitProviderLandingStyleAfterPaint(list) {
+  requestAnimationFrame(() => {
+    setTimeout(() => list?.classList.remove('is-landing'), 0);
+  });
+}
+
+// The final DOM positions and the drag transforms both encode the same move.
+// Keep transform transitions disabled through the first landed paint so rows
+// do not briefly apply both offsets and animate back from a double displacement.
+function finishLimitProviderDrag(commit) {
+  const drag = limitProviderDrag;
+  if (!drag) return;
+  // The DOM reorder itself runs before the asynchronous settings save. Moving
+  // the focused row (and every sibling via appendChild) can trigger browser
+  // scroll anchoring immediately, so the save-time scroll guard is already too
+  // late. Preserve the panel around the whole landing transaction, including a
+  // deferred repaint that was held while dragging.
+  preserveSettingsPanelScroll(() => {
+    if (drag.scrollFrame) cancelAnimationFrame(drag.scrollFrame);
+    setLimitProviderDragListeners(false);
+    // Released before the reorder moves the node: relocating a captured element
+    // fires `lostpointercapture`, which would re-enter this as an abort.
+    const captureEl = drag.captureEl;
+    captureEl?.removeEventListener('lostpointercapture', onLimitProviderDragAbort);
+    try {
+      if (captureEl?.hasPointerCapture?.(drag.pointerId)) captureEl.releasePointerCapture(drag.pointerId);
+    } catch (_) {}
+    const list = els.limitProviderCheckboxes;
+    if (drag.started) {
+      const landing = Boolean(commit && drag.changed && drag.order?.length);
+      if (landing) list?.classList.add('is-landing');
+      if (landing) applyPreferenceOrder('provider', drag.order);
+      for (const { el } of drag.rows) {
+        el.style.removeProperty('--drag-y');
+        el.style.removeProperty('--drag-shift');
+        el.classList.remove('dragging');
+      }
+      list?.classList.remove('drag-active');
+      list?.classList.remove('is-reordering');
+      if (drag.expandedBefore) setLimitProviderSettingsExpanded(drag.expandedBefore);
+      suppressNextLimitProviderClick();
+      if (landing) releaseLimitProviderLandingStyleAfterPaint(list);
+    }
+    const renderPending = drag.renderPending;
+    limitProviderDrag = null;
+    if (renderPending) renderLimitProviderCheckboxes();
+  });
+}
+
+// The same main-row button owns click-to-expand and drag-to-reorder. Cancelling
+// its click after a completed drag prevents the drop from also toggling details.
+function suppressNextLimitProviderClick() {
+  const swallow = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+  window.addEventListener('click', swallow, true);
+  setTimeout(() => window.removeEventListener('click', swallow, true), 0);
+}
 
 function renderViewPreferences() {
   if (!els.viewDisplayList) return;
@@ -8673,380 +8876,14 @@ function renderServiceProviderList() {
 }
 
 function localDevice() {
-  return clientHealthPresentationApi.exactDevice(state.stats, state.settings?.deviceId);
+  const devices = state.stats?.devices || [];
+  const localId = state.settings?.deviceId || '';
+  return (localId && devices.find((device) => device.deviceId === localId))
+    || (devices.length === 1 ? devices[0] : null);
 }
 
 function localClientStatus() {
   return localDevice()?.clientStatus || {};
-}
-
-function localClientHealth() {
-  return localDevice()?.clientHealth || null;
-}
-
-// Single entry point for the tracked-tool detail accordion, mirroring the limits
-// list: the drag gesture collapses and restores it too, so the class and aria
-// bookkeeping cannot live inside the disclosure's own click handler.
-function setClientHealthExpanded(clientId) {
-  state.clientHealthExpanded = clientId || '';
-  const rows = els.clientDisplayList?.querySelectorAll('.tool-preference-row[data-client]') || [];
-  for (const row of rows) {
-    const disclosure = row.querySelector('.tool-preference-main');
-    const container = row.querySelector(':scope > .accordion-animated-container');
-    if (!disclosure || !container) continue;
-    const open = row.dataset.client === state.clientHealthExpanded;
-    // Filled here rather than during the repaint. Only one row can be open, so
-    // building all of them cost 219 of the list's 552 nodes — 40% of its DOM,
-    // rebuilt every stats tick — to render nothing. A panel already filled is
-    // left alone so a collapse still has something to animate.
-    if (open) {
-      loadClientSources(row.dataset.client);
-      if (container.childElementCount === 0) {
-        fillClientHealthPanel(container, row.dataset.client);
-      }
-    }
-    disclosure.setAttribute('aria-expanded', String(open));
-    row.classList.toggle('expanded', open);
-    container.classList.toggle('hidden', !open);
-  }
-}
-
-// This client's numbers across the three periods, straight off the stats the app
-// already renders everywhere else. No new wire field and no new collection —
-// the panel just puts them side by side, which is the whole point.
-function clientPeriodUsage(clientId) {
-  return clientHealthPresentationApi.clientPeriodUsage(localDevice(), clientId);
-}
-
-// Where this machine looks for each tool's data. A check id answers "which kind
-// of root", but "did I install it somewhere else" needs the path itself — and a
-// path only exists on the machine that probed it, so it comes over IPC rather
-// than the wire. Probe only the open client and cache it for this health
-// snapshot: a panel is rebuilt on every stats tick, and refetching made the
-// paths flicker back to bare ids. The health envelope's observedAt changes
-// only when a full source probe completes, so it refreshes path existence once
-// per snapshot without spending IPC on progressive previews that carry the old
-// envelope.
-function clientSourcesIdentity(clientId) {
-  return {
-    deviceId: String(localDevice()?.deviceId || ''),
-    clientId: String(clientId || ''),
-    observedAt: String(localClientHealth()?.observedAt || '')
-  };
-}
-
-function exactLocalClientSources(clientId) {
-  return clientSourceCacheApi.readClientSources(
-    state.clientSources,
-    clientSourcesIdentity(clientId)
-  );
-}
-
-function localClientSources(clientId) {
-  const identity = clientSourcesIdentity(clientId);
-  const exactSources = exactLocalClientSources(clientId);
-  const key = clientSourceCacheApi.clientSourceRequestKey(identity);
-  const pendingSources = key && state.clientSourcesKey === key;
-  const sources = pendingSources
-    ? (exactSources ?? clientSourceCacheApi.readLatestClientSources(state.clientSources, identity) ?? [])
-      .map((source) => ({ ...source, exists: false, pending: true }))
-    : exactSources;
-  const detectedInWsl = localDevice()?.wslStatus?.detected?.includes(clientId);
-  if (!detectedInWsl) return sources;
-  return [...(sources || []), { id: 'wsl-home', dir: '', exists: true }];
-}
-
-function loadClientSources(clientId, options = {}) {
-  const id = String(clientId || '');
-  const identity = clientSourcesIdentity(id);
-  const key = clientSourceCacheApi.clientSourceRequestKey(identity);
-  if (!key) return false;
-  if (!options.force && state.clientSourcesKey === key) return true;
-  if (
-    !options.force
-    && clientSourceCacheApi.readClientSources(state.clientSources, identity) !== null
-  ) return false;
-  state.clientSourcesKey = key;
-  const request = ++state.clientSourcesRequest;
-  void window.tokenMonitor?.clientSources?.(id).then((result) => {
-    if (!result || typeof result !== 'object') throw new TypeError('Invalid client source result');
-    if (state.clientSourcesRequest !== request || state.clientSourcesKey !== key) return;
-    clientSourceCacheApi.writeClientSources(
-      state.clientSources,
-      identity,
-      Array.isArray(result.sources) ? result.sources : []
-    );
-    state.clientSourcesKey = '';
-    refillOpenClientHealthPanel();
-  }).catch(() => {
-    if (state.clientSourcesRequest !== request || state.clientSourcesKey !== key) return;
-    state.clientSourcesKey = '';
-    refillOpenClientHealthPanel();
-  });
-  return true;
-}
-
-function refillOpenClientHealthPanel() {
-  const clientId = state.clientHealthExpanded;
-  if (!clientId) return;
-  const row = els.clientDisplayList?.querySelector(`.tool-preference-row[data-client="${CSS.escape(clientId)}"]`);
-  const container = row?.querySelector(':scope > .accordion-animated-container');
-  if (container) fillClientHealthPanel(container, clientId);
-}
-
-// Everything the panel draws beyond the health record itself: the numbers the
-// app already renders elsewhere, and this machine's own paths.
-function clientHealthDetailFor(clientId) {
-  return clientHealthPresentationApi.clientHealthDetail(localClientHealth(), clientId, {
-    usage: clientPeriodUsage(clientId),
-    sources: localClientSources(clientId)
-  });
-}
-
-function sameRenderedNode(current, next) {
-  if (current.nodeType !== next.nodeType) return false;
-  if (current.nodeType !== Node.ELEMENT_NODE) return true;
-  if (current.tagName !== next.tagName || current.className !== next.className) return false;
-  const currentAction = current.dataset?.healthAction || '';
-  const nextAction = next.dataset?.healthAction || '';
-  return currentAction === nextAction;
-}
-
-function patchRenderedNode(current, next) {
-  if (current.nodeType === Node.TEXT_NODE) {
-    if (current.nodeValue !== next.nodeValue) current.nodeValue = next.nodeValue;
-    return;
-  }
-  for (const name of current.getAttributeNames()) {
-    if (!next.hasAttribute(name)) current.removeAttribute(name);
-  }
-  for (const name of next.getAttributeNames()) {
-    const value = next.getAttribute(name);
-    if (current.getAttribute(name) !== value) current.setAttribute(name, value);
-  }
-  const currentChildren = Array.from(current.childNodes);
-  const nextChildren = Array.from(next.childNodes);
-  for (let index = 0; index < nextChildren.length; index += 1) {
-    const currentChild = currentChildren[index];
-    const nextChild = nextChildren[index];
-    if (!currentChild) {
-      current.append(nextChild);
-    } else if (sameRenderedNode(currentChild, nextChild)) {
-      patchRenderedNode(currentChild, nextChild);
-    } else {
-      currentChild.replaceWith(nextChild);
-    }
-  }
-  for (let index = nextChildren.length; index < currentChildren.length; index += 1) {
-    currentChildren[index].remove();
-  }
-}
-
-function fillClientHealthPanel(container, clientId) {
-  const detail = clientHealthDetailFor(clientId);
-  if (!detail) return;
-  const next = clientHealthPanel(detail, clientId);
-  const current = container.firstElementChild;
-  if (current && sameRenderedNode(current, next)) patchRenderedNode(current, next);
-  else container.replaceChildren(next);
-}
-
-// Home-relative so the panel does not print the user's account name back at
-// them; absolute paths remain local and are never added to the health record.
-function friendlyPath(dir) {
-  return clientHealthPresentationApi.friendlyPath(dir, state.appInfo?.homeDir, state.appInfo?.platform);
-}
-
-// Values are formatted here and nowhere else — the presentation helper returns
-// three semantic groups containing only raw numbers, timestamps and i18n keys.
-function clientHealthGroup(group, notes) {
-  const section = document.createElement('section');
-  section.className = `tool-health-group tool-health-group-${group.id}`;
-  const heading = document.createElement('h4');
-  heading.className = 'tool-health-group-title';
-  heading.textContent = t(group.key);
-  const body = document.createElement('div');
-  body.className = 'tool-health-group-body';
-
-  if (group.id === 'source') {
-    const summary = document.createElement('div');
-    summary.className = 'tool-health-group-summary';
-    summary.textContent = t(`settings.tools.health.source.${group.state}`, {
-      detected: group.detectedCount,
-      checked: group.checkedCount
-    });
-    body.append(summary);
-    if (group.checks.length > 0) {
-      const list = document.createElement('div');
-      list.className = 'tool-health-checks';
-      for (const check of group.checks) {
-        const paths = check.paths?.length ? check.paths : [{ dir: '', exists: check.exists }];
-        for (const pathInfo of paths) {
-          const chip = document.createElement('code');
-          chip.className = `tool-health-check${pathInfo.exists ? ' found' : pathInfo.pending ? ' pending' : ''}`;
-          chip.textContent = pathInfo.dir ? friendlyPath(pathInfo.dir) : check.id;
-          if (pathInfo.dir) chip.title = pathInfo.dir;
-          list.append(chip);
-        }
-      }
-      body.append(list);
-    }
-  } else if (group.id === 'collection') {
-    const summary = document.createElement('div');
-    summary.className = 'tool-health-group-summary';
-    summary.textContent = t(`settings.tools.health.sync.${group.state}`);
-    body.append(summary);
-    const stamps = [
-      ['lastAttemptAt', 'settings.tools.health.lastAttempt'],
-      ['lastSuccessAt', 'settings.tools.health.lastSuccess']
-    ];
-    for (const [field, key] of stamps) {
-      const stamp = group[field];
-      if (!stamp) continue;
-      const elapsed = Math.max(0, Date.now() - (Date.parse(stamp) || Date.now()));
-      const meta = document.createElement('div');
-      meta.className = 'tool-health-group-meta';
-      meta.textContent = t(key, { time: formatAgo(elapsed) });
-      body.append(meta);
-    }
-  } else {
-    if (group.periods) {
-      const usage = document.createElement('div');
-      usage.className = 'tool-health-usage';
-      for (const entry of group.periods) {
-        const cell = document.createElement('div');
-        cell.className = 'tool-health-usage-cell';
-        const head = document.createElement('span');
-        head.className = 'tool-health-usage-label';
-        head.textContent = t(`trayComposer.period.${entry.period}`);
-        const amount = document.createElement('span');
-        amount.className = 'tool-health-usage-value';
-        amount.textContent = formatCompact(entry.tokens);
-        cell.append(head, amount);
-        if (entry.cost > 0) {
-          const cost = document.createElement('span');
-          cost.className = 'tool-health-usage-cost';
-          cost.textContent = formatCost(entry.cost);
-          cell.append(cost);
-        }
-        usage.append(cell);
-      }
-      body.append(usage);
-    } else {
-      const tokens = document.createElement('div');
-      tokens.className = 'tool-health-group-summary';
-      tokens.textContent = t('settings.tools.health.tokensValue', { tokens: formatCompact(group.tokens) });
-      body.append(tokens);
-    }
-    if (group.lastActivityDay) {
-      const activity = document.createElement('div');
-      activity.className = 'tool-health-group-meta';
-      activity.textContent = t('settings.tools.health.lastActivityValue', {
-        relative: relativeDayLabel(group.lastActivityDay),
-        day: group.lastActivityDay
-      });
-      body.append(activity);
-    }
-  }
-
-  for (const note of notes) {
-    const line = document.createElement('div');
-    line.className = `tool-health-note-line tone-${note.tone}`;
-    line.textContent = t(`settings.tools.health.code.${note.code}`);
-    body.append(line);
-  }
-  section.append(heading, body);
-  return section;
-}
-
-function localDayKey(date = new Date()) {
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
-}
-
-// Days come from the daily history buckets, which are local dates — the same
-// boundary computePeriodWindows() rolls "today" over on. A day in the future
-// (a clock that moved) has no honest phrase, so it stays a plain date.
-function relativeDayLabel(day) {
-  const today = localDayKey();
-  if (day === today) return t('settings.tools.health.day.today');
-  const parsed = Date.parse(`${day}T00:00:00`);
-  if (!Number.isFinite(parsed)) return day;
-  const days = Math.round((Date.parse(`${today}T00:00:00`) - parsed) / 86400000);
-  if (days === 1) return t('settings.tools.health.day.yesterday');
-  if (days > 1) return t('settings.tools.health.day.daysAgo', { n: days });
-  return day;
-}
-
-function clientHealthActions(clientId) {
-  const actions = document.createElement('div');
-  actions.className = 'tool-health-actions';
-  const button = (labelKey, onClick) => {
-    const control = document.createElement('button');
-    control.type = 'button';
-    control.className = 'tool-health-action';
-    control.textContent = t(labelKey);
-    control.addEventListener('click', onClick);
-    actions.append(control);
-    return control;
-  };
-  // The detail is already bound to the exact local device. Renderer mode is a
-  // transport state (`local`/`sync`), not topology, so host and client collectors
-  // expose the same targeted capability through preload.
-  if (localDevice() && typeof window.tokenMonitor?.rescanClient === 'function') {
-    const rescanState = state.clientRescans.snapshot(clientId);
-    const feedback = document.createElement('span');
-    feedback.className = 'tool-health-action-feedback';
-    feedback.dataset.healthAction = 'rescan-feedback';
-    feedback.setAttribute('role', 'status');
-    feedback.setAttribute('aria-live', 'polite');
-    feedback.textContent = rescanState.failed ? t('settings.tools.health.rescanFailed') : '';
-    const rescan = button('settings.tools.health.rescan', async () => {
-      const requestId = state.clientRescans.begin(clientId);
-      let succeeded = false;
-      try {
-        succeeded = await window.tokenMonitor.rescanClient(clientId) === true;
-        if (succeeded) loadClientSources(clientId, { force: true });
-      } catch (_) {
-        succeeded = false;
-      } finally {
-        state.clientRescans.finish(clientId, requestId, succeeded);
-      }
-    });
-    rescan.dataset.healthAction = 'rescan';
-    rescan.id = `toolHealthRescan-${clientId}`;
-    rescan.disabled = rescanState.pending;
-    actions.append(feedback);
-  }
-  // Only where something was actually found: the button opens the first existing
-  // root, and offering it for a tool with none would open nothing.
-  if ((exactLocalClientSources(clientId) || []).some((source) => source.dir && source.exists)) {
-    const reveal = button('settings.tools.health.reveal', () => { void window.tokenMonitor?.revealClientSource?.(clientId); });
-    reveal.dataset.healthAction = 'reveal';
-    reveal.id = `toolHealthReveal-${clientId}`;
-  }
-  return actions;
-}
-
-function clientHealthPanel(detail, clientId) {
-  const inner = document.createElement('div');
-  inner.className = 'accordion-animation-inner';
-  // The padded, tinted box is a child rather than the animated element itself:
-  // a collapsed accordion is a grid row sized to 0fr, and padding does not
-  // compress — an inner with its own padding stays that many pixels tall and
-  // pads every collapsed row in the list.
-  const box = document.createElement('div');
-  box.className = 'tool-health-inner';
-  inner.append(box);
-  const groups = document.createElement('div');
-  groups.className = 'tool-health-groups';
-  for (const group of detail.groups) {
-    groups.append(clientHealthGroup(
-      group,
-      detail.notes.filter((note) => note.group === group.id)
-    ));
-  }
-  box.append(groups, clientHealthActions(clientId));
-  return inner;
 }
 
 function localWslStatus() {
@@ -9113,110 +8950,19 @@ function renderWslPanel() {
   }
 }
 
-// The tracked-tools list drags from the whole row too, on the same controller
-// as the limits list. What differs is the commit: its order is not one setting.
-// While the list is on its default order the pinned block is the only thing
-// shaping it, so a drop can mean either a pin change or an explicit order.
-// `clientDisplayOrderCommit` decides, and the patch it returns is carried from
-// the local mirror to the save rather than derived twice — the mirror writes
-// the very keys that decision reads.
-const CLIENT_PREFERENCE_DRAG_EXCLUDED = 'button:not(.tool-preference-main), input, select, textarea, a, label, .accordion-animated-container';
-
-const clientPreferenceRowDrag = rowDragControllerApi.createRowDragController({
-  dragSort: verticalDragSortApi,
-  getList: () => els.clientDisplayList,
-  getScrollPanel: () => els.settingsPanel,
-  rowSelector: '.tool-preference-row[data-client]',
-  idKey: 'client',
-  dragExcluded: CLIENT_PREFERENCE_DRAG_EXCLUDED,
-  getExpanded: () => state.clientHealthExpanded,
-  setExpanded: setClientHealthExpanded,
-  applyOrder: (order) => applyPreferenceOrder('client', order),
-  preserveScroll: preserveSettingsPanelScroll,
-  mirrorOrder: (order, id) => {
-    const patch = clientDisplayPreferencesApi.clientDisplayOrderCommit(order, KNOWN_CLIENTS, state.settings?.clientDisplayOrder, state.settings?.pinnedClients, id);
-    state.settings = { ...state.settings, ...patch };
-    return patch;
-  },
-  persistOrder: (_order, _id, patch) => void saveSettings(patch),
-  requestRender: () => renderToolPreferences()
-});
-
 function renderToolPreferences() {
   if (!els.clientDisplayList) return;
-  // A stats update mid-drag would replace the rows under the pointer and kill
-  // the gesture silently. Defer the repaint until the drop.
-  if (clientPreferenceRowDrag.deferRender()) return;
-  return preserveSettingsPanelScroll(renderToolPreferencesNow);
-}
-
-function toolPreferenceRenderSignature() {
-  const clientStatus = localClientStatus();
-  const health = localClientHealth();
-  const device = localDevice();
-  return JSON.stringify({
-    settings: [
-      [...enabledClientSet()].sort(),
-      state.settings?.hiddenClients || '',
-      state.settings?.pinnedClients || '',
-      state.settings?.clientDisplayOrder || '',
-      state.settings?.locale || state.settings?.language || '',
-      state.settings?.currency || '',
-      state.settings?.compactTokenUnits || ''
-    ],
-    deviceId: device?.deviceId || '',
-    clientStatus,
-    healthRows: KNOWN_CLIENTS.map(({ id }) => [
-      id,
-      health?.clients?.[id]?.overall || '',
-      Boolean(health?.clients?.[id])
-    ])
-  });
-}
-
-function renderToolPreferencesNow() {
-  const renderSignature = toolPreferenceRenderSignature();
-  const detailSignature = JSON.stringify([
-    localClientHealth(),
-    localDevice(),
-    state.settings?.currencyRatesEffective || null
-  ]);
-  const sourceSignature = clientSourceCacheApi.clientSourceRequestKey(
-    clientSourcesIdentity(state.clientHealthExpanded)
-  );
-  if (
-    state.toolPreferenceRenderSignature
-    && state.toolPreferenceRenderSignature === renderSignature
-    && els.clientDisplayList.children.length === KNOWN_CLIENTS.length
-  ) {
-    if (state.toolPreferenceDetailSignature !== detailSignature) {
-      state.toolPreferenceDetailSignature = detailSignature;
-      if (state.toolPreferenceSourceSignature !== sourceSignature) {
-        state.toolPreferenceSourceSignature = sourceSignature;
-        loadClientSources(state.clientHealthExpanded);
-        refillOpenClientHealthPanel();
-      } else {
-        refillOpenClientHealthPanel();
-      }
-    }
-    return;
-  }
-  state.toolPreferenceRenderSignature = renderSignature;
-  state.toolPreferenceDetailSignature = detailSignature;
-  state.toolPreferenceSourceSignature = sourceSignature;
-  const previousRows = Array.from(els.clientDisplayList.children);
-  const focusedId = document.activeElement?.id || '';
   const enabled = enabledClientSet();
   const hidden = hiddenClientSet();
   const pinned = pinnedClientSet();
   const clientStatus = localClientStatus();
-  const health = localClientHealth();
   const clients = clientDisplayPreferencesApi.orderedClients(KNOWN_CLIENTS, state.settings?.clientDisplayOrder, state.settings?.pinnedClients);
   const hasCustomOrder = clientDisplayPreferencesApi.hasCustomDisplayOrder(state.settings?.clientDisplayOrder);
   const hasPinnedClients = pinned.size > 0;
   const hasHiddenClients = hidden.size > 0;
   if (els.resetClientDisplayOrderButton) els.resetClientDisplayOrderButton.disabled = !hasCustomOrder && !hasPinnedClients;
   if (els.showAllClientsButton) els.showAllClientsButton.disabled = !hasHiddenClients;
+  els.clientDisplayList.replaceChildren();
   for (const { id, label } of clients) {
     const row = document.createElement('div');
     row.className = 'tool-preference-row';
@@ -9234,15 +8980,7 @@ function renderToolPreferencesNow() {
     if (enabled.has(id)) {
       // A tracked client with no reported status yet (first collect still running)
       // reads as "waiting for data" rather than a bare blank.
-      //
-      // `attention` overrides it. The legacy status is derived from usage, so a
-      // client whose sync broke this morning still counts yesterday's tokens and
-      // would keep reporting "Tracking" — leaving the one state this whole
-      // feature exists to surface invisible until the row is expanded.
-      const needsAttention = health?.clients?.[id]?.overall === 'attention';
-      const tagInfo = needsAttention
-        ? { key: 'settings.tools.status.attention', tone: 'warn' }
-        : clientStatusPresentationApi.clientStatusTag(id, clientStatus[id] || 'waiting');
+      const tagInfo = clientStatusPresentationApi.clientStatusTag(id, clientStatus[id] || 'waiting');
       if (tagInfo) {
         const tag = document.createElement('span');
         tag.className = `tool-status-tag tool-status-tag-${tagInfo.tone}`;
@@ -9254,21 +8992,14 @@ function renderToolPreferencesNow() {
     track.className = 'tool-preference-toggle';
     const trackInput = document.createElement('input');
     trackInput.type = 'checkbox';
-    trackInput.id = `toolTrackEnabled-${id}`;
     trackInput.dataset.client = id;
     trackInput.dataset.preference = 'track';
     trackInput.checked = enabled.has(id);
     trackInput.setAttribute('aria-label', t('settings.tools.trackClient', { name: label }));
     trackInput.addEventListener('change', onToolTrackingToggle);
-    // The drag handle is gone, so the checkbox carries the keyboard reorder
-    // shortcuts. A checkbox has no native arrow-key behaviour, so the existing
-    // key bindings transfer unchanged.
-    trackInput.setAttribute('aria-keyshortcuts', 'ArrowUp ArrowDown Home End');
-    trackInput.addEventListener('keydown', (event) => onPreferenceOrderKeydown(event, 'client', id));
     track.append(trackInput);
     const visibility = document.createElement('button');
     visibility.type = 'button';
-    visibility.id = `toolVisibility-${id}`;
     visibility.className = `tool-visibility-button${isHidden ? ' is-hidden' : ''}`;
     visibility.dataset.client = id;
     visibility.title = t(isHidden ? 'settings.tools.showClient' : 'settings.tools.hideClient', { name: label });
@@ -9278,7 +9009,6 @@ function renderToolPreferencesNow() {
     visibility.addEventListener('click', () => onClientVisibilityToggle(id));
     const pin = document.createElement('button');
     pin.type = 'button';
-    pin.id = `toolPin-${id}`;
     pin.className = `tool-pin-button${isPinned ? ' is-pinned' : ''}`;
     pin.dataset.client = id;
     pin.title = t(isPinned ? 'settings.tools.unpinClient' : 'settings.tools.pinClient', { name: label });
@@ -9286,51 +9016,12 @@ function renderToolPreferencesNow() {
     pin.setAttribute('aria-pressed', String(isPinned));
     pin.append(pinIcon());
     pin.addEventListener('click', () => onClientPinnedToggle(id));
+    const handle = createPreferenceOrderHandle({ kind: 'client', id, label, count: clients.length });
     const actions = document.createElement('div');
     actions.className = 'tool-preference-actions';
-    actions.append(visibility, pin);
-    // A device whose agent predates the health field gets no chevron rather than
-    // one that opens onto an empty panel.
-    const detail = clientHealthPresentationApi.clientHealthDetail(health, id);
-    if (detail) {
-      const expanded = state.clientHealthExpanded === id;
-      row.classList.toggle('expanded', expanded);
-      const main = document.createElement('button');
-      main.type = 'button';
-      main.id = `toolHealthDisclosure-${id}`;
-      main.className = 'tool-preference-main';
-      main.title = t('settings.tools.health.open', { name: label });
-      main.setAttribute('aria-label', main.title);
-      main.setAttribute('aria-expanded', String(expanded));
-      const disclosureIcon = document.createElement('span');
-      disclosureIcon.className = 'cursor-disclosure-icon';
-      disclosureIcon.setAttribute('aria-hidden', 'true');
-      main.append(disclosureIcon);
-      const panel = document.createElement('div');
-      panel.id = `toolHealthPanel-${id}`;
-      panel.className = `accordion-animated-container${expanded ? '' : ' hidden'}`;
-      main.setAttribute('aria-controls', panel.id);
-      if (expanded) {
-        loadClientSources(id);
-        panel.append(clientHealthPanel(clientHealthDetailFor(id) || detail, id));
-      }
-      main.addEventListener('click', () => setClientHealthExpanded(state.clientHealthExpanded === id ? '' : id));
-      // Last of the row's controls, where the eye and the pin already are —
-      // the label stays plain text, exactly as it reads without this feature.
-      actions.append(main);
-      row.classList.add('has-health');
-      row.append(track, labelGroup, actions, panel);
-    } else {
-      row.append(track, labelGroup, actions);
-    }
-    row.addEventListener('pointerdown', (event) => clientPreferenceRowDrag.startRowDrag(event, id));
+    actions.append(track, visibility, pin, handle);
+    row.append(labelGroup, actions);
     els.clientDisplayList.appendChild(row);
-  }
-  // Appended first and only then swapped out: replacing the list wholesale
-  // would destroy the row under the pointer on every stats tick.
-  for (const row of previousRows) row.remove();
-  if (focusedId && document.activeElement === document.body) {
-    document.getElementById(focusedId)?.focus({ preventScroll: true });
   }
 }
 
@@ -9349,32 +9040,16 @@ function renderLimitProviderCheckboxes() {
   if (!els.limitProviderCheckboxes) return;
   // A stats update mid-drag would replace the rows under the pointer and kill
   // the gesture silently. Defer the repaint until the drop.
-  if (limitProviderRowDrag.deferRender()) return;
+  if (limitProviderDrag) {
+    limitProviderDrag.renderPending = true;
+    return;
+  }
   return preserveSettingsPanelScroll(renderLimitProviderCheckboxesNow);
 }
 
 function renderLimitProviderCheckboxesNow() {
-  const renderSignature = limitProviderSettingsRenderSignature();
-  if (
-    state.limitProviderRenderSignature === renderSignature
-    && els.limitProviderCheckboxes.children.length === LIMIT_PROVIDERS.length
-  ) {
-    return;
-  }
   const previousRows = Array.from(els.limitProviderCheckboxes.children);
   const focusedId = document.activeElement?.id || '';
-  const reusableSettingInputs = new Map();
-  for (const row of previousRows) {
-    const providerId = row.dataset?.provider || '';
-    const settings = LIMIT_PROVIDER_SETTINGS[providerId] || [];
-    const inputs = row.querySelectorAll?.(
-      ':scope > .accordion-animated-container .limit-provider-settings-list > .settings-item > input[type="checkbox"]'
-    ) || [];
-    settings.forEach((setting, index) => {
-      const input = inputs[index];
-      if (input) reusableSettingInputs.set(`${providerId}:${setting.key}`, input);
-    });
-  }
   const enabled = enabledLimitProviderSet();
   const collected = new Map((state.stats?.limits?.providers || []).map((provider) => [provider.provider, provider]));
   const providers = limitProviderOrderApi.orderedLimitProviders(LIMIT_PROVIDERS, state.settings?.limitProviderOrder);
@@ -9477,7 +9152,7 @@ function renderLimitProviderCheckboxesNow() {
         accountGroup.classList.add('limit-provider-account-group');
       }
       if (connectionDetailKey) optionsInner.append(limitProviderConnectionDetail(connectionDetailKey));
-      if (settings) optionsInner.append(limitProviderSettingsList(id, settings, reusableSettingInputs));
+      if (settings) optionsInner.append(limitProviderSettingsList(id, settings));
       optionsContainer.append(optionsInner);
       const toggleOptions = () => {
         const opening = state.limitProviderSettingsExpanded !== id;
@@ -9494,7 +9169,7 @@ function renderLimitProviderCheckboxesNow() {
     } else {
       row.append(wrap, copy, actions);
     }
-    row.addEventListener('pointerdown', (event) => limitProviderRowDrag.startRowDrag(event, id));
+    row.addEventListener('pointerdown', (event) => startLimitProviderRowDrag(event, id));
     // Kept inside the row rather than as a sibling: reordering moves only
     // `.limit-provider-row` nodes, so a sibling panel would be stranded when the
     // list is dragged.
@@ -9509,7 +9184,6 @@ function renderLimitProviderCheckboxesNow() {
   if (focusedId && document.activeElement === document.body) {
     document.getElementById(focusedId)?.focus({ preventScroll: true });
   }
-  state.limitProviderRenderSignature = renderSignature;
 }
 
 function limitProviderAccountGroup(providerId) {
@@ -9561,60 +9235,10 @@ const LIMIT_PROVIDER_SETTINGS = {
     descKey: 'settings.limits.prepaidBalanceDesc',
     requiresConfiguredKey: 'claudeWebCookieConfigured',
     defaultValue: true
-  }],
-  opencode: [{
-    key: 'opencodeLocalLimitsEnabled',
-    titleKey: 'settings.limits.opencodeLocalLimits',
-    descKey: 'settings.limits.opencodeLocalLimitsDesc',
-    defaultValue: false
   }]
 };
 
-function limitProviderSettingsRenderSignature() {
-  const settings = state.settings || {};
-  const providerSignature = (provider) => {
-    return [
-      provider?.provider || '',
-      provider?.status || '',
-      Boolean(provider?.stale),
-      provider?.source || '',
-      provider?.sourceDetail || '',
-      provider?.sourceDeviceId || '',
-      provider?.accountKey || ''
-    ];
-  };
-  const deviceSignature = (device) => [
-    device?.deviceId || '',
-    device?.hostname || '',
-    (device?.limits?.providers || []).map((provider) => [
-      provider?.provider || '',
-      provider?.status || '',
-      provider?.accountKey || ''
-    ])
-  ];
-  const settingValues = Object.values(LIMIT_PROVIDER_SETTINGS).flatMap((entries) => entries.map((setting) => [
-    setting.key,
-    settings[setting.key],
-    setting.requiresConfiguredKey ? Boolean(settings[setting.requiresConfiguredKey]) : true
-  ]));
-  return JSON.stringify({
-    locale: currentLocale(),
-    mode: state.mode,
-    hubUrl: settings.hubUrl || '',
-    settings: [
-      settings.limitsEnabled !== false,
-      [...enabledLimitProviderSet()].sort(),
-      limitProviderOrderApi.orderedLimitProviders(LIMIT_PROVIDERS, settings.limitProviderOrder).map(({ id }) => id),
-      settings.deviceId || '',
-      settingValues,
-      state.limitProviderSettingsExpanded
-    ],
-    providers: (state.stats?.limits?.providers || []).map(providerSignature),
-    devices: (state.stats?.devices || []).map(deviceSignature)
-  });
-}
-
-function limitProviderSettingsList(providerId, settings, reusableInputs = null) {
+function limitProviderSettingsList(providerId, settings) {
   const list = document.createElement('div');
   list.className = 'settings-nested-list limit-provider-settings-list';
   for (const setting of settings) {
@@ -9630,21 +9254,18 @@ function limitProviderSettingsList(providerId, settings, reusableInputs = null) 
     title.className = 'settings-item-title';
     title.textContent = t(setting.titleKey);
     copy.append(title);
-    const inputKey = `${providerId}:${setting.key}`;
-    const existingInput = reusableInputs?.get(inputKey);
-    const input = existingInput || document.createElement('input');
+    const input = document.createElement('input');
     input.type = 'checkbox';
     const available = !setting.requiresConfiguredKey || Boolean(state.settings?.[setting.requiresConfiguredKey]);
-    const storedValue = state.settings?.[setting.key];
-    const defaultValue = setting.defaultValue !== false;
-    input.checked = available && (storedValue === undefined ? defaultValue : storedValue !== false);
+    input.checked = available && state.settings?.[setting.key] !== false;
     input.disabled = !available;
     item.classList.toggle('is-disabled', !available);
-    if (!existingInput) {
-      input.addEventListener('change', async () => {
-        await saveSettings({ [setting.key]: input.checked });
-      });
-    }
+    input.addEventListener('change', async () => {
+      await saveSettings({ [setting.key]: input.checked });
+      // Switching this off hides the row immediately; the request it also stops
+      // would otherwise only be skipped on the next refresh.
+      renderLimits();
+    });
     const desc = document.createElement('span');
     desc.className = 'settings-note settings-item-desc';
     desc.textContent = t(setting.descKey);
@@ -9871,11 +9492,24 @@ async function onPreferenceReorder(kind, id, targetIndex) {
   else await onLimitProviderReorder(id, targetIndex);
 }
 
-// Only the handle-based lists commit through here; the two whole-row lists save
-// from their own drag wiring, because this compares against the value they have
-// already mirrored into `state.settings` and would read the write as a no-op.
-async function onPreferenceOrderCommit(kind, order) {
+async function onPreferenceOrderCommit(kind, order, id) {
   const value = (order || []).join(',');
+  if (kind === 'client') {
+    const pinned = clientDisplayPreferencesApi.normalizePinnedClients(state.settings?.pinnedClients, KNOWN_CLIENTS).split(',').filter(Boolean);
+    const hasCustomOrder = clientDisplayPreferencesApi.hasCustomDisplayOrder(state.settings?.clientDisplayOrder);
+    if (!hasCustomOrder && pinned.includes(id)) {
+      const pinnedSet = new Set(pinned);
+      const nextPinned = (order || []).slice(0, pinned.length);
+      if (nextPinned.length === pinned.length && nextPinned.every((clientId) => pinnedSet.has(clientId))) {
+        const pinnedValue = nextPinned.join(',');
+        if (pinnedValue !== pinned.join(',')) await saveSettings({ pinnedClients: pinnedValue });
+        return;
+      }
+    }
+    const current = clientDisplayPreferencesApi.normalizeClientDisplayOrder(state.settings?.clientDisplayOrder, KNOWN_CLIENTS).join(',');
+    if (value !== current || pinned.length > 0) await saveSettings({ clientDisplayOrder: value, pinnedClients: '' });
+    return;
+  }
   if (kind === 'view') {
     const current = viewDisplayPreferencesApi.normalizeViewDisplayOrder(effectiveViewDisplayOrderValue(), VIEW_DISPLAY_OPTIONS).join(',');
     if (value !== current) await saveSettings({ viewDisplayOrder: value });
@@ -9894,7 +9528,10 @@ async function onPreferenceOrderCommit(kind, order) {
   if (kind === 'statusProvider') {
     const current = serviceStatusProviderPreferencesApi.normalizeOrder(state.settings?.serviceProviderDisplayOrder, SERVICE_PROVIDER_OPTIONS).join(',');
     if (value !== current) await saveSettings({ serviceProviderDisplayOrder: value });
+    return;
   }
+  const current = limitProviderOrderApi.normalizeLimitProviderOrder(state.settings?.limitProviderOrder, LIMIT_PROVIDERS).join(',');
+  if (value !== current) await saveSettings({ limitProviderOrder: value });
 }
 
 function onPreferenceOrderKeydown(event, kind, id) {
@@ -9953,7 +9590,6 @@ function preserveSettingsPanelScroll(callback) {
 }
 
 async function saveSettings(patch) {
-  const settingsPushRevision = state.settingsPushRevision;
   try {
     state.settings = await window.tokenMonitor.updateSettings(patch);
   } catch (error) {
@@ -9966,13 +9602,7 @@ async function saveSettings(patch) {
     throw error;
   }
   applyEffectiveCurrencyRates();
-  // settings:update broadcasts the normalized settings before resolving the
-  // IPC request. The push already ran the full sync; repeating it when the
-  // promise resolves rebuilds the provider rows a second time and restarts
-  // their accordion/switch layout transition.
-  if (state.settingsPushRevision === settingsPushRevision) {
-    preserveSettingsPanelScroll(syncSettingsForm);
-  }
+  preserveSettingsPanelScroll(syncSettingsForm);
   restartTimer();
   maybeUpdateBarsIcon();
   if (patch.showTrayProviderBadge !== undefined) {
@@ -10043,7 +9673,6 @@ async function init() {
     state.settings.startAtLogin = Boolean(state.appInfo.loginItemOpenAtLogin);
   }
   syncSettingsForm();
-  diagnosticsPanel?.render();
   publishViewState();
   await refreshHubInfo();
   await refreshTokscaleStatus();
@@ -10515,7 +10144,7 @@ els.floatingBubbleTab.addEventListener('keydown', (event) => {
 });
 
 async function runAppUpdateAction() {
-  const mode = appUpdatePresentationApi.appUpdateActionMode(state.appUpdate);
+  const mode = appUpdateActionMode(state.appUpdate);
   if (mode === 'install') {
     state.appUpdate = await window.tokenMonitor.installAppUpdate();
   } else if (mode === 'download') {
@@ -10533,7 +10162,7 @@ async function runAppUpdateAction() {
 
 els.appUpdatePillAction.addEventListener('click', async () => {
   if (!renderAppUpdatePopover(state.appUpdate) || typeof els.appUpdatePopover.showPopover !== 'function') {
-    if (appUpdatePresentationApi.appUpdateActionMode(state.appUpdate) === 'install') {
+    if (appUpdateActionMode(state.appUpdate) === 'install') {
       const url = state.appUpdate?.latest?.htmlUrl;
       if (url) await window.tokenMonitor.openExternal(url);
       return;
@@ -10606,7 +10235,6 @@ els.appUpdateReleaseNotesButton.addEventListener('click', async () => {
 
 window.tokenMonitor.onSettingsPush?.((next) => {
   if (!next) return;
-  state.settingsPushRevision += 1;
   const prevMetric = state.settings?.heatmapMetric;
   const prevLanguage = state.settings?.language;
   const prevCompactTokenUnits = state.settings?.compactTokenUnits;
@@ -10662,8 +10290,6 @@ window.tokenMonitor.onTokscalePush?.((payload) => {
 
 function renderStatsUpdate() {
   render();
-  renderCodexAccounts();
-  renderSettingsSummaries();
   renderLimitProviderCheckboxes();
   renderToolPreferences();
   renderWslPanel();
@@ -10700,7 +10326,7 @@ window.tokenMonitor.onStatsPush?.((payload) => {
     // Local collector overlays update client-mode data independently of the
     // Hub SSE transport. Preserve its current Offline/error state until a
     // real stream status or remote stats event proves the connection changed.
-    if (payload.data?.reason !== 'local' && payload.data?.reason !== 'presentation') {
+    if (payload.data?.reason !== 'local') {
       state.streamConnected = true;
       state.streamFailure = null;
     }
@@ -11944,6 +11570,10 @@ function setMimoAccountExpanded(expanded) {
   setAccountGroupExpanded('mimo', expanded, 'mimoAccountExpanded');
 }
 
+function setOllamaAccountExpanded(expanded) {
+  setAccountGroupExpanded('ollama', expanded, 'ollamaAccountExpanded');
+}
+
 function setCopilotAccountExpanded(expanded) {
   setAccountGroupExpanded('copilot', expanded, 'copilotAccountExpanded');
 }
@@ -12018,7 +11648,6 @@ function renderCodexAccounts() {
     empty.textContent = t('settings.codex.empty');
     listEl.append(empty);
   } else {
-    const codexProviders = localProviderStatuses('codex');
     for (const account of accounts) {
       const enabled = account.enabled !== false;
       const row = document.createElement('div');
@@ -12058,11 +11687,7 @@ function renderCodexAccounts() {
         : account.workspaceLabel;
       const accountMetadata = [
         workspaceLabel,
-        enabled
-          ? limitProviderPresentationApi.limitProviderDisplayLabel(
-            accountIdentityApi.codexManagedAccountPlanLabel(account, codexProviders)
-          )
-          : t('settings.codex.disabled')
+        enabled ? limitProviderPresentationApi.limitProviderDisplayLabel(account.accountLabel) : t('settings.codex.disabled')
       ].filter((value, index, values) => value && values.indexOf(value) === index);
       info.textContent = accountMetadata.join(' · ');
       info.title = accountMetadata.join(' · ');
@@ -12273,6 +11898,185 @@ function renderMimoStatus() {
     }
   }
   renderSettingsSummaries();
+}
+
+function renderOllamaStatus() {
+  const statusEl = document.getElementById('ollamaAccountStatus');
+  const listEl = document.getElementById('ollamaAccountList');
+  const emptyEl = document.getElementById('ollamaAccountEmpty');
+  const errorEl = document.getElementById('ollamaAccountErrorMessage');
+  if (!statusEl || !listEl || !emptyEl || !errorEl) return;
+  const accounts = state.settings?.ollamaManagedAccounts || [];
+  const enabledCount = accounts.filter((account) => account.enabled !== false).length;
+  const statusText = accounts.length === 0
+    ? t('settings.ollama.notConfigured')
+    : t('settings.ollama.connected', { linked: enabledCount, total: accounts.length });
+  setCursorStatusText(statusEl, statusText);
+  errorEl.textContent = state.ollamaAccountError || '';
+  errorEl.classList.toggle('hidden', !state.ollamaAccountError);
+  emptyEl.classList.toggle('hidden', accounts.length > 0);
+
+  listEl.replaceChildren();
+  if (accounts.length > 0) {
+    for (const [index, account] of accounts.entries()) {
+      const enabled = account.enabled !== false;
+      const accountName = ollamaSettingsAccountTitle(account, index);
+      const row = document.createElement('div');
+      row.className = 'managed-account-row';
+      row.classList.toggle('disabled', !enabled);
+
+      const input = document.createElement('input');
+      input.className = 'managed-account-checkbox';
+      input.type = 'checkbox';
+      input.checked = enabled;
+      input.setAttribute('aria-label', t('settings.ollama.toggleAccount', {
+        account: accountName
+      }));
+      input.addEventListener('change', async () => {
+        input.disabled = true;
+        const result = await window.tokenMonitor.ollama.setAccountEnabled(account.id, input.checked);
+        if (!result?.ok) {
+          state.ollamaAccountError = result?.error || t('settings.ollama.toggleFailed');
+        } else {
+          state.ollamaAccountError = '';
+          state.settings.ollamaManagedAccounts = result.accounts || [];
+        }
+        renderOllamaStatus();
+        renderSettingsSummaries();
+      });
+
+      const main = document.createElement('div');
+      main.className = 'managed-account-main';
+      const label = document.createElement('div');
+      label.className = 'managed-account-email';
+      label.textContent = accountName;
+      main.append(label);
+
+      const right = document.createElement('span');
+      right.className = 'managed-account-right';
+      const info = document.createElement('span');
+      info.className = 'managed-account-info';
+      info.textContent = enabled ? limitProviderPresentationApi.limitProviderDisplayLabel(account.accountLabel) : t('settings.ollama.disabled');
+
+      const remove = document.createElement('button');
+      remove.type = 'button';
+      remove.className = 'managed-account-remove';
+      remove.textContent = '✕';
+      remove.title = t('settings.ollama.remove');
+      let confirmingRemove = false;
+      remove.addEventListener('click', async () => {
+        if (!confirmingRemove) {
+          confirmingRemove = true;
+          remove.classList.add('confirming');
+          remove.textContent = '✓';
+          remove.title = t('settings.ollama.removeConfirm', {
+            account: accountName
+          });
+          return;
+        }
+        const result = await window.tokenMonitor.ollama.removeAccount(account.id);
+        if (result?.ok) {
+          state.ollamaAccountError = '';
+          state.settings.ollamaManagedAccounts = result.accounts || [];
+          renderOllamaStatus();
+          renderSettingsSummaries();
+          refreshStats({ force: true }).catch(() => {});
+          return;
+        }
+        state.ollamaAccountError = result?.error || t('settings.ollama.removeFailed');
+        renderOllamaStatus();
+        renderSettingsSummaries();
+      });
+
+      right.append(info, remove);
+      row.append(input, main, right);
+      listEl.append(row);
+    }
+  }
+  renderSettingsSummaries();
+}
+
+function freeLlmAccountLabel(account, index) {
+  return String(account?.accountEmail || account?.accountLabel || '').trim() || `Ollama account ${index + 1}`;
+}
+
+function renderFreeLlmRouting() {
+  const enabledInput = document.getElementById('freeLlmEnabledInput');
+  const endpoint = document.getElementById('freeLlmEndpoint');
+  const select = document.getElementById('freeLlmAccountSelect');
+  const list = document.getElementById('freeLlmKeyList');
+  const empty = document.getElementById('freeLlmKeyEmpty');
+  const error = document.getElementById('freeLlmError');
+  if (!enabledInput || !endpoint || !select || !list || !empty || !error) return;
+  const routing = state.settings || {};
+  const status = routing.freeLlmRoutingStatus || {};
+  const accounts = routing.ollamaManagedAccounts || [];
+  const keys = routing.freeLlmRoutingKeys || [];
+  enabledInput.checked = routing.freeLlmRoutingEnabled === true;
+  endpoint.textContent = status.running ? `http://127.0.0.1:${status.port}/v1` : (status.error || 'Not running');
+  error.textContent = state.freeLlmRoutingError || '';
+  error.classList.toggle('hidden', !state.freeLlmRoutingError);
+  select.replaceChildren();
+  for (const [index, account] of accounts.entries()) {
+    const option = document.createElement('option');
+    option.value = account.id;
+    option.textContent = freeLlmAccountLabel(account, index);
+    option.disabled = account.enabled === false;
+    select.append(option);
+  }
+  select.disabled = accounts.length === 0;
+  list.replaceChildren();
+  empty.classList.toggle('hidden', keys.length > 0);
+  for (const key of keys) {
+    const account = accounts.find((entry) => entry.id === key.ollamaAccountId);
+    const row = document.createElement('div');
+    row.className = 'managed-account-row';
+    row.classList.toggle('disabled', key.enabled === false);
+    const checkbox = document.createElement('input');
+    checkbox.className = 'managed-account-checkbox';
+    checkbox.type = 'checkbox';
+    checkbox.checked = key.enabled !== false;
+    checkbox.setAttribute('aria-label', `Route with ${key.label || freeLlmAccountLabel(account, 0)}`);
+    checkbox.addEventListener('change', async () => {
+      checkbox.disabled = true;
+      const result = await window.tokenMonitor.freellm.setKeyEnabled(key.id, checkbox.checked);
+      if (!result?.ok) state.freeLlmRoutingError = result?.error || 'Could not update the routing key.';
+      else {
+        state.freeLlmRoutingError = '';
+        state.settings.freeLlmRoutingKeys = result.keys || [];
+        state.settings.freeLlmRoutingStatus = result.status || {};
+      }
+      renderFreeLlmRouting();
+      renderSettingsSummaries();
+    });
+    const main = document.createElement('div');
+    main.className = 'managed-account-main';
+    const label = document.createElement('div');
+    label.className = 'managed-account-email';
+    label.textContent = key.label || freeLlmAccountLabel(account, 0);
+    const detail = document.createElement('div');
+    detail.className = 'managed-account-info';
+    detail.textContent = account ? `Monitors ${freeLlmAccountLabel(account, 0)}` : 'Linked account removed';
+    main.append(label, detail);
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'managed-account-remove';
+    remove.textContent = '✕';
+    remove.title = 'Remove routing key';
+    remove.addEventListener('click', async () => {
+      const result = await window.tokenMonitor.freellm.removeKey(key.id);
+      if (!result?.ok) state.freeLlmRoutingError = result?.error || 'Could not remove the routing key.';
+      else {
+        state.freeLlmRoutingError = '';
+        state.settings.freeLlmRoutingKeys = result.keys || [];
+        state.settings.freeLlmRoutingStatus = result.status || {};
+      }
+      renderFreeLlmRouting();
+      renderSettingsSummaries();
+    });
+    row.append(checkbox, main, remove);
+    list.append(row);
+  }
 }
 
 function minimaxProviderStatus() {
@@ -12546,14 +12350,6 @@ function kimiPlatformUrl() {
 
 function ollamaPlatformUrl() {
   return 'https://ollama.com/settings';
-}
-
-function ollamaValidationError(provider) {
-  if (provider?.status === 'unauthorized') return t('settings.ollama.validationInvalid');
-  if (provider?.status === 'rateLimited' || provider?.status === 'sourceRateLimited') {
-    return t('settings.ollama.validationRateLimited');
-  }
-  return t('settings.ollama.validationUnavailable');
 }
 
 function renderExternalProviderStatus(providerName) {
@@ -13468,7 +13264,9 @@ function setupCustomPricingUI() {
       outputPerM: outputEl.value === '' ? undefined : Number(outputEl.value),
       cacheReadPerM: cacheReadEl.value === '' ? undefined : Number(cacheReadEl.value)
     };
-    if (!customPricingFormApi.hasUsableBasePrice(entry)) { showError(t('settings.customPricing.errorNoPrice')); return; }
+    const hasInput = typeof entry.inputPerM === 'number' && entry.inputPerM > 0;
+    const hasOutput = typeof entry.outputPerM === 'number' && entry.outputPerM > 0;
+    if (!hasInput && !hasOutput) { showError(t('settings.customPricing.errorNoPrice')); return; }
     const next = customPricingFormApi.upsertOverride(state.settings?.customModelPricing || [], entry);
     await saveSettings({ customModelPricing: next });
     closeForm();
@@ -14223,64 +14021,116 @@ function setupCursorAccountUI() {
 
   const ollamaToggle = document.getElementById('ollamaSettingsToggle');
   if (ollamaToggle) {
-    ollamaToggle.addEventListener('click', () => setExternalAccountExpanded('ollama', !state.ollamaAccountExpanded));
-    setExternalAccountExpanded('ollama', false);
-    renderExternalProviderStatus('ollama');
+    ollamaToggle.addEventListener('click', () => setOllamaAccountExpanded(!state.ollamaAccountExpanded));
+
+    const addToggle = document.getElementById('ollamaAddToggle');
+    const addDetails = document.getElementById('ollamaAddDetails');
+    function setOllamaAddExpanded(expanded) {
+      const next = Boolean(expanded);
+      addToggle?.setAttribute('aria-expanded', next ? 'true' : 'false');
+      addDetails?.classList.toggle('hidden', !next);
+      document.getElementById('ollamaManualPanel')?.classList.toggle('expanded', next);
+    }
+    addToggle?.addEventListener('click', () => setOllamaAddExpanded(addDetails?.classList.contains('hidden')));
+    setOllamaAccountExpanded(false);
+    renderOllamaStatus();
+
+    window.tokenMonitor.ollama.onAccounts((accounts) => {
+      state.settings.ollamaManagedAccounts = accounts || [];
+      renderOllamaStatus();
+    });
+
+    window.tokenMonitor.ollama.accounts().then((accounts) => {
+      state.settings.ollamaManagedAccounts = accounts || [];
+      renderOllamaStatus();
+    }).catch(() => {});
 
     document.getElementById('ollamaOpenBrowser').addEventListener('click', () => {
       window.tokenMonitor.openExternal(ollamaPlatformUrl());
     });
-    document.getElementById('ollamaLogoutButton').addEventListener('click', async () => {
-      await saveSettings({ ollamaCookie: '' });
-      clearExternalProviderCheckPending('ollama');
-      clearExternalProviderPendingStatus('ollama');
-      renderExternalProviderStatus('ollama');
-      await refreshStats({ force: true });
-    });
-    document.getElementById('ollamaRefreshButton').addEventListener('click', async () => {
-      await refreshStats({ force: true });
-    });
-    document.getElementById('ollamaCookieSubmit').addEventListener('click', async () => {
+
+    document.getElementById('ollamaSaveAccountButton').addEventListener('click', async () => {
       const input = document.getElementById('ollamaCookieInput');
-      const errorEl = document.getElementById('ollamaErrorMessage');
-      errorEl.classList.add('hidden');
-      if (!String(input.value || '').trim()) {
-        errorEl.textContent = t('settings.ollama.statusNotSet');
-        errorEl.classList.remove('hidden');
+      const saveButton = document.getElementById('ollamaSaveAccountButton');
+      saveButton.disabled = true;
+      saveButton.textContent = t('settings.ollama.checking');
+      let result;
+      try {
+        result = await window.tokenMonitor.ollama.addAccount(input.value);
+      } catch (_) {
+        result = { ok: false, errorCode: 'validationUnavailable' };
+      } finally {
+        saveButton.disabled = false;
+        saveButton.textContent = t('settings.ollama.saveAccount');
+      }
+      if (!result?.ok) {
+        if (result?.errorCode === 'missingRequiredCookies') {
+          state.ollamaAccountError = t('settings.ollama.missingCookies', { cookies: (result.missingCookies || []).join(', ') });
+        } else if (result?.errorCode === 'invalidCookie') {
+          state.ollamaAccountError = t('settings.ollama.invalidCookie');
+        } else if (result?.errorCode === 'validationRateLimited') {
+          state.ollamaAccountError = t('settings.ollama.validationRateLimited');
+        } else if (result?.errorCode === 'validationUnavailable') {
+          state.ollamaAccountError = t('settings.ollama.validationUnavailable');
+        } else if (result?.errorCode === 'credentialStorageUnavailable') {
+          state.ollamaAccountError = t('settings.ollama.credentialStorageUnavailable');
+        } else {
+          state.ollamaAccountError = result?.error || t('settings.ollama.addFailed');
+        }
+        renderOllamaStatus();
         return;
       }
-      try {
-        markExternalProviderCheckPending('ollama');
-        renderExternalProviderStatus('ollama');
-        const validation = await window.tokenMonitor.ollama.validateCookie(input.value);
-        if (!validation?.ok) {
-          clearExternalProviderCheckPending('ollama');
-          renderExternalProviderStatus('ollama');
-          errorEl.textContent = ollamaValidationError(validation);
-          errorEl.classList.remove('hidden');
-          return;
-        }
-        await saveSettings({
-          ollamaCookie: input.value,
-          limitProviders: limitProviderSelectionIncluding('ollama'),
-          limitsEnabled: true
-        });
-        if (!state.settings?.ollamaCookieConfigured) {
-          clearExternalProviderCheckPending('ollama');
-          renderExternalProviderStatus('ollama');
-          errorEl.textContent = t('settings.ollama.validationInvalid');
-          errorEl.classList.remove('hidden');
-          return;
-        }
-        input.value = '';
-        renderExternalProviderStatus('ollama');
-      } catch (err) {
-        clearExternalProviderCheckPending('ollama');
-        renderExternalProviderStatus('ollama');
-        errorEl.textContent = t('settings.ollama.saveFailed', { message: err.message });
-        errorEl.classList.remove('hidden');
-      }
+      input.value = '';
+      state.ollamaAccountError = '';
+      state.settings.ollamaManagedAccounts = await window.tokenMonitor.ollama.accounts();
+      renderOllamaStatus();
+      setOllamaAddExpanded(false);
+      // Ensure Ollama is in the active provider list and limits are on,
+      // matching the behaviour of the old single-cookie save path.
+      await saveSettings({
+        limitProviders: limitProviderSelectionIncluding('ollama'),
+        limitsEnabled: true
+      });
+      await refreshStats({ force: true });
     });
+  }
+
+  const freeLlmEnabledInput = document.getElementById('freeLlmEnabledInput');
+  if (freeLlmEnabledInput) {
+    freeLlmEnabledInput.addEventListener('change', async () => {
+      freeLlmEnabledInput.disabled = true;
+      const result = await window.tokenMonitor.freellm.setEnabled(freeLlmEnabledInput.checked);
+      if (!result?.ok) state.freeLlmRoutingError = result?.status?.error || result?.error || 'Could not start FreeLLM routing.';
+      else {
+        state.freeLlmRoutingError = '';
+        state.settings.freeLlmRoutingEnabled = freeLlmEnabledInput.checked;
+        state.settings.freeLlmRoutingStatus = result.status || {};
+      }
+      freeLlmEnabledInput.disabled = false;
+      renderFreeLlmRouting();
+      renderSettingsSummaries();
+    });
+    document.getElementById('freeLlmCopyEndpoint').addEventListener('click', async () => {
+      const status = state.settings?.freeLlmRoutingStatus || {};
+      if (status.running) await window.tokenMonitor.copyText(`http://127.0.0.1:${status.port}/v1`);
+    });
+    document.getElementById('freeLlmAddKey').addEventListener('click', async () => {
+      const label = document.getElementById('freeLlmKeyLabel');
+      const apiKey = document.getElementById('freeLlmApiKey');
+      const account = document.getElementById('freeLlmAccountSelect');
+      const result = await window.tokenMonitor.freellm.addKey({ label: label.value, apiKey: apiKey.value, ollamaAccountId: account.value });
+      if (!result?.ok) state.freeLlmRoutingError = result?.error || 'Could not add the routing key.';
+      else {
+        state.freeLlmRoutingError = '';
+        apiKey.value = '';
+        label.value = '';
+        state.settings.freeLlmRoutingKeys = result.keys || [];
+        state.settings.freeLlmRoutingStatus = result.status || {};
+      }
+      renderFreeLlmRouting();
+      renderSettingsSummaries();
+    });
+    renderFreeLlmRouting();
   }
 
   const kimiToggle = document.getElementById('kimiSettingsToggle');

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -14025,13 +14025,27 @@ function setupCursorAccountUI() {
 
     const addToggle = document.getElementById('ollamaAddToggle');
     const addDetails = document.getElementById('ollamaAddDetails');
+    const uploadToggle = document.getElementById('ollamaUploadToggle');
+    const uploadDetails = document.getElementById('ollamaUploadDetails');
+    
     function setOllamaAddExpanded(expanded) {
       const next = Boolean(expanded);
       addToggle?.setAttribute('aria-expanded', next ? 'true' : 'false');
       addDetails?.classList.toggle('hidden', !next);
-      document.getElementById('ollamaManualPanel')?.classList.toggle('expanded', next);
+      document.getElementById('ollamaManualPanel')?.classList.toggle('expanded', next || (uploadDetails && !uploadDetails.classList.contains('hidden')));
+      if (next && uploadToggle) setOllamaUploadExpanded(false);
     }
+    
+    function setOllamaUploadExpanded(expanded) {
+      const next = Boolean(expanded);
+      uploadToggle?.setAttribute('aria-expanded', next ? 'true' : 'false');
+      uploadDetails?.classList.toggle('hidden', !next);
+      document.getElementById('ollamaManualPanel')?.classList.toggle('expanded', next || (addDetails && !addDetails.classList.contains('hidden')));
+      if (next && addToggle) setOllamaAddExpanded(false);
+    }
+    
     addToggle?.addEventListener('click', () => setOllamaAddExpanded(addDetails?.classList.contains('hidden')));
+    uploadToggle?.addEventListener('click', () => setOllamaUploadExpanded(uploadDetails?.classList.contains('hidden')));
     setOllamaAccountExpanded(false);
     renderOllamaStatus();
 
@@ -14093,6 +14107,26 @@ function setupCursorAccountUI() {
       });
       await refreshStats({ force: true });
     });
+
+    document.getElementById('ollamaCookieUploadButtonDirect').addEventListener('click', () => {
+      document.getElementById('ollamaCookieUploadFile').click();
+    });
+
+    document.getElementById('ollamaCookieUploadFile').addEventListener('change', async (e) => {
+      const file = e.target.files[0];
+      if (!file) return;
+      const text = await file.text();
+      const lines = text.split('\n');
+      const cookieLine = lines.find(line => line.includes('aid=') && line.includes('__Secure-session='));
+      if (cookieLine) {
+        document.getElementById('ollamaCookieInput').value = cookieLine.trim();
+        document.getElementById('ollamaSaveAccountButton').click();
+      } else {
+        state.ollamaAccountError = 'Could not find a valid Ollama cookie in the uploaded file.';
+        renderOllamaStatus();
+      }
+      e.target.value = '';
+    });
   }
 
   const freeLlmEnabledInput = document.getElementById('freeLlmEnabledInput');
@@ -14130,6 +14164,8 @@ function setupCursorAccountUI() {
       renderFreeLlmRouting();
       renderSettingsSummaries();
     });
+
+
     renderFreeLlmRouting();
   }
 

--- a/src/electron/renderer/index.html
+++ b/src/electron/renderer/index.html
@@ -1296,6 +1296,35 @@
           </div>
         </div>
 
+        <div class="settings-group settings-collapsible-group settings-limits-group">
+          <button class="settings-section-toggle" type="button" data-settings-section="routing" aria-expanded="false" aria-controls="routingSettingsDetails">
+            <span class="settings-section-heading"><span class="settings-section-icon settings-section-icon-limits" aria-hidden="true"></span><span>FreeLLM Routing</span></span>
+            <span class="settings-section-meta"><span id="routingSettingsSummary" class="settings-section-summary"></span><span class="settings-section-disclosure" aria-hidden="true"></span></span>
+          </button>
+          <div id="routingSettingsDetails" class="settings-section-details hidden">
+            <div class="settings-subgroup">
+              <label class="checkbox-label settings-item"><span class="settings-item-text"><span class="settings-item-title">Enable local Ollama routing</span><span class="settings-note settings-item-desc">Runs only while Token Monitor is open. Keys rotate using the linked Ollama account’s monitored quota.</span></span><input id="freeLlmEnabledInput" type="checkbox" /></label>
+              <div class="settings-item"><span class="settings-item-text"><span class="settings-item-title">OpenAI-compatible endpoint</span><span id="freeLlmEndpoint" class="settings-note settings-item-desc">Not running</span></span><button id="freeLlmCopyEndpoint" type="button">Copy</button></div>
+            </div>
+            <div class="settings-subgroup">
+              <div class="settings-group-header"><span>Ollama API keys</span></div>
+              <div id="freeLlmKeyList" class="managed-account-list"></div>
+              <p id="freeLlmKeyEmpty" class="settings-note">Add a key for each monitored Ollama account you want to route through.</p>
+              <div class="opencode-add-form expanded">
+                <div class="opencode-add-details">
+                  <div class="opencode-add-body">
+                    <label class="settings-field"><span>Label (optional)</span><input id="freeLlmKeyLabel" type="text" maxlength="80" autocomplete="off" placeholder="Personal Ollama" /></label>
+                    <label class="settings-field"><span>Monitored Ollama account</span><select id="freeLlmAccountSelect"></select></label>
+                    <label class="settings-field"><span>Ollama API key</span><input id="freeLlmApiKey" type="password" autocomplete="off" spellcheck="false" placeholder="Paste API key" /></label>
+                    <div class="settings-actions"><button id="freeLlmAddKey" type="button">Add API key</button></div>
+                  </div>
+                </div>
+              </div>
+              <p id="freeLlmError" class="settings-note error hidden" role="alert"></p>
+            </div>
+          </div>
+        </div>
+
         <div class="settings-group settings-collapsible-group settings-sync-group">
           <button class="settings-section-toggle" type="button" data-settings-section="sync" aria-expanded="false" aria-controls="syncSettingsDetails">
             <span class="settings-section-heading"><span class="settings-section-icon settings-section-icon-sync" aria-hidden="true"></span><span data-i18n="settings.sync.title">Multi-device Sync</span></span>

--- a/src/electron/renderer/index.html
+++ b/src/electron/renderer/index.html
@@ -141,27 +141,6 @@
                 <button id="openRepositoryButton" type="button" class="inline-link" data-i18n="settings.about.repository">GitHub</button>
                 <button id="openWebsiteButton" type="button" class="inline-link" data-i18n="settings.about.website">Website</button>
                 <button id="reportIssueButton" type="button" class="inline-link" data-i18n="settings.about.reportIssue">Report an issue</button>
-                <button id="diagnosticToggleButton" type="button" class="inline-link" data-i18n="settings.about.diagnostics.toggle" aria-expanded="false" aria-controls="diagnosticDetails">Diagnostics</button>
-              </div>
-              <div id="diagnosticDetails" class="about-settings-diagnostics accordion-animated-container hidden" aria-hidden="true" inert>
-                <div class="accordion-animation-inner about-settings-diagnostics-inner">
-                  <div class="about-settings-diagnostics-heading" data-i18n="settings.about.diagnostics.title">Diagnostics &amp; support</div>
-                  <p class="settings-note" data-i18n="settings.about.diagnostics.description">Create a redacted system diagnostic to help report issues.</p>
-                  <div class="diagnostic-actions">
-                    <button id="generateDiagnosticButton" type="button" data-i18n="settings.about.diagnostics.generate">Generate report</button>
-                    <button id="copyDiagnosticButton" type="button" class="hidden" data-i18n="settings.about.diagnostics.copy" hidden>Copy report</button>
-                    <button id="previewDiagnosticButton" type="button" class="inline-link hidden" data-i18n="settings.about.diagnostics.preview" aria-expanded="false" aria-controls="diagnosticPreview" hidden>View report</button>
-                    <button id="regenerateDiagnosticButton" type="button" class="inline-link hidden" data-i18n="settings.about.diagnostics.regenerate" hidden>Regenerate</button>
-                  </div>
-                  <p class="settings-note diagnostic-privacy-note" data-i18n="settings.about.diagnostics.privacy">Includes versions, collection state and token totals; excludes credentials, conversations, accounts, full paths and raw errors.</p>
-                  <div id="diagnosticStatus" class="diagnostic-status" role="status" aria-live="polite"></div>
-                  <div id="diagnosticPreview" class="diagnostic-preview hidden" aria-hidden="true" inert aria-label="Report preview" data-i18n-aria-label="settings.about.diagnostics.previewTitle">
-                    <div class="diagnostic-preview-header">
-                      <span data-i18n="settings.about.diagnostics.previewTitle">Report preview</span>
-                    </div>
-                    <pre id="diagnosticReportText" tabindex="0"></pre>
-                  </div>
-                </div>
               </div>
             </div>
           </div>
@@ -388,7 +367,7 @@
           <div id="toolsSettingsDetails" class="settings-section-details hidden">
             <div class="settings-subgroup settings-tools-subgroup">
               <div class="settings-note-row">
-                <p class="settings-note" data-i18n="settings.tools.note">Track controls collection. Show controls the main Tools list. Drag a row to reorder.</p>
+                <p class="settings-note" data-i18n="settings.tools.note">Track controls collection. Show controls the main Tools list.</p>
                 <div class="tool-header-actions">
                   <button id="resetClientDisplayOrderButton" class="tool-header-action" type="button" title="Reset order" aria-label="Reset order" data-i18n-title="settings.tools.resetOrder" data-i18n-aria-label="settings.tools.resetOrder"><span aria-hidden="true">↺</span></button>
                   <button id="showAllClientsButton" class="tool-header-action" type="button" title="Show all" aria-label="Show all" data-i18n-title="settings.tools.showAll" data-i18n-aria-label="settings.tools.showAll"><span class="tool-header-eye" aria-hidden="true"></span></button>
@@ -923,24 +902,55 @@
                 </span>
               </button>
               <div id="ollamaSettingsDetails" class="cursor-settings-details hidden">
-                <div class="settings-actions">
-                  <button id="ollamaOpenBrowser" data-i18n="settings.ollama.openBrowser">Open Ollama settings</button>
-                  <button id="ollamaLogoutButton" class="hidden" data-i18n="settings.ollama.clearCookie">Clear cookie</button>
-                  <button id="ollamaRefreshButton" data-i18n="settings.common.refresh">Refresh</button>
-                </div>
-                <div id="ollamaManualPanel">
-                  <p class="settings-note">
-                    <strong>1.</strong> <span data-i18n="settings.ollama.step1">Open Ollama settings in your browser (button above) and sign in.</span><br>
-                    <strong>2.</strong> <span data-i18n="settings.ollama.step2">Open DevTools (F12 or Cmd+Opt+I) -> Network, reload the page, then select the settings document request.</span><br>
-                    <strong>3.</strong> <span data-i18n="settings.ollama.step3">In Headers -> Request Headers, copy the full Cookie value.</span><br>
-                    <strong>4.</strong> <span data-i18n="settings.ollama.step4">Paste it below and click Save cookie.</span>
-                  </p>
-                  <textarea id="ollamaCookieInput" rows="3" spellcheck="false" placeholder="wos-session=..." data-i18n-placeholder="settings.ollama.cookiePlaceholder"></textarea>
-                  <div class="settings-actions">
-                    <button id="ollamaCookieSubmit" data-i18n="settings.ollama.saveCookie">Save cookie</button>
+                <div id="ollamaAccountList" class="managed-account-list"></div>
+                <div id="ollamaAccountEmpty" class="opencode-empty" data-i18n="settings.ollama.emptyList">No accounts yet. Click "+ Add account" below to get started.</div>
+                <div id="ollamaManualPanel" class="opencode-add-form">
+                  <div style="display: flex; gap: 8px;">
+                    <button id="ollamaAddToggle" class="opencode-add-summary" type="button" aria-expanded="false" aria-controls="ollamaAddDetails" style="flex: 1; border-radius: 6px;">
+                      <svg class="add-icon" width="14" height="14" viewBox="0 0 14 14" fill="none">
+                        <path d="M7 1v12M1 7h12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                      </svg>
+                      <span data-i18n="settings.ollama.addAccount">Add account</span>
+                    </button>
+                    <button id="ollamaUploadToggle" class="opencode-add-summary" type="button" aria-expanded="false" aria-controls="ollamaUploadDetails" style="flex: 1; border-radius: 6px;">
+                      <svg class="add-icon" width="14" height="14" viewBox="0 0 14 14" fill="none">
+                        <path d="M7 1v12M1 7h12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                      </svg>
+                      <span>Upload cookie</span>
+                    </button>
+                  </div>
+                  <div id="ollamaAddDetails" class="opencode-add-details accordion-animated-container hidden">
+                    <div class="accordion-animation-inner opencode-add-body">
+                      <div class="settings-actions">
+                        <button id="ollamaOpenBrowser" type="button" data-i18n="settings.ollama.openBrowser">Open Ollama settings</button>
+                      </div>
+                      <p class="settings-note">
+                        <strong>1.</strong> <span data-i18n="settings.ollama.step1">Open Ollama settings in your browser (button above) and sign in.</span><br>
+                        <strong>2.</strong> <span data-i18n="settings.ollama.step2">Open DevTools (F12 or Cmd+Opt+I) -> Network, reload the page, then select the settings document request.</span><br>
+                        <strong>3.</strong> <span data-i18n="settings.ollama.step3">In Headers -> Request Headers, copy the full Cookie value.</span><br>
+                        <strong>4.</strong> <span data-i18n="settings.ollama.step4">Paste it below and click Save cookie.</span>
+                      </p>
+                      <textarea id="ollamaCookieInput" rows="3" spellcheck="false" placeholder="wos-session=..." data-i18n-placeholder="settings.ollama.cookiePlaceholder"></textarea>
+                      <div class="settings-actions">
+                        <button id="ollamaSaveAccountButton" data-i18n="settings.ollama.saveAccount">Add account</button>
+                      </div>
+                    </div>
+                  </div>
+                  <div id="ollamaUploadDetails" class="opencode-add-details accordion-animated-container hidden">
+                    <div class="accordion-animation-inner opencode-add-body">
+                      <p class="settings-note">
+                        <strong>1.</strong> Create a .txt file containing the API keys and the Cookie.<br>
+                        <strong>2.</strong> Ensure the Cookie is present in the format <code>aid=...; __Secure-session=...</code>.<br>
+                        <strong>3.</strong> Click the button below to upload the file.
+                      </p>
+                      <div class="settings-actions">
+                        <input type="file" id="ollamaCookieUploadFile" accept=".txt" hidden="hidden" style="display: none !important; position: absolute; width: 0; height: 0;" />
+                        <button id="ollamaCookieUploadButtonDirect" type="button">Choose file to upload</button>
+                      </div>
+                    </div>
                   </div>
                 </div>
-                <div id="ollamaErrorMessage" class="settings-note error hidden"></div>
+                <div id="ollamaAccountErrorMessage" class="settings-note error hidden"></div>
               </div>
             </div>
             <div id="kimiAccountGroup" class="settings-group cursor-account-group">
@@ -1316,7 +1326,9 @@
                     <label class="settings-field"><span>Label (optional)</span><input id="freeLlmKeyLabel" type="text" maxlength="80" autocomplete="off" placeholder="Personal Ollama" /></label>
                     <label class="settings-field"><span>Monitored Ollama account</span><select id="freeLlmAccountSelect"></select></label>
                     <label class="settings-field"><span>Ollama API key</span><input id="freeLlmApiKey" type="password" autocomplete="off" spellcheck="false" placeholder="Paste API key" /></label>
-                    <div class="settings-actions"><button id="freeLlmAddKey" type="button">Add API key</button></div>
+                    <div class="settings-actions">
+                      <button id="freeLlmAddKey" type="button">Add API key</button>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -1452,9 +1464,6 @@
     <script src="limitProviderPresentation.js"></script>
     <script src="limitDisplayMode.js"></script>
     <script src="clientStatusPresentation.js"></script>
-    <script src="clientHealthPresentation.js"></script>
-    <script src="clientSourceCache.js"></script>
-    <script src="clientRescanState.js"></script>
     <script src="wslStatusPresentation.js"></script>
     <script src="serviceStatusPresentation.js"></script>
     <script src="serviceStatusProviderPreferences.js"></script>
@@ -1463,7 +1472,6 @@
     <script src="homeModulePreferences.js"></script>
     <script src="preferenceDragSort.js"></script>
     <script src="verticalDragSort.js"></script>
-    <script src="rowDragController.js"></script>
     <script src="i18n.js"></script>
     <script src="sessionRows.js"></script>
     <script src="breakdownRenderPolicy.js"></script>
@@ -1485,7 +1493,6 @@
     <script src="windowsGlass.js"></script>
     <script src="glassRendering.js"></script>
     <script src="trayComposer.js"></script>
-    <script src="diagnosticsPanel.js"></script>
     <script src="app.js"></script>
   </body>
 </html>

--- a/src/shared/credentialStore.js
+++ b/src/shared/credentialStore.js
@@ -120,34 +120,11 @@ function readRegularFileNoFollow(filePath, options = {}) {
     descriptor = fsApi.openSync(filePath, constants.O_RDONLY | noFollow);
     const descriptorStat = fsApi.fstatSync(descriptor);
     if (!descriptorStat.isFile()) throw new Error(`${description} must be a regular file`);
-    const maxBytes = Number.isFinite(options.maxBytes)
-      ? Math.max(0, Math.floor(options.maxBytes))
-      : null;
-    if (maxBytes !== null && descriptorStat.size > maxBytes) {
-      throw new Error(`${description} exceeds ${maxBytes} bytes`);
-    }
     if (pathStat && (pathStat.dev !== descriptorStat.dev || pathStat.ino !== descriptorStat.ino)) {
       throw new Error(`${description} changed while it was being opened`);
     }
     if (options.mode !== undefined && process.platform !== 'win32') {
       fsApi.fchmodSync(descriptor, options.mode);
-    }
-    if (maxBytes !== null) {
-      const buffer = Buffer.allocUnsafe(maxBytes + 1);
-      let bytesRead = 0;
-      while (bytesRead < buffer.length) {
-        const count = fsApi.readSync(
-          descriptor,
-          buffer,
-          bytesRead,
-          buffer.length - bytesRead,
-          null
-        );
-        if (count === 0) break;
-        bytesRead += count;
-      }
-      if (bytesRead > maxBytes) throw new Error(`${description} exceeds ${maxBytes} bytes`);
-      return buffer.subarray(0, bytesRead).toString(options.encoding || 'utf8');
     }
     return fsApi.readFileSync(descriptor, options.encoding || 'utf8');
   } catch (error) {
@@ -354,6 +331,57 @@ class CredentialStore {
     deleteValueAt(document.credentials, ['providers', 'mimo', 'accounts', accountId]);
     this.writeDocument(document);
     return !this.readMimoCredential(accountId);
+  }
+
+  readOllamaCredential(id, document = this.readDocument()) {
+    const accountId = safeDynamicKey(id);
+    if (!accountId) return '';
+    const value = valueAt(document.credentials, ['providers', 'ollama', 'accounts', accountId, 'cookieHeader']);
+    return typeof value === 'string' ? value : '';
+  }
+
+  writeOllamaCredential(id, cookieHeader) {
+    const accountId = safeDynamicKey(id);
+    if (!accountId || !credentialValuePresent(cookieHeader)) return false;
+    const document = this.readDocument();
+    setValueAt(document.credentials, ['providers', 'ollama', 'accounts', accountId, 'cookieHeader'], cookieHeader);
+    this.writeDocument(document);
+    return true;
+  }
+
+  removeOllamaCredential(id) {
+    const accountId = safeDynamicKey(id);
+    if (!accountId) return false;
+    const document = this.readDocument();
+    deleteValueAt(document.credentials, ['providers', 'ollama', 'accounts', accountId]);
+    this.writeDocument(document);
+    return !this.readOllamaCredential(accountId);
+  }
+
+  readFreeLlmRoutingKey(id, document = this.readDocument()) {
+    const keyId = safeDynamicKey(id);
+    if (!keyId) return '';
+    const value = valueAt(document.credentials, ['providers', 'freellmRouting', 'keys', keyId, 'apiKey']);
+    return typeof value === 'string' ? value : '';
+  }
+
+  writeFreeLlmRoutingKey(id, apiKey) {
+    const keyId = safeDynamicKey(id);
+    const value = typeof apiKey === 'string' ? apiKey.trim() : '';
+    if (!keyId || !value) return false;
+    const document = this.readDocument();
+    setValueAt(document.credentials, ['providers', 'freellmRouting', 'keys', keyId, 'apiKey'], value);
+    this.writeDocument(document);
+    return true;
+  }
+
+  removeFreeLlmRoutingKey(id) {
+    const keyId = safeDynamicKey(id);
+    if (!keyId) return false;
+    const document = this.readDocument();
+    deleteValueAt(document.credentials, ['providers', 'freellmRouting', 'keys', keyId]);
+    this.writeDocument(document);
+    return !this.readFreeLlmRoutingKey(keyId);
   }
 
   migrateLegacyMimoCredentials(entries) {

--- a/src/shared/freellmRouter.js
+++ b/src/shared/freellmRouter.js
@@ -1,0 +1,217 @@
+'use strict';
+
+const http = require('node:http');
+const { Readable } = require('node:stream');
+
+const DEFAULT_PORT = 19512;
+const DEFAULT_THRESHOLD_PERCENT = 97;
+const UPSTREAM_BASE_URL = 'https://ollama.com/v1';
+const MAX_BODY_BYTES = 10 * 1024 * 1024;
+
+function clampThreshold(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return DEFAULT_THRESHOLD_PERCENT;
+  return Math.max(50, Math.min(99, Math.round(number * 10) / 10));
+}
+
+function normalizePort(value) {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number < 1024 || number > 65535) return DEFAULT_PORT;
+  return number;
+}
+
+function normalizeKeys(value) {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set();
+  return value.flatMap((entry) => {
+    const id = String(entry?.id || '').trim();
+    const apiKey = String(entry?.apiKey || '').trim();
+    const ollamaAccountId = String(entry?.ollamaAccountId || '').trim();
+    if (!id || !apiKey || !ollamaAccountId || seen.has(id)) return [];
+    seen.add(id);
+    return [{
+      id,
+      apiKey,
+      label: String(entry?.label || '').trim(),
+      ollamaAccountId,
+      accountKey: String(entry?.accountKey || '').trim(),
+      enabled: entry?.enabled !== false
+    }];
+  });
+}
+
+function worstQuotaWindow(provider) {
+  const windows = Array.isArray(provider?.windows) ? provider.windows : [];
+  return windows.reduce((worst, window) => {
+    const usedPercent = Number(window?.usedPercent);
+    if (!Number.isFinite(usedPercent)) return worst;
+    if (!worst || usedPercent > worst.usedPercent) {
+      return { usedPercent, resetsAt: window?.resetsAt || null };
+    }
+    return worst;
+  }, null);
+}
+
+function selectKey(keys, quotas, thresholdPercent, blocked = new Map(), nowMs = Date.now()) {
+  const byAccountId = new Map((quotas || []).map((quota) => [String(quota?.accountId || ''), quota]));
+  for (const key of normalizeKeys(keys)) {
+    if (!key.enabled) continue;
+    const block = blocked.get(key.id);
+    if (block?.until > nowMs) continue;
+    if (block) blocked.delete(key.id);
+    const quota = byAccountId.get(key.ollamaAccountId);
+    // Routing is deliberately coupled to Token Monitor's authenticated quota data.
+    // A missing or stale source should never make a key look unlimited.
+    if (!quota || quota.status !== 'ok') continue;
+    const worst = worstQuotaWindow(quota);
+    if (!worst || worst.usedPercent >= thresholdPercent) continue;
+    return { key, quota, window: worst };
+  }
+  return null;
+}
+
+function blockSelection(blocked, selection, nowMs = Date.now()) {
+  const fallbackUntil = nowMs + 60 * 60 * 1000;
+  const reset = Date.parse(selection.window?.resetsAt || '');
+  const until = Number.isFinite(reset) && reset > nowMs ? reset : fallbackUntil;
+  blocked.set(selection.key.id, { until });
+}
+
+async function proxyChatCompletion({ keys, quotas, config = {}, blocked = new Map(), fetchFn, body }) {
+  const normalizedKeys = normalizeKeys(keys);
+  const upstreamBaseUrl = String(config.upstreamBaseUrl || UPSTREAM_BASE_URL).replace(/\/$/, '');
+  for (let attempt = 0; attempt < normalizedKeys.length; attempt += 1) {
+    const selection = selectKey(normalizedKeys, quotas, clampThreshold(config.thresholdPercent), blocked);
+    if (!selection) return { error: 'No Ollama routing key has usable monitored quota.', statusCode: 503 };
+    try {
+      const response = await fetchFn(`${upstreamBaseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${selection.key.apiKey}`, 'content-type': 'application/json' },
+        body
+      });
+      if (response.status === 429) {
+        blockSelection(blocked, selection);
+        continue;
+      }
+      return { selection, response };
+    } catch (error) {
+      return { error: `Ollama upstream request failed: ${error.message}`, statusCode: 502 };
+    }
+  }
+  return { error: 'All Ollama routing keys are rate limited.', statusCode: 503 };
+}
+
+function json(response, status, value) {
+  response.writeHead(status, { 'content-type': 'application/json; charset=utf-8' });
+  response.end(JSON.stringify(value));
+}
+
+function requestBody(request) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let size = 0;
+    request.on('data', (chunk) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        reject(Object.assign(new Error('Request body too large'), { statusCode: 413 }));
+        request.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    request.on('end', () => resolve(Buffer.concat(chunks)));
+    request.on('error', reject);
+  });
+}
+
+function proxyHeaders(upstream) {
+  const headers = { 'x-freellm-account': upstream.label || upstream.id };
+  const contentType = upstream.response.headers.get('content-type');
+  if (contentType) headers['content-type'] = contentType;
+  return headers;
+}
+
+function createFreeLlmRouter(options = {}) {
+  const fetchFn = options.fetch || globalThis.fetch;
+  if (typeof fetchFn !== 'function') throw new Error('A fetch implementation is required');
+  const getKeys = options.getKeys || (() => []);
+  const getQuotas = options.getQuotas || (() => []);
+  const getConfig = options.getConfig || (() => ({}));
+  const blocked = new Map();
+  let server = null;
+  let status = { running: false, port: null, error: '', activeKeyId: '' };
+
+  async function forward(request, response) {
+    let body;
+    try {
+      body = await requestBody(request);
+      JSON.parse(body.toString('utf8'));
+    } catch (error) {
+      return json(response, error?.statusCode || 400, { error: { message: error?.message || 'Invalid JSON body', type: 'invalid_request_error' } });
+    }
+    const result = await proxyChatCompletion({
+      keys: getKeys(), quotas: getQuotas(), config: getConfig() || {}, blocked, fetchFn, body
+    });
+    if (result.error) {
+      return json(response, result.statusCode, { error: { message: result.error, type: result.statusCode === 503 ? 'freellm_exhausted' : 'upstream_error' } });
+    }
+    status.activeKeyId = result.selection.key.id;
+    response.writeHead(result.response.status, proxyHeaders({ ...result.selection.key, response: result.response }));
+    if (!result.response.body) return response.end();
+    Readable.fromWeb(result.response.body).pipe(response);
+    return undefined;
+  }
+
+  async function handler(request, response) {
+    if (request.method === 'GET' && request.url === '/health') return json(response, 200, { status: 'ok', service: 'freellm-router' });
+    if (request.method === 'GET' && request.url === '/v1/models') {
+      return json(response, 200, { object: 'list', data: [] });
+    }
+    if (request.method === 'POST' && request.url === '/v1/chat/completions') return forward(request, response);
+    return json(response, 404, { error: { message: 'Not found', type: 'not_found' } });
+  }
+
+  return {
+    getStatus: () => ({ ...status, blockedKeyIds: [...blocked.keys()] }),
+    async start() {
+      if (server) return this.getStatus();
+      const port = normalizePort(getConfig()?.port);
+      server = http.createServer((request, response) => { void handler(request, response); });
+      await new Promise((resolve, reject) => {
+        const onError = (error) => { server?.off('listening', onListening); reject(error); };
+        const onListening = () => { server?.off('error', onError); resolve(); };
+        server.once('error', onError);
+        server.once('listening', onListening);
+        server.listen(port, '127.0.0.1');
+      }).catch((error) => {
+        server = null;
+        status = { running: false, port: null, error: error.message, activeKeyId: '' };
+        throw error;
+      });
+      status = { running: true, port, error: '', activeKeyId: '' };
+      return this.getStatus();
+    },
+    async stop() {
+      if (!server) return this.getStatus();
+      const active = server;
+      server = null;
+      await new Promise((resolve) => active.close(resolve));
+      status = { running: false, port: null, error: '', activeKeyId: '' };
+      return this.getStatus();
+    }
+  };
+}
+
+module.exports = {
+  DEFAULT_PORT,
+  DEFAULT_THRESHOLD_PERCENT,
+  UPSTREAM_BASE_URL,
+  clampThreshold,
+  normalizeKeys,
+  normalizePort,
+  selectKey,
+  blockSelection,
+  proxyChatCompletion,
+  worstQuotaWindow,
+  createFreeLlmRouter
+};

--- a/tests/shared/credentialStore.test.js
+++ b/tests/shared/credentialStore.test.js
@@ -303,3 +303,14 @@ test('stores, migrates, and removes MiMo account cookies in the unified store', 
   assert.equal(store.readMimoCredential('account-1'), '');
   assert.equal(store.writeMimoCredential('__proto__', 'serviceToken=unsafe'), false);
 });
+
+test('stores FreeLLM routing API keys outside settings metadata', (t) => {
+  const store = new CredentialStore(tempDataDir(t));
+  assert.equal(store.writeFreeLlmRoutingKey('key-1', 'ollama-api-secret'), true);
+  assert.equal(store.readFreeLlmRoutingKey('key-1'), 'ollama-api-secret');
+  const document = store.readDocument();
+  assert.equal(document.credentials.providers.freellmRouting.keys['key-1'].apiKey, 'ollama-api-secret');
+  assert.equal(store.removeFreeLlmRoutingKey('key-1'), true);
+  assert.equal(store.readFreeLlmRoutingKey('key-1'), '');
+  assert.equal(store.writeFreeLlmRoutingKey('constructor', 'unsafe'), false);
+});

--- a/tests/shared/freellmRouter.test.js
+++ b/tests/shared/freellmRouter.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  proxyChatCompletion,
+  selectKey,
+  worstQuotaWindow
+} = require('../../src/shared/freellmRouter');
+
+function quota(accountId, usedPercent, status = 'ok') {
+  return {
+    accountId,
+    status,
+    windows: [{ kind: 'weekly', usedPercent, resetsAt: '2030-01-01T00:00:00.000Z' }]
+  };
+}
+
+test('selectKey uses the first enabled key whose monitored account has quota', () => {
+  const keys = [
+    { id: 'first', apiKey: 'one', ollamaAccountId: 'account-1', enabled: true },
+    { id: 'second', apiKey: 'two', ollamaAccountId: 'account-2', enabled: true }
+  ];
+  const selection = selectKey(keys, [quota('account-1', 98), quota('account-2', 24)], 97);
+  assert.equal(selection.key.id, 'second');
+});
+
+test('selectKey refuses keys without a current successful monitored quota', () => {
+  const key = { id: 'only', apiKey: 'one', ollamaAccountId: 'account-1', enabled: true };
+  assert.equal(selectKey([key], [], 97), null);
+  assert.equal(selectKey([key], [quota('account-1', 2, 'unavailable')], 97), null);
+});
+
+test('worstQuotaWindow selects the most-consumed monitored window', () => {
+  assert.deepEqual(worstQuotaWindow({ windows: [
+    { kind: 'session', usedPercent: 12 },
+    { kind: 'weekly', usedPercent: 82, resetsAt: '2030-01-01T00:00:00.000Z' }
+  ] }), { usedPercent: 82, resetsAt: '2030-01-01T00:00:00.000Z' });
+});
+
+test('router retries the next routing key after an upstream 429', async () => {
+  const calls = [];
+  const result = await proxyChatCompletion({
+    config: { thresholdPercent: 97, upstreamBaseUrl: 'https://upstream.example/v1' },
+    keys: [
+      { id: 'first', apiKey: 'one', ollamaAccountId: 'account-1', enabled: true },
+      { id: 'second', apiKey: 'two', ollamaAccountId: 'account-2', enabled: true }
+    ],
+    quotas: [quota('account-1', 5), quota('account-2', 5)],
+    fetchFn: async (_url, options) => {
+      calls.push(options.headers.authorization);
+      if (calls.length === 1) return new Response(JSON.stringify({ error: 'limited' }), { status: 429 });
+      return new Response(JSON.stringify({ id: 'chatcmpl_1' }), { status: 200, headers: { 'content-type': 'application/json' } });
+    },
+    body: JSON.stringify({ model: 'test', messages: [] })
+  });
+  assert.deepEqual(calls, ['Bearer one', 'Bearer two']);
+  assert.equal(result.selection.key.id, 'second');
+  assert.equal(result.response.status, 200);
+});


### PR DESCRIPTION
## Summary

Adds support for managing multiple Ollama accounts with per-account limit tracking, following the same managed-account pattern already used by Codex, OpenCode, MiMo, and OpenRouter.

### Changes

- **`src/shared/ollamaLimits.js`** — extends `fetchOllamaLimits` to fan out across an array of managed accounts and aggregate results; adds `normalizeOllamaManagedAccounts` and `createOllamaManagedAccount` helpers
- **`src/electron/main.js`** — adds account CRUD helpers (`addOllamaManagedAccount`, `removeOllamaManagedAccount`, `setOllamaManagedAccountEnabled`, `ollamaManagedAccountsForCollector`); env-cookie is injected as a read-only synthetic account so it is not silently dropped when GUI accounts also exist
- **`src/electron/preload.js`** — exposes account IPC bridge (`ollama.accounts`, `ollama.addAccount`, `ollama.removeAccount`, `ollama.setEnabled`)
- **`src/electron/renderer/app.js`** — adds the managed-account UI section (account list, add/remove/toggle, cookie upload)
- **`src/electron/renderer/index.html`** — replaces the single-cookie textarea with the managed-account panel
- **`src/shared/credentialStore.js`** — adds `writeOllamaCredential`, `readOllamaCredential`, `removeOllamaCredential` per-account storage methods
- **`tests/shared/credentialStore.test.js`** — adds coverage for the new credential methods

### Testing

`npm run verify` passes (lint + tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi-account support for Ollama with per-account limit tracking and a local OpenAI-compatible FreeLLM router that rotates keys using monitored quotas. Updates the UI, IPC, and credential storage to manage accounts and routing keys, and fixes the env-injected account being dropped.

- **New Features**
  - Managed Ollama accounts: add/remove/enable, per-account cookie storage, fan-out limit fetching with aggregation.
  - Env cookie is injected as a read-only synthetic account with a stable account key so it persists.
  - UI: managed-account panel replaces the single-cookie field; supports add/toggle/remove and cookie upload.
  - FreeLLM routing: local endpoint (127.0.0.1:19512) proxies `/v1/chat/completions`, auto-rotates Ollama API keys under a configurable quota threshold; IPC (`status`, `setEnabled`, `addKey`, `removeKey`, `setKeyEnabled`) and secure key storage added.
  - Added `freellmRouter` module and tests for routing selection; expanded credential store with per-account Ollama cookies and FreeLLM routing keys.

- **Bug Fixes**
  - Preserve the synthetic env Ollama account by deriving a real `accountKey` so it survives normalization.

<sup>Written for commit b59ba8e5f723ceb0f9e8745041925601abfdae2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

