### PR TITLE
fix(reasonix): bound native sidecar reads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,12 +26,6 @@ TOKEN_MONITOR_SYNC_UPLOAD_INTERVAL_MS=0
 # Example: claude,codex,hermes,opencode,openclaw,cursor,antigravity,cline,kimi,qwen,grok,copilot,pi,zed,kilocode,micode,zcode,kiro,codebuddy,workbuddy,proma,reasonix
 TOKEN_MONITOR_CLIENTS=claude,codex,hermes,opencode,openclaw,cursor,antigravity,cline,kimi,qwen,grok,copilot,pi,zed,kilocode,micode,zcode,kiro,codebuddy,workbuddy,proma,reasonix
 
-# Reasonix stats location. Optional; Reasonix itself resolves these as
-# REASONIX_STATE_HOME → REASONIX_HOME → the platform default. Token Monitor
-# watches the same resolved stats directory that Tokscale reads.
-REASONIX_STATE_HOME=
-REASONIX_HOME=
-
 # File-watch strategy — override how client data directories are watched.
 # Optional. The default is native filesystem events on every platform, in every
 # collection mode, and in the headless agent. If the OS refuses to hand out

--- a/src/shared/reasonixFileIo.js
+++ b/src/shared/reasonixFileIo.js
@@ -3,8 +3,12 @@
 const fs = require('node:fs');
 
 const REASONIX_META_MAX_BYTES = 1 << 20;
-const REASONIX_TELEMETRY_MAX_BYTES = 4 << 20;
+// This bounds only the telemetry projection Token Monitor materializes. The
+// complete Reasonix sidecar may be larger because its preceding ReadFiles array
+// grows with a long-lived session.
+const REASONIX_TELEMETRY_USAGE_MAX_BYTES = 4 << 20;
 const REASONIX_SIDECAR_READ_CHUNK_BYTES = 64 << 10;
+const REASONIX_TELEMETRY_TAIL_OVERHEAD_BYTES = 64 << 10;
 
 function objectValue(value) {
   return value && typeof value === 'object' && !Array.isArray(value) ? value : null;
@@ -43,8 +47,84 @@ function readBoundedJson(filePath, maxBytes, fsApi = fs) {
   }
 }
 
+function telemetryUsage(value) {
+  const object = objectValue(value);
+  return objectValue(object?.usage) || object;
+}
+
+function readFileWindow(fsApi, fileDescriptor, start, length) {
+  const buffer = Buffer.allocUnsafe(length);
+  let totalBytes = 0;
+  while (totalBytes < length) {
+    const bytesRead = fsApi.readSync(
+      fileDescriptor,
+      buffer,
+      totalBytes,
+      Math.min(REASONIX_SIDECAR_READ_CHUNK_BYTES, length - totalBytes),
+      start + totalBytes
+    );
+    if (bytesRead === 0) break;
+    totalBytes += bytesRead;
+  }
+  return buffer.subarray(0, totalBytes);
+}
+
+function trailingTelemetryUsage(text) {
+  let index = text.lastIndexOf('"usage"');
+  while (index >= 0) {
+    let previous = index - 1;
+    while (previous >= 0 && /\s/.test(text[previous])) previous -= 1;
+    if (previous >= 0 && (text[previous] === ',' || text[previous] === '{')) {
+      try {
+        // Reasonix's json.MarshalIndent output writes usage as the final
+        // top-level field. Rebuilding only that suffix avoids materializing the
+        // potentially huge ReadFiles value which precedes it.
+        const projected = objectValue(JSON.parse(`{${text.slice(index)}`));
+        const usage = objectValue(projected?.usage);
+        if (usage) return usage;
+      } catch (_) {}
+    }
+    index = text.lastIndexOf('"usage"', index - 1);
+  }
+  return null;
+}
+
+function readReasonixTelemetryUsage(filePath, fsApi = fs) {
+  if (!filePath) return null;
+  let fileDescriptor;
+  try {
+    const initialStat = fsApi.statSync(filePath);
+    if (!initialStat.isFile()) return null;
+    fileDescriptor = fsApi.openSync(filePath, 'r');
+    const openedStat = fsApi.fstatSync(fileDescriptor);
+    if (!openedStat.isFile() || !Number.isSafeInteger(openedStat.size) || openedStat.size < 0) return null;
+
+    if (openedStat.size <= REASONIX_TELEMETRY_USAGE_MAX_BYTES) {
+      const bytes = readFileWindow(fsApi, fileDescriptor, 0, openedStat.size);
+      if (bytes.length !== openedStat.size) return null;
+      return telemetryUsage(JSON.parse(bytes.toString('utf8')));
+    }
+
+    const windowBytes = Math.min(
+      openedStat.size,
+      REASONIX_TELEMETRY_USAGE_MAX_BYTES + REASONIX_TELEMETRY_TAIL_OVERHEAD_BYTES
+    );
+    const bytes = readFileWindow(fsApi, fileDescriptor, openedStat.size - windowBytes, windowBytes);
+    if (bytes.length !== windowBytes) return null;
+    return trailingTelemetryUsage(bytes.toString('utf8'));
+  } catch (_) {
+    return null;
+  } finally {
+    if (fileDescriptor !== undefined) {
+      try { fsApi.closeSync(fileDescriptor); } catch (_) {}
+    }
+  }
+}
+
 module.exports = {
   readBoundedJson,
+  readReasonixTelemetryUsage,
   REASONIX_META_MAX_BYTES,
-  REASONIX_TELEMETRY_MAX_BYTES
+  REASONIX_TELEMETRY_USAGE_MAX_BYTES,
+  REASONIX_TELEMETRY_TAIL_OVERHEAD_BYTES
 };

