### PR TITLE
fix(tray): keep composer pickers open during live updates

### DIFF
--- a/src/electron/renderer/trayComposer.js
+++ b/src/electron/renderer/trayComposer.js
@@ -90,6 +90,16 @@
     };
   }
 
+  function handlePickerDocumentScroll(picker, eventTarget, actions = {}) {
+    if (picker?.menu?.contains?.(eventTarget)) return 'ignore';
+    if (!picker?.owner?.isConnected || !picker?.trigger?.isConnected) {
+      actions.close?.();
+      return 'close';
+    }
+    actions.reposition?.();
+    return 'reposition';
+  }
+
   function syncTrayComposerSurfaces(surfaces, composers, createComposer) {
     for (const surface of surfaces) {
       surface.root?.classList.toggle('hidden', !surface.visible);
@@ -435,8 +445,14 @@
         closePickerMenu();
       };
       const onDocumentScroll = (event) => {
-        if (menu.contains(event.target)) return;
-        closePickerMenu({ restoreFocus: false });
+        // Stats updates can adjust the settings page's scroll position while a
+        // picker is open. Keep the in-progress control stable and follow its
+        // connected trigger instead of treating that layout correction as an
+        // outside dismissal.
+        handlePickerDocumentScroll(activePicker, event.target, {
+          close: () => closePickerMenu({ restoreFocus: false }),
+          reposition: positionPickerMenu
+        });
       };
       activePicker = {
         owner,
@@ -1234,6 +1250,7 @@
     accountModeSourcePatch,
     createTrayComposer,
     duplicateTrayLayoutItem,
+    handlePickerDocumentScroll,
     moveTrayLayoutItemByKey,
     periodItemPatch,
     syncTrayComposerSurfaces

--- a/tests/electron/trayComposer.test.js
+++ b/tests/electron/trayComposer.test.js
@@ -10,6 +10,7 @@ const {
   accountModeSourcePatch,
   createTrayComposer,
   duplicateTrayLayoutItem,
+  handlePickerDocumentScroll,
   moveTrayLayoutItemByKey,
   periodItemPatch,
   syncTrayComposerSurfaces
@@ -111,6 +112,43 @@ test('keyboard movement returns the reordered layout and respects boundaries', (
   const boundary = moveTrayLayoutItemByKey(trayLayoutApi, moved.layout, 'selected', 'ArrowRight');
   assert.equal(boundary.moved, false);
   assert.deepEqual(boundary.layout, moved.layout);
+});
+
+test('an open picker follows outer scroll updates while its trigger stays connected', () => {
+  const menu = { contains: (target) => target === 'menu-scroll' };
+  const connected = {
+    menu,
+    owner: { isConnected: true },
+    trigger: { isConnected: true }
+  };
+  const calls = [];
+  const actions = {
+    close: () => calls.push('close'),
+    reposition: () => calls.push('reposition')
+  };
+
+  assert.equal(handlePickerDocumentScroll(connected, 'menu-scroll', actions), 'ignore');
+  assert.deepEqual(calls, []);
+  assert.equal(handlePickerDocumentScroll(connected, 'settings-scroll', actions), 'reposition');
+  assert.deepEqual(calls, ['reposition']);
+  assert.equal(
+    handlePickerDocumentScroll(
+      { ...connected, trigger: { isConnected: false } },
+      'settings-scroll',
+      actions
+    ),
+    'close'
+  );
+  assert.deepEqual(calls, ['reposition', 'close']);
+  assert.equal(
+    handlePickerDocumentScroll(
+      { ...connected, owner: { isConnected: false } },
+      'settings-scroll',
+      actions
+    ),
+    'close'
+  );
+  assert.deepEqual(calls, ['reposition', 'close', 'close']);
 });
 
 test('composer visibility destroys hidden surfaces and creates newly visible surfaces', () => {


### PR DESCRIPTION
## Summary

- Keep an open tray composer picker attached to its trigger when the settings page scrolls during live stats updates.
- Reposition the picker instead of dismissing it while its editor and trigger remain connected.
- Preserve normal dismissal when the editor is removed, while leaving picker-internal scrolling unchanged.
- Add regression coverage for connected and disconnected picker states.

## Testing

- `node --test tests/electron/trayComposer.test.js`
- `npm run verify`
- Manually verified with live updates in an isolated Electron profile.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep composer pickers open during live stats scroll corrections so users don’t lose in-progress selections. Previously any document scroll dismissed the picker; now we reposition it while its owner and trigger remain connected, and still close if either disconnects.

- Introduces and exports `handlePickerDocumentScroll(picker, eventTarget, actions)` to ignore menu-internal scrolls, reposition on outer scroll, and close on disconnect; integrates it into the tray composer.
- Preserves normal dismissal when the editor is removed; picker-internal scrolling is unchanged.
- Adds tests covering ignore/reposition/close outcomes for connected and disconnected states.

<sup>Written for commit d7ee7e4cb7783d74ff3ae49bae43e1b6096789fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

