### PR TITLE
feat(win): allow choosing installation directory in the NSIS installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,10 @@
       "description": "Real-time token, cost, and AI limits widget with multi-device sync for Claude Code, Codex, OpenCode and more."
     },
     "nsis": {
-      "artifactName": "Token-Monitor-Setup-${version}.${ext}"
+      "artifactName": "Token-Monitor-Setup-${version}.${ext}",
+      "oneClick": false,
+      "perMachine": false,
+      "allowToChangeInstallationDirectory": true
     },
     "portable": {
       "artifactName": "Token-Monitor-${version}.${ext}"

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
       "artifactName": "Token-Monitor-Setup-${version}.${ext}",
       "oneClick": false,
       "perMachine": false,
-      "allowToChangeInstallationDirectory": true
+      "allowToChangeInstallationDirectory": true,
+      "include": "scripts/nsis-installer.nsh"
     },
     "portable": {
       "artifactName": "Token-Monitor-${version}.${ext}"

--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -1,0 +1,7 @@
+# In assisted mode, perMachine: false allows users to choose between
+# per-user and per-machine installation. Force per-user installation.
+!macro customInstallMode
+  !ifndef BUILD_UNINSTALLER
+    StrCpy $isForceCurrentInstall "1"
+  !endif
+!macroend

--- a/tests/shared/nsisInstallerMode.test.js
+++ b/tests/shared/nsisInstallerMode.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.resolve(__dirname, '../..');
+const packageJson = require('../../package.json');
+const installerInclude = fs.readFileSync(
+  path.join(ROOT, packageJson.build.nsis.include),
+  'utf8'
+);
+const PINNED_BUILDER = '26.15.3';
+
+function readBuilderFile(relativePath) {
+  try {
+    return fs.readFileSync(path.join(ROOT, 'node_modules', 'app-builder-lib', relativePath), 'utf8');
+  } catch (_) {
+    return null;
+  }
+}
+
+function slice(source, from, to) {
+  const start = source.indexOf(from);
+  assert.ok(start >= 0, `${from} not found upstream`);
+  const end = source.indexOf(to, start + from.length);
+  return source.slice(start, end === -1 ? source.length : end);
+}
+
+test('Windows installer stays assisted, current-user only, and starts at the directory page', () => {
+  assert.deepEqual(
+    {
+      oneClick: packageJson.build.nsis.oneClick,
+      perMachine: packageJson.build.nsis.perMachine,
+      allowToChangeInstallationDirectory:
+        packageJson.build.nsis.allowToChangeInstallationDirectory,
+      include: packageJson.build.nsis.include
+    },
+    {
+      oneClick: false,
+      perMachine: false,
+      allowToChangeInstallationDirectory: true,
+      include: 'scripts/nsis-installer.nsh'
+    }
+  );
+
+  assert.match(
+    installerInclude,
+    /!macro customInstallMode\s+!ifndef BUILD_UNINSTALLER\s+StrCpy \$isForceCurrentInstall "1"\s+!endif\s+!macroend/
+  );
+  assert.doesNotMatch(installerInclude, /\$isForceMachineInstall/);
+  assert.doesNotMatch(installerInclude, /customWelcomePage|MUI_PAGE_WELCOME/);
+  assert.doesNotMatch(installerInclude, /MUI_PAGE_CUSTOMFUNCTION|nsDialogs|NSD_/);
+});
+
+test('the pinned electron-builder loads and honors the current-user install hook', (t) => {
+  const target = readBuilderFile('out/targets/nsis/NsisTarget.js');
+  const installModeUi = readBuilderFile('templates/nsis/multiUserUi.nsh');
+  if (!target || !installModeUi) return t.skip('electron-builder is not installed');
+
+  assert.equal(packageJson.devDependencies['electron-builder'], PINNED_BUILDER);
+  assert.equal(require('app-builder-lib/package.json').version, PINNED_BUILDER);
+
+  assert.match(
+    target,
+    /getResource\(this\.options\.include, "installer\.nsh"\)/,
+    'the configured NSIS include must remain supported upstream'
+  );
+
+  const installModePre = slice(
+    installModeUi,
+    '!macro FUNCTION_INSTALL_MODE_PAGE_FUNCTION',
+    '\n\tFunction "${UNINSTALLER_FUNCPREFIX}${LEAVE}"'
+  );
+  const hook = installModePre.indexOf('!insertmacro customInstallMode');
+  const forceCurrent = installModePre.indexOf('${if} $isForceCurrentInstall == "1"');
+  assert.ok(hook >= 0, 'customInstallMode hook not found upstream');
+  assert.ok(forceCurrent > hook, 'the custom hook must run before force-current is evaluated');
+  assert.match(
+    installModePre.slice(forceCurrent),
+    /\$isForceCurrentInstall == "1"[\s\S]*?!insertmacro setInstallModePerUser[\s\S]*?Abort/,
+    'force-current must select the per-user registry context and skip the mode page'
+  );
+
+  const assistedInstaller = readBuilderFile('templates/nsis/assistedInstaller.nsh');
+  assert.ok(assistedInstaller, 'assisted installer template not found upstream');
+  const installMode = assistedInstaller.indexOf('!insertmacro PAGE_INSTALL_MODE');
+  const directory = assistedInstaller.indexOf('!insertmacro MUI_PAGE_DIRECTORY');
+  assert.ok(
+    installMode >= 0 && installMode < directory,
+    'the skipped install-mode page must remain immediately before the visible directory page'
+  );
+});


### PR DESCRIPTION
# 摘要 Summary

The Windows installer previously used the one-click NSIS flow, which silently installs per-user to % LOCALAPPDATA%\Programs\Token Monitor with no way to change the destination. This switches the installer to the assisted flow with allowToChangeInstallationDirectory: true, so users can pick the install location themselves.
中文：Windows 安装程序此前采用 NSIS 一键静默安装模式，仅针对当前用户安装至 % LOCALAPPDATA%\Programs\Token Monitor，且无法自定义安装路径。本次修改将安装程序切换为向导式安装流程，并开启 allowToChangeInstallationDirectory: true 配置，支持用户自主选择安装目录。

# 修改内容 Changes

- package.json: set nsis.oneClick: false, keep perMachine: false, and enable allowToChangeInstallationDirectory: true.
中文：package.json：将 nsis.oneClick 设置为 false，保持 perMachine 为 false，同时启用 allowToChangeInstallationDirectory: true。

# 验证方案 Verification

- Built locally with npm run dist:win and confirmed the installer presents the "Choose installation directory" page.
中文：本地执行 npm run dist:win 打包构建，已验证安装程序会弹出「选择安装目录」页面。

# 补充说明 Notes

- The in-app auto-update path in main.js (autoUpdater.quitAndInstall) is unchanged. Updates remain silent for default-location installs; users who install elsewhere will see the assisted flow on the next full install.
中文：main.js 内应用内置自动更新逻辑（autoUpdater.quitAndInstall）保持不变。安装在默认路径的用户后续更新仍为静默更新；自定义安装路径的用户，下次完整重装时会走向导式安装流程。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Windows NSIS installer to an assisted flow so users can choose the installation directory. Installs remain current-user only; update behavior is unchanged.

- **New Features**
  - In `package.json`, set `nsis.oneClick: false`, keep `nsis.perMachine: false`, enable `nsis.allowToChangeInstallationDirectory`, and add `nsis.include: scripts/nsis-installer.nsh`.

- **Bug Fixes**
  - Enforce current-user installs in assisted mode via `scripts/nsis-installer.nsh` (`customInstallMode` sets `$isForceCurrentInstall`).
  - Add tests to lock installer mode, directory page order, and confirm `electron-builder@26.15.3` supports the include hook.

<sup>Written for commit 5a325f4bc11021a497e5fcf262c43c6dd74dc74a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

