### PR TITLE
fix(macos): separate app and Widget system requirements

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,7 +14,7 @@
     <a href="https://github.com/Javis603/token-monitor/releases"><img src="https://img.shields.io/github/v/release/Javis603/token-monitor?include_prereleases&style=flat-square&label=release&color=22c55e" alt="最新リリース" /></a>
     <a href="https://github.com/Javis603/token-monitor/releases"><img src="https://img.shields.io/github/downloads/Javis603/token-monitor/total?style=flat-square&color=22c55e" alt="総ダウンロード数" /></a>
     <img src="https://img.shields.io/badge/Windows-10%2B-0078D4?style=flat-square" alt="Windows 10 以降" />
-    <img src="https://img.shields.io/badge/macOS-14%2B-0A84FF?style=flat-square&logo=apple&logoColor=white" alt="macOS 14 以降" />
+    <img src="https://img.shields.io/badge/macOS-12%2B-0A84FF?style=flat-square&logo=apple&logoColor=white" alt="macOS 12 以降" />
     <img src="https://img.shields.io/badge/Linux-x64-64748b?style=flat-square&logo=linux&logoColor=white" alt="Linux x64" />
     <a href="https://discord.gg/HmdNVVvw5P"><img src="https://img.shields.io/discord/1344259784219689031?color=5865F2&label=Discord&logo=discord&logoColor=white&style=flat-square" alt="Discord"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-A855F7?style=flat-square" alt="ライセンス: MIT" /></a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -14,7 +14,7 @@
     <a href="https://github.com/Javis603/token-monitor/releases"><img src="https://img.shields.io/github/v/release/Javis603/token-monitor?include_prereleases&style=flat-square&label=release&color=22c55e" alt="최신 릴리스" /></a>
     <a href="https://github.com/Javis603/token-monitor/releases"><img src="https://img.shields.io/github/downloads/Javis603/token-monitor/total?style=flat-square&color=22c55e" alt="총 다운로드" /></a>
     <img src="https://img.shields.io/badge/Windows-10%2B-0078D4?style=flat-square" alt="Windows 10 이상" />
-    <img src="https://img.shields.io/badge/macOS-14%2B-0A84FF?style=flat-square&logo=apple&logoColor=white" alt="macOS 14 or later" />
+    <img src="https://img.shields.io/badge/macOS-12%2B-0A84FF?style=flat-square&logo=apple&logoColor=white" alt="macOS 12 or later" />
     <img src="https://img.shields.io/badge/Linux-x64-64748b?style=flat-square&logo=linux&logoColor=white" alt="Linux x64" />
     <a href="https://discord.gg/HmdNVVvw5P"><img src="https://img.shields.io/discord/1344259784219689031?color=5865F2&label=Discord&logo=discord&logoColor=white&style=flat-square" alt="Discord"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-A855F7?style=flat-square" alt="라이선스: MIT" /></a>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
     <a href="https://github.com/Javis603/token-monitor/releases"><img src="https://img.shields.io/github/v/release/Javis603/token-monitor?include_prereleases&style=flat-square&label=release&color=22c55e" alt="Latest release" /></a>
     <a href="https://github.com/Javis603/token-monitor/releases"><img src="https://img.shields.io/github/downloads/Javis603/token-monitor/total?style=flat-square&color=22c55e" alt="Total downloads" /></a>
     <img src="https://img.shields.io/badge/Windows-10%2B-0078D4?style=flat-square" alt="Windows 10 or later" />
-    <img src="https://img.shields.io/badge/macOS-14%2B-0A84FF?style=flat-square&logo=apple&logoColor=white" alt="macOS 14 or later" />
+    <img src="https://img.shields.io/badge/macOS-12%2B-0A84FF?style=flat-square&logo=apple&logoColor=white" alt="macOS 12 or later" />
     <img src="https://img.shields.io/badge/Linux-x64-64748b?style=flat-square&logo=linux&logoColor=white" alt="Linux x64" />
     <a href="https://discord.gg/HmdNVVvw5P"><img src="https://img.shields.io/discord/1344259784219689031?color=5865F2&label=Discord&logo=discord&logoColor=white&style=flat-square" alt="Discord"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-A855F7?style=flat-square" alt="License: MIT" /></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@
     <a href="https://github.com/Javis603/token-monitor/releases"><img src="https://img.shields.io/github/v/release/Javis603/token-monitor?include_prereleases&style=flat-square&label=release&color=22c55e" alt="最新发布" /></a>
     <a href="https://github.com/Javis603/token-monitor/releases"><img src="https://img.shields.io/github/downloads/Javis603/token-monitor/total?style=flat-square&color=22c55e" alt="总下载量" /></a>
     <img src="https://img.shields.io/badge/Windows-10%2B-0078D4?style=flat-square" alt="Windows 10 或更新" />