--- a/src/shared/reasonixFileIo.js
+++ b/src/shared/reasonixFileIo.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const fs = require('node:fs');
+
+const REASONIX_META_MAX_BYTES = 1 << 20;
+const REASONIX_TELEMETRY_MAX_BYTES = 4 << 20;
+const REASONIX_SIDECAR_READ_CHUNK_BYTES = 64 << 10;
+
+function objectValue(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : null;
+}
+
+function readBoundedJson(filePath, maxBytes, fsApi = fs) {
+  if (!filePath || !Number.isSafeInteger(maxBytes) || maxBytes <= 0) return null;
+  let fileDescriptor;
+  try {
+    // statSync follows symlinks; this validates the resolved target before the
+    // opened descriptor is checked again below.
+    const initialStat = fsApi.statSync(filePath);
+    if (!initialStat.isFile() || initialStat.size > maxBytes) return null;
+    fileDescriptor = fsApi.openSync(filePath, 'r');
+    const openedStat = fsApi.fstatSync(fileDescriptor);
+    if (!openedStat.isFile() || openedStat.size > maxBytes) return null;
+
+    const chunks = [];
+    const buffer = Buffer.allocUnsafe(Math.min(REASONIX_SIDECAR_READ_CHUNK_BYTES, maxBytes + 1));
+    let totalBytes = 0;
+    while (true) {
+      const bytesRead = fsApi.readSync(fileDescriptor, buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      totalBytes += bytesRead;
+      if (totalBytes > maxBytes) return null;
+      chunks.push(Buffer.from(buffer.subarray(0, bytesRead)));
+    }
+    const value = JSON.parse(Buffer.concat(chunks, totalBytes).toString('utf8'));
+    return objectValue(value);
+  } catch (_) {
+    return null;
+  } finally {
+    if (fileDescriptor !== undefined) {
+      try { fsApi.closeSync(fileDescriptor); } catch (_) {}
+    }
+  }
+}
+
+module.exports = {
+  readBoundedJson,
+  REASONIX_META_MAX_BYTES,
+  REASONIX_TELEMETRY_MAX_BYTES
+};

--- a/src/shared/reasonixSessionDetail.js
+++ b/src/shared/reasonixSessionDetail.js
@@ -10,6 +10,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { StringDecoder } = require('node:string_decoder');
 
+const { readBoundedJson, REASONIX_META_MAX_BYTES } = require('./reasonixFileIo');
 const { resolveReasonixHome } = require('./reasonixPaths');
 
 const SESSION_PREFIX = 'reasonix:';
@@ -830,15 +831,6 @@ function tokenDataAvailable(events) {
   return turns.length > 0 && turns.every((event) => event.tokensAvailable !== false);
 }
 
-function readJson(fsApi, filePath) {
-  try {
-    const value = JSON.parse(fsApi.readFileSync(filePath, 'utf8'));
-    return objectValue(value);
-  } catch (_) {
-    return null;
-  }
-}
-
 function isFile(fsApi, filePath) {
   try { return fsApi.statSync(filePath).isFile(); } catch (_) { return false; }
 }
@@ -892,7 +884,7 @@ function findSessionEventFile({ sessionId, home, options = {} } = {}) {
       .sort((left, right) => left.name.localeCompare(right.name) || left.priority - right.priority);
     for (const candidate of candidates) {
       const metaPath = pathApi.join(directory, candidate.name);
-      const meta = readJson(fsApi, metaPath);
+      const meta = readBoundedJson(metaPath, REASONIX_META_MAX_BYTES, fsApi);
       if (stableId(meta) !== id) continue;
       const eventsPath = pathApi.join(directory, `${candidate.stem}${EVENTS_SUFFIX}`);
       if (isFile(fsApi, eventsPath)) return eventsPath;

--- a/src/shared/reasonixSessions.js
+++ b/src/shared/reasonixSessions.js
@@ -25,6 +25,9 @@ const TELEMETRY_SUFFIX = '.jsonl.telemetry.json';
 const EVENTS_SUFFIX = '.events.jsonl';
 const NATIVE_SESSION_PREFIX = `${REASONIX_CLIENT}:`;
 const BRANCH_META_COUNTS_VERSION = 1;
+const REASONIX_META_MAX_BYTES = 1 << 20;
+const REASONIX_TELEMETRY_MAX_BYTES = 4 << 20;
+const REASONIX_SIDECAR_READ_CHUNK_BYTES = 64 << 10;
 
 function hasOwn(value, key) {
   return Object.prototype.hasOwnProperty.call(value || {}, key);
@@ -97,14 +100,34 @@ function firstTimestamp(source, keys) {
   return date && !Number.isNaN(date.getTime()) ? date.toISOString() : '';
 }
 
-function readJson(filePath) {
-  let text;
+function readBoundedJson(filePath, maxBytes, fsApi = fs) {
+  if (!filePath || !Number.isSafeInteger(maxBytes) || maxBytes <= 0) return null;
+  let fileDescriptor;
   try {
-    text = fs.readFileSync(filePath, 'utf8');
-    const value = JSON.parse(text);
+    const initialStat = fsApi.statSync(filePath);
+    if (!initialStat.isFile() || initialStat.size > maxBytes) return null;
+    fileDescriptor = fsApi.openSync(filePath, 'r');
+    const openedStat = fsApi.fstatSync(fileDescriptor);
+    if (!openedStat.isFile() || openedStat.size > maxBytes) return null;
+
+    const chunks = [];
+    const buffer = Buffer.allocUnsafe(Math.min(REASONIX_SIDECAR_READ_CHUNK_BYTES, maxBytes + 1));
+    let totalBytes = 0;
+    while (true) {
+      const bytesRead = fsApi.readSync(fileDescriptor, buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      totalBytes += bytesRead;
+      if (totalBytes > maxBytes) return null;
+      chunks.push(Buffer.from(buffer.subarray(0, bytesRead)));
+    }
+    const value = JSON.parse(Buffer.concat(chunks, totalBytes).toString('utf8'));
     return objectValue(value);
   } catch (_) {
     return null;
+  } finally {
+    if (fileDescriptor !== undefined) {
+      try { fsApi.closeSync(fileDescriptor); } catch (_) {}
+    }
   }
 }
 
@@ -318,7 +341,8 @@ function validWorkspaceRoot(value) {
 }
 
 function readReasonixNativeSession(metaPath, telemetryPath, options = {}) {
-  const meta = readJson(metaPath);
+  const fsApi = options.fsModule || fs;
+  const meta = readBoundedJson(metaPath, REASONIX_META_MAX_BYTES, fsApi);
   if (!meta) return null;
   const branchMeta = objectValue(firstValue(meta, ['BranchMeta', 'branchMeta', 'branch_meta', 'branch']));
   const id = textValue(firstValue(meta, ['id', 'ID']), 256)
@@ -331,7 +355,7 @@ function readReasonixNativeSession(metaPath, telemetryPath, options = {}) {
   // Desktop's official trusted cumulative session usage, not authoritative
   // per-turn usage. Without reliable per-turn usage/cost, Session Detail remains
   // closed.
-  const telemetry = readJson(telemetryPath);
+  const telemetry = readBoundedJson(telemetryPath, REASONIX_TELEMETRY_MAX_BYTES, fsApi);
   const usage = telemetryUsage(telemetry);
   const eventFilePresent = Boolean(fileSignature(options.eventPath));
   const transcript = readTranscriptInfo(options.eventPath, options.replayLimits);
@@ -659,6 +683,8 @@ function readReasonixNativeSessions(options = {}) {
 module.exports = {
   META_SUFFIX,
   NATIVE_SESSION_PREFIX,
+  REASONIX_META_MAX_BYTES,
+  REASONIX_TELEMETRY_MAX_BYTES,
   TELEMETRY_SUFFIX,
   EVENTS_SUFFIX,
   buildNativeView,

--- a/src/shared/reasonixSessions.js
+++ b/src/shared/reasonixSessions.js
@@ -14,8 +14,9 @@ const path = require('node:path');
 const { REASONIX_CLIENT, resolveReasonixHome } = require('./reasonixPaths');
 const {
   readBoundedJson,
+  readReasonixTelemetryUsage,
   REASONIX_META_MAX_BYTES,
-  REASONIX_TELEMETRY_MAX_BYTES
+  REASONIX_TELEMETRY_USAGE_MAX_BYTES
 } = require('./reasonixFileIo');
 const { canonicalProjectKey, deterministicProjectLabel } = require('./projectKey');
 const { normalizeModelNameForClient } = require('./usage');
@@ -247,12 +248,6 @@ function sessionTitle(meta, { trustedPreview = '' } = {}) {
     || 'Reasonix Session';
 }
 
-function telemetryUsage(telemetry) {
-  const usage = objectValue(telemetry?.usage) || telemetry;
-  if (!usage || !hasFiniteNumber(firstValue(usage, ['totalTokens', 'total_tokens']))) return null;
-  return usage;
-}
-
 function reportedCostUsd(usage) {
   const explicitUsd = firstValue(usage, ['sessionCostUsd', 'session_cost_usd']);
   if (hasFiniteNumber(explicitUsd)) return Math.max(0, finiteNumber(explicitUsd));
@@ -326,8 +321,10 @@ function readReasonixNativeSession(metaPath, telemetryPath, options = {}) {
   // Desktop's official trusted cumulative session usage, not authoritative
   // per-turn usage. Without reliable per-turn usage/cost, Session Detail remains
   // closed.
-  const telemetry = readBoundedJson(telemetryPath, REASONIX_TELEMETRY_MAX_BYTES, fsApi);
-  const usage = telemetryUsage(telemetry);
+  const telemetryUsage = readReasonixTelemetryUsage(telemetryPath, fsApi);
+  const usage = telemetryUsage && hasFiniteNumber(firstValue(telemetryUsage, ['totalTokens', 'total_tokens']))
+    ? telemetryUsage
+    : null;
   const eventFilePresent = Boolean(fileSignature(options.eventPath));
   const transcript = readTranscriptInfo(options.eventPath, options.replayLimits);
   if (eventFilePresent && !transcript) return null;
@@ -655,7 +652,7 @@ module.exports = {
   META_SUFFIX,
   NATIVE_SESSION_PREFIX,
   REASONIX_META_MAX_BYTES,
-  REASONIX_TELEMETRY_MAX_BYTES,
+  REASONIX_TELEMETRY_USAGE_MAX_BYTES,
   TELEMETRY_SUFFIX,
   EVENTS_SUFFIX,
   buildNativeView,

--- a/src/shared/reasonixSessions.js
+++ b/src/shared/reasonixSessions.js
@@ -12,6 +12,11 @@ const os = require('node:os');
 const path = require('node:path');
 
 const { REASONIX_CLIENT, resolveReasonixHome } = require('./reasonixPaths');
+const {
+  readBoundedJson,
+  REASONIX_META_MAX_BYTES,
+  REASONIX_TELEMETRY_MAX_BYTES
+} = require('./reasonixFileIo');
 const { canonicalProjectKey, deterministicProjectLabel } = require('./projectKey');
 const { normalizeModelNameForClient } = require('./usage');
 const {
@@ -25,9 +30,6 @@ const TELEMETRY_SUFFIX = '.jsonl.telemetry.json';
 const EVENTS_SUFFIX = '.events.jsonl';
 const NATIVE_SESSION_PREFIX = `${REASONIX_CLIENT}:`;
 const BRANCH_META_COUNTS_VERSION = 1;
-const REASONIX_META_MAX_BYTES = 1 << 20;
-const REASONIX_TELEMETRY_MAX_BYTES = 4 << 20;
-const REASONIX_SIDECAR_READ_CHUNK_BYTES = 64 << 10;
 
 function hasOwn(value, key) {
   return Object.prototype.hasOwnProperty.call(value || {}, key);
@@ -98,37 +100,6 @@ function firstTimestamp(source, keys) {
     date = /^[-+]?\d+$/.test(text) ? new Date(Number(text)) : new Date(text);
   }
   return date && !Number.isNaN(date.getTime()) ? date.toISOString() : '';
-}
-
-function readBoundedJson(filePath, maxBytes, fsApi = fs) {
-  if (!filePath || !Number.isSafeInteger(maxBytes) || maxBytes <= 0) return null;
-  let fileDescriptor;
-  try {
-    const initialStat = fsApi.statSync(filePath);
-    if (!initialStat.isFile() || initialStat.size > maxBytes) return null;
-    fileDescriptor = fsApi.openSync(filePath, 'r');
-    const openedStat = fsApi.fstatSync(fileDescriptor);
-    if (!openedStat.isFile() || openedStat.size > maxBytes) return null;
-
-    const chunks = [];
-    const buffer = Buffer.allocUnsafe(Math.min(REASONIX_SIDECAR_READ_CHUNK_BYTES, maxBytes + 1));
-    let totalBytes = 0;
-    while (true) {
-      const bytesRead = fsApi.readSync(fileDescriptor, buffer, 0, buffer.length, null);
-      if (bytesRead === 0) break;
-      totalBytes += bytesRead;
-      if (totalBytes > maxBytes) return null;
-      chunks.push(Buffer.from(buffer.subarray(0, bytesRead)));
-    }
-    const value = JSON.parse(Buffer.concat(chunks, totalBytes).toString('utf8'));
-    return objectValue(value);
-  } catch (_) {
-    return null;
-  } finally {
-    if (fileDescriptor !== undefined) {
-      try { fsApi.closeSync(fileDescriptor); } catch (_) {}
-    }
-  }
 }
 
 function dirExists(dir) {

--- a/tests/shared/reasonixSessionDetail.test.js
+++ b/tests/shared/reasonixSessionDetail.test.js
@@ -7,6 +7,7 @@ const path = require('node:path');
 const test = require('node:test');
 
 const { readSessionDetail } = require('../../src/shared/sessionDetail');
+const { REASONIX_META_MAX_BYTES } = require('../../src/shared/reasonixFileIo');
 const {
   countReasonixProviderMessages,
   parseReasonixEventLog,
@@ -19,6 +20,12 @@ const {
 function writeJson(filePath, value) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, JSON.stringify(value));
+}
+
+function paddedJson(value, size) {
+  const json = Buffer.from(JSON.stringify(value));
+  assert.ok(json.length <= size);
+  return Buffer.concat([json, Buffer.alloc(size - json.length, 0x20)]);
 }
 
 function writeSidecarSession(stateHome, directoryName, stem, meta, lines) {
@@ -461,4 +468,21 @@ test('Reasonix detail skips missing or corrupt identity/transcript files', () =>
   assert.equal(readReasonix(root, stateHome, 'reasonix:missing-id').found, false);
   assert.equal(readReasonix(root, stateHome, 'reasonix:corrupt').found, false);
   assert.equal(readReasonix(root, stateHome, 'reasonix:no-events').found, false);
+});
+
+test('Reasonix detail bounds metadata lookup before opening the event log', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'reasonix-detail-meta-bound-'));
+  const stateHome = path.join(root, 'state');
+  const sessions = path.join(stateHome, 'sessions');
+  fs.mkdirSync(sessions, { recursive: true });
+  fs.writeFileSync(
+    path.join(sessions, 'oversized.jsonl.meta'),
+    paddedJson({ id: 'oversized' }, REASONIX_META_MAX_BYTES + 1)
+  );
+  fs.writeFileSync(
+    path.join(sessions, 'oversized.events.jsonl'),
+    `${JSON.stringify({ type: 'user.message', text: 'must not be reached' })}\n`
+  );
+
+  assert.equal(readReasonix(root, stateHome, 'reasonix:oversized').found, false);
 });

--- a/tests/shared/reasonixSessions.test.js
+++ b/tests/shared/reasonixSessions.test.js
@@ -12,9 +12,13 @@ const {
   isReasonixNativeSessionSidecar,
   readReasonixNativeSession,
   REASONIX_META_MAX_BYTES,
-  REASONIX_TELEMETRY_MAX_BYTES,
+  REASONIX_TELEMETRY_USAGE_MAX_BYTES,
   reasonixNativeSessionWatchRoots
 } = require('../../src/shared/reasonixSessions');
+const {
+  readReasonixTelemetryUsage,
+  REASONIX_TELEMETRY_TAIL_OVERHEAD_BYTES
+} = require('../../src/shared/reasonixFileIo');
 const { collectUsageOnce, projectIdentity, watchIgnoreMatcher, watchPathsForClients } = require('../../src/shared/collector');
 const { syncPayload } = require('../../src/shared/syncPayload');
 const { createDeviceState } = require('../../src/shared/deviceState');
@@ -889,9 +893,9 @@ test('readReasonixNativeSession skips missing stable ID and missing/corrupt tele
   assert.equal(readReasonixNativeSession(metaPath, telemetryPath), null);
 });
 
-test('readReasonixNativeSession bounds metadata and telemetry to regular files', () => {
+test('readReasonixNativeSession bounds metadata and projected telemetry usage to regular files', () => {
   assert.equal(REASONIX_META_MAX_BYTES, 1 * 1024 * 1024);
-  assert.equal(REASONIX_TELEMETRY_MAX_BYTES, 4 * 1024 * 1024);
+  assert.equal(REASONIX_TELEMETRY_USAGE_MAX_BYTES, 4 * 1024 * 1024);
 
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'reasonix-native-sidecar-bounds-'));
   const metaPath = path.join(root, 'session.jsonl.meta');
@@ -906,7 +910,7 @@ test('readReasonixNativeSession bounds metadata and telemetry to regular files',
   writeJson(metaPath, { id: 'bounded' });
   fs.writeFileSync(
     telemetryPath,
-    paddedJson(nativeTelemetry(), REASONIX_TELEMETRY_MAX_BYTES + 1)
+    paddedJson(nativeTelemetry(), REASONIX_TELEMETRY_USAGE_MAX_BYTES + 1)
   );
   assert.equal(readReasonixNativeSession(metaPath, telemetryPath), null);
 
@@ -943,4 +947,46 @@ test('readReasonixNativeSession bounds metadata and telemetry to regular files',
   assert.ok(totalReadBytes < growingContent.length);
   assert.ok(readCalls < Math.ceil(growingContent.length / (64 * 1024)));
   assert.equal(closed, true);
+});
+
+test('readReasonixNativeSession projects usage without reading oversized official ReadFiles', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'reasonix-large-official-telemetry-'));
+  const metaPath = path.join(root, 'session.jsonl.meta');
+  const telemetryPath = path.join(root, 'session.jsonl.telemetry.json');
+  writeJson(metaPath, { id: 'large-official' });
+  const telemetry = JSON.stringify({
+    version: 3,
+    readFiles: [{
+      path: 'x'.repeat(
+        REASONIX_TELEMETRY_USAGE_MAX_BYTES + REASONIX_TELEMETRY_TAIL_OVERHEAD_BYTES + 1024
+      ),
+      turn: 1,
+      time: 1
+    }],
+    usage: nativeTelemetry({ totalTokens: 987654 })
+  }, null, 2);
+  assert.ok(Buffer.byteLength(telemetry) > REASONIX_TELEMETRY_USAGE_MAX_BYTES);
+  fs.writeFileSync(telemetryPath, telemetry);
+
+  let totalReadBytes = 0;
+  const measuringFs = {
+    statSync: fs.statSync,
+    openSync: fs.openSync,
+    fstatSync: fs.fstatSync,
+    readSync: (...args) => {
+      const bytesRead = fs.readSync(...args);
+      totalReadBytes += bytesRead;
+      return bytesRead;
+    },
+    closeSync: fs.closeSync
+  };
+  const projected = readReasonixTelemetryUsage(telemetryPath, measuringFs);
+  assert.equal(projected.totalTokens, 987654);
+  assert.ok(totalReadBytes <= REASONIX_TELEMETRY_USAGE_MAX_BYTES + REASONIX_TELEMETRY_TAIL_OVERHEAD_BYTES);
+  assert.ok(totalReadBytes < Buffer.byteLength(telemetry));
+
+  const session = readReasonixNativeSession(metaPath, telemetryPath);
+  assert.notEqual(session, null);
+  assert.equal(session.totalTokens, 987654);
+  assert.equal(session.requestCount, 7);
 });

--- a/tests/shared/reasonixSessions.test.js
+++ b/tests/shared/reasonixSessions.test.js
@@ -11,6 +11,8 @@ const {
   isReasonixNativeSessionPath,
   isReasonixNativeSessionSidecar,
   readReasonixNativeSession,
+  REASONIX_META_MAX_BYTES,
+  REASONIX_TELEMETRY_MAX_BYTES,
   reasonixNativeSessionWatchRoots
 } = require('../../src/shared/reasonixSessions');
 const { collectUsageOnce, projectIdentity, watchIgnoreMatcher, watchPathsForClients } = require('../../src/shared/collector');
@@ -879,4 +881,49 @@ test('readReasonixNativeSession skips missing stable ID and missing/corrupt tele
   assert.equal(readReasonixNativeSession(metaPath, path.join(root, 'missing')), null);
   fs.writeFileSync(telemetryPath, '{bad');
   assert.equal(readReasonixNativeSession(metaPath, telemetryPath), null);
+});
+
+test('readReasonixNativeSession bounds metadata and telemetry to regular files', () => {
+  assert.equal(REASONIX_META_MAX_BYTES, 1 * 1024 * 1024);
+  assert.equal(REASONIX_TELEMETRY_MAX_BYTES, 4 * 1024 * 1024);
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'reasonix-native-sidecar-bounds-'));
+  const metaPath = path.join(root, 'session.jsonl.meta');
+  const telemetryPath = path.join(root, 'session.jsonl.telemetry.json');
+  writeJson(metaPath, { id: 'bounded' });
+  writeJson(telemetryPath, nativeTelemetry());
+  assert.notEqual(readReasonixNativeSession(metaPath, telemetryPath), null);
+
+  fs.writeFileSync(metaPath, Buffer.alloc(REASONIX_META_MAX_BYTES + 1, 0x20));
+  assert.equal(readReasonixNativeSession(metaPath, telemetryPath), null);
+
+  writeJson(metaPath, { id: 'bounded' });
+  fs.writeFileSync(telemetryPath, Buffer.alloc(REASONIX_TELEMETRY_MAX_BYTES + 1, 0x20));
+  assert.equal(readReasonixNativeSession(metaPath, telemetryPath), null);
+
+  const metaDirectory = path.join(root, 'meta-directory');
+  const telemetryDirectory = path.join(root, 'telemetry-directory');
+  fs.mkdirSync(metaDirectory);
+  fs.mkdirSync(telemetryDirectory);
+  writeJson(telemetryPath, nativeTelemetry());
+  assert.equal(readReasonixNativeSession(metaDirectory, telemetryPath), null);
+  writeJson(metaPath, { id: 'bounded' });
+  assert.equal(readReasonixNativeSession(metaPath, telemetryDirectory), null);
+
+  let growingBytes = REASONIX_META_MAX_BYTES + 1;
+  let closed = false;
+  const growingFs = {
+    statSync: () => ({ isFile: () => true, size: 2 }),
+    openSync: () => 1,
+    fstatSync: () => ({ isFile: () => true, size: 2 }),
+    readSync: (_descriptor, buffer, offset, length) => {
+      const bytesRead = Math.min(length, growingBytes);
+      if (bytesRead > 0) buffer.fill(0x20, offset, offset + bytesRead);
+      growingBytes -= bytesRead;
+      return bytesRead;
+    },
+    closeSync: () => { closed = true; }
+  };
+  assert.equal(readReasonixNativeSession('growing.json', 'unused.json', { fsModule: growingFs }), null);
+  assert.equal(closed, true);
 });

--- a/tests/shared/reasonixSessions.test.js
+++ b/tests/shared/reasonixSessions.test.js
@@ -28,6 +28,12 @@ function writeJson(filePath, value) {
   fs.writeFileSync(filePath, JSON.stringify(value));
 }
 
+function paddedJson(value, size) {
+  const json = Buffer.from(JSON.stringify(value));
+  assert.ok(json.length <= size);
+  return Buffer.concat([json, Buffer.alloc(size - json.length, 0x20)]);
+}
+
 function sidecars(directory, id, meta, telemetry) {
   const metaPath = path.join(directory, `${id}.jsonl.meta`);
   const telemetryPath = path.join(directory, `${id}.jsonl.telemetry.json`);
@@ -894,11 +900,14 @@ test('readReasonixNativeSession bounds metadata and telemetry to regular files',
   writeJson(telemetryPath, nativeTelemetry());
   assert.notEqual(readReasonixNativeSession(metaPath, telemetryPath), null);
 
-  fs.writeFileSync(metaPath, Buffer.alloc(REASONIX_META_MAX_BYTES + 1, 0x20));
+  fs.writeFileSync(metaPath, paddedJson({ id: 'oversized-meta' }, REASONIX_META_MAX_BYTES + 1));
   assert.equal(readReasonixNativeSession(metaPath, telemetryPath), null);
 
   writeJson(metaPath, { id: 'bounded' });
-  fs.writeFileSync(telemetryPath, Buffer.alloc(REASONIX_TELEMETRY_MAX_BYTES + 1, 0x20));
+  fs.writeFileSync(
+    telemetryPath,
+    paddedJson(nativeTelemetry(), REASONIX_TELEMETRY_MAX_BYTES + 1)
+  );
   assert.equal(readReasonixNativeSession(metaPath, telemetryPath), null);
 
   const metaDirectory = path.join(root, 'meta-directory');
@@ -910,20 +919,28 @@ test('readReasonixNativeSession bounds metadata and telemetry to regular files',
   writeJson(metaPath, { id: 'bounded' });
   assert.equal(readReasonixNativeSession(metaPath, telemetryDirectory), null);
 
-  let growingBytes = REASONIX_META_MAX_BYTES + 1;
+  const growingContent = paddedJson({ id: 'grew-after-fstat' }, REASONIX_META_MAX_BYTES * 2);
+  let readOffset = 0;
+  let totalReadBytes = 0;
+  let readCalls = 0;
   let closed = false;
   const growingFs = {
     statSync: () => ({ isFile: () => true, size: 2 }),
     openSync: () => 1,
     fstatSync: () => ({ isFile: () => true, size: 2 }),
     readSync: (_descriptor, buffer, offset, length) => {
-      const bytesRead = Math.min(length, growingBytes);
-      if (bytesRead > 0) buffer.fill(0x20, offset, offset + bytesRead);
-      growingBytes -= bytesRead;
+      readCalls += 1;
+      const bytesRead = Math.min(length, growingContent.length - readOffset);
+      if (bytesRead > 0) growingContent.copy(buffer, offset, readOffset, readOffset + bytesRead);
+      readOffset += bytesRead;
+      totalReadBytes += bytesRead;
       return bytesRead;
     },
     closeSync: () => { closed = true; }
   };
   assert.equal(readReasonixNativeSession('growing.json', 'unused.json', { fsModule: growingFs }), null);
+  assert.ok(totalReadBytes > REASONIX_META_MAX_BYTES);
+  assert.ok(totalReadBytes < growingContent.length);
+  assert.ok(readCalls < Math.ceil(growingContent.length / (64 * 1024)));
   assert.equal(closed, true);
 });


### PR DESCRIPTION
## Summary

- Replace unbounded synchronous reads of Reasonix `.jsonl.meta` and `.jsonl.telemetry.json` sidecars with a bounded chunked reader.
- Limit BranchMeta files to 1 MiB and telemetry files to 4 MiB.
- Verify both the path and opened descriptor are regular files, and enforce the byte budget throughout the read so post-`stat` growth also fails closed.
- Add regression coverage for oversized metadata, oversized telemetry, non-file paths, and files that grow after `fstat`.

## Why

PR #365 added bounded replay for potentially large `.events.jsonl` logs, but the smaller native metadata sidecars were still read with an unbounded `readFileSync()` during automatic reconciliation.

BranchMeta contains fixed session listing and recovery fields, while telemetry may additionally contain `ReadFiles`, so telemetry receives a wider budget. Oversized, malformed, or unexpected sidecars are now skipped without affecting Tokscale aggregate usage or the existing local-only Session and Project boundary.

## Testing

- `node --test tests/shared/reasonixSessions.test.js`
- `npm run verify`
- `npm run sync:worker` with no generated drift

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound Reasonix native sidecar reads to prevent unbounded `readFileSync` and keep usage reporting for long sessions. Telemetry now reads only the trailing `usage` projection when snapshots are large.

- **Bug Fixes**
  - Added `readBoundedJson` for `.jsonl.meta` (1 MiB, 64 KiB chunks) and `readReasonixTelemetryUsage` to read full telemetry up to 4 MiB or a bounded tail window for `usage`.
  - Validates both path and opened descriptor are regular files; enforces byte limits and closes descriptors to fail closed on post-`stat` growth.
  - Added tests for oversized meta, large telemetry preserving usage, non-file paths, corrupted telemetry, growth after `fstat`, and bounded metadata lookup before opening the event log; exported `REASONIX_META_MAX_BYTES`, `REASONIX_TELEMETRY_USAGE_MAX_BYTES`, and `REASONIX_TELEMETRY_TAIL_OVERHEAD_BYTES`.

- **Refactors**
  - Removed redundant `REASONIX_STATE_HOME` and `REASONIX_HOME` from `.env.example`.

<sup>Written for commit 26438ca9203a55ea4fb08f8b31fdb643f4225612. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

