### PR TITLE
perf(renderer): suspend hidden and inactive rendering

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -2486,13 +2486,13 @@ function nativeBlurEnabled(source = settings) {
 
 function applyNativeMaterial(source = settings) {
   const enabled = nativeBlurEnabled(source);
-  if (mainWindow && !mainWindow.isDestroyed()) {
+  if (mainWindow && !mainWindow.isDestroyed() && mainWindowNativeBlurEnabled !== enabled) {
     mainWindowNativeBlurEnabled = enabled;
     syncNativeMaterialVisibility(mainWindow, enabled);
   }
-  // The Dashboard has its own lifecycle. This also runs on every floating-bubble
-  // collapse/expand, which says nothing about the Dashboard, so re-applying an
-  // unchanged material there would rebuild its native effect view for nothing.
+  // This also runs for every appearance slider preview and floating-bubble
+  // transition, so re-applying an unchanged material would rebuild its native
+  // effect view for nothing.
   if (dashboardWindow && !dashboardWindow.isDestroyed() && dashboardWindowNativeBlurEnabled !== enabled) {
     dashboardWindowNativeBlurEnabled = enabled;
     syncNativeMaterialVisibility(dashboardWindow, enabled);
@@ -5834,7 +5834,7 @@ function createWindow(boundsOverride, options = {}) {
     // it macOS falls back to followWindow and the glass greys out on blur. The
     // vibrancy here is immediately re-evaluated by applyNativeMaterial() below, so
     // a window that is not on screen still ends up with no material attached.
-    ...(process.platform === 'darwin' && glass ? { vibrancy: 'hud', visualEffectState: 'active' } : {}),
+    ...(process.platform === 'darwin' ? { vibrancy: 'hud', visualEffectState: 'active' } : {}),
     ...(process.platform === 'win32' && glass && !windowsAccent ? { backgroundMaterial: 'acrylic' } : {}),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
@@ -5843,6 +5843,7 @@ function createWindow(boundsOverride, options = {}) {
     }
   });
   mainWindow = win;
+  mainWindowNativeBlurEnabled = null;
   mainWindowChrome = { collapsedFloatingBubble };
   applyMacSpaceBehavior();
   applyWindowsChrome(win, { round: true });
@@ -5998,7 +5999,7 @@ function createDashboardWindow() {
     backgroundColor: '#00000000',
     ...appWindowIcon(),
     skipTaskbar: false,
-    ...(process.platform === 'darwin' && glass ? { vibrancy: 'hud', visualEffectState: 'active' } : {}),
+    ...(process.platform === 'darwin' ? { vibrancy: 'hud', visualEffectState: 'active' } : {}),
     ...(process.platform === 'win32' && glass ? { backgroundMaterial: 'acrylic' } : {}),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -1810,6 +1810,11 @@ function sendFloatingBubbleState() {
   try { mainWindow.webContents.send('floatingBubble:state', floatingBubblePayload()); } catch (_) {}
 }
 
+function sendMainWindowVisibility(win = mainWindow) {
+  if (!win || win !== mainWindow || win.isDestroyed() || win.webContents.isDestroyed()) return;
+  win.webContents.send('window:visibility', win.isVisible() && !win.isMinimized());
+}
+
 function stopFloatingBubbleAutoCollapseTimer() {
   if (floatingBubbleAutoCollapseTimer) clearTimeout(floatingBubbleAutoCollapseTimer);
   floatingBubbleAutoCollapseTimer = null;
@@ -5901,7 +5906,14 @@ function createWindow(boundsOverride, options = {}) {
     }
   });
   win.webContents.on('before-input-event', handleZoomShortcut);
-  win.webContents.once('did-finish-load', sendFloatingBubbleState);
+  win.on('show', () => sendMainWindowVisibility(win));
+  win.on('hide', () => sendMainWindowVisibility(win));
+  win.on('minimize', () => sendMainWindowVisibility(win));
+  win.on('restore', () => sendMainWindowVisibility(win));
+  win.webContents.once('did-finish-load', () => {
+    sendFloatingBubbleState();
+    sendMainWindowVisibility(win);
+  });
   loadWindowFile(win, {
     waitForContent: options.waitForContent === true,
     inactive: options.inactive === true,
@@ -5913,6 +5925,7 @@ function createWindow(boundsOverride, options = {}) {
         suppressInitialNumberAnimation: options.suppressInitialNumberAnimation === true,
         viewState: rendererViewState
       }),
+      ...(settings?.trayMode ? { windowHidden: '1' } : {}),
       ...(settings?.systemGlass === false ? { systemGlassDisabled: '1' } : {}),
       ...(windowsAccentFallback ? { windowsBackdropFallback: '1' } : {})
     }

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -324,6 +324,10 @@ const {
   normalizeWindowsBackdropMode
 } = require('./windowsBackdropMode');
 const { applyWindowsAccentBlur } = require('./windowsBackdrop');
+const {
+  attachNativeMaterialVisibility,
+  syncNativeMaterialVisibility
+} = require('./nativeMaterialVisibility');
 
 if (!app.isPackaged) loadDotEnv();
 
@@ -380,7 +384,9 @@ const DEFAULT_HOME_MODULE_LIST = ['limits', 'tool', 'device', 'model', 'trends']
 const TRAY_OPEN_VIEW_IDS = new Set(['home', 'project', 'session', 'limits', 'trends', 'status']);
 
 let mainWindow = null;
+let mainWindowNativeBlurEnabled = false;
 let dashboardWindow = null;
+let dashboardWindowNativeBlurEnabled = false;
 let settingsPath = null;
 let settings = null;
 let claudeWebCookieMutationRevision = 0;
@@ -2475,20 +2481,22 @@ function nativeBlurEnabled(source = settings) {
 
 function keepNativeBlurActive() {
   if (!mainWindow) return;
-  if (!nativeBlurEnabled()) return;
+  if (!mainWindowNativeBlurEnabled) return;
+  if (!mainWindow.isVisible() || mainWindow.isMinimized()) return;
   if (process.platform === 'darwin' && typeof mainWindow.setVisualEffectState === 'function') {
     mainWindow.setVisualEffectState('active');
   }
 }
 
 function applyNativeMaterial(source = settings) {
-  if (!mainWindow) return;
   const enabled = nativeBlurEnabled(source);
-  if (process.platform === 'darwin' && typeof mainWindow.setVibrancy === 'function') {
-    mainWindow.setVibrancy(enabled ? 'hud' : null);
-    if (typeof mainWindow.setVisualEffectState === 'function') {
-      mainWindow.setVisualEffectState(enabled ? 'active' : 'inactive');
-    }
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindowNativeBlurEnabled = enabled;
+    syncNativeMaterialVisibility(mainWindow, enabled);
+  }
+  if (dashboardWindow && !dashboardWindow.isDestroyed()) {
+    dashboardWindowNativeBlurEnabled = enabled;
+    syncNativeMaterialVisibility(dashboardWindow, enabled);
   }
   // Windows: backgroundMaterial is locked in at window creation. setBackgroundMaterial('none')
   // does not restore layered-window transparency once DWM SystemBackdrop has been engaged,
@@ -5821,7 +5829,6 @@ function createWindow(boundsOverride, options = {}) {
     // Keeps a popover unmaximizable across rebuilds, which never re-run enterTrayMode().
     ...(settings?.trayMode ? { maximizable: false } : {}),
     ...floatingBubbleWindowChrome(process.platform, collapsedFloatingBubble),
-    ...(process.platform === 'darwin' && glass ? { vibrancy: 'hud', visualEffectState: 'active' } : {}),
     ...(process.platform === 'win32' && glass && !windowsAccent ? { backgroundMaterial: 'acrylic' } : {}),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
@@ -5867,6 +5874,7 @@ function createWindow(boundsOverride, options = {}) {
     if (isAllowedExternalUrl(url)) shell.openExternal(url);
   });
   applyWindowSettings();
+  attachNativeMaterialVisibility(win, () => mainWindowNativeBlurEnabled);
   applyNativeMaterial();
   keepNativeBlurActive();
   win.on('focus', () => {
@@ -5972,7 +5980,6 @@ function createDashboardWindow() {
     backgroundColor: '#00000000',
     ...appWindowIcon(),
     skipTaskbar: false,
-    ...(process.platform === 'darwin' && glass ? { vibrancy: 'hud', visualEffectState: 'active' } : {}),
     ...(process.platform === 'win32' && glass ? { backgroundMaterial: 'acrylic' } : {}),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
@@ -5981,7 +5988,10 @@ function createDashboardWindow() {
     }
   });
   dashboardWindow = win;
+  dashboardWindowNativeBlurEnabled = glass;
   applyWindowsChrome(win, { round: true });
+  attachNativeMaterialVisibility(win, () => dashboardWindowNativeBlurEnabled);
+  syncNativeMaterialVisibility(win, dashboardWindowNativeBlurEnabled);
   win.webContents.setWindowOpenHandler(({ url }) => {
     if (isAllowedExternalUrl(url)) shell.openExternal(url);
     return { action: 'deny' };
@@ -6003,7 +6013,10 @@ function createDashboardWindow() {
   win.on('unresponsive', () => {
     if (!win.isVisible()) discardFailedDashboardWindow(win, 'renderer became unresponsive while opening');
   });
-  win.on('closed', () => { dashboardWindow = null; });
+  win.on('closed', () => {
+    dashboardWindow = null;
+    dashboardWindowNativeBlurEnabled = false;
+  });
   win.loadFile(path.join(__dirname, 'renderer', 'dashboard.html'))
     .catch((error) => discardFailedDashboardWindow(win, `load failed: ${error.message}`));
   return win;

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -2484,22 +2484,16 @@ function nativeBlurEnabled(source = settings) {
   return floatingBubbleNativeGlassEnabled(source);
 }
 
-function keepNativeBlurActive() {
-  if (!mainWindow) return;
-  if (!mainWindowNativeBlurEnabled) return;
-  if (!mainWindow.isVisible() || mainWindow.isMinimized()) return;
-  if (process.platform === 'darwin' && typeof mainWindow.setVisualEffectState === 'function') {
-    mainWindow.setVisualEffectState('active');
-  }
-}
-
 function applyNativeMaterial(source = settings) {
   const enabled = nativeBlurEnabled(source);
   if (mainWindow && !mainWindow.isDestroyed()) {
     mainWindowNativeBlurEnabled = enabled;
     syncNativeMaterialVisibility(mainWindow, enabled);
   }
-  if (dashboardWindow && !dashboardWindow.isDestroyed()) {
+  // The Dashboard has its own lifecycle. This also runs on every floating-bubble
+  // collapse/expand, which says nothing about the Dashboard, so re-applying an
+  // unchanged material there would rebuild its native effect view for nothing.
+  if (dashboardWindow && !dashboardWindow.isDestroyed() && dashboardWindowNativeBlurEnabled !== enabled) {
     dashboardWindowNativeBlurEnabled = enabled;
     syncNativeMaterialVisibility(dashboardWindow, enabled);
   }
@@ -5834,6 +5828,13 @@ function createWindow(boundsOverride, options = {}) {
     // Keeps a popover unmaximizable across rebuilds, which never re-run enterTrayMode().
     ...(settings?.trayMode ? { maximizable: false } : {}),
     ...floatingBubbleWindowChrome(process.platform, collapsedFloatingBubble),
+    // visualEffectState is construction-time only — Electron exposes no setter for
+    // it (verified: BrowserWindow has setVibrancy but no setVisualEffectState), and
+    // it is what keeps the material vibrant while the window is not key. Without
+    // it macOS falls back to followWindow and the glass greys out on blur. The
+    // vibrancy here is immediately re-evaluated by applyNativeMaterial() below, so
+    // a window that is not on screen still ends up with no material attached.
+    ...(process.platform === 'darwin' && glass ? { vibrancy: 'hud', visualEffectState: 'active' } : {}),
     ...(process.platform === 'win32' && glass && !windowsAccent ? { backgroundMaterial: 'acrylic' } : {}),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
@@ -5881,13 +5882,10 @@ function createWindow(boundsOverride, options = {}) {
   applyWindowSettings();
   attachNativeMaterialVisibility(win, () => mainWindowNativeBlurEnabled);
   applyNativeMaterial();
-  keepNativeBlurActive();
   win.on('focus', () => {
     stopFloatingBubbleAutoCollapseTimer();
-    keepNativeBlurActive();
   });
   win.on('blur', () => {
-    keepNativeBlurActive();
     if (settings?.trayMode && !suppressNextBlurHide && !quitRequested) hidePopover();
     else if (!quitRequested) scheduleFloatingBubbleAutoCollapse();
   });
@@ -5912,7 +5910,14 @@ function createWindow(boundsOverride, options = {}) {
   win.on('restore', () => sendMainWindowVisibility(win));
   win.webContents.once('did-finish-load', () => {
     sendFloatingBubbleState();
-    sendMainWindowVisibility(win);
+    // Only report a window that is already on screen. A window still awaiting its
+    // reveal reports isVisible() === false, and loadWindowFile({ waitForContent })
+    // reveals it *because* the renderer painted real content — pushing "hidden"
+    // here stops that render, so the reveal could only come from the 2.5s
+    // fallback. Electron reports visibilityState 'visible' for a show:false
+    // window, which is the default the renderer keeps; trayMode instead seeds the
+    // hidden state through the windowHidden query flag.
+    if (win.isVisible()) sendMainWindowVisibility(win);
   });
   loadWindowFile(win, {
     waitForContent: options.waitForContent === true,
@@ -5993,6 +5998,7 @@ function createDashboardWindow() {
     backgroundColor: '#00000000',
     ...appWindowIcon(),
     skipTaskbar: false,
+    ...(process.platform === 'darwin' && glass ? { vibrancy: 'hud', visualEffectState: 'active' } : {}),
     ...(process.platform === 'win32' && glass ? { backgroundMaterial: 'acrylic' } : {}),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),

--- a/src/electron/nativeMaterialVisibility.js
+++ b/src/electron/nativeMaterialVisibility.js
@@ -1,11 +1,13 @@
 'use strict';
 
+// Attaches or detaches the native material only. The active/inactive state of the
+// material is a construction-time BrowserWindow property (visualEffectState);
+// Electron ships no setVisualEffectState method, so calling one here would be a
+// silent no-op that reads as if the state were being managed.
 function syncNativeMaterialVisibility(win, enabled, platform = process.platform) {
   if (!win || win.isDestroyed?.() || platform !== 'darwin') return;
   const active = Boolean(enabled) && win.isVisible() && !win.isMinimized();
-  if (!active) win.setVisualEffectState?.('inactive');
   win.setVibrancy?.(active ? 'hud' : null);
-  if (active) win.setVisualEffectState?.('active');
 }
 
 function attachNativeMaterialVisibility(win, isEnabled, platform = process.platform) {

--- a/src/electron/nativeMaterialVisibility.js
+++ b/src/electron/nativeMaterialVisibility.js
@@ -1,0 +1,23 @@
+'use strict';
+
+function syncNativeMaterialVisibility(win, enabled, platform = process.platform) {
+  if (!win || win.isDestroyed?.() || platform !== 'darwin') return;
+  const active = Boolean(enabled) && win.isVisible() && !win.isMinimized();
+  if (!active) win.setVisualEffectState?.('inactive');
+  win.setVibrancy?.(active ? 'hud' : null);
+  if (active) win.setVisualEffectState?.('active');
+}
+
+function attachNativeMaterialVisibility(win, isEnabled, platform = process.platform) {
+  for (const event of ['show', 'restore']) {
+    win.on(event, () => syncNativeMaterialVisibility(win, isEnabled(), platform));
+  }
+  for (const event of ['hide', 'minimize']) {
+    win.on(event, () => syncNativeMaterialVisibility(win, false, platform));
+  }
+}
+
+module.exports = {
+  attachNativeMaterialVisibility,
+  syncNativeMaterialVisibility
+};

--- a/src/electron/preload.js
+++ b/src/electron/preload.js
@@ -44,6 +44,11 @@ contextBridge.exposeInMainWorld('tokenMonitor', {
     ipcRenderer.on('stats:push', listener);
     return () => ipcRenderer.removeListener('stats:push', listener);
   },
+  onWindowVisibilityPush: (callback) => {
+    const listener = (_event, visible) => { try { callback(Boolean(visible)); } catch (_) {} };
+    ipcRenderer.on('window:visibility', listener);
+    return () => ipcRenderer.removeListener('window:visibility', listener);
+  },
   onSettingsPush: (callback) => {
     const listener = (_event, payload) => { try { callback(payload); } catch (_) {} };
     ipcRenderer.on('settings:push', listener);

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -5939,7 +5939,9 @@ function isSettingsSurfaceVisible() {
 }
 
 function serviceStatusSurfaceVisible() {
-  return visibleStatsSurface() === 'main' && state.breakdown === 'status';
+  return visibleStatsSurface() === 'main'
+    && state.breakdown === 'status'
+    && !els.serviceStatusPanel?.classList.contains('hidden');
 }
 
 function openHomeSettings() {
@@ -5950,6 +5952,7 @@ function openHomeSettings() {
   setSettingsSectionExpanded('main', true);
   state.homeSettingsExpanded = true;
   syncSettingsForm();
+  ensureServiceStatusTicker();
   requestAnimationFrame(() => {
     document.getElementById('homeSettingsContainer')?.scrollIntoView({ block: 'nearest' });
   });
@@ -5963,6 +5966,7 @@ function openTrendSettings() {
   setSettingsSectionExpanded('main', true);
   state.trendSettingsExpanded = true;
   syncSettingsForm();
+  ensureServiceStatusTicker();
   requestAnimationFrame(() => {
     document.getElementById('trendSettingsContainer')?.scrollIntoView({ block: 'nearest' });
   });
@@ -8666,6 +8670,9 @@ function syncSettingsForm() {
   applySettingsTranslations();
   applyInitialBreakdownPreference();
   syncPeriodTabs();
+  applyVendorColorOverrides(state.settings.vendorColors);
+  applyAppearanceSettings(state.settings);
+  if (!isSettingsSurfaceVisible()) return;
   syncHubModeUi();
   if (els.languageInput) els.languageInput.value = currentLanguage();
   if (els.periodMonthModeInput) {
@@ -8793,17 +8800,12 @@ function syncSettingsForm() {
   renderOpenCodeProfiles();
   renderOpenRouterProfiles();
   renderThirdPartyProfiles();
-  applyVendorColorOverrides(state.settings.vendorColors);
-  applyAppearanceSettings(state.settings);
   buildAppearanceColorControls();
   renderTokscaleStatus();
   renderSettingsAppUpdateRow();
   renderCodexAccounts();
   renderCustomPricing();
   renderCursorStatus();
-  applyFloatingBubbleState(state.floatingBubble);
-  if (state.breakdown === 'limits') renderLimits();
-  else render();
 }
 
 function enabledClientSet() {
@@ -11052,6 +11054,7 @@ async function saveSettings(patch) {
     try { state.settings = await window.tokenMonitor.getSettings(); } catch (_) {}
     applyEffectiveCurrencyRates();
     preserveSettingsPanelScroll(syncSettingsForm);
+    if (!isSettingsSurfaceVisible()) statsRenderScheduler.request();
     restartTimer();
     maybeUpdateBarsIcon();
     throw error;
@@ -11063,6 +11066,7 @@ async function saveSettings(patch) {
   // their accordion/switch layout transition.
   if (state.settingsPushRevision === settingsPushRevision) {
     preserveSettingsPanelScroll(syncSettingsForm);
+    if (!isSettingsSurfaceVisible()) statsRenderScheduler.request();
   }
   restartTimer();
   maybeUpdateBarsIcon();
@@ -11826,24 +11830,11 @@ els.appUpdateReleaseNotesButton.addEventListener('click', async () => {
 window.tokenMonitor.onSettingsPush?.((next) => {
   if (!next) return;
   state.settingsPushRevision += 1;
-  const prevMetric = state.settings?.heatmapMetric;
-  const prevLanguage = state.settings?.language;
-  const prevCompactTokenUnits = state.settings?.compactTokenUnits;
-  const prevShowCompactTotalTokens = state.settings?.showCompactTotalTokens;
   state.settings = next;
   applyEffectiveCurrencyRates();
   preserveSettingsPanelScroll(syncSettingsForm);
+  if (!isSettingsSurfaceVisible()) statsRenderScheduler.request();
   maybeUpdateBarsIcon();
-  if ((prevMetric || 'cost') !== (next.heatmapMetric || 'cost')) {
-    render();
-  } else if (
-    prevLanguage !== next.language
-    || prevCompactTokenUnits !== next.compactTokenUnits
-  ) {
-    render();
-  } else if (prevShowCompactTotalTokens !== next.showCompactTotalTokens) {
-    updateTotalCompact(state.currentTotal);
-  }
 });
 
 reducedMotionMedia?.addEventListener?.('change', () => {
@@ -11932,7 +11923,7 @@ document.addEventListener('visibilitychange', () => {
     void refreshHubBuildStatus();
   }
   statsRenderScheduler.flush();
-  if (isSettingsSurfaceVisible()) refreshTrayComposers();
+  if (isSettingsSurfaceVisible()) syncSettingsForm();
   ensureServiceStatusTicker();
 });
 

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -8670,7 +8670,19 @@ function reconcileHubDraftsAfterSave(submitted, submittedRevisions) {
   syncHubDraftFields();
 }
 
+let settingsDomSyncPending = false;
 function syncSettingsForm() {
+  if (isRendererWindowHidden()) {
+    applyInitialBreakdownPreference();
+    applyVendorColorOverrides(state.settings.vendorColors);
+    appliedThemeOverrides = themePresetsApi.normalizeOverrides(
+      state.settings.themeColors,
+      themePresetsApi.INTERFACE_COLOR_KEYS
+    );
+    settingsDomSyncPending = true;
+    return;
+  }
+  settingsDomSyncPending = false;
   applySettingsTranslations();
   applyInitialBreakdownPreference();
   syncPeriodTabs();
@@ -11030,6 +11042,7 @@ async function showAllViews() {
 }
 
 function preserveSettingsPanelScroll(callback) {
+  if (isRendererWindowHidden()) return callback();
   const panel = els.settingsPanel;
   if (!panel || panel.classList.contains('hidden')) return callback();
   const scrollTop = panel.scrollTop;
@@ -11932,6 +11945,7 @@ function handleWindowVisibilityChange() {
     syncSettingsForm();
     renderConnectionStatus('settings');
   } else {
+    if (settingsDomSyncPending) syncSettingsForm();
     statsRenderScheduler.flush();
   }
   ensureServiceStatusTicker();

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -8068,10 +8068,14 @@ function handleWindowShortcutRecordKey(event) {
   syncWindowShortcutStatus();
 }
 
-function applyFloatingBubbleState(payload = {}) {
+function applyFloatingBubbleState(payload = {}, options = {}) {
   const wasCollapsed = state.floatingBubble.collapsed;
   const side = payload?.collapsed && ['left', 'right'].includes(payload.side) ? payload.side : null;
   state.floatingBubble = { collapsed: Boolean(side), side };
+  if (isRendererWindowHidden()) {
+    statsRenderScheduler.request();
+    return;
+  }
   document.documentElement.classList.toggle('floating-bubble-collapsed-left', side === 'left');
   document.documentElement.classList.toggle('floating-bubble-collapsed-right', side === 'right');
   document.body.classList.toggle('floating-bubble-collapsed-left', side === 'left');
@@ -8081,6 +8085,7 @@ function applyFloatingBubbleState(payload = {}) {
     els.floatingBubbleTab.title = title;
     els.floatingBubbleTab.setAttribute('aria-label', title);
   }
+  if (options.renderContent === false) return;
   if (wasCollapsed && !state.floatingBubble.collapsed) {
     if (isSettingsPanelOpen()) {
       syncSettingsForm();
@@ -11940,6 +11945,7 @@ const statsRenderScheduler = statsRenderSchedulerApi.createStatsRenderScheduler(
 function handleWindowVisibilityChange() {
   if (!statsRenderScheduler.visibilityChanged()) return;
   if (isRendererWindowHidden()) cancelTokenRateBoost();
+  else applyFloatingBubbleState(state.floatingBubble, { renderContent: false });
   if (!isRendererWindowHidden() && state.settings?.hubMode === 'client' && hubBuildStatusRefreshDue()) {
     void refreshHubBuildStatus();
   }
@@ -13066,7 +13072,8 @@ function syncCustomTrayClockTimer() {
   if (clockNeeded && !customTrayClockTimer) {
     customTrayClockTimer = setInterval(() => {
       void maybeUpdateBarsIcon({ refreshComposers: false });
-      renderFloatingBubbleContent();
+      if (isRendererWindowHidden()) statsRenderScheduler.request();
+      else renderFloatingBubbleContent();
     }, 30 * 1000);
   } else if (!clockNeeded && customTrayClockTimer) {
     clearInterval(customTrayClockTimer);

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -8688,6 +8688,10 @@ function syncSettingsForm() {
   syncPeriodTabs();
   applyVendorColorOverrides(state.settings.vendorColors);
   applyAppearanceSettings(state.settings);
+  // Drives the header pin button as well as the Settings select, so it has to run
+  // whenever the window is on screen — the pin button is reachable, and changes,
+  // while the Settings panel is closed.
+  syncWindowBehaviorControls();
   if (!isSettingsSurfaceVisible()) return;
   syncHubModeUi();
   if (els.languageInput) els.languageInput.value = currentLanguage();
@@ -8763,7 +8767,6 @@ function syncSettingsForm() {
   );
   els.swapSettingsRefreshInput.checked = state.settings.settingsInTitlebar === true;
   els.discordRpcInput.checked = Boolean(state.settings.discordRpcEnabled);
-  syncWindowBehaviorControls();
   els.floatingBubbleInput.checked = state.settings.floatingBubbleEnabled === true;
   const floatingBubbleTrigger = state.settings.floatingBubbleTrigger === 'hover' ? 'hover' : 'click';
   for (const input of els.floatingBubbleTriggerInputs || []) input.checked = input.value === floatingBubbleTrigger;
@@ -11944,6 +11947,10 @@ function handleWindowVisibilityChange() {
     statsRenderScheduler.clear();
     syncSettingsForm();
     renderConnectionStatus('settings');
+    // syncSettingsForm() covers what the dropped catch-up render would have
+    // drawn, but it is not a stats render and never reaches signalContentReady().
+    // A window revealed straight into Settings must still report it has painted.
+    signalContentReady();
   } else {
     if (settingsDomSyncPending) syncSettingsForm();
     statsRenderScheduler.flush();

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -5694,12 +5694,13 @@ function updateServiceStatusAgoLabels() {
 }
 
 function onServiceStatusTick() {
-  if (state.breakdown !== 'status') { stopServiceStatusTicker(); return; }
+  if (!serviceStatusSurfaceVisible()) { stopServiceStatusTicker(); return; }
   updateServiceStatusAgoLabels();
   maybeFetchServiceStatus();
 }
 
 function ensureServiceStatusTicker() {
+  if (!serviceStatusSurfaceVisible()) { stopServiceStatusTicker(); return; }
   if (state.serviceStatusTicker) return;
   state.serviceStatusTicker = setInterval(onServiceStatusTick, 1000);
   onServiceStatusTick();
@@ -5845,6 +5846,12 @@ function turnNode(turn) {
 
 let contentReadySignaled = false;
 
+function signalContentReady() {
+  if (contentReadySignaled || !state.settings || !state.stats) return;
+  contentReadySignaled = true;
+  window.tokenMonitor.signalContentReady?.();
+}
+
 function renderTrends() {
   const charts = window.TokenMonitorUsageCharts;
   const previousBars = captureTrendBarMotion();
@@ -5908,6 +5915,26 @@ function viewLabelById(id) {
   return view ? viewLabel(view) : id;
 }
 
+function isSettingsPanelOpen() {
+  return Boolean(els.settingsPanel && !els.settingsPanel.classList.contains('hidden'));
+}
+
+function visibleStatsSurface() {
+  return statsRenderSchedulerApi.visibleStatsSurface(
+    document.hidden,
+    state.floatingBubble.collapsed,
+    isSettingsPanelOpen()
+  );
+}
+
+function isSettingsSurfaceVisible() {
+  return visibleStatsSurface() === 'settings';
+}
+
+function serviceStatusSurfaceVisible() {
+  return visibleStatsSurface() === 'main' && state.breakdown === 'status';
+}
+
 function openHomeSettings() {
   if (!els.settingsPanel) return;
   els.settingsPanel.classList.remove('hidden');
@@ -5939,18 +5966,22 @@ function openSettingsPanel() {
   if (state.viewSwitcherOpen) setViewSwitcherOpen(false);
   els.settingsPanel.classList.remove('hidden');
   els.shell.classList.add('settings-open');
+  syncSettingsForm();
+  ensureServiceStatusTicker();
   els.shell.style.transform = 'translateZ(0)';
   requestAnimationFrame(() => { els.shell.style.transform = ''; });
 }
 
 function openViewFromTray(viewId) {
   if (!availableBreakdownIds().includes(viewId)) return;
+  const settingsWasOpen = isSettingsPanelOpen();
   if (state.viewSwitcherOpen) setViewSwitcherOpen(false);
   stopWindowShortcutRecording();
   els.settingsPanel?.classList.add('hidden');
   els.shell.classList.remove('settings-open');
   state.openSession = null;
-  renderBreakdownChange(viewId, { allowHidden: true });
+  if (!renderBreakdownChange(viewId, { allowHidden: true }) && settingsWasOpen) render();
+  ensureServiceStatusTicker();
 }
 
 const HOME_HISTORY_MAX_RETRIES = 3;
@@ -7216,10 +7247,7 @@ function render() {
     state.currentTotal = fixedUnavailable ? 0 : Number(period.totalTokens || 0);
     hidePeriodContentForMessage(fixedPeriodMessage(state.fixedPeriodSnapshot, detailUnavailable ? state.breakdown : ''));
     renderFloatingBubbleContent();
-    if (!contentReadySignaled) {
-      contentReadySignaled = true;
-      window.tokenMonitor.signalContentReady?.();
-    }
+    signalContentReady();
     return;
   }
   els.fixedPeriodMessage.classList.add('hidden');
@@ -7314,10 +7342,7 @@ function render() {
   renderFloatingBubbleContent();
   // Tell main the window has painted real content (not the static "0" defaults),
   // so a recreated window can stay hidden until it's populated. See loadWindowFile.
-  if (!contentReadySignaled) {
-    contentReadySignaled = true;
-    window.tokenMonitor.signalContentReady?.();
-  }
+  signalContentReady();
 }
 
 function setStatus(text, isError = false) {
@@ -7461,7 +7486,6 @@ async function refreshStats(options = {}) {
       state.homeHistorySignature = '';
     }
     applyCodexActiveAccountFromStats();
-    setStatus(statusTextFor(state.mode, state.streamConnected));
     const forceFixedPeriodHistory = options.forceHistory === true;
     if (fixedPeriodRangesApi.isDerived(state.period)) {
       await warmFixedPeriodHistory({
@@ -7485,7 +7509,9 @@ async function refreshStats(options = {}) {
     // live-dot tooltip + sync settings line, so keep the header status pill
     // hidden instead of surfacing the raw hub error (e.g. a 404 HTML page).
     console.log(`[refresh] getStats failed: ${error.message}`);
-    setStatus(statusTextFor(state.mode, state.streamConnected));
+    if (!document.hidden && !state.floatingBubble.collapsed) {
+      setStatus(statusTextFor(state.mode, state.streamConnected));
+    }
     if (feedback) settleRefreshButtonState('error');
   } finally {
     if (feedback) state.refreshBusy = false;
@@ -8028,6 +8054,7 @@ function handleWindowShortcutRecordKey(event) {
 }
 
 function applyFloatingBubbleState(payload = {}) {
+  const wasCollapsed = state.floatingBubble.collapsed;
   const side = payload?.collapsed && ['left', 'right'].includes(payload.side) ? payload.side : null;
   state.floatingBubble = { collapsed: Boolean(side), side };
   document.documentElement.classList.toggle('floating-bubble-collapsed-left', side === 'left');
@@ -8039,7 +8066,17 @@ function applyFloatingBubbleState(payload = {}) {
     els.floatingBubbleTab.title = title;
     els.floatingBubbleTab.setAttribute('aria-label', title);
   }
-  renderFloatingBubbleContent();
+  if (wasCollapsed && !state.floatingBubble.collapsed) {
+    if (isSettingsPanelOpen()) {
+      syncSettingsForm();
+      renderConnectionStatus('settings');
+    } else {
+      renderStatsUpdate();
+    }
+  } else {
+    renderFloatingBubbleContent();
+  }
+  ensureServiceStatusTicker();
 }
 
 const BUBBLE_CONTENT_VALUES = ['icon', 'tokens', 'cost', 'both', 'tokensAll', 'costAll', 'bothAll', 'limitsAllSessions', 'bars', 'barsSession', 'barsWeekly', 'barsAllSessions', 'custom'];
@@ -11249,12 +11286,15 @@ els.pinButton.addEventListener('click', () => {
 els.settingsButton.addEventListener('click', (event) => {
   if (state.viewSwitcherOpen) setViewSwitcherOpen(false);
   els.settingsPanel.classList.toggle('hidden');
-  const settingsOpen = !els.settingsPanel.classList.contains('hidden');
+  const settingsOpen = isSettingsPanelOpen();
+  if (settingsOpen) syncSettingsForm();
+  else render();
   if (!settingsOpen) stopWindowShortcutRecording();
   els.shell.classList.toggle('settings-open', settingsOpen);
   if (!settingsOpen && event.detail > 0) els.settingsButton.blur();
   els.shell.style.transform = 'translateZ(0)';
   requestAnimationFrame(() => { els.shell.style.transform = ''; });
+  ensureServiceStatusTicker();
 });
 els.saveSettingsButton.addEventListener('click', async () => {
   const submittedHubFields = {
@@ -11814,26 +11854,45 @@ window.tokenMonitor.onFloatingBubbleState?.((payload) => {
 window.tokenMonitor.onHubPush?.((payload) => {
   if (!payload?.info) return;
   state.hubInfo = payload.info;
+  const settingsVisible = isSettingsSurfaceVisible();
   // The first switch to Host mode generates the shared secret asynchronously
   // after settings:update has already returned, so mirror the freshly minted
   // value back into state + input — otherwise the Shared Secret field stays
   // blank and other devices can't pair until the user clicks Regenerate.
   if (payload.info.secret && payload.info.secret !== state.settings?.hubHostSecret) {
     state.settings = { ...state.settings, hubHostSecret: payload.info.secret };
-    if (els.hubSecretInput && state.settings.hubMode === 'host') {
+    if (settingsVisible && els.hubSecretInput && state.settings.hubMode === 'host') {
       els.hubSecretInput.value = payload.info.secret;
     }
   }
-  renderHubStatus();
+  if (settingsVisible) renderHubStatus();
 });
 
 window.tokenMonitor.onTokscalePush?.((payload) => {
   mergeTokscalePayload(payload);
-  renderTokscaleStatus();
+  if (isSettingsSurfaceVisible()) renderTokscaleStatus();
 });
 
+function renderConnectionStatus(surface = visibleStatsSurface()) {
+  if (surface !== 'main' && surface !== 'settings') return;
+  setLiveDot(state.streamConnected);
+  setStatus(statusTextFor(state.mode, state.streamConnected));
+  if (surface === 'settings') renderSyncClientStatus();
+}
+
 function renderStatsUpdate() {
-  render();
+  const surface = visibleStatsSurface();
+  renderConnectionStatus(surface);
+  if (surface === 'main') {
+    render();
+    return;
+  }
+  if (surface === 'bubble') {
+    renderFloatingBubbleContent();
+    signalContentReady();
+    return;
+  }
+  if (surface !== 'settings') return;
   renderCodexAccounts();
   renderSettingsSummaries();
   renderLimitProviderCheckboxes();
@@ -11853,6 +11912,7 @@ function renderStatsUpdate() {
   renderExternalProviderStatus('kimi');
   renderExternalProviderStatus('ollama');
   renderCopilotStatus();
+  signalContentReady();
 }
 
 const statsRenderScheduler = statsRenderSchedulerApi.createStatsRenderScheduler({
@@ -11865,6 +11925,8 @@ document.addEventListener('visibilitychange', () => {
     void refreshHubBuildStatus();
   }
   statsRenderScheduler.flush();
+  if (isSettingsSurfaceVisible()) refreshTrayComposers();
+  ensureServiceStatusTicker();
 });
 
 window.tokenMonitor.onStatsPush?.((payload) => {
@@ -11892,9 +11954,10 @@ window.tokenMonitor.onStatsPush?.((payload) => {
   } else {
     return;
   }
-  setLiveDot(state.streamConnected);
-  setStatus(statusTextFor(state.mode, state.streamConnected));
-  renderSyncClientStatus();
+  if (payload.event === 'status') {
+    if (document.hidden) statsRenderScheduler.request();
+    else renderConnectionStatus();
+  }
   if (!wasStreamConnected && state.streamConnected && state.settings?.hubMode === 'client') {
     void refreshHubBuildStatus();
   }
@@ -12668,7 +12731,8 @@ function trayDataUrlForMode(mode, size = 44, colors, options = {}) {
 }
 
 async function maybeUpdateBarsIcon(options = {}) {
-  if (options.refreshComposers !== false) refreshTrayComposers();
+  if (options.refreshComposers !== false && isSettingsSurfaceVisible()) refreshTrayComposers();
+  else syncCustomTrayClockTimer();
   const mode = state.settings?.trayContent;
   if (!window.TokenMonitorTrayText.isGeneratedTrayIconMode(mode)) return;
   if (!window.tokenMonitor.setTrayIcons) return;
@@ -12957,17 +13021,7 @@ function createTrayComposer(surface) {
   });
 }
 
-function refreshTrayComposers() {
-  const surfaces = [
-    { id: 'tray', root: els.trayComposer, visible: state.settings?.showTrayIcon !== false },
-    { id: 'floatingBubble', root: els.floatingBubbleComposer, visible: state.settings?.floatingBubbleEnabled === true }
-  ];
-  window.TokenMonitorTrayComposer.syncTrayComposerSurfaces(
-    surfaces,
-    trayComposers,
-    createTrayComposer
-  );
-  Object.values(trayComposers).forEach((composer) => composer?.refresh());
+function syncCustomTrayClockTimer() {
   const clockNeeded = (
     state.settings?.trayContent === 'custom'
       && trayLayoutApi.trayLayoutNeedsClock(state.settings?.trayCustomLayout)
@@ -12984,6 +13038,20 @@ function refreshTrayComposers() {
     clearInterval(customTrayClockTimer);
     customTrayClockTimer = null;
   }
+}
+
+function refreshTrayComposers() {
+  const surfaces = [
+    { id: 'tray', root: els.trayComposer, visible: state.settings?.showTrayIcon !== false },
+    { id: 'floatingBubble', root: els.floatingBubbleComposer, visible: state.settings?.floatingBubbleEnabled === true }
+  ];
+  window.TokenMonitorTrayComposer.syncTrayComposerSurfaces(
+    surfaces,
+    trayComposers,
+    createTrayComposer
+  );
+  Object.values(trayComposers).forEach((composer) => composer?.refresh());
+  syncCustomTrayClockTimer();
 }
 
 function loadImage(src) {

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -1955,15 +1955,29 @@ function renderRows(rows, { incompleteHint = '' } = {}) {
     return;
   }
   const max = Math.max(1, ...rows.map((row) => row.value));
-  const liveMotionSnapshot = !state.periodMotionActive && !state.animateBarsFromZero
-    ? captureBreakdownMotion()
-    : null;
   const hintText = incompleteHint ? t(incompleteHint) : '';
   const signature = JSON.stringify([state.breakdown, hintText, rows.map((row) => row.key)]);
   const children = Array.from(els.breakdown.children);
   const existingHint = children.find((child) => child.classList.contains('breakdown-incomplete-hint'));
   const existing = new Map(children.filter((child) => child !== existingHint).map((child) => [child.dataset.key, child]));
   const structureChanged = signature !== state.rowSignature;
+  const renderContext = {
+    breakdown: state.breakdown,
+    currency: currentCurrency(),
+    currencyRatesEffective: state.settings?.currencyRatesEffective || null,
+    locale: currentLocale(),
+    showToolIcons: toolIconsEnabled(state.settings?.showToolIcons)
+  };
+  const nextFingerprints = new Map(rows.map((row) => [
+    row.key,
+    rowRenderFingerprint(row, max, renderContext)
+  ]));
+  const rowsChanged = structureChanged || rows.some((row) => (
+    rowRenderFingerprints.get(existing.get(row.key)) !== nextFingerprints.get(row.key)
+  ));
+  const liveMotionSnapshot = rowsChanged && !state.periodMotionActive && !state.animateBarsFromZero
+    ? captureBreakdownMotion()
+    : null;
   if (structureChanged) {
     const nodes = rows.map((row) => existing.get(row.key) || rowTemplate(row));
     if (incompleteHint) {
@@ -1980,17 +1994,10 @@ function renderRows(rows, { incompleteHint = '' } = {}) {
   const current = new Map(Array.from(els.breakdown.children)
     .filter((child) => !child.classList.contains('breakdown-incomplete-hint'))
     .map((child) => [child.dataset.key, child]));
-  const renderContext = {
-    breakdown: state.breakdown,
-    currency: currentCurrency(),
-    currencyRatesEffective: state.settings?.currencyRatesEffective || null,
-    locale: currentLocale(),
-    showToolIcons: toolIconsEnabled(state.settings?.showToolIcons)
-  };
   for (const rowData of rows) {
     const row = current.get(rowData.key);
     if (!row) continue;
-    const fingerprint = rowRenderFingerprint(rowData, max, renderContext);
+    const fingerprint = nextFingerprints.get(rowData.key);
     if (rowRenderFingerprints.get(row) === fingerprint) continue;
     updateRow(row, { ...rowData, max });
     rowRenderFingerprints.set(row, fingerprint);

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -315,7 +315,7 @@ function normalizeInitialViewValue(value, allowed, fallback) {
   return allowed.has(raw) ? raw : fallback;
 }
 
-const state = { period: normalizeInitialViewValue(initialViewState.period, viewPeriodValues, 'today'), appUpdate: null, breakdown: normalizeInitialViewValue(initialViewState.breakdown, viewBreakdownValues, 'home'), viewSwitcherOpen: false, viewSwitcherHasOpened: false, limitDetailTooltipHasOpened: false, limitDetailTooltipActive: false, limitDetailTooltipRenderPending: false, settings: null, stats: null, homeHistory: null, homeHistoryBusy: false, homeHistoryRequested: false, homeHistorySignature: '', homeHistoryRetries: 0, homeHistoryRetryTimer: null, homeActivityScrollLeft: null, homeActivityFollowEnd: true, homeActivityResizeObserver: null, serviceStatus: null, serviceStatusBusy: false, serviceProvidersExpanded: false, trendSettingsExpanded: false, trendsActivating: false, homeSettingsExpanded: false, homeLimitSettingsExpanded: false, limitProviderSettingsExpanded: '', clientHealthExpanded: '', clientSources: clientSourceCacheApi.createClientSourceCache(), clientSourcesKey: '', clientSourcesRequest: 0, subscriptionEditingId: '', subscriptionTopUps: [], subscriptionFormBase: null, subscriptionEditorTransitionId: 0, serviceStatusTicker: null, refreshTimer: null, refreshBusy: false, refreshFeedbackTimer: null, currentTotal: 0, rowSignature: '', streamConnected: false, streamFailure: null, mode: 'idle', appInfo: null, systemDarkUi: false, tokscaleStatus: null, tokscaleCheck: null, tokscaleBusy: false, hubInfo: null, hubBuildStatus: null, cursorAccount: { status: null, error: '' }, cursorAccountExpanded: false, codexAccountExpanded: false, codexAccountError: '', codexSignInBusy: false, codexSignInFlowId: '', codexLoginUrl: '', codexLoginStatus: '', codexLoginOutput: '', codexWorkspaceChoices: [], codexWorkspaceId: '', codexActiveAccount: null, codexPendingActiveAccount: null, codexPendingActiveAccountUntil: 0, codexPendingActiveAccountTimer: null, codexSystemSwitchingAccountId: '', codexSystemSwitchErrorAccountId: '', codexSystemSwitchError: '', codexSwitchPopoverHasOpened: false, codexSwitchPopoverActive: false, codexSwitchPopoverRenderPending: false, customPricingExpanded: false, claudeAccountExpanded: false, claudePendingCheckSince: 0, opencodeProfileCount: 0, opencodeCookieExpanded: false, openrouterProfileCount: 0, openrouterAccountExpanded: false, thirdPartyProfileCount: 0, thirdPartyAccountExpanded: false, deepseekAccountExpanded: false, deepseekPendingCheckSince: 0, minimaxAccountExpanded: false, minimaxPendingCheckSince: 0, zaiAccountExpanded: false, zaiPendingCheckSince: 0, zaiteamAccountExpanded: false, zaiteamPendingCheckSince: 0, volcengineAccountExpanded: false, volcenginePendingCheckSince: 0, volcengineAgentExpanded: false, qoderAccountExpanded: false, qoderPendingCheckSince: 0, commandcodeAccountExpanded: false, commandcodePendingCheckSince: 0, kimiAccountExpanded: false, kimiPendingCheckSince: 0, ollamaAccountExpanded: false, ollamaPendingCheckSince: 0, mimoAccountExpanded: false, mimoAccountError: '', copilotAccountExpanded: false, copilotManualExpanded: false, copilotPendingCheckSince: 0, copilotSignInBusy: false, copilotSignInCancelable: false, copilotSignInFlowId: '', copilotAuthorizeMessage: '', copilotLoginStatus: '', copilotErrorMessage: '', floatingBubble: initialFloatingBubble, suppressInitialNumberAnimation: window.__TOKEN_MONITOR_SUPPRESS_INITIAL_NUMBER_ANIMATION__ === true, openSession: null, detailSort: 'time', recordingWindowShortcut: false, windowShortcutInvalid: false };
+const state = { period: normalizeInitialViewValue(initialViewState.period, viewPeriodValues, 'today'), appUpdate: null, breakdown: normalizeInitialViewValue(initialViewState.breakdown, viewBreakdownValues, 'home'), viewSwitcherOpen: false, viewSwitcherHasOpened: false, limitDetailTooltipHasOpened: false, limitDetailTooltipActive: false, limitDetailTooltipRenderPending: false, settings: null, windowVisible: new URLSearchParams(window.location.search).get('windowHidden') !== '1', stats: null, homeHistory: null, homeHistoryBusy: false, homeHistoryRequested: false, homeHistorySignature: '', homeHistoryRetries: 0, homeHistoryRetryTimer: null, homeActivityScrollLeft: null, homeActivityFollowEnd: true, homeActivityResizeObserver: null, serviceStatus: null, serviceStatusBusy: false, serviceProvidersExpanded: false, trendSettingsExpanded: false, trendsActivating: false, homeSettingsExpanded: false, homeLimitSettingsExpanded: false, limitProviderSettingsExpanded: '', clientHealthExpanded: '', clientSources: clientSourceCacheApi.createClientSourceCache(), clientSourcesKey: '', clientSourcesRequest: 0, subscriptionEditingId: '', subscriptionTopUps: [], subscriptionFormBase: null, subscriptionEditorTransitionId: 0, serviceStatusTicker: null, refreshTimer: null, refreshBusy: false, refreshFeedbackTimer: null, currentTotal: 0, rowSignature: '', streamConnected: false, streamFailure: null, mode: 'idle', appInfo: null, systemDarkUi: false, tokscaleStatus: null, tokscaleCheck: null, tokscaleBusy: false, hubInfo: null, hubBuildStatus: null, cursorAccount: { status: null, error: '' }, cursorAccountExpanded: false, codexAccountExpanded: false, codexAccountError: '', codexSignInBusy: false, codexSignInFlowId: '', codexLoginUrl: '', codexLoginStatus: '', codexLoginOutput: '', codexWorkspaceChoices: [], codexWorkspaceId: '', codexActiveAccount: null, codexPendingActiveAccount: null, codexPendingActiveAccountUntil: 0, codexPendingActiveAccountTimer: null, codexSystemSwitchingAccountId: '', codexSystemSwitchErrorAccountId: '', codexSystemSwitchError: '', codexSwitchPopoverHasOpened: false, codexSwitchPopoverActive: false, codexSwitchPopoverRenderPending: false, customPricingExpanded: false, claudeAccountExpanded: false, claudePendingCheckSince: 0, opencodeProfileCount: 0, opencodeCookieExpanded: false, openrouterProfileCount: 0, openrouterAccountExpanded: false, thirdPartyProfileCount: 0, thirdPartyAccountExpanded: false, deepseekAccountExpanded: false, deepseekPendingCheckSince: 0, minimaxAccountExpanded: false, minimaxPendingCheckSince: 0, zaiAccountExpanded: false, zaiPendingCheckSince: 0, zaiteamAccountExpanded: false, zaiteamPendingCheckSince: 0, volcengineAccountExpanded: false, volcenginePendingCheckSince: 0, volcengineAgentExpanded: false, qoderAccountExpanded: false, qoderPendingCheckSince: 0, commandcodeAccountExpanded: false, commandcodePendingCheckSince: 0, kimiAccountExpanded: false, kimiPendingCheckSince: 0, ollamaAccountExpanded: false, ollamaPendingCheckSince: 0, mimoAccountExpanded: false, mimoAccountError: '', copilotAccountExpanded: false, copilotManualExpanded: false, copilotPendingCheckSince: 0, copilotSignInBusy: false, copilotSignInCancelable: false, copilotSignInFlowId: '', copilotAuthorizeMessage: '', copilotLoginStatus: '', copilotErrorMessage: '', floatingBubble: initialFloatingBubble, suppressInitialNumberAnimation: window.__TOKEN_MONITOR_SUPPRESS_INITIAL_NUMBER_ANIMATION__ === true, openSession: null, detailSort: 'time', recordingWindowShortcut: false, windowShortcutInvalid: false };
 state.clientRescans = clientRescanStateApi.createClientRescanState({
   onChange: (clientId) => {
     if (state.clientHealthExpanded === clientId) refillOpenClientHealthPanel();
@@ -5926,9 +5926,13 @@ function isSettingsPanelOpen() {
   return Boolean(els.settingsPanel && !els.settingsPanel.classList.contains('hidden'));
 }
 
+function isRendererWindowHidden() {
+  return document.hidden || !state.windowVisible;
+}
+
 function visibleStatsSurface() {
   return statsRenderSchedulerApi.visibleStatsSurface(
-    document.hidden,
+    isRendererWindowHidden(),
     state.floatingBubble.collapsed,
     isSettingsPanelOpen()
   );
@@ -7520,7 +7524,7 @@ async function refreshStats(options = {}) {
     // live-dot tooltip + sync settings line, so keep the header status pill
     // hidden instead of surfacing the raw hub error (e.g. a 404 HTML page).
     console.log(`[refresh] getStats failed: ${error.message}`);
-    if (!document.hidden && !state.floatingBubble.collapsed) {
+    if (!isRendererWindowHidden() && !state.floatingBubble.collapsed) {
       setStatus(statusTextFor(state.mode, state.streamConnected));
     }
     if (feedback) settleRefreshButtonState('error');
@@ -11914,17 +11918,27 @@ function renderStatsUpdate() {
 }
 
 const statsRenderScheduler = statsRenderSchedulerApi.createStatsRenderScheduler({
-  isHidden: () => document.hidden,
+  isHidden: isRendererWindowHidden,
   render: renderStatsUpdate
 });
-document.addEventListener('visibilitychange', () => {
-  if (document.hidden) cancelTokenRateBoost();
-  if (!document.hidden && state.settings?.hubMode === 'client' && hubBuildStatusRefreshDue()) {
+function handleWindowVisibilityChange() {
+  if (isRendererWindowHidden()) cancelTokenRateBoost();
+  if (!isRendererWindowHidden() && state.settings?.hubMode === 'client' && hubBuildStatusRefreshDue()) {
     void refreshHubBuildStatus();
   }
-  statsRenderScheduler.flush();
-  if (isSettingsSurfaceVisible()) syncSettingsForm();
+  if (isSettingsSurfaceVisible()) {
+    statsRenderScheduler.clear();
+    syncSettingsForm();
+    renderConnectionStatus('settings');
+  } else {
+    statsRenderScheduler.flush();
+  }
   ensureServiceStatusTicker();
+}
+document.addEventListener('visibilitychange', handleWindowVisibilityChange);
+window.tokenMonitor.onWindowVisibilityPush?.((visible) => {
+  state.windowVisible = visible;
+  handleWindowVisibilityChange();
 });
 
 window.tokenMonitor.onStatsPush?.((payload) => {
@@ -11953,7 +11967,7 @@ window.tokenMonitor.onStatsPush?.((payload) => {
     return;
   }
   if (payload.event === 'status') {
-    if (document.hidden) statsRenderScheduler.request();
+    if (isRendererWindowHidden()) statsRenderScheduler.request();
     else renderConnectionStatus();
   }
   if (!wasStreamConnected && state.streamConnected && state.settings?.hubMode === 'client') {

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -769,6 +769,7 @@ function settingsSectionSummary(section) {
 }
 
 function renderSettingsSummaries() {
+  if (!isSettingsSurfaceVisible()) return;
   for (const section of SETTINGS_SECTION_IDS) {
     const el = els[`${section}SettingsSummary`];
     if (el) el.textContent = settingsSectionSummary(section);
@@ -3090,6 +3091,7 @@ function renderSubscriptionTotal() {
 }
 
 function renderSubscriptionSettings() {
+  if (!isSettingsSurfaceVisible()) return;
   renderSubscriptionNote();
   renderSubscriptionOrphanNotice();
   renderSubscriptionSyncError();
@@ -5584,6 +5586,7 @@ function serviceStatusIconId(id) {
 }
 
 function renderServiceStatus() {
+  if (!serviceStatusSurfaceVisible()) return;
   if (!els.serviceStatusPanel) return;
   const rows = serviceStatusRows().map((provider) => {
     const row = document.createElement('button');
@@ -5719,6 +5722,17 @@ function stopServiceStatusTicker() {
   state.serviceStatusTicker = null;
 }
 
+function applySessionDetailResult(request, options) {
+  if (state.openSession !== request) return;
+  request.renderOptions = options;
+  if (visibleStatsSurface() !== 'main') {
+    if (isRendererWindowHidden()) statsRenderScheduler.request();
+    return;
+  }
+  request.renderOptions = null;
+  renderSessionDetail(options);
+}
+
 async function openSessionDetail({ client, sessionId, sessionCost, title }) {
   const request = { client, sessionId, sessionCost, title, period: state.period, detail: null };
   state.openSession = request;
@@ -5727,10 +5741,10 @@ async function openSessionDetail({ client, sessionId, sessionCost, title }) {
     const detail = await window.tokenMonitor.getSessionDetail({ client, sessionId, period: request.period, sessionCost });
     if (state.openSession === request) {
       request.detail = detail;
-      renderSessionDetail({ detail });
+      applySessionDetailResult(request, { detail });
     }
   } catch (_) {
-    if (state.openSession === request) renderSessionDetail({ error: true });
+    applySessionDetailResult(request, { error: true });
   }
 }
 
@@ -5944,8 +5958,7 @@ function isSettingsSurfaceVisible() {
 
 function serviceStatusSurfaceVisible() {
   return visibleStatsSurface() === 'main'
-    && state.breakdown === 'status'
-    && !els.serviceStatusPanel?.classList.contains('hidden');
+    && state.breakdown === 'status';
 }
 
 function openHomeSettings() {
@@ -7225,6 +7238,11 @@ function renderHome() {
 }
 
 function render() {
+  const surface = visibleStatsSurface();
+  if (surface !== 'main') {
+    if (!surface) statsRenderScheduler.request();
+    return;
+  }
   if (!state.stats) return;
   renderSessionUsageArchiveStatus();
   ensureBreakdownVisible();
@@ -7338,6 +7356,11 @@ function render() {
     els.trendsPanel.classList.add('hidden');
     els.homePanel.classList.add('hidden');
     els.breakdown.classList.add('hidden');
+    if (state.openSession.renderOptions) {
+      const options = state.openSession.renderOptions;
+      state.openSession.renderOptions = null;
+      renderSessionDetail(options);
+    }
   } else {
     els.homePanel.classList.add('hidden');
     els.limitsPanel.classList.add('hidden');
@@ -8123,6 +8146,7 @@ function floatingBubbleGeneratedColors() {
 }
 
 function renderFloatingBubbleContent() {
+  if (visibleStatsSurface() !== 'bubble') return;
   const el = els.floatingBubbleContent;
   if (!el || !state.floatingBubble.collapsed) return;
   const mode = state.settings?.floatingBubbleContent || 'icon';
@@ -13373,6 +13397,7 @@ function renderCodexLoginStatus() {
 }
 
 function renderCodexAccounts() {
+  if (!isSettingsSurfaceVisible()) return;
   const statusEl = document.getElementById('codexAccountStatus');
   const listEl = document.getElementById('codexAccountList');
   const errorEl = document.getElementById('codexAccountErrorMessage');
@@ -13555,6 +13580,7 @@ function clearDeepseekProviderStatus() {
 }
 
 function renderMimoStatus() {
+  if (!isSettingsSurfaceVisible()) return;
   const statusEl = document.getElementById('mimoAccountStatus');
   const listEl = document.getElementById('mimoAccountList');
   const emptyEl = document.getElementById('mimoAccountEmpty');
@@ -14110,12 +14136,14 @@ function renderDeepseekStatus() {
 }
 
 function renderOpenCodeProfiles() {
+  if (!isSettingsSurfaceVisible()) return;
   const listEl = document.getElementById('opencodeProfileList');
   if (!listEl) return;
 
   const api = window.tokenMonitor.opencode;
 
   api.getProfiles().then(({ profiles, hasEnvVar, hasAmbientKey, ambientEnabled = true }) => {
+    if (!isSettingsSurfaceVisible()) return;
     listEl.innerHTML = '';
     const entries = Object.entries(profiles);
 
@@ -14904,6 +14932,7 @@ function appendNamedApiProfileRow(listEl, config) {
 }
 
 function renderNamedApiProfiles(config) {
+  if (!isSettingsSurfaceVisible()) return;
   const {
     providerId,
     profileSettingsKey,
@@ -14918,6 +14947,7 @@ function renderNamedApiProfiles(config) {
   const listEl = document.getElementById(`${providerId}ProfileList`);
   if (!listEl || !api) return;
   api.getProfiles().then(({ profiles, hasEnvVar }) => {
+    if (!isSettingsSurfaceVisible()) return;
     listEl.replaceChildren();
     state.settings[profileSettingsKey] = profiles;
     state.settings[envConfiguredKey] = Boolean(hasEnvVar);
@@ -15002,6 +15032,7 @@ function renderThirdPartyProfiles() {
 }
 
 function renderCursorStatus() {
+  if (!isSettingsSurfaceVisible()) return;
   const statusEl = document.getElementById('cursorAccountStatus');
   const listEl = document.getElementById('cursorAccountList');
   const errorEl = document.getElementById('cursorErrorMessage');
@@ -15162,6 +15193,7 @@ function customPricingMeta(ov) {
 }
 
 function renderCustomPricing() {
+  if (!isSettingsSurfaceVisible()) return;
   const listEl = document.getElementById('customPricingList');
   const statusEl = document.getElementById('customPricingStatus');
   if (!listEl) return;

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -11922,6 +11922,7 @@ const statsRenderScheduler = statsRenderSchedulerApi.createStatsRenderScheduler(
   render: renderStatsUpdate
 });
 function handleWindowVisibilityChange() {
+  if (!statsRenderScheduler.visibilityChanged()) return;
   if (isRendererWindowHidden()) cancelTokenRateBoost();
   if (!isRendererWindowHidden() && state.settings?.hubMode === 'client' && hubBuildStatusRefreshDue()) {
     void refreshHubBuildStatus();

--- a/src/electron/renderer/dashboard.html
+++ b/src/electron/renderer/dashboard.html
@@ -67,6 +67,7 @@
     <script src="../../shared/compactMoney.js"></script>
     <script src="../../shared/fontSettings.js"></script>
     <script src="../motionPreference.js"></script>
+    <script src="statsRenderScheduler.js"></script>
     <script src="dashboard.js"></script>
   </body>
 </html>

--- a/src/electron/renderer/dashboard.js
+++ b/src/electron/renderer/dashboard.js
@@ -8,6 +8,7 @@ const compactMoneyApi = window.TokenMonitorCompactMoney;
 const compactTokenApi = window.TokenMonitorCompactTokens;
 const motionPreferenceApi = window.TokenMonitorMotionPreference;
 const fontSettingsApi = window.TokenMonitorFontSettings;
+const statsRenderSchedulerApi = window.TokenMonitorStatsRenderScheduler;
 const reducedMotionMedia = window.matchMedia?.('(prefers-reduced-motion: reduce)');
 
 // Canonical brand colours, captured before any override (clientColors is shared
@@ -48,6 +49,8 @@ const KLINE_MOTION_MS = 560;
 const HEATMAP_MOTION_MS = 720;
 const HEAT_CELL_MOTION_MS = 280;
 let heatmapMotionGeneration = 0;
+let dashboardReady = false;
+let dashboardRefreshFrame = 0;
 
 function prefersReducedMotion() {
   return motionPreferenceApi.shouldReduceMotion(state.reduceMotion, reducedMotionMedia?.matches);
@@ -513,7 +516,7 @@ function renderActivity() {
   renderBreakdown();
 }
 
-function render() {
+function renderNow() {
   hideTooltip();
   const hasData = (state.history?.daily || []).length > 0 || (state.history?.monthly || []).length > 0;
   els.empty.classList.toggle('hidden', hasData);
@@ -532,6 +535,37 @@ function render() {
   }
   state.motion = 'none';
 }
+
+const dashboardRenderScheduler = statsRenderSchedulerApi.createStatsRenderScheduler({
+  isHidden: () => dashboardReady && document.hidden,
+  render: renderNow
+});
+
+function render() {
+  dashboardRenderScheduler.request();
+}
+
+function scheduleDashboardRefresh() {
+  if (dashboardRefreshFrame) cancelAnimationFrame(dashboardRefreshFrame);
+  dashboardRefreshFrame = requestAnimationFrame(() => {
+    dashboardRefreshFrame = 0;
+    if (document.hidden || refreshRunning) return;
+    refreshQueued = false;
+    void refresh();
+  });
+}
+
+function handleDashboardVisibilityChange() {
+  if (!dashboardRenderScheduler.visibilityChanged()) return;
+  if (!document.hidden) {
+    scheduleDashboardRefresh();
+    return;
+  }
+  if (dashboardRefreshFrame) cancelAnimationFrame(dashboardRefreshFrame);
+  dashboardRefreshFrame = 0;
+}
+
+document.addEventListener('visibilitychange', handleDashboardVisibilityChange);
 
 function hideTooltip() { els.tooltip.classList.add('hidden'); }
 
@@ -596,7 +630,7 @@ async function refresh() {
     console.log(`[dashboard] history failed: ${error.message}`);
   } finally {
     refreshRunning = false;
-    if (refreshQueued) {
+    if (refreshQueued && !document.hidden) {
       refreshQueued = false;
       void refresh();
     }
@@ -619,6 +653,7 @@ async function boot() {
   populateRangeSelect();
   render();
   await refresh();
+  dashboardReady = true;
   window.tokenMonitor.dashboard.ready();
 }
 
@@ -670,7 +705,15 @@ reducedMotionMedia?.addEventListener?.('change', () => {
   render();
 });
 
-window.tokenMonitor.onDashboardHistoryChanged?.(() => { void refresh(); });
+function handleDashboardHistoryChanged() {
+  if (document.hidden) {
+    refreshQueued = true;
+    return;
+  }
+  void refresh();
+}
+
+window.tokenMonitor.onDashboardHistoryChanged?.(handleDashboardHistoryChanged);
 
 els.tabs.forEach((tab) => tab.addEventListener('click', () => {
   if (state.tab === tab.dataset.tab) return;
@@ -730,6 +773,10 @@ window.addEventListener('resize', () => {
   clearTimeout(resizeTimer);
   resizeTimer = setTimeout(() => { state.motion = 'none'; render(); }, 120); // both the chart and the heatmap are sized to the window
 });
-window.addEventListener('focus', refresh);
+function handleDashboardFocus() {
+  if (!document.hidden) scheduleDashboardRefresh();
+}
+
+window.addEventListener('focus', handleDashboardFocus);
 
 boot();

--- a/src/electron/renderer/statsRenderScheduler.js
+++ b/src/electron/renderer/statsRenderScheduler.js
@@ -14,6 +14,7 @@
   function createStatsRenderScheduler({ isHidden, render }) {
     if (typeof isHidden !== 'function') throw new TypeError('isHidden must be a function');
     if (typeof render !== 'function') throw new TypeError('render must be a function');
+    let rendererHidden = isHidden();
     let renderPending = false;
 
     function request() {
@@ -35,10 +36,18 @@
       renderPending = false;
     }
 
+    function visibilityChanged() {
+      const hidden = isHidden();
+      if (hidden === rendererHidden) return false;
+      rendererHidden = hidden;
+      return true;
+    }
+
     return {
       clear,
       flush,
-      request
+      request,
+      visibilityChanged
     };
   }
 

--- a/src/electron/renderer/statsRenderScheduler.js
+++ b/src/electron/renderer/statsRenderScheduler.js
@@ -5,6 +5,12 @@
   if (typeof module === 'object' && module.exports) module.exports = api;
   if (root) root.TokenMonitorStatsRenderScheduler = api;
 })(typeof window !== 'undefined' ? window : null, function createStatsRenderSchedulerApi() {
+  function visibleStatsSurface(rendererHidden, floatingBubbleCollapsed, settingsOpen) {
+    if (rendererHidden) return null;
+    if (floatingBubbleCollapsed) return 'bubble';
+    return settingsOpen ? 'settings' : 'main';
+  }
+
   function createStatsRenderScheduler({ isHidden, render }) {
     if (typeof isHidden !== 'function') throw new TypeError('isHidden must be a function');
     if (typeof render !== 'function') throw new TypeError('render must be a function');
@@ -32,6 +38,7 @@
   }
 
   return {
-    createStatsRenderScheduler
+    createStatsRenderScheduler,
+    visibleStatsSurface
   };
 });

--- a/src/electron/renderer/statsRenderScheduler.js
+++ b/src/electron/renderer/statsRenderScheduler.js
@@ -31,7 +31,12 @@
       renderPending = false;
     }
 
+    function clear() {
+      renderPending = false;
+    }
+
     return {
+      clear,
       flush,
       request
     };

--- a/tests/electron/cursorSettingsLayout.test.js
+++ b/tests/electron/cursorSettingsLayout.test.js
@@ -1773,7 +1773,7 @@ test('remote Hub build status is wired as a separate localized sync hint', () =>
   assert.match(refreshBody, /const request = \+\+hubBuildStatusRequest/);
   assert.equal([...refreshBody.matchAll(/request !== hubBuildStatusRequest/g)].length, 2);
   assert.match(app, /HUB_BUILD_STATUS_REFRESH_TTL_MS = 5 \* 60 \* 1000/);
-  assert.match(app, /visibilitychange[\s\S]*hubBuildStatusRefreshDue\(\)[\s\S]*void refreshHubBuildStatus\(\)/);
+  assert.match(app, /handleWindowVisibilityChange[\s\S]*hubBuildStatusRefreshDue\(\)[\s\S]*void refreshHubBuildStatus\(\)/);
   assert.match(preload, /getHubBuildStatus: \(\) => ipcRenderer\.invoke\('hub:getBuildStatus'\)/);
   assert.match(main, /ipcMain\.handle\('hub:getBuildStatus'/);
   assert.equal([...i18n.matchAll(/'settings\.sync\.hubBuild\.current':/g)].length, 5);

--- a/tests/electron/dashboardWindow.test.js
+++ b/tests/electron/dashboardWindow.test.js
@@ -4,10 +4,19 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
+const vm = require('node:vm');
 
 const rootDir = path.join(__dirname, '..', '..');
 const read = (...p) => fs.readFileSync(path.join(rootDir, ...p), 'utf8');
 const { usageConfigFromSettings } = require('../../src/electron/runtimeConfig');
+
+function dashboardFunction(name, endMarker, context) {
+  const source = read('src', 'electron', 'renderer', 'dashboard.js');
+  const asyncStart = source.indexOf(`async function ${name}(`);
+  const start = asyncStart >= 0 ? asyncStart : source.indexOf(`function ${name}(`);
+  const body = source.slice(start, source.indexOf(endMarker));
+  return new vm.Script(`${body}\n${name};`).runInNewContext(context);
+}
 
 test('preload exposes the dashboard IPC surface', () => {
   const preload = read('src', 'electron', 'preload.js');
@@ -146,7 +155,137 @@ test('dashboard.js fetches history over IPC and renders both tabs', () => {
   assert.match(js, /updateSettings\(\{ dashboardFlat: state\.flat \}\)/);
   assert.match(js, /dashboard\.minimize\(\)/);
   assert.match(js, /dashboard\.ready\(\)/);
-  assert.match(js, /onDashboardHistoryChanged\?\.\(\(\) => \{ void refresh\(\); \}\)/);
+  assert.match(js, /onDashboardHistoryChanged\?\.\(handleDashboardHistoryChanged\)/);
+});
+
+test('dashboard reuses the shared scheduler to defer hidden render work', () => {
+  const html = read('src', 'electron', 'renderer', 'dashboard.html');
+  const js = read('src', 'electron', 'renderer', 'dashboard.js');
+  const schedulerScript = html.indexOf('<script src="statsRenderScheduler.js"></script>');
+  const dashboardScript = html.indexOf('<script src="dashboard.js"></script>');
+
+  assert.ok(schedulerScript >= 0 && schedulerScript < dashboardScript);
+  assert.match(js, /createStatsRenderScheduler\(\{[\s\S]*isHidden: \(\) => dashboardReady && document\.hidden,[\s\S]*render: renderNow/);
+  assert.match(js, /function render\(\) \{\s*dashboardRenderScheduler\.request\(\);\s*\}/);
+  assert.match(js, /function handleDashboardVisibilityChange\(\)[\s\S]*visibilityChanged\(\)[\s\S]*scheduleDashboardRefresh\(\)/);
+  assert.match(js, /document\.addEventListener\('visibilitychange', handleDashboardVisibilityChange\)/);
+});
+
+test('dashboard restore coalesces either native event order into one refresh', () => {
+  let hidden = true;
+  let focused = true;
+  let refreshRunning = false;
+  let refreshQueued = false;
+  let refreshes = 0;
+  let frame = null;
+  const context = {
+    document: {
+      get hidden() { return hidden; },
+      hasFocus: () => focused
+    },
+    requestAnimationFrame(callback) { frame = callback; return 1; },
+    cancelAnimationFrame() { frame = null; },
+    dashboardRenderScheduler: {
+      visibilityChanged: () => true
+    },
+    refresh: () => { refreshes += 1; },
+    get refreshRunning() { return refreshRunning; },
+    get refreshQueued() { return refreshQueued; },
+    set refreshQueued(value) { refreshQueued = value; },
+    get dashboardRefreshFrame() { return frame ? 1 : 0; },
+    set dashboardRefreshFrame(value) { if (!value) frame = null; }
+  };
+  const scheduleRefresh = dashboardFunction(
+    'scheduleDashboardRefresh',
+    '\nfunction handleDashboardVisibilityChange',
+    context
+  );
+  context.scheduleDashboardRefresh = scheduleRefresh;
+  const visibilityChanged = dashboardFunction(
+    'handleDashboardVisibilityChange',
+    "\ndocument.addEventListener('visibilitychange'",
+    context
+  );
+  const focus = dashboardFunction(
+    'handleDashboardFocus',
+    "\nwindow.addEventListener('focus'",
+    context
+  );
+  const runFrame = () => { const callback = frame; frame = null; callback(); };
+
+  focus();
+  assert.equal(frame, null, 'macOS focuses the window while its document is still hidden');
+
+  hidden = false;
+  visibilityChanged();
+  focus();
+  runFrame();
+  assert.equal(refreshes, 1, 'focus then visibility shares one animation-frame refresh');
+
+  hidden = true;
+  visibilityChanged();
+  focused = false;
+  hidden = false;
+  visibilityChanged();
+  focused = true;
+  focus();
+  runFrame();
+  assert.equal(refreshes, 2, 'visibility then focus also shares one animation-frame refresh');
+
+  refreshRunning = true;
+  visibilityChanged();
+  runFrame();
+  assert.equal(refreshes, 2, 'an in-flight history refresh will render the latest state itself');
+});
+
+test('dashboard history invalidation defers IPC while hidden', () => {
+  let hidden = true;
+  let refreshQueued = false;
+  let refreshes = 0;
+  const context = {
+    document: { get hidden() { return hidden; } },
+    refresh: () => { refreshes += 1; },
+    get refreshQueued() { return refreshQueued; },
+    set refreshQueued(value) { refreshQueued = value; }
+  };
+  const historyChanged = dashboardFunction(
+    'handleDashboardHistoryChanged',
+    '\nwindow.tokenMonitor.onDashboardHistoryChanged',
+    context
+  );
+
+  historyChanged();
+  historyChanged();
+  assert.equal(refreshes, 0);
+  assert.equal(refreshQueued, true);
+
+  hidden = false;
+  historyChanged();
+  assert.equal(refreshes, 1);
+});
+
+test('an in-flight Dashboard refresh preserves a hidden invalidation for restore', async () => {
+  let refreshRunning = false;
+  let refreshQueued = true;
+  let requests = 0;
+  const context = {
+    document: { hidden: true },
+    state: { history: null, motion: 'none' },
+    window: { tokenMonitor: { getDashboardHistory: async () => { requests += 1; return {}; } } },
+    render() {},
+    console: { log() {} },
+    get refreshRunning() { return refreshRunning; },
+    set refreshRunning(value) { refreshRunning = value; },
+    get refreshQueued() { return refreshQueued; },
+    set refreshQueued(value) { refreshQueued = value; }
+  };
+  const refresh = dashboardFunction('refresh', '\nasync function boot(', context);
+
+  await refresh();
+  await Promise.resolve();
+
+  assert.equal(requests, 1);
+  assert.equal(refreshQueued, true);
 });
 
 test('heatmap metric preserves the legacy cost default and normalizes settings', () => {

--- a/tests/electron/electronApiSurface.test.js
+++ b/tests/electron/electronApiSurface.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const electronDir = path.join(repoRoot, 'src', 'electron');
+const typingsPath = path.join(repoRoot, 'node_modules', 'electron', 'electron.d.ts');
+
+// BrowserWindow inherits these; electron.d.ts declares them on the base class.
+const INHERITED_METHODS = new Set([
+  'addListener', 'emit', 'eventNames', 'getMaxListeners', 'listenerCount', 'listeners',
+  'off', 'on', 'once', 'prependListener', 'prependOnceListener', 'rawListeners',
+  'removeAllListeners', 'removeListener', 'setMaxListeners'
+]);
+
+// Locals that hold a BrowserWindow. A `foo.webContents.send()` chain does not match,
+// because `webContents` is not followed by a call.
+const WINDOW_CALL = /\b(?:mainWindow|dashboardWindow|win|target)\.([a-zA-Z][A-Za-z0-9]*)\s*\??\.?\(/g;
+
+function browserWindowMethods() {
+  const typings = fs.readFileSync(typingsPath, 'utf8');
+  const body = typings.match(/\n {2}class BrowserWindow extends .*?\{\n([\s\S]*?)\n {2}\}\n/);
+  assert.ok(body, 'could not locate the BrowserWindow class in electron.d.ts');
+  const declared = body[1].matchAll(/^ {4}([a-zA-Z][A-Za-z0-9]*)\s*\(/gm);
+  const methods = new Set([...declared].map((match) => match[1]));
+  assert.ok(methods.has('setVibrancy'), 'BrowserWindow method extraction produced nothing usable');
+  return new Set([...methods, ...INHERITED_METHODS]);
+}
+
+// `win.setVisualEffectState?.('active')` read as if it managed the material's active
+// state. The method has never existed on BrowserWindow, and the optional call swallowed
+// that without a crash, a warning or a lint error, so only the constructor option was
+// ever doing the work — deleting it greyed the glass out on every unfocused window, and
+// the unit test passed anyway because its fake window supplied the missing method.
+test('every BrowserWindow method the window lifecycle calls exists in Electron', () => {
+  const known = browserWindowMethods();
+  const offenders = [];
+  let scanned = 0;
+
+  for (const entry of fs.readdirSync(electronDir).filter((name) => name.endsWith('.js')).sort()) {
+    const lines = fs.readFileSync(path.join(electronDir, entry), 'utf8').split('\n');
+    lines.forEach((line, index) => {
+      for (const [, method] of line.matchAll(WINDOW_CALL)) {
+        scanned += 1;
+        if (!known.has(method)) offenders.push(`${entry}:${index + 1} calls win.${method}()`);
+      }
+    });
+  }
+
+  assert.ok(scanned > 20, `expected to scan real BrowserWindow calls, saw ${scanned}`);
+  assert.deepEqual(offenders, [], `not a BrowserWindow method:\n  ${offenders.join('\n  ')}`);
+});

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -1644,6 +1644,7 @@ test('background provider rerenders preserve settings scroll without a focused c
     {
       cancelAnimationFrame: () => {},
       els,
+      isRendererWindowHidden: () => false,
       limitProviderRowDrag: { deferRender: () => false },
       renderLimitProviderCheckboxesNow,
       requestAnimationFrame: (callback) => frames.push(callback)
@@ -1660,6 +1661,37 @@ test('background provider rerenders preserve settings scroll without a focused c
   frames[0]();
   assert.equal(panel.scrollTop, 684);
   assert.equal(panel.scrollLeft, 9);
+});
+
+test('hidden settings rerenders skip settings panel scroll DOM', () => {
+  const app = readRendererFile('app.js');
+  const preserveScroll = functionBody(app, 'preserveSettingsPanelScroll', 'saveSettings');
+  let reads = 0;
+  let writes = 0;
+  const metrics = { callbacks: 0 };
+  const panel = { classList: { contains: () => false } };
+  for (const key of ['scrollTop', 'scrollLeft']) {
+    Object.defineProperty(panel, key, {
+      get() { reads += 1; return 0; },
+      set() { writes += 1; }
+    });
+  }
+
+  vm.runInNewContext(
+    `${preserveScroll}\npreserveSettingsPanelScroll(() => { metrics.callbacks += 1; });`,
+    {
+      els: { settingsPanel: panel },
+      isRendererWindowHidden: () => true,
+      metrics,
+      panel,
+      requestAnimationFrame: () => { throw new Error('hidden render scheduled a frame'); },
+      settingsScrollInteractionRevision: 0
+    }
+  );
+
+  assert.equal(reads, 0);
+  assert.equal(writes, 0);
+  assert.equal(metrics.callbacks, 1);
 });
 
 test('user scrolling wins over a pending provider scroll restore', () => {
@@ -1702,6 +1734,7 @@ renderLimitProviderCheckboxes();`,
       cancelAnimationFrame: () => {},
       document: { querySelectorAll: () => [] },
       els,
+      isRendererWindowHidden: () => false,
       limitProviderRowDrag: { deferRender: () => false },
       renderLimitProviderCheckboxesNow,
       requestAnimationFrame: (callback) => frames.push(callback)
@@ -2800,6 +2833,7 @@ test('deleting a subscription preserves the settings scroll position and renders
   };
   const context = vm.createContext({
     els: { settingsPanel: panel },
+    isRendererWindowHidden: () => false,
     panel,
     settingsScrollInteractionRevision: 0,
     requestAnimationFrame(callback) {

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -769,13 +769,16 @@ test('hidden Settings keeps the custom tray clock running without refreshing com
   const syncClock = functionBody(app, 'syncCustomTrayClockTimer', 'refreshTrayComposers');
   const maybeUpdateBarsIcon = `async ${functionBody(app, 'maybeUpdateBarsIcon', 'loadImage')}`;
   const intervals = [];
+  let bubbleRenders = 0;
+  let scheduledRenders = 0;
   const context = {
     customTrayClockTimer: null,
+    isRendererWindowHidden: () => true,
     isSettingsSurfaceVisible: () => false,
     refreshTrayComposers: () => { throw new Error('hidden Settings refreshed composer DOM'); },
-    renderFloatingBubbleContent() {},
-    setInterval: (_callback, delay) => {
-      intervals.push(delay);
+    renderFloatingBubbleContent() { bubbleRenders += 1; },
+    setInterval: (callback, delay) => {
+      intervals.push({ callback, delay });
       return 1;
     },
     clearInterval() {},
@@ -785,6 +788,7 @@ test('hidden Settings keeps the custom tray clock running without refreshing com
         trayCustomLayout: { items: [{ type: 'clock' }] }
       }
     },
+    statsRenderScheduler: { request() { scheduledRenders += 1; } },
     trayLayoutApi: { trayLayoutNeedsClock: () => true },
     window: {
       TokenMonitorTrayText: { isGeneratedTrayIconMode: () => false },
@@ -797,7 +801,11 @@ test('hidden Settings keeps the custom tray clock running without refreshing com
     context
   );
 
-  assert.deepEqual(intervals, [30_000]);
+  assert.equal(intervals.length, 1);
+  assert.equal(intervals[0].delay, 30_000);
+  await intervals[0].callback();
+  assert.equal(bubbleRenders, 0);
+  assert.equal(scheduledRenders, 1);
 });
 
 test('provider tray badges are opt-in and keep monochrome assets visible', () => {

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -1905,11 +1905,15 @@ test('provider option rerenders reuse the existing switch DOM', () => {
 test('settings pushes do not trigger a second full settings sync after save', () => {
   const app = readRendererFile('app.js');
   const save = functionBody(app, 'saveSettings', 'renderHomeIfVisible');
+  const syncSettings = functionBody(app, 'syncSettingsForm', 'enabledClientSet');
   const settingsPush = app.match(/window\.tokenMonitor\.onSettingsPush\?\.\(\(next\) => \{[\s\S]*?\n\}\);/)?.[0] || '';
 
   assert.match(save, /const settingsPushRevision = state\.settingsPushRevision;/);
   assert.match(save, /if \(state\.settingsPushRevision === settingsPushRevision\) \{\s*preserveSettingsPanelScroll\(syncSettingsForm\);/);
   assert.match(settingsPush, /state\.settingsPushRevision \+= 1;/);
+  assert.match(syncSettings, /if \(!isSettingsSurfaceVisible\(\)\) return;/);
+  assert.doesNotMatch(syncSettings, /\b(?:render|renderLimits|applyFloatingBubbleState)\(/);
+  assert.match(settingsPush, /if \(!isSettingsSurfaceVisible\(\)\) statsRenderScheduler\.request\(\);/);
 });
 
 test('main limits rerenders coalesce identical visible provider data', () => {

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -764,6 +764,42 @@ test('limit percent tray mode renders provider icons into a generated tray image
   assert.doesNotMatch(main, /process\.platform === 'darwin'\) sized\.setTemplateImage\(true\)/);
 });
 
+test('hidden Settings keeps the custom tray clock running without refreshing composer DOM', async () => {
+  const app = readRendererFile('app.js');
+  const syncClock = functionBody(app, 'syncCustomTrayClockTimer', 'refreshTrayComposers');
+  const maybeUpdateBarsIcon = `async ${functionBody(app, 'maybeUpdateBarsIcon', 'loadImage')}`;
+  const intervals = [];
+  const context = {
+    customTrayClockTimer: null,
+    isSettingsSurfaceVisible: () => false,
+    refreshTrayComposers: () => { throw new Error('hidden Settings refreshed composer DOM'); },
+    renderFloatingBubbleContent() {},
+    setInterval: (_callback, delay) => {
+      intervals.push(delay);
+      return 1;
+    },
+    clearInterval() {},
+    state: {
+      settings: {
+        trayContent: 'custom',
+        trayCustomLayout: { items: [{ type: 'clock' }] }
+      }
+    },
+    trayLayoutApi: { trayLayoutNeedsClock: () => true },
+    window: {
+      TokenMonitorTrayText: { isGeneratedTrayIconMode: () => false },
+      tokenMonitor: {}
+    }
+  };
+
+  await vm.runInNewContext(
+    `${syncClock}\n${maybeUpdateBarsIcon}\nmaybeUpdateBarsIcon();`,
+    context
+  );
+
+  assert.deepEqual(intervals, [30_000]);
+});
+
 test('provider tray badges are opt-in and keep monochrome assets visible', () => {
   const app = readRendererFile('app.js');
   const html = readRendererFile('index.html');

--- a/tests/electron/nativeMaterialVisibility.test.js
+++ b/tests/electron/nativeMaterialVisibility.test.js
@@ -12,7 +12,6 @@ const {
 
 function fakeWindow() {
   const listeners = new Map();
-  const states = [];
   const materials = [];
   let visible = false;
   let minimized = false;
@@ -25,9 +24,7 @@ function fakeWindow() {
     on(event, callback) { listeners.set(event, callback); },
     setMinimized(value) { minimized = value; },
     setVisible(value) { visible = value; },
-    setVibrancy(value) { materials.push(value); },
-    setVisualEffectState(value) { states.push(value); },
-    states
+    setVibrancy(value) { materials.push(value); }
   };
 }
 
@@ -43,7 +40,6 @@ test('native material is active only for a visible non-minimized macOS window', 
   syncNativeMaterialVisibility(win, true, 'win32');
 
   assert.deepEqual(win.materials, ['hud', null, null]);
-  assert.deepEqual(win.states, ['active', 'inactive', 'inactive']);
 });
 
 test('window lifecycle suspends and restores the latest material preference', () => {
@@ -60,12 +56,30 @@ test('window lifecycle suspends and restores the latest material preference', ()
   win.emit('restore');
 
   assert.deepEqual(win.materials, ['hud', null, null]);
-  assert.deepEqual(win.states, ['active', 'inactive', 'inactive']);
+});
+
+test('an unchanged material preference does not re-apply to the Dashboard', () => {
+  const main = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'electron', 'main.js'), 'utf8');
+  const applyMaterial = main.slice(
+    main.indexOf('function applyNativeMaterial(source = settings)'),
+    main.indexOf('function createWindow(')
+  );
+
+  // applyNativeMaterial() runs on every floating-bubble collapse/expand, which
+  // carries no information about the Dashboard.
+  assert.match(
+    applyMaterial,
+    /dashboardWindowNativeBlurEnabled !== enabled\) \{\s*dashboardWindowNativeBlurEnabled = enabled;\s*syncNativeMaterialVisibility\(dashboardWindow, enabled\);/
+  );
 });
 
 test('main and Dashboard windows use the visibility-aware material lifecycle', () => {
   const main = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'electron', 'main.js'), 'utf8');
   assert.equal([...main.matchAll(/attachNativeMaterialVisibility\(win,/g)].length, 2);
-  assert.doesNotMatch(main, /vibrancy:\s*'hud'/);
+  // Electron has no setVisualEffectState, so 'active' can only be set at
+  // construction. Losing it makes macOS fall back to followWindow, which greys
+  // the glass out whenever the window is not key.
+  assert.equal([...main.matchAll(/visualEffectState: 'active'/g)].length, 2);
+  assert.doesNotMatch(main, /\.setVisualEffectState\(/);
   assert.equal([...main.matchAll(/syncNativeMaterialVisibility\((?:mainWindow|dashboardWindow),/g)].length, 2);
 });

--- a/tests/electron/nativeMaterialVisibility.test.js
+++ b/tests/electron/nativeMaterialVisibility.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  attachNativeMaterialVisibility,
+  syncNativeMaterialVisibility
+} = require('../../src/electron/nativeMaterialVisibility');
+
+function fakeWindow() {
+  const listeners = new Map();
+  const states = [];
+  const materials = [];
+  let visible = false;
+  let minimized = false;
+  return {
+    emit(event) { listeners.get(event)?.(); },
+    isDestroyed: () => false,
+    isMinimized: () => minimized,
+    isVisible: () => visible,
+    materials,
+    on(event, callback) { listeners.set(event, callback); },
+    setMinimized(value) { minimized = value; },
+    setVisible(value) { visible = value; },
+    setVibrancy(value) { materials.push(value); },
+    setVisualEffectState(value) { states.push(value); },
+    states
+  };
+}
+
+test('native material is active only for a visible non-minimized macOS window', () => {
+  const win = fakeWindow();
+  win.setVisible(true);
+  syncNativeMaterialVisibility(win, true, 'darwin');
+  win.setVisible(false);
+  syncNativeMaterialVisibility(win, true, 'darwin');
+  win.setVisible(true);
+  win.setMinimized(true);
+  syncNativeMaterialVisibility(win, true, 'darwin');
+  syncNativeMaterialVisibility(win, true, 'win32');
+
+  assert.deepEqual(win.materials, ['hud', null, null]);
+  assert.deepEqual(win.states, ['active', 'inactive', 'inactive']);
+});
+
+test('window lifecycle suspends and restores the latest material preference', () => {
+  const win = fakeWindow();
+  let enabled = true;
+  attachNativeMaterialVisibility(win, () => enabled, 'darwin');
+
+  win.setVisible(true);
+  win.emit('show');
+  win.setVisible(false);
+  win.emit('hide');
+  enabled = false;
+  win.setVisible(true);
+  win.emit('restore');
+
+  assert.deepEqual(win.materials, ['hud', null, null]);
+  assert.deepEqual(win.states, ['active', 'inactive', 'inactive']);
+});
+
+test('main and Dashboard windows use the visibility-aware material lifecycle', () => {
+  const main = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'electron', 'main.js'), 'utf8');
+  assert.equal([...main.matchAll(/attachNativeMaterialVisibility\(win,/g)].length, 2);
+  assert.doesNotMatch(main, /vibrancy:\s*'hud'/);
+  assert.equal([...main.matchAll(/syncNativeMaterialVisibility\((?:mainWindow|dashboardWindow),/g)].length, 2);
+});

--- a/tests/electron/nativeMaterialVisibility.test.js
+++ b/tests/electron/nativeMaterialVisibility.test.js
@@ -58,15 +58,19 @@ test('window lifecycle suspends and restores the latest material preference', ()
   assert.deepEqual(win.materials, ['hud', null, null]);
 });
 
-test('an unchanged material preference does not re-apply to the Dashboard', () => {
+test('an unchanged material preference does not re-apply to either window', () => {
   const main = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'electron', 'main.js'), 'utf8');
   const applyMaterial = main.slice(
     main.indexOf('function applyNativeMaterial(source = settings)'),
-    main.indexOf('function createWindow(')
+    main.indexOf('function withHistoryPreview(')
   );
 
-  // applyNativeMaterial() runs on every floating-bubble collapse/expand, which
-  // carries no information about the Dashboard.
+  // applyNativeMaterial() also runs for every appearance slider preview and
+  // floating-bubble transition; neither should rebuild an unchanged effect.
+  assert.match(
+    applyMaterial,
+    /mainWindowNativeBlurEnabled !== enabled\) \{\s*mainWindowNativeBlurEnabled = enabled;\s*syncNativeMaterialVisibility\(mainWindow, enabled\);/
+  );
   assert.match(
     applyMaterial,
     /dashboardWindowNativeBlurEnabled !== enabled\) \{\s*dashboardWindowNativeBlurEnabled = enabled;\s*syncNativeMaterialVisibility\(dashboardWindow, enabled\);/
@@ -75,11 +79,25 @@ test('an unchanged material preference does not re-apply to the Dashboard', () =
 
 test('main and Dashboard windows use the visibility-aware material lifecycle', () => {
   const main = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'electron', 'main.js'), 'utf8');
+  const mainWindowConstructor = main.slice(
+    main.indexOf('function createWindow('),
+    main.indexOf('function handleZoomShortcut(')
+  );
+  const dashboardWindowConstructor = main.slice(
+    main.indexOf('function createDashboardWindow('),
+    main.indexOf('async function getDashboardHistory(')
+  );
   assert.equal([...main.matchAll(/attachNativeMaterialVisibility\(win,/g)].length, 2);
   // Electron has no setVisualEffectState, so 'active' can only be set at
-  // construction. Losing it makes macOS fall back to followWindow, which greys
-  // the glass out whenever the window is not key.
-  assert.equal([...main.matchAll(/visualEffectState: 'active'/g)].length, 2);
+  // construction. Both windows must retain that construction-time capability
+  // even when system glass starts disabled and is enabled later at runtime.
+  for (const constructor of [mainWindowConstructor, dashboardWindowConstructor]) {
+    assert.match(
+      constructor,
+      /process\.platform === 'darwin' \? \{ vibrancy: 'hud', visualEffectState: 'active' \} : \{\}/
+    );
+  }
+  assert.match(mainWindowConstructor, /mainWindow = win;\s*mainWindowNativeBlurEnabled = null;/);
   assert.doesNotMatch(main, /\.setVisualEffectState\(/);
   assert.equal([...main.matchAll(/syncNativeMaterialVisibility\((?:mainWindow|dashboardWindow),/g)].length, 2);
 });

--- a/tests/electron/rendererMotion.test.js
+++ b/tests/electron/rendererMotion.test.js
@@ -61,8 +61,10 @@ test('period changes preserve row identity, animate rank changes, and count from
 
 test('live row updates count and resize bars together without slowing the headline', () => {
   const app = read('app.js');
+  const renderRows = app.slice(app.indexOf('function renderRows('), app.indexOf('function deviceLabel('));
 
-  assert.match(app, /const liveMotionSnapshot = !state\.periodMotionActive && !state\.animateBarsFromZero[\s\S]*?captureBreakdownMotion\(\)/);
+  assert.match(renderRows, /const rowsChanged =[\s\S]*?const liveMotionSnapshot = rowsChanged && !state\.periodMotionActive && !state\.animateBarsFromZero[\s\S]*?captureBreakdownMotion\(\)/);
+  assert.ok(renderRows.indexOf('captureBreakdownMotion()') < renderRows.indexOf('if (structureChanged)'));
   assert.match(app, /if \(liveMotionSnapshot\) animateBreakdownFrom\(liveMotionSnapshot, \{ duration: 600 \}\)/);
   assert.match(app, /const animationFrom = numberAnimHandle \? numberAnimValue : state\.currentTotal/);
   assert.match(app, /animateTotalNumber\(els\.totalTokens, animationFrom, nextTotal, state\.periodMotionActive \? 800 : 1000\)/);

--- a/tests/electron/sessionDetail.test.js
+++ b/tests/electron/sessionDetail.test.js
@@ -21,13 +21,16 @@ function deferred() {
 }
 
 function sessionDetailHarness(getSessionDetail) {
-  const start = rendererSource.indexOf('async function openSessionDetail(');
+  const start = rendererSource.indexOf('function applySessionDetailResult(');
   const end = rendererSource.indexOf('\nfunction toggleDetailSort', start);
   assert.ok(start >= 0 && end > start, 'openSessionDetail should be present');
   const renders = [];
   const state = { period: 'today', openSession: null };
   const context = {
     state,
+    visibleStatsSurface: () => 'main',
+    isRendererWindowHidden: () => false,
+    statsRenderScheduler: { request() {} },
     renderSessionDetail: (args) => renders.push(args),
     window: { tokenMonitor: { getSessionDetail } }
   };

--- a/tests/electron/statsRenderScheduler.test.js
+++ b/tests/electron/statsRenderScheduler.test.js
@@ -11,6 +11,7 @@ const {
 } = require('../../src/electron/renderer/statsRenderScheduler');
 
 const rendererDir = path.join(__dirname, '..', '..', 'src', 'electron', 'renderer');
+const electronDir = path.join(rendererDir, '..');
 
 test('hidden stats updates coalesce into one render when visibility returns', () => {
   let hidden = true;
@@ -42,6 +43,21 @@ test('visible stats updates continue rendering every push', () => {
   scheduler.request();
   scheduler.request();
   assert.equal(renders, 2);
+});
+
+test('clearing a hidden update prevents a redundant catch-up render', () => {
+  let hidden = true;
+  let renders = 0;
+  const scheduler = createStatsRenderScheduler({
+    isHidden: () => hidden,
+    render: () => { renders += 1; }
+  });
+
+  scheduler.request();
+  scheduler.clear();
+  hidden = false;
+  scheduler.flush();
+  assert.equal(renders, 0);
 });
 
 test('visible stats update only the exposed surface', () => {
@@ -88,8 +104,8 @@ test('renderer wires visibility scheduling without deferring tray icon updates',
   const statsPush = app.match(/window\.tokenMonitor\.onStatsPush\?\.\(\(payload\) => \{[\s\S]*?\n\}\);/)?.[0] || '';
   const schedulerIndex = html.indexOf('<script src="statsRenderScheduler.js"></script>');
   const appIndex = html.indexOf('<script src="app.js"></script>');
-  const visibilityListenerStart = app.indexOf("document.addEventListener('visibilitychange'");
-  const visibilityListenerEnd = app.indexOf('window.tokenMonitor.onStatsPush', visibilityListenerStart);
+  const visibilityListenerStart = app.indexOf('function handleWindowVisibilityChange()');
+  const visibilityListenerEnd = app.indexOf("document.addEventListener('visibilitychange'", visibilityListenerStart);
   const visibilityListener = visibilityListenerStart >= 0 && visibilityListenerEnd > visibilityListenerStart
     ? app.slice(visibilityListenerStart, visibilityListenerEnd)
     : '';
@@ -99,14 +115,47 @@ test('renderer wires visibility scheduling without deferring tray icon updates',
   assert.ok(schedulerIndex < appIndex);
   assert.notEqual(visibilityListenerStart, -1);
   assert.notEqual(visibilityListenerEnd, -1);
+  assert.match(app, /document\.addEventListener\('visibilitychange', handleWindowVisibilityChange\)/);
   assert.match(visibilityListener, /cancelTokenRateBoost\(\)/);
-  assert.match(visibilityListener, /!document\.hidden[\s\S]*hubBuildStatusRefreshDue\(\)[\s\S]*refreshHubBuildStatus\(\)/);
-  assert.match(visibilityListener, /statsRenderScheduler\.flush\(\)/);
-  assert.match(visibilityListener, /if \(isSettingsSurfaceVisible\(\)\) syncSettingsForm\(\);/);
+  assert.match(visibilityListener, /!isRendererWindowHidden\(\)[\s\S]*hubBuildStatusRefreshDue\(\)[\s\S]*refreshHubBuildStatus\(\)/);
+  assert.match(visibilityListener, /if \(isSettingsSurfaceVisible\(\)\)[\s\S]*statsRenderScheduler\.clear\(\)[\s\S]*syncSettingsForm\(\)[\s\S]*else[\s\S]*statsRenderScheduler\.flush\(\)/);
+  assert.match(app, /isHidden: isRendererWindowHidden/);
+  assert.match(app, /onWindowVisibilityPush\?\.\(\(visible\) => \{/);
   assert.match(
     statsPush,
     /state\.stats = overlayAllTimeSessions\(payload\.data\.stats\);[\s\S]*statsRenderScheduler\.request\(\);[\s\S]*maybeUpdateBarsIcon\(\);/
   );
+});
+
+test('native window visibility covers a tray window that has never been shown', () => {
+  const main = fs.readFileSync(path.join(electronDir, 'main.js'), 'utf8');
+  const preload = fs.readFileSync(path.join(electronDir, 'preload.js'), 'utf8');
+  const app = fs.readFileSync(path.join(rendererDir, 'app.js'), 'utf8');
+
+  assert.match(main, /webContents\.send\('window:visibility'/);
+  assert.match(main, /win\.on\('show',[\s\S]*win\.on\('hide',[\s\S]*win\.on\('minimize',[\s\S]*win\.on\('restore'/);
+  assert.match(main, /settings\?\.trayMode \? \{ windowHidden: '1' \} : \{\}/);
+  assert.match(preload, /onWindowVisibilityPush:[\s\S]*ipcRenderer\.on\('window:visibility'/);
+  assert.match(app, /windowVisible: new URLSearchParams\(window\.location\.search\)\.get\('windowHidden'\) !== '1'/);
+  assert.match(app, /return document\.hidden \|\| !state\.windowVisible;/);
+});
+
+test('hidden event sources defer DOM work and visible surfaces catch up', () => {
+  const app = fs.readFileSync(path.join(rendererDir, 'app.js'), 'utf8');
+  const settingsPush = app.match(/window\.tokenMonitor\.onSettingsPush\?\.\(\(next\) => \{[\s\S]*?\n\}\);/)?.[0] || '';
+  const hubPush = app.match(/window\.tokenMonitor\.onHubPush\?\.\(\(payload\) => \{[\s\S]*?\n\}\);/)?.[0] || '';
+  const statsPush = app.match(/window\.tokenMonitor\.onStatsPush\?\.\(\(payload\) => \{[\s\S]*?\n\}\);/)?.[0] || '';
+  const statsRender = app.slice(app.indexOf('function renderStatsUpdate()'), app.indexOf('const statsRenderScheduler ='));
+  const bubbleState = app.slice(app.indexOf('function applyFloatingBubbleState('), app.indexOf('const BUBBLE_CONTENT_VALUES'));
+
+  assert.match(settingsPush, /statsRenderScheduler\.request\(\)/);
+  assert.match(hubPush, /if \(settingsVisible\) renderHubStatus\(\)/);
+  assert.match(hubPush, /const settingsVisible = isSettingsSurfaceVisible\(\)[\s\S]*settingsVisible && els\.hubSecretInput/);
+  assert.doesNotMatch(statsPush, /\b(?:setLiveDot|setStatus|renderSyncClientStatus)\(/);
+  assert.match(statsPush, /if \(isRendererWindowHidden\(\)\) statsRenderScheduler\.request\(\);[\s\S]*else renderConnectionStatus\(\);/);
+  assert.match(statsRender, /renderConnectionStatus\(surface\)/);
+  assert.match(bubbleState, /isSettingsPanelOpen\(\)[\s\S]*syncSettingsForm\(\)[\s\S]*renderStatsUpdate\(\)/);
+  assert.match(bubbleState, /syncSettingsForm\(\);[\s\S]*renderConnectionStatus\('settings'\)/);
 });
 
 test('all stats refreshes use visibility-aware rendering', () => {

--- a/tests/electron/statsRenderScheduler.test.js
+++ b/tests/electron/statsRenderScheduler.test.js
@@ -60,6 +60,31 @@ test('clearing a hidden update prevents a redundant catch-up render', () => {
   assert.equal(renders, 0);
 });
 
+test('page and native visibility signals report each combined edge once', () => {
+  let pageHidden = false;
+  let nativeVisible = true;
+  const scheduler = createStatsRenderScheduler({
+    isHidden: () => pageHidden || !nativeVisible,
+    render: () => {}
+  });
+
+  for (const [nextPageHidden, nextNativeVisible, changed] of [
+    [false, true, false],
+    [true, true, true],
+    [true, false, false],
+    [false, false, false],
+    [false, true, true],
+    [false, false, true],
+    [true, false, false],
+    [true, true, false],
+    [false, true, true]
+  ]) {
+    pageHidden = nextPageHidden;
+    nativeVisible = nextNativeVisible;
+    assert.equal(scheduler.visibilityChanged(), changed);
+  }
+});
+
 test('visible stats update only the exposed surface', () => {
   assert.equal(visibleStatsSurface(false, false, false), 'main');
   assert.equal(visibleStatsSurface(false, false, true), 'settings');

--- a/tests/electron/statsRenderScheduler.test.js
+++ b/tests/electron/statsRenderScheduler.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
+const vm = require('node:vm');
 
 const {
   createStatsRenderScheduler,
@@ -12,6 +13,12 @@ const {
 
 const rendererDir = path.join(__dirname, '..', '..', 'src', 'electron', 'renderer');
 const electronDir = path.join(rendererDir, '..');
+
+function rendererFunction(name, endMarker, context) {
+  const app = fs.readFileSync(path.join(rendererDir, 'app.js'), 'utf8');
+  const source = app.slice(app.indexOf(`function ${name}(`), app.indexOf(endMarker));
+  return new vm.Script(`${source}\n${name};`).runInNewContext(context);
+}
 
 test('hidden stats updates coalesce into one render when visibility returns', () => {
   let hidden = true;
@@ -91,6 +98,31 @@ test('visible stats update only the exposed surface', () => {
   assert.equal(visibleStatsSurface(false, true, false), 'bubble');
   assert.equal(visibleStatsSurface(true, false, false), null);
   assert.equal(visibleStatsSurface(true, true, false), null);
+});
+
+test('a hidden floating-bubble state update changes state without touching DOM', () => {
+  let scheduledRenders = 0;
+  const state = { floatingBubble: { collapsed: false, side: null } };
+  const applyFloatingBubbleState = rendererFunction(
+    'applyFloatingBubbleState',
+    'const BUBBLE_CONTENT_VALUES',
+    {
+      document: {
+        get documentElement() {
+          return assert.fail('hidden floating-bubble state touched DOM');
+        }
+      },
+      isRendererWindowHidden: () => true,
+      state,
+      statsRenderScheduler: { request() { scheduledRenders += 1; } }
+    }
+  );
+
+  applyFloatingBubbleState({ collapsed: true, side: 'left' });
+
+  assert.equal(state.floatingBubble.collapsed, true);
+  assert.equal(state.floatingBubble.side, 'left');
+  assert.equal(scheduledRenders, 1);
 });
 
 test('hidden payloads keep the latest state and tray updates before visible rendering resumes', () => {
@@ -242,6 +274,7 @@ test('hidden event sources defer DOM work and visible surfaces catch up', () => 
     assert.ok(hiddenReturn < settingsSync.indexOf(domCall));
   }
   assert.match(settingsSync, /if \(isRendererWindowHidden\(\)\) \{[\s\S]*settingsDomSyncPending = true;[\s\S]*return;/);
+  assert.match(visibilityHandler, /else applyFloatingBubbleState\(state\.floatingBubble, \{ renderContent: false \}\);/);
   assert.match(visibilityHandler, /else \{[\s\S]*if \(settingsDomSyncPending\) syncSettingsForm\(\);[\s\S]*statsRenderScheduler\.flush\(\);/);
 });
 

--- a/tests/electron/statsRenderScheduler.test.js
+++ b/tests/electron/statsRenderScheduler.test.js
@@ -172,6 +172,10 @@ test('hidden event sources defer DOM work and visible surfaces catch up', () => 
   const statsPush = app.match(/window\.tokenMonitor\.onStatsPush\?\.\(\(payload\) => \{[\s\S]*?\n\}\);/)?.[0] || '';
   const statsRender = app.slice(app.indexOf('function renderStatsUpdate()'), app.indexOf('const statsRenderScheduler ='));
   const bubbleState = app.slice(app.indexOf('function applyFloatingBubbleState('), app.indexOf('const BUBBLE_CONTENT_VALUES'));
+  const settingsSync = app.slice(app.indexOf('function syncSettingsForm()'), app.indexOf('function enabledClientSet()'));
+  const visibilityHandler = app.slice(app.indexOf('function handleWindowVisibilityChange()'), app.indexOf("document.addEventListener('visibilitychange'"));
+  const hiddenGuard = settingsSync.indexOf('if (isRendererWindowHidden())');
+  const hiddenReturn = settingsSync.indexOf('return;', hiddenGuard);
 
   assert.match(settingsPush, /statsRenderScheduler\.request\(\)/);
   assert.match(hubPush, /if \(settingsVisible\) renderHubStatus\(\)/);
@@ -181,6 +185,15 @@ test('hidden event sources defer DOM work and visible surfaces catch up', () => 
   assert.match(statsRender, /renderConnectionStatus\(surface\)/);
   assert.match(bubbleState, /isSettingsPanelOpen\(\)[\s\S]*syncSettingsForm\(\)[\s\S]*renderStatsUpdate\(\)/);
   assert.match(bubbleState, /syncSettingsForm\(\);[\s\S]*renderConnectionStatus\('settings'\)/);
+  assert.ok(hiddenGuard < settingsSync.indexOf('applyInitialBreakdownPreference()'));
+  assert.ok(settingsSync.indexOf('applyInitialBreakdownPreference()') < hiddenReturn);
+  assert.ok(hiddenGuard < settingsSync.indexOf('applyVendorColorOverrides('));
+  assert.ok(settingsSync.indexOf('applyVendorColorOverrides(') < hiddenReturn);
+  for (const domCall of ['applySettingsTranslations()', 'syncPeriodTabs()', 'applyAppearanceSettings(']) {
+    assert.ok(hiddenReturn < settingsSync.indexOf(domCall));
+  }
+  assert.match(settingsSync, /if \(isRendererWindowHidden\(\)\) \{[\s\S]*settingsDomSyncPending = true;[\s\S]*return;/);
+  assert.match(visibilityHandler, /else \{[\s\S]*if \(settingsDomSyncPending\) syncSettingsForm\(\);[\s\S]*statsRenderScheduler\.flush\(\);/);
 });
 
 test('all stats refreshes use visibility-aware rendering', () => {

--- a/tests/electron/statsRenderScheduler.test.js
+++ b/tests/electron/statsRenderScheduler.test.js
@@ -102,6 +102,7 @@ test('renderer wires visibility scheduling without deferring tray icon updates',
   assert.match(visibilityListener, /cancelTokenRateBoost\(\)/);
   assert.match(visibilityListener, /!document\.hidden[\s\S]*hubBuildStatusRefreshDue\(\)[\s\S]*refreshHubBuildStatus\(\)/);
   assert.match(visibilityListener, /statsRenderScheduler\.flush\(\)/);
+  assert.match(visibilityListener, /if \(isSettingsSurfaceVisible\(\)\) syncSettingsForm\(\);/);
   assert.match(
     statsPush,
     /state\.stats = overlayAllTimeSessions\(payload\.data\.stats\);[\s\S]*statsRenderScheduler\.request\(\);[\s\S]*maybeUpdateBarsIcon\(\);/

--- a/tests/electron/statsRenderScheduler.test.js
+++ b/tests/electron/statsRenderScheduler.test.js
@@ -165,6 +165,55 @@ test('native window visibility covers a tray window that has never been shown', 
   assert.match(app, /return document\.hidden \|\| !state\.windowVisible;/);
 });
 
+test('a window awaiting its content-ready reveal is not reported as hidden', () => {
+  const main = fs.readFileSync(path.join(electronDir, 'main.js'), 'utf8');
+  const createWindow = main.slice(main.indexOf('function createWindow('), main.indexOf('function handleZoomShortcut('));
+  const finishLoad = createWindow.slice(createWindow.indexOf("win.webContents.once('did-finish-load'"));
+
+  // loadWindowFile({ waitForContent }) reveals on window:contentReady, which the
+  // renderer only sends once it renders — and it does not render while it
+  // believes it is hidden. Reporting the pre-reveal isVisible() === false here
+  // would leave the 2.5s fallback as the only way a replaced window can appear.
+  assert.match(finishLoad, /if \(win\.isVisible\(\)\) sendMainWindowVisibility\(win\);/);
+  assert.doesNotMatch(finishLoad, /^\s*sendMainWindowVisibility\(win\);/m);
+  assert.match(main, /win\.on\('show', \(\) => sendMainWindowVisibility\(win\)\)/);
+});
+
+test('a window revealed straight into Settings still reports painted content', () => {
+  const app = fs.readFileSync(path.join(rendererDir, 'app.js'), 'utf8');
+  const visibilityHandler = app.slice(
+    app.indexOf('function handleWindowVisibilityChange()'),
+    app.indexOf("document.addEventListener('visibilitychange'")
+  );
+  const settingsBranch = visibilityHandler.slice(
+    visibilityHandler.indexOf('if (isSettingsSurfaceVisible())'),
+    visibilityHandler.indexOf('} else {')
+  );
+
+  // clear() drops the catch-up render that would otherwise have signalled, and
+  // syncSettingsForm() is not a stats render, so the signal has to be explicit.
+  assert.match(settingsBranch, /statsRenderScheduler\.clear\(\)/);
+  assert.match(settingsBranch, /signalContentReady\(\);/);
+});
+
+test('the closed-Settings guard does not strand main-surface controls', () => {
+  const app = fs.readFileSync(path.join(rendererDir, 'app.js'), 'utf8');
+  const body = app.slice(app.indexOf('function syncSettingsForm()'), app.indexOf('function enabledClientSet()'));
+  const guard = body.indexOf('if (!isSettingsSurfaceVisible()) return;');
+
+  // The pin button lives in the header and is clickable while Settings is closed,
+  // so the only thing that redraws it has to run before the guard. Behind it, the
+  // icon silently keeps the previous mode while the window behaviour changes.
+  assert.ok(guard > 0);
+  assert.ok(body.indexOf('syncWindowBehaviorControls()') < guard);
+
+  // Nothing reached after the guard may write main-surface DOM.
+  const after = body.slice(guard);
+  for (const el of ['pinButton', 'shell', 'totalTokens', 'breakdown', 'homePanel', 'viewSwitcher']) {
+    assert.doesNotMatch(after, new RegExp(`els\\.${el}\\b`), `syncSettingsForm writes els.${el} behind the Settings guard`);
+  }
+});
+
 test('hidden event sources defer DOM work and visible surfaces catch up', () => {
   const app = fs.readFileSync(path.join(rendererDir, 'app.js'), 'utf8');
   const settingsPush = app.match(/window\.tokenMonitor\.onSettingsPush\?\.\(\(next\) => \{[\s\S]*?\n\}\);/)?.[0] || '';

--- a/tests/electron/statsRenderScheduler.test.js
+++ b/tests/electron/statsRenderScheduler.test.js
@@ -246,6 +246,105 @@ test('the closed-Settings guard does not strand main-surface controls', () => {
   }
 });
 
+test('heavy render roots reject work for an inactive surface', () => {
+  const app = fs.readFileSync(path.join(rendererDir, 'app.js'), 'utf8');
+  const body = (name, next) => app.slice(app.indexOf(`function ${name}(`), app.indexOf(next));
+
+  assert.match(body('renderServiceStatus', '\nasync function refreshServiceStatus('), /function renderServiceStatus\(\) \{\n {2}if \(!serviceStatusSurfaceVisible\(\)\) return;/);
+  assert.match(body('renderFloatingBubbleContent', '\nfunction setupFloatingBubbleInteraction('), /function renderFloatingBubbleContent\(\) \{\n {2}if \(visibleStatsSurface\(\) !== 'bubble'\) return;/);
+
+  for (const [name, next] of [
+    ['renderSettingsSummaries', '\nfunction formatNumber('],
+    ['renderSubscriptionSettings', '\n// The list may live on a hub'],
+    ['renderCodexAccounts', '\nasync function refreshCodexAccounts('],
+    ['renderMimoStatus', '\nfunction externalLimitProviderConfig('],
+    ['renderOpenCodeProfiles', '\nfunction normalizeProfileName('],
+    ['renderNamedApiProfiles', '\nfunction renderOpenRouterProfiles('],
+    ['renderCursorStatus', '\nasync function refreshCursorStatus('],
+    ['renderCustomPricing', '\nfunction setupCustomPricingUI(']
+  ]) {
+    assert.match(body(name, next), new RegExp(`function ${name}\\([^)]*\\) \\{\\n {2}if \\(!isSettingsSurfaceVisible\\(\\)\\) return;`));
+  }
+
+  assert.match(body('renderOpenCodeProfiles', '\nfunction normalizeProfileName('), /\.then\(\([^)]*\) => \{\n {4}if \(!isSettingsSurfaceVisible\(\)\) return;/);
+  assert.match(body('renderNamedApiProfiles', '\nfunction renderOpenRouterProfiles('), /\.then\(\([^)]*\) => \{\n {4}if \(!isSettingsSurfaceVisible\(\)\) return;/);
+});
+
+test('entering Status does not depend on the panel class from the previous render', () => {
+  const serviceStatusSurfaceVisible = rendererFunction(
+    'serviceStatusSurfaceVisible',
+    '\nfunction openHomeSettings(',
+    {
+      visibleStatsSurface: () => 'main',
+      state: { breakdown: 'status' },
+      els: { serviceStatusPanel: { classList: { contains: () => true } } }
+    }
+  );
+
+  assert.equal(serviceStatusSurfaceVisible(), true);
+});
+
+test('a hidden Session detail result waits for the main surface to return', () => {
+  let surface = null;
+  let scheduled = 0;
+  const rendered = [];
+  const request = {};
+  const state = { openSession: request };
+  const applySessionDetailResult = rendererFunction(
+    'applySessionDetailResult',
+    '\nasync function openSessionDetail(',
+    {
+      visibleStatsSurface: () => surface,
+      isRendererWindowHidden: () => surface === null,
+      statsRenderScheduler: { request() { scheduled += 1; } },
+      renderSessionDetail: (options) => rendered.push(options),
+      state
+    }
+  );
+
+  const options = { detail: { turns: [1, 2, 3] } };
+  applySessionDetailResult(request, options);
+  assert.equal(scheduled, 1);
+  assert.deepEqual(rendered, []);
+  assert.equal(request.renderOptions, options);
+
+  surface = 'settings';
+  applySessionDetailResult(request, options);
+  assert.equal(scheduled, 1);
+  assert.deepEqual(rendered, []);
+
+  surface = 'main';
+  applySessionDetailResult(request, options);
+  assert.deepEqual(rendered, [options]);
+  assert.equal(request.renderOptions, null);
+
+  const renderBody = fs.readFileSync(path.join(rendererDir, 'app.js'), 'utf8');
+  const sessionBranch = renderBody.slice(
+    renderBody.indexOf('} else if (state.openSession) {'),
+    renderBody.indexOf('} else {', renderBody.indexOf('} else if (state.openSession) {'))
+  );
+  assert.match(sessionBranch, /state\.openSession\.renderOptions[\s\S]*renderSessionDetail/);
+});
+
+test('a direct main render defers only while the window is hidden', () => {
+  let surface = 'settings';
+  let scheduled = 0;
+  const render = rendererFunction('render', '\nfunction setStatus(', {
+    visibleStatsSurface: () => surface,
+    statsRenderScheduler: { request() { scheduled += 1; } },
+    state: { stats: null }
+  });
+
+  render();
+  surface = 'bubble';
+  render();
+  assert.equal(scheduled, 0);
+
+  surface = null;
+  render();
+  assert.equal(scheduled, 1);
+});
+
 test('hidden event sources defer DOM work and visible surfaces catch up', () => {
   const app = fs.readFileSync(path.join(rendererDir, 'app.js'), 'utf8');
   const settingsPush = app.match(/window\.tokenMonitor\.onSettingsPush\?\.\(\(next\) => \{[\s\S]*?\n\}\);/)?.[0] || '';

--- a/tests/electron/statsRenderScheduler.test.js
+++ b/tests/electron/statsRenderScheduler.test.js
@@ -6,7 +6,8 @@ const path = require('node:path');
 const test = require('node:test');
 
 const {
-  createStatsRenderScheduler
+  createStatsRenderScheduler,
+  visibleStatsSurface
 } = require('../../src/electron/renderer/statsRenderScheduler');
 
 const rendererDir = path.join(__dirname, '..', '..', 'src', 'electron', 'renderer');
@@ -41,6 +42,14 @@ test('visible stats updates continue rendering every push', () => {
   scheduler.request();
   scheduler.request();
   assert.equal(renders, 2);
+});
+
+test('visible stats update only the exposed surface', () => {
+  assert.equal(visibleStatsSurface(false, false, false), 'main');
+  assert.equal(visibleStatsSurface(false, false, true), 'settings');
+  assert.equal(visibleStatsSurface(false, true, false), 'bubble');
+  assert.equal(visibleStatsSurface(true, false, false), null);
+  assert.equal(visibleStatsSurface(true, true, false), null);
 });
 
 test('hidden payloads keep the latest state and tray updates before visible rendering resumes', () => {
@@ -111,5 +120,6 @@ test('all stats refreshes use visibility-aware rendering', () => {
   );
 
   assert.match(refreshStats, /getStats\(options\)[\s\S]*statsRenderScheduler\.request\(\);/);
+  assert.equal([...refreshStats.matchAll(/setStatus\(statusTextFor/g)].length, 1);
   assert.doesNotMatch(statsRender, /renderMimoStatus\(\);/);
 });

--- a/tests/electron/tokenRate.test.js
+++ b/tests/electron/tokenRate.test.js
@@ -358,7 +358,7 @@ test('the token-rate hold has release, cancellation, reduced-motion, and click-g
   assert.match(app, /tokenRateBoost\.refresh\(\);\s*const \{ burn, rate \} = currentTokenRateValue\(\)/);
   assert.match(app, /document\.addEventListener\('pointercancel', \(event\) => \{\s*cancelTokenRateBoost\(event\)/);
   assert.match(app, /window\.addEventListener\('blur', \(\) => \{\s*cancelTokenRateBoost\(\)/);
-  assert.match(app, /if \(document\.hidden\) cancelTokenRateBoost\(\)/);
+  assert.match(app, /if \(isRendererWindowHidden\(\)\) cancelTokenRateBoost\(\)/);
   assert.match(tokenRatePresentation, /const enabled = canStart\(\);/);
   assert.match(tokenRatePresentation, /const reduced = prefersReducedMotion\(\);/);
   assert.match(tokenRatePresentation, /if \(!enabled \|\| reduced\) return false/);

--- a/tests/electron/totalTokenCompact.test.js
+++ b/tests/electron/totalTokenCompact.test.js
@@ -127,7 +127,6 @@ test('compact total is an opt-in appearance preference', () => {
   assert.doesNotMatch(languageHandler, /render\(\)/);
   assert.doesNotMatch(compactUnitsHandler, /render\(\)/);
   assert.doesNotMatch(compactVisibilityHandler, /updateTotalCompact|renderTokenRate|render\(\)/);
-  assert.match(app, /window\.tokenMonitor\.onSettingsPush[\s\S]*?renderStatsUpdate\(\)/);
   assert.doesNotMatch(i18n, /settings\.tray\.(?:tokensToday|bothToday|tokensTotal|bothTotal)':[^\n]*(?:1\.2M|1\.36B)/);
 });
 

--- a/tests/electron/totalTokenCompact.test.js
+++ b/tests/electron/totalTokenCompact.test.js
@@ -127,8 +127,7 @@ test('compact total is an opt-in appearance preference', () => {
   assert.doesNotMatch(languageHandler, /render\(\)/);
   assert.doesNotMatch(compactUnitsHandler, /render\(\)/);
   assert.doesNotMatch(compactVisibilityHandler, /updateTotalCompact|renderTokenRate|render\(\)/);
-  assert.match(app, /prevShowCompactTotalTokens !== next\.showCompactTotalTokens\) \{[\s\S]*?updateTotalCompact\(state\.currentTotal\)/);
-  assert.doesNotMatch(app, /prevCompactTokenUnits !== next\.compactTokenUnits[\s\S]*?\|\| prevShowCompactTotalTokens !== next\.showCompactTotalTokens/);
+  assert.match(app, /window\.tokenMonitor\.onSettingsPush[\s\S]*?renderStatsUpdate\(\)/);
   assert.doesNotMatch(i18n, /settings\.tray\.(?:tokensToday|bothToday|tokensTotal|bothTotal)':[^\n]*(?:1\.2M|1\.36B)/);
 });
 


### PR DESCRIPTION
## Summary

- stop invisible macOS native-material composition while collection and tray behavior continue
- limit each stats update to the active renderer surface and avoid layout capture for unchanged breakdown rows
- guard every heavy render exit by surface ownership: main `render()`, the floating bubble, the Status panel, and the Settings sub-renderers (Cursor, Codex, MiMo, OpenCode, OpenRouter, third-party, subscriptions, custom pricing) do nothing for an inactive surface, including async profile callbacks; a session-detail request landing while the main surface is away repaints once on return
- defer Dashboard rendering, restore refreshes, and history invalidation through the shared stats scheduler while the Dashboard window is hidden

## Before and after

| Scenario | Before | After |
|---|---|---|
| Main or Dashboard hidden/minimized on macOS | Native vibrancy remains active | Vibrancy is detached and restored when the window becomes visible |
| Hidden stats updates | Page Visibility can miss tray windows that were never shown | Native visibility coalesces updates into one latest-state catch-up render |
| Settings closed or floating bubble collapsed | Inactive Settings, provider, composer, or main-surface work can still run | Only the active surface renders |
| Unchanged breakdown rows | Animation layout is captured before fingerprint checks | Layout is captured only when rendered row output changes |

Home, Trends, View Switcher, and Dashboard retain their existing visible-surface render behavior. This change adds no render-output cache and does not change the glass appearance, collection, settings semantics, tray icons, or custom tray clock.

## Performance

Controlled `powermetrics` A/B ran on macOS 26.3 (Mac17,3) using eight interleaved baseline/candidate × foreground/hidden stages, a 75-second warm-up, and 40 retained one-second samples per stage. Both locally built arm64 apps used isolated user-data directories; process selection was tied to those directories, and all four foreground stages verified the expected frontmost PID. CDP drove the same real `refreshStats()` path at 1 Hz; all stages completed 48/48 refreshes without errors.

| State | Renderer Energy Impact | GPU Helper Energy Impact | App Energy Impact |
|---|---:|---:|---:|
| Foreground | 45.096 → 31.603 (**-29.92%**) | 10.331 → 7.346 (**-28.89%**) | 56.911 → 40.172 (**-29.41%**) |
| Hidden | 43.225 → 14.032 (**-67.54%**) | 10.116 → 0.014 (**-99.86%**) | 54.794 → 15.243 (**-72.18%**) |

On upstream, hiding reduced Renderer Energy Impact by only 4.15% and GPU Helper Energy Impact by 2.08%. With the candidate, the same foreground-to-hidden reductions were 55.60% and 99.81%, confirming that invisible rendering and composition were actually suspended.

The result reproduced across both runs: foreground Renderer Energy Impact changed by -30.66%/-29.16%, hidden Renderer Energy Impact by -68.31%/-66.75%, and hidden GPU Helper Energy Impact by -99.87%/-99.86%.

The measured binaries were upstream `3e82f76` and candidate `82752ea`. The branch has since been rebased onto current `main` and gained a custom-clock correctness fix; no fresh power result is claimed for that rebased binary. The follow-up commits keep the measured logic intact: the same surface gating, hidden deferral, and single catch-up repaint paths, with the restore event orders (focus while hidden, or visibility first) coalesced into one refresh.

## State coverage

Renderer suspension is a function of six state dimensions: native window visibility (shown / hidden), first-reveal timing (before / after `did-finish-load`), the main window's active surface (a single enum — none while hidden, bubble, Settings, or main with Home/Trends/Status/Limits breakdowns), the Dashboard window's lifecycle, native-material attachment (attached / detached), and window identity (original / floating-bubble replacement) — on macOS and Windows. The surface enum's mutual exclusions and the windows' separate lifecycles collapse the cross product into a small reachable set; the rows below are its behaviour-relevant transitions, and each traces to a regression this PR or its review actually hit:

| ID | Transition | Required behaviour |
|---|---|---|
| M1 | first launch before reveal | content paints on `window:contentReady`, never the 2.5s fallback |
| M2 | visible Home/Trends | stats keep updating; only the active surface renders |
| M3 | revealed straight into Settings | controls complete; stats do not rebuild the main surface |
| M4 | Settings closed, then a stats push | Settings provider DOM untouched; main surface still updates |
| M5 | native window hidden, repeated pushes | state, tray, and clocks stay fresh; DOM and composer idle; one catch-up repaint on restore |
| M6 | hidden bubble state or 30s clock tick | state-only update plus a deferred repaint; tray clock continues |
| M7 | minimize → restore | material detached while hidden, restored per latest settings, no double repaint |
| M8 | system glass off → on after start | both windows switch correctly, including the glass-disabled-at-construction path |
| M9 | repeated unchanged appearance preview | no repeated native material rebuild |
| M10 | main window ↔ floating-bubble replacement | the new instance receives material, content, and side; the old one is destroyed without a blank flash |
| M11 | Dashboard open, hide, reopen | nothing unready is revealed; data and material restore |
| M12 | platform boundary | macOS as above; Windows backdrop/z-order chains are not rewritten by this PR |

On the final commit stack, M1–M5 and M7–M11 were exercised live against the packaged app (isolated profile; CDP probes with real menu, tray, and window controls): hidden-phase DOM writes measured at zero across repeated pushes, one catch-up repaint on restore, the tray icon refreshing while hidden, and no renderer errors. M6's push-path refresh is live-verified, and its hidden-event and clock-tick deferral are pinned by the scheduler unit suite; M8 is confirmed visually (glass off renders opaque, on translucent, unchanged while unfocused) and pinned, including the disabled-at-construction path, by the native-material unit suite. M12 is a scope statement, not a test. Two boundaries are likewise stated rather than tested: sync/client mode feeds the same stats-push entry from SSE, and Windows behavior beyond M12 relies on the review-stage reveal measurement.

## CDP verification

- the packaged arm64 app is launched with an isolated `--user-data-dir` and `--remote-debugging-port`; the installed release is never touched
- OS-level hide/minimize/restore is driven through real window controls, never by faking visibility, while CDP `Runtime.evaluate` probes stay read-only
- probes install DOM-mutation, layout, and RAF counters across hide → push burst → restore cycles; this is what surfaced the restore double-paint (focus while hidden → visibilitychange) that the coalescing fix removed — hidden-phase DOM work is now zero and either restore order repaints exactly once
- the same harness drove `refreshStats()` at 1 Hz during the powermetrics A/B stages

## Risk

- The native-material lifecycle change is macOS-only; Windows background material behavior is unchanged.
- Hidden windows still receive and store stats, maintain tray output, and restart existing refresh timers. Only invisible DOM and composition work is deferred.
- Restoring a window renders the latest state once rather than replaying every hidden update.
- Restoring into collapsed-bubble mode syncs the bubble shell immediately; bubble content refreshes with the next stats push instead of drawing twice at restore.
- A session-detail result landing while another surface is showing repaints with the next main-surface render (the next stats push), not synchronously.

## Testing

- `npm run verify` — 3,769 passed, 1 skipped (pre-existing), 0 failed; lint clean
- state coverage above — M1–M11 on the packaged app per the channel notes, M12 declared; targeted transition suite 48/48
- manual UI checks — Home, Trends, Limits, Settings close/reopen, Provider settings, floating bubble, Dashboard, and hide/restore latest-state catch-up
- `git diff --check upstream/main...HEAD`

Closes #385