-    <img src="https://img.shields.io/badge/macOS-14%2B-0A84FF?style=flat-square&logo=apple&logoColor=white" alt="macOS 14 或更新" />
+    <img src="https://img.shields.io/badge/macOS-12%2B-0A84FF?style=flat-square&logo=apple&logoColor=white" alt="macOS 12 或更新" />
     <img src="https://img.shields.io/badge/Linux-x64-64748b?style=flat-square&logo=linux&logoColor=white" alt="Linux x64" />
     <a href="https://discord.gg/HmdNVVvw5P"><img src="https://img.shields.io/discord/1344259784219689031?color=5865F2&label=Discord&logo=discord&logoColor=white&style=flat-square" alt="Discord"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-A855F7?style=flat-square" alt="许可证：MIT" /></a>

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -14,7 +14,7 @@
     <a href="https://github.com/Javis603/token-monitor/releases"><img src="https://img.shields.io/github/v/release/Javis603/token-monitor?include_prereleases&style=flat-square&label=release&color=22c55e" alt="最新發布" /></a>
     <a href="https://github.com/Javis603/token-monitor/releases"><img src="https://img.shields.io/github/downloads/Javis603/token-monitor/total?style=flat-square&color=22c55e" alt="總下載量" /></a>
     <img src="https://img.shields.io/badge/Windows-10%2B-0078D4?style=flat-square" alt="Windows 10 或更新" />
-    <img src="https://img.shields.io/badge/macOS-14%2B-0A84FF?style=flat-square&logo=apple&logoColor=white" alt="macOS 14 或更新" />
+    <img src="https://img.shields.io/badge/macOS-12%2B-0A84FF?style=flat-square&logo=apple&logoColor=white" alt="macOS 12 或更新" />
     <img src="https://img.shields.io/badge/Linux-x64-64748b?style=flat-square&logo=linux&logoColor=white" alt="Linux x64" />
     <a href="https://discord.gg/HmdNVVvw5P"><img src="https://img.shields.io/discord/1344259784219689031?color=5865F2&label=Discord&logo=discord&logoColor=white&style=flat-square" alt="Discord"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-A855F7?style=flat-square" alt="授權：MIT" /></a>

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "zip"
       ],
       "forceCodeSigning": true,
