### PR TITLE
fix(proma): use obj.uuid when msg.id is missing in assistant messages

### DIFF
--- a/src/shared/promaUsage.js
+++ b/src/shared/promaUsage.js
@@ -81,7 +81,8 @@ function collectSessionRows(filePath, options = {}) {
       if (obj.type !== 'assistant') continue;
       const msg = obj.message;
       if (!msg || !msg.usage) continue;
-      const msgId = msg.id;
+      // Message ID: some tools set msg.id, Proma uses obj.uuid instead.
+      const msgId = msg?.id || obj.uuid;
       if (!msgId) continue;
 
       const model = msg.model || obj._channelModelId || 'unknown';


### PR DESCRIPTION
## Problem

Proma token usage always shows as **0 / waiting for data** despite having session files (`~/.proma/agent-sessions/*.jsonl`) with real token usage data. Other tools like Claude Code work fine.

## Root Cause

The `promaUsage.js` parser at line ~85 checks for `msg.id`:

```js
const msgId = msg.id;    // ← undefined for Proma
if (!msgId) continue;    // ← ALL assistant messages are skipped!
```

But Proma's JSONL format does **not** include `message.id`. Each assistant message has a top-level `uuid` field instead:

```json
{
  "type": "assistant",
  "uuid": "a39388ec-5326-4d23-bf03-d4a383e96ec9",
  "_createdAt": 1786512259076,
  "message": {
    "usage": { "input_tokens": 17502, "output_tokens": 735 },
    "model": "qwen3.7-flash"
    // ❌ No `id` field here
  }
}
```

This means every single assistant message is filtered out by `if (!msgId) continue`, resulting in 0 tokens → "waiting for data".

## Fix

One-line change — use `obj.uuid` as fallback when `msg.id` is absent:

```diff
- const msgId = msg.id;
+ const msgId = msg?.id || obj.uuid;
  if (!msgId) continue;
```

Some tools set `msg.id`, Proma uses `obj.uuid` — both are unique per message, so this keeps backward compatibility.

## Verification

After applying this one-line patch, the parser correctly reads from local Proma sessions:
- Input tokens: **814,377**
- Output tokens: **53,201**
- Cache read: **3,196,682**
- 5 model entries across 3 sessions

Made-with: Proma

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Proma token usage parsing by using the top-level uuid when message.id is missing, so assistant messages are not skipped. Usage stats now populate correctly from local session files.

- **Bug Fixes**
  - Fallback to `obj.uuid` when `msg.id` is undefined, preserving compatibility with tools that set `msg.id`.

<sup>Written for commit e2760b11efe70e7ab35bee3810c1e4246d258a6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