-      "minimumSystemVersion": "14.0",
+      "minimumSystemVersion": "12.0",
       "category": "public.app-category.developer-tools",
       "icon": "assets/icon.png",
       "extendInfo": {

--- a/scripts/merge-mac-updater-metadata.js
+++ b/scripts/merge-mac-updater-metadata.js
@@ -3,6 +3,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { artifactNameFromReference } = require('./verify-updater-artifact-names');
+const { MAC_APP_MIN_DARWIN_VERSION } = require('../src/shared/macSystemRequirements');
 
 function stripYamlQuotes(value) {
   const trimmed = String(value || '').trim();
@@ -45,6 +46,16 @@ function parseMacUpdaterMetadata(contents, label = 'metadata') {
     throw new Error(`${label} must have exactly one top-level path`);
   }
   const pathName = artifactNameFromReference(pathLines[0].replace(/^path:\s*/, ''));
+  const minimumSystemVersionLines = lines.filter((line) => /^minimumSystemVersion:\s*/.test(line));
+  if (minimumSystemVersionLines.length > 1) {
+    throw new Error(`${label} must have at most one top-level minimumSystemVersion`);
+  }
+  const minimumSystemVersion = minimumSystemVersionLines.length === 0
+    ? null
+    : stripYamlQuotes(minimumSystemVersionLines[0].replace(/^minimumSystemVersion:\s*/, ''));
+  if (minimumSystemVersionLines.length === 1 && !minimumSystemVersion) {
+    throw new Error(`${label} has an empty top-level minimumSystemVersion`);
+  }
 
   return {
     label,
@@ -54,8 +65,30 @@ function parseMacUpdaterMetadata(contents, label = 'metadata') {
     filesEnd,
     fileLines,
     fileNames,
-    pathName
+    pathName,
+    minimumSystemVersion
   };
+}
+
+function assertMinimumSystemVersion(metadata) {
+  if (
+    metadata.minimumSystemVersion !== null
+    && metadata.minimumSystemVersion !== MAC_APP_MIN_DARWIN_VERSION
+  ) {
+    throw new Error(
+      `${metadata.label} minimumSystemVersion ${metadata.minimumSystemVersion} does not match release policy ${MAC_APP_MIN_DARWIN_VERSION}`
+    );
+  }
+}
+
+function applyMinimumSystemVersion(lines) {
+  // electron-builder does not carry mac.minimumSystemVersion into latest-mac.yml.
+  // The merged feed is the only metadata file published by the release workflow,
+  // so enforce the updater half of the policy at that final boundary.
+  const output = lines.filter((line) => !/^minimumSystemVersion:\s*/.test(line));
+  const versionIndex = output.findIndex((line) => /^version:\s*\S/.test(line));
+  output.splice(versionIndex + 1, 0, `minimumSystemVersion: ${MAC_APP_MIN_DARWIN_VERSION}`);
+  return output;
 }
 
 function assertArchitecture(metadata, arch) {
@@ -86,6 +119,8 @@ function mergeMacUpdaterMetadata(arm64Contents, x64Contents) {
   const x64 = parseMacUpdaterMetadata(x64Contents, 'x64 metadata');
   assertArchitecture(arm64, 'arm64');
   assertArchitecture(x64, 'x64');
+  assertMinimumSystemVersion(arm64);
+  assertMinimumSystemVersion(x64);
   if (arm64.version !== x64.version) {
     throw new Error(`mac updater versions differ: arm64=${arm64.version}, x64=${x64.version}`);
   }
@@ -97,12 +132,13 @@ function mergeMacUpdaterMetadata(arm64Contents, x64Contents) {
 
   // Keep arm64 as the base so path/sha512 stay valid for existing Apple Silicon
   // installs. New Intel builds use the architecture-filtered files list.
-  return [
+  const mergedLines = [
     ...arm64.lines.slice(0, arm64.filesIndex + 1),
     ...arm64.fileLines,
     ...x64.fileLines,
     ...arm64.lines.slice(arm64.filesEnd)
-  ].join('\n').replace(/\n*$/, '\n');
+  ];
+  return applyMinimumSystemVersion(mergedLines).join('\n').replace(/\n*$/, '\n');
 }
 
 function mergeMacUpdaterMetadataFiles(outputPath, arm64Path, x64Path) {

--- a/src/electron/macWidgetLaunchServicesRecovery.js
+++ b/src/electron/macWidgetLaunchServicesRecovery.js
@@ -146,6 +146,9 @@ function createMacWidgetLaunchServicesRecovery(options = {}) {
     if (input.platform !== 'darwin') {
       return { status: 'skipped', reason: 'unsupported-platform' };
     }
+    if (input.runtimeSupported === false) {
+      return { status: 'skipped', reason: 'unsupported-os' };
+    }
     if (input.isPackaged !== true) {
       return { status: 'skipped', reason: 'unpackaged' };
     }

--- a/src/electron/macWidgetReloader.js
+++ b/src/electron/macWidgetReloader.js
@@ -100,6 +100,7 @@ function scheduleTrailingReload(request, minIntervalMs, now, scheduler) {
 function requestMacWidgetReload(options = {}) {
   const platform = options.platform || process.platform;
   if (platform !== 'darwin') return { ok: false, reason: 'unsupported-platform' };
+  if (options.runtimeSupported === false) return { ok: false, reason: 'unsupported-os' };
   const scheduler = schedulerFor(options);
   const schedulerNow = Number(scheduler.now());
   const now = Number.isFinite(options.now) ? options.now : schedulerNow;

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -18,6 +18,7 @@ const {
 } = require('../shared/credentialStore');
 const { installSafeStdout } = require('../shared/safeStdio');
 const { appVersion } = require('../shared/appVersion');
+const { macWidgetRuntimeSupport } = require('../shared/macSystemRequirements');
 const { exportFileSet, exportSignature, EXPORT_FILENAMES } = require('../shared/exporter');
 const { createDefaultTrayLayout, normalizeTrayLayout } = require('../shared/trayLayout');
 const motionPreferenceApi = require('./motionPreference');
@@ -3387,7 +3388,7 @@ function injectLocalDeviceStatus(stats) {
 }
 
 function macWidgetConfiguration() {
-  if (process.platform !== 'darwin') return null;
+  if (!macWidgetRuntimeSupported()) return null;
   if (cachedMacWidgetConfiguration !== undefined) return cachedMacWidgetConfiguration;
 
   let appGroup = String(process.env.TOKEN_MONITOR_APP_GROUP || '').trim();
@@ -3428,6 +3429,13 @@ function macWidgetConfiguration() {
     })()
   };
   return cachedMacWidgetConfiguration;
+}
+
+function macWidgetRuntimeSupported(
+  platform = process.platform,
+  osRelease = platform === 'darwin' ? os.release() : ''
+) {
+  return macWidgetRuntimeSupport({ platform, osRelease }).supported;
 }
 
 function historyResolverOptions() {
@@ -3513,7 +3521,7 @@ function captureMacWidgetWork({ stats, owner }) {
 }
 
 function ensureMacWidgetSnapshotController() {
-  if (process.platform !== 'darwin') return null;
+  if (!macWidgetRuntimeSupported()) return null;
   if (macWidgetSnapshotController) return macWidgetSnapshotController;
   macWidgetSnapshotController = createMacWidgetSnapshotController({
     startPaused: !macWidgetPublicationReady,
@@ -3559,6 +3567,7 @@ function ensureMacWidgetSnapshotController() {
     reloadSnapshot: (work, options) => requestMacWidgetReload({
       widgetKind: work.widgetKind,
       isCurrent: options.isCurrent,
+      runtimeSupported: macWidgetRuntimeSupported(),
       logger: (message) => console.warn(message)
     }),
     logger: (message) => console.warn(message)
@@ -3585,7 +3594,7 @@ function refreshMacWidgetHistorySource() {
 }
 
 function scheduleMacWidgetSnapshot(stats, producerOwner) {
-  if (process.platform !== 'darwin' || !stats) return false;
+  if (!macWidgetRuntimeSupported() || !stats) return false;
   return ensureMacWidgetSnapshotController()?.enqueue({ stats, producerOwner }) || false;
 }
 
@@ -5612,17 +5621,25 @@ function rebuildWindow() {
 app.whenReady().then(() => {
   if (process.platform === 'darwin' && app.dock) app.dock.setIcon(APP_ICON_PATH);
   ensureSettingsLoaded();
-  const widgetRecoveryAbort = new AbortController();
-  const abortWidgetRecovery = () => widgetRecoveryAbort.abort();
-  app.once('before-quit', abortWidgetRecovery);
-  const widgetRecovery = recoverMacWidgetLaunchServicesRegistration({
+  const widgetRuntime = macWidgetRuntimeSupport({
     platform: process.platform,
-    isPackaged: app.isPackaged,
-    resourcesPath: process.resourcesPath,
-    userDataPath: app.getPath('userData'),
-    signal: widgetRecoveryAbort.signal,
-    logger: (message) => console.warn(message)
+    osRelease: process.platform === 'darwin' ? os.release() : ''
   });
+  const widgetRuntimeSupported = widgetRuntime.supported;
+  const widgetRecoveryAbort = widgetRuntimeSupported ? new AbortController() : null;
+  const abortWidgetRecovery = () => widgetRecoveryAbort?.abort();
+  if (widgetRecoveryAbort) app.once('before-quit', abortWidgetRecovery);
+  const widgetRecovery = widgetRuntimeSupported
+    ? recoverMacWidgetLaunchServicesRegistration({
+      platform: process.platform,
+      runtimeSupported: true,
+      isPackaged: app.isPackaged,
+      resourcesPath: process.resourcesPath,
+      userDataPath: app.getPath('userData'),
+      signal: widgetRecoveryAbort.signal,
+      logger: (message) => console.warn(message)
+    })
+    : Promise.resolve({ status: 'skipped', reason: widgetRuntime.reason });
   session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
     callback({
       responseHeaders: {
@@ -5640,11 +5657,11 @@ app.whenReady().then(() => {
   if (pendingMacWidgetOpen) setImmediate(openMainWindowFromWidget);
   if (settings.trayMode) enterTrayMode();
   regenerateTokscalePricing();
-  ensureMacWidgetDemand();
+  if (widgetRuntimeSupported) ensureMacWidgetDemand();
   startMode();
   void widgetRecovery.finally(() => {
-    app.removeListener('before-quit', abortWidgetRecovery);
-    if (!widgetRecoveryAbort.signal.aborted) {
+    if (widgetRecoveryAbort) app.removeListener('before-quit', abortWidgetRecovery);
+    if (!widgetRecoveryAbort?.signal.aborted) {
       macWidgetPublicationReady = true;
       macWidgetSnapshotController?.resume();
     }

--- a/src/shared/macSystemRequirements.js
+++ b/src/shared/macSystemRequirements.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const semver = require('semver');
+
+// electron-builder writes the marketing version into LSMinimumSystemVersion,
+// while electron-updater compares update metadata against Darwin's os.release().
+const MAC_APP_MIN_VERSION = '12.0';
+const MAC_APP_MIN_DARWIN_VERSION = '21.0.0';
+const MAC_WIDGET_MIN_VERSION = '14.0';
+const MAC_WIDGET_MIN_DARWIN_VERSION = '23.0.0';
+
+function macWidgetRuntimeSupport({ platform = process.platform, osRelease = '' } = {}) {
+  if (platform !== 'darwin') {
+    return { supported: false, reason: 'unsupported-platform' };
+  }
+  const current = semver.valid(String(osRelease || '').trim());
+  if (!current || semver.lt(current, MAC_WIDGET_MIN_DARWIN_VERSION)) {
+    return { supported: false, reason: 'unsupported-os' };
+  }
+  return { supported: true, reason: null };
+}
+
+module.exports = {
+  MAC_APP_MIN_DARWIN_VERSION,
+  MAC_APP_MIN_VERSION,
+  MAC_WIDGET_MIN_DARWIN_VERSION,
+  MAC_WIDGET_MIN_VERSION,
+  macWidgetRuntimeSupport
+};

--- a/tests/electron/macWidgetIntegration.test.js
+++ b/tests/electron/macWidgetIntegration.test.js
@@ -52,6 +52,10 @@ const {
   widgetArtifactPaths
 } = require('../../scripts/macos-packaging');
 const { normalizeWidgetURLScheme } = require('../../src/shared/macWidgetConfig');
+const {
+  MAC_APP_MIN_VERSION,
+  MAC_WIDGET_MIN_VERSION
+} = require('../../src/shared/macSystemRequirements');
 const { projectLimitStatsForDisplay } = require('../../src/electron/limitStatsPresentation');
 
 function functionSource(name, nextName) {
@@ -239,19 +243,18 @@ test('starts the runtime immediately and holds only Widget publication until hos
   assert.ok(readyStart >= 0 && readyEnd > readyStart, 'ready callback should exist');
   const readySource = mainSource.slice(readyStart, readyEnd);
   const settingsIndex = readySource.indexOf('ensureSettingsLoaded();');
-  const recoveryStartIndex = readySource.indexOf(
-    'const widgetRecovery = recoverMacWidgetLaunchServicesRegistration({'
-  );
+  const supportIndex = readySource.indexOf('const widgetRuntime = macWidgetRuntimeSupport({');
+  const recoveryStartIndex = readySource.indexOf('const widgetRecovery = widgetRuntimeSupported');
   const windowIndex = readySource.indexOf('createWindow();');
   const modeIndex = readySource.indexOf('startMode();');
   const recoveryCompletionIndex = readySource.indexOf('void widgetRecovery.finally(() => {');
-  assert.ok(settingsIndex >= 0 && recoveryStartIndex > settingsIndex);
+  assert.ok(settingsIndex >= 0 && supportIndex > settingsIndex && recoveryStartIndex > supportIndex);
   assert.ok(windowIndex > recoveryStartIndex);
   assert.ok(modeIndex > windowIndex && recoveryCompletionIndex > modeIndex);
   assert.doesNotMatch(readySource, /await widgetRecovery/);
   assert.match(
     readySource,
-    /startMode\(\);\s*void widgetRecovery\.finally\(\(\) => \{\s*app\.removeListener\('before-quit', abortWidgetRecovery\);\s*if \(!widgetRecoveryAbort\.signal\.aborted\) \{\s*macWidgetPublicationReady = true;\s*macWidgetSnapshotController\?\.resume\(\);\s*\}\s*\}\);/
+    /startMode\(\);\s*void widgetRecovery\.finally\(\(\) => \{\s*if \(widgetRecoveryAbort\) app\.removeListener\('before-quit', abortWidgetRecovery\);\s*if \(!widgetRecoveryAbort\?\.signal\.aborted\) \{\s*macWidgetPublicationReady = true;\s*macWidgetSnapshotController\?\.resume\(\);\s*\}\s*\}\);/
   );
   assert.match(mainSource, /let macWidgetPublicationReady = false;/);
   assert.match(
@@ -259,16 +262,16 @@ test('starts the runtime immediately and holds only Widget publication until hos
     /createMacWidgetSnapshotController\(\{\s*startPaused: !macWidgetPublicationReady,/
   );
   assert.match(readySource, /platform: process\.platform/);
+  assert.match(readySource, /runtimeSupported: true/);
   assert.match(readySource, /isPackaged: app\.isPackaged/);
   assert.match(readySource, /resourcesPath: process\.resourcesPath/);
   assert.match(readySource, /userDataPath: app\.getPath\('userData'\)/);
 });
 
-function executeMacWidgetRecoveryWiring() {
-  const bootstrapStart = mainSource.indexOf('const widgetRecoveryAbort = new AbortController();');
-  const loggerIndex = mainSource.indexOf('logger: (message) => console.warn(message)', bootstrapStart);
-  const recoveryCallEnd = mainSource.indexOf('});', loggerIndex) + 3;
-  assert.ok(bootstrapStart >= 0 && loggerIndex > bootstrapStart && recoveryCallEnd > loggerIndex, 'recovery bootstrap should exist');
+function executeMacWidgetRecoveryWiring(runtimeSupported = true) {
+  const bootstrapStart = mainSource.indexOf('const widgetRuntime = macWidgetRuntimeSupport({');
+  const recoveryCallEnd = mainSource.indexOf('\n  session.defaultSession', bootstrapStart);
+  assert.ok(bootstrapStart >= 0 && recoveryCallEnd > bootstrapStart, 'recovery bootstrap should exist');
   const finallyStart = mainSource.indexOf('void widgetRecovery.finally(() => {');
   const finallyEnd = mainSource.indexOf('\n  });', finallyStart) + '\n  });'.length;
   assert.ok(finallyStart >= 0 && finallyEnd > finallyStart, 'recovery settle should exist');
@@ -280,7 +283,9 @@ function executeMacWidgetRecoveryWiring() {
   let beforeQuitHandler;
   const context = vm.createContext({
     AbortController,
+    Promise,
     console: { warn() {} },
+    os: { release: () => (runtimeSupported ? '23.0.0' : '22.0.0') },
     process: { platform: 'darwin', resourcesPath: '/acceptance/resources' },
     app: {
       isPackaged: true,
@@ -292,6 +297,10 @@ function executeMacWidgetRecoveryWiring() {
       calls.recoveryOptions = options;
       return recoveryPromise;
     },
+    macWidgetRuntimeSupport: () => ({
+      supported: runtimeSupported,
+      reason: runtimeSupported ? null : 'unsupported-os'
+    }),
     macWidgetPublicationReady: false,
     macWidgetSnapshotController: { resume: () => { calls.resumed += 1; } }
   });
@@ -305,6 +314,7 @@ function executeMacWidgetRecoveryWiring() {
       const options = calls.recoveryOptions;
       assert.ok(options, 'recovery should be invoked with the packaged wiring options');
       assert.equal(options.platform, 'darwin');
+      assert.equal(options.runtimeSupported, true);
       assert.equal(options.isPackaged, true);
       assert.equal(options.resourcesPath, '/acceptance/resources');
       assert.equal(options.userDataPath, '/acceptance/user-data');
@@ -330,6 +340,16 @@ test('main wiring resumes Widget publication when host registration settles on a
     assert.equal(execution.calls.resumed, 1, `${outcome.status} settle should resume the snapshot controller`);
     assert.deepEqual(execution.calls.removeListener, ['before-quit']);
   }
+});
+
+test('main wiring does not initialize Widget recovery below macOS 14', async () => {
+  const execution = executeMacWidgetRecoveryWiring(false);
+  assert.equal(execution.calls.recoveryOptions, undefined);
+  assert.deepEqual(execution.calls.once, []);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(execution.context.macWidgetPublicationReady, true);
+  assert.equal(execution.calls.resumed, 1);
+  assert.deepEqual(execution.calls.removeListener, []);
 });
 
 test('main wiring holds Widget publication when the app quits before registration settles', async () => {
@@ -455,6 +475,7 @@ test('keeps Widget packaging opt-in and injects artifacts only after a successfu
   assert.equal(normal.extraFiles, undefined);
   assert.equal(normal.extraResources, undefined);
   assert.equal(normal.extendInfo.CFBundleURLTypes, undefined);
+  assert.equal(normal.minimumSystemVersion, MAC_APP_MIN_VERSION);
   assert.equal(packageJson.scripts.predistMac, undefined);
   assert.equal(packageJson.scripts['predist:mac'], undefined);
 
@@ -475,6 +496,7 @@ test('keeps Widget packaging opt-in and injects artifacts only after a successfu
   fs.rmSync(artifactRoot, { recursive: true, force: true });
 
   const mac = widget;
+  assert.equal(mac.minimumSystemVersion, MAC_APP_MIN_VERSION);
   assert.deepEqual(mac.extendInfo.CFBundleURLTypes[0].CFBundleURLSchemes, ['token-monitor']);
   assert.equal(mac.extraFiles[0].to, 'PlugIns/TokenMonitorWidget.appex');
   assert.equal(mac.extraResources[0].to, 'token-monitor-widget.json');
@@ -485,6 +507,8 @@ test('keeps Widget packaging opt-in and injects artifacts only after a successfu
   assert.match(packageJson.scripts['dist:mac:widget'], /TOKEN_MONITOR_WIDGET_ENABLED=1 TOKEN_MONITOR_WIDGET_DISTRIBUTION=1 TOKEN_MONITOR_WIDGET_ARCH=arm64 electron-builder/);
   assert.match(packageJson.scripts['dist:mac:widget:x64'], /TOKEN_MONITOR_WIDGET_ARCH=x64/);
   assert.match(packageJson.scripts['pack:mac:widget:x64'], /--mac --x64 --dir/);
+  assert.equal(packageJson.build.mac.minimumSystemVersion, MAC_APP_MIN_VERSION);
+  assert.match(widgetProject, new RegExp(`MACOSX_DEPLOYMENT_TARGET = ${MAC_WIDGET_MIN_VERSION.replace('.', '\\.')}\\;`));
 });
 
 test('preserves generic macOS packaging config and fails fast on signing ownership conflicts', () => {

--- a/tests/electron/macWidgetLaunchServicesRecovery.test.js
+++ b/tests/electron/macWidgetLaunchServicesRecovery.test.js
@@ -91,6 +91,19 @@ test('skips unsupported and unpackaged processes before filesystem access', asyn
     reason: 'unsupported-platform'
   });
 
+  const unsupportedOs = createMacWidgetLaunchServicesRecovery({
+    fs: fsApi,
+    execFile: () => { launches += 1; }
+  });
+  assert.deepEqual(await unsupportedOs({
+    platform: 'darwin',
+    runtimeSupported: false,
+    isPackaged: true
+  }), {
+    status: 'skipped',
+    reason: 'unsupported-os'
+  });
+
   const unpackaged = createMacWidgetLaunchServicesRecovery({
     fs: fsApi,
     execFile: () => { launches += 1; }

--- a/tests/electron/macWidgetReloader.test.js
+++ b/tests/electron/macWidgetReloader.test.js
@@ -24,6 +24,19 @@ test('resolves the packaged Widget reloader only on macOS', () => {
   }
 });
 
+test('does not resolve or launch the reloader on an unsupported macOS version', () => {
+  let launches = 0;
+  assert.deepEqual(requestMacWidgetReload({
+    platform: 'darwin',
+    runtimeSupported: false,
+    execFile: () => { launches += 1; }
+  }), {
+    ok: false,
+    reason: 'unsupported-os'
+  });
+  assert.equal(launches, 0);
+});
+
 test('requests a throttled Widget timeline reload through the helper', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'token-monitor-reloader-'));
   try {

--- a/tests/shared/macSystemRequirements.test.js
+++ b/tests/shared/macSystemRequirements.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  MAC_APP_MIN_DARWIN_VERSION,
+  MAC_APP_MIN_VERSION,
+  MAC_WIDGET_MIN_DARWIN_VERSION,
+  MAC_WIDGET_MIN_VERSION,
+  macWidgetRuntimeSupport
+} = require('../../src/shared/macSystemRequirements');
+
+test('keeps host, updater and Widget minimum versions explicit and aligned', () => {
+  assert.equal(MAC_APP_MIN_VERSION, '12.0');
+  assert.equal(MAC_APP_MIN_DARWIN_VERSION, '21.0.0');
+  assert.equal(MAC_WIDGET_MIN_VERSION, '14.0');
+  assert.equal(MAC_WIDGET_MIN_DARWIN_VERSION, '23.0.0');
+});
+
+test('enables the native Widget only on macOS 14 and later', () => {
+  assert.deepEqual(macWidgetRuntimeSupport({ platform: 'linux', osRelease: '23.0.0' }), {
+    supported: false,
+    reason: 'unsupported-platform'
+  });
+  for (const osRelease of ['', 'invalid', '21.6.0', '22.6.0']) {
+    assert.deepEqual(macWidgetRuntimeSupport({ platform: 'darwin', osRelease }), {
+      supported: false,
+      reason: 'unsupported-os'
+    });
+  }
+  for (const osRelease of ['23.0.0', '23.6.0', '24.0.0']) {
+    assert.deepEqual(macWidgetRuntimeSupport({ platform: 'darwin', osRelease }), {
+      supported: true,
+      reason: null
+    });
+  }
+});

--- a/tests/shared/releaseArtifactNames.test.js
+++ b/tests/shared/releaseArtifactNames.test.js
@@ -14,6 +14,7 @@ const {
 } = require('../../scripts/verify-updater-artifact-names');
 const { mergeMacUpdaterMetadata } = require('../../scripts/merge-mac-updater-metadata');
 const { extractReleaseNotes } = require('../../src/shared/appUpdater');
+const { MAC_APP_MIN_DARWIN_VERSION } = require('../../src/shared/macSystemRequirements');
 
 function macUpdaterMetadata(version, arch) {
   return [
@@ -157,6 +158,8 @@ test('merges arm64 and x64 mac updater files into one architecture-aware feed', 
     `Token-Monitor-${version}-x64.dmg`
   ]);
   assert.match(merged, new RegExp(`^path: Token-Monitor-${version}-arm64\\.zip$`, 'm'));
+  assert.match(merged, new RegExp(`^minimumSystemVersion: ${MAC_APP_MIN_DARWIN_VERSION.replaceAll('.', '\\.')}$`, 'm'));
+  assert.equal((merged.match(/^minimumSystemVersion:/gm) || []).length, 1);
   assert.match(merged, /arm64 release notes survive metadata processing/);
   assert.doesNotMatch(merged, /x64 release notes survive metadata processing/);
 
@@ -198,6 +201,26 @@ test('rejects mismatched or mislabelled mac updater metadata', () => {
       macUpdaterMetadata('0.33.0', 'arm64')
     ),
     /expected only arm64 artifacts/
+  );
+  assert.throws(
+    () => mergeMacUpdaterMetadata(
+      macUpdaterMetadata('0.33.0', 'arm64').replace(
+        'files:',
+        'minimumSystemVersion: 23.0.0\nfiles:'
+      ),
+      macUpdaterMetadata('0.33.0', 'x64')
+    ),
+    /does not match release policy/
+  );
+  assert.throws(
+    () => mergeMacUpdaterMetadata(
+      macUpdaterMetadata('0.33.0', 'arm64').replace(
+        'files:',
+        'minimumSystemVersion:\nfiles:'
+      ),
+      macUpdaterMetadata('0.33.0', 'x64')
+    ),
+    /empty top-level minimumSystemVersion/
   );
 });
 


### PR DESCRIPTION
## Summary

- restore the packaged Token Monitor host app baseline to macOS 12
- keep the native Widget extension and reloader on macOS 14
- skip Widget recovery, demand watching, snapshot publication, and reload helpers below macOS 14
- add `minimumSystemVersion: 21.0.0` to the final merged macOS updater feed
- reject empty, duplicate, or conflicting updater system-version metadata
- update all localized README badges to advertise the host app's macOS 12 baseline

The production release workflow remains unchanged and continues to build with `TOKEN_MONITOR_WIDGET_ENABLED=0`. Widget-enabled builds keep the host app on macOS 12 while the embedded Widget targets macOS 14.

## Why

v0.43.0 applied the Widget's macOS 14 deployment requirement to every packaged macOS build, including production artifacts that do not contain the Widget. Its published updater metadata also omitted the corresponding system requirement, allowing older installations to update into an app that macOS refused to launch.

This separates the host application requirement from the optional Widget capability and ensures future update feeds advertise the host application's actual Darwin requirement.

Fixes #391

## Validation

- `node --test tests/shared/macSystemRequirements.test.js tests/shared/releaseArtifactNames.test.js tests/electron/macWidgetIntegration.test.js tests/electron/macWidgetLaunchServicesRecovery.test.js tests/electron/macWidgetReloader.test.js`
- `npm run sync:worker`
- `npm run verify`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separate macOS system requirements for the app and the Widget: keep the host app on macOS 12 while gating the native Widget at macOS 14. This prevents updates that install on older macOS but then fail to launch.

- **Bug Fixes**
  - Restore host app baseline to macOS 12.0; keep Widget at macOS 14.0.
  - Gate Widget-only code (recovery, demand, snapshots, reload) behind a runtime check; skip on unsupported macOS.
  - Enforce and inject `minimumSystemVersion: 21.0.0` in the merged mac updater feed; reject empty, duplicate, or mismatched values.
  - Update README badges to macOS 12 and add tests for system requirements, widget gating, and feed validation.
  - No workflow changes; production builds still ship with `TOKEN_MONITOR_WIDGET_ENABLED=0`.

<sup>Written for commit 63c3354cdd31f987065b3457e1f0f8b5e86b59c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

