### PR TITLE
feat(release): add generated changelog details

### DIFF
--- a/.github/RELEASE_NOTES_FORMAT.md
+++ b/.github/RELEASE_NOTES_FORMAT.md
@@ -13,10 +13,19 @@ This file documents the stable Markdown shape of that release body.
 - Keep the existing divider between the English and Simplified Chinese
   sections. After the Simplified Chinese section, put one final `---` divider
   before the additional-language area.
-- Put exactly one `**Full Changelog:**` compare link immediately below the
-  divider.
-- Put the additional-language area after that link inside one collapsed outer
-  `<details>` block with the plain summary `繁體中文 · 한국어 · 日本語`.
+- Put one collapsed `Full Changelog` details block immediately below the
+  divider. Its summary contains the single version compare link; clicking the
+  summary label expands the generated details, while clicking the version
+  opens GitHub's comparison. Keep the `<!-- github-generated-release-notes -->`
+  marker as the only content inside the disclosure. The release workflow
+  replaces it with GitHub's merged-PR, author, and new-contributor notes for the
+  tag. Direct commits that are not associated with a merged pull request are
+  added to `What's Changed` with their author and commit link; the release
+  commit itself is omitted. Do not add a Markdown `Contributors` list: GitHub
+  renders its own contributor section with avatars outside the release body.
+- Put the additional-language area after that details block inside one
+  collapsed outer `<details>` block with the plain summary
+  `繁體中文 · 한국어 · 日本語`.
 - Put Traditional Chinese, Korean, and Japanese in three separate nested
   collapsed `<details>` blocks. Each block has its own language heading and
   translated update heading.
@@ -68,7 +77,12 @@ each language block.
 
 ---
 
-**Full Changelog:** [vPREVIOUS...vCURRENT](https://github.com/Javis603/token-monitor/compare/vPREVIOUS...vCURRENT)
+<details>
+<summary><strong>Full Changelog:</strong> <a href="https://github.com/Javis603/token-monitor/compare/vPREVIOUS...vCURRENT">vPREVIOUS...vCURRENT</a></summary>
+
+<!-- github-generated-release-notes -->
+
+</details>
 
 <details>
 <summary>繁體中文 · 한국어 · 日本語</summary>

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -108,7 +108,12 @@ https://github.com/junhoyeo/tokscale
 
 ---
 
-**Full Changelog:** [v0.42.1...v0.43.0](https://github.com/Javis603/token-monitor/compare/v0.42.1...v0.43.0)
+<details>
+<summary><strong>Full Changelog:</strong> <a href="https://github.com/Javis603/token-monitor/compare/v0.42.1...v0.43.0">v0.42.1...v0.43.0</a></summary>
+
+<!-- github-generated-release-notes -->
+
+</details>
 
 <details>
 <summary>繁體中文 · 한국어 · 日本語</summary>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,6 +266,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
@@ -295,6 +296,10 @@ jobs:
             artifacts/token-monitor-mac-arm64/latest-mac.yml \
             artifacts/token-monitor-mac-x64/latest-mac.yml
           node scripts/verify-updater-artifact-names.js release-artifacts
+      - name: Add generated changelog details to release notes
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/prepare-github-release-notes.js .github/RELEASE_TEMPLATE.md release-notes.md
       - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: |
@@ -306,4 +311,4 @@ jobs:
             release-artifacts/latest-mac.yml
             release-artifacts/latest-linux.yml
             release-artifacts/*.blockmap
-          body_path: .github/RELEASE_TEMPLATE.md
+          body_path: release-notes.md

--- a/scripts/prepare-github-release-notes.js
+++ b/scripts/prepare-github-release-notes.js
@@ -3,6 +3,41 @@
 const fs = require('node:fs/promises');
 
 const GENERATED_NOTES_MARKER = '<!-- github-generated-release-notes -->';
+const GITHUB_API_VERSION = '2026-03-10';
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_COMPARE_PAGES = 10_000;
+
+function apiEndpoint(apiUrl, pathname) {
+  const base = String(apiUrl || '').trim().replace(/\/+$/, '');
+  if (!/^https?:\/\//i.test(base)) {
+    throw new Error(`invalid GITHUB_API_URL: ${apiUrl}`);
+  }
+  return `${base}${pathname}`;
+}
+
+function requestHeaders(token) {
+  return {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'X-GitHub-Api-Version': GITHUB_API_VERSION,
+    'User-Agent': 'token-monitor-release-workflow'
+  };
+}
+
+function requestSignal() {
+  return AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+}
+
+async function githubFetch(url, options, fetchImpl, context) {
+  try {
+    return await fetchImpl(url, options);
+  } catch (error) {
+    if (options.signal?.aborted || error?.name === 'AbortError' || error?.name === 'TimeoutError') {
+      throw new Error(`${context} timed out`, { cause: error });
+    }
+    throw new Error(`${context} request failed: ${error?.message || error}`, { cause: error });
+  }
+}
 
 function generatedNotesWithoutFullChangelog(notes) {
   return String(notes || '')
@@ -51,55 +86,73 @@ function composeReleaseNotes(template, generatedNotes, { repository = '', direct
 }
 
 function fullChangelogRange(template) {
-  const matches = [...template.matchAll(/^<summary><strong>Full Changelog:<\/strong> <a href="https:\/\/github\.com\/Javis603\/token-monitor\/compare\/(v[^.\s"]+(?:\.[^.\s"]+){2})\.\.\.(v[^.\s"]+(?:\.[^.\s"]+){2})">\1\.\.\.\2<\/a><\/summary>$/gm)];
+  const matches = [...template.matchAll(/^<summary><strong>Full Changelog:<\/strong> <a href="https:\/\/github\.com\/Javis603\/token-monitor\/compare\/([^"\s]+)">([^<]+)<\/a><\/summary>$/gm)];
   if (matches.length !== 1) {
     throw new Error(`expected exactly one versioned Full Changelog link, found ${matches.length}`);
   }
-  return { previousTag: matches[0][1], currentTag: matches[0][2] };
+  const hrefRange = matches[0][1];
+  const linkText = matches[0][2];
+  const tags = hrefRange.split('...');
+  if (tags.length !== 2 || tags.some((tag) => !tag.startsWith('v') || tag.length === 1)) {
+    throw new Error(`invalid Full Changelog range: ${hrefRange}`);
+  }
+  if (linkText !== hrefRange) {
+    throw new Error(`Full Changelog text ${linkText} does not match href range ${hrefRange}`);
+  }
+  return { previousTag: tags[0], currentTag: tags[1] };
 }
 
-async function fetchGeneratedNotes({ repository, tag, previousTag, token, fetchImpl = fetch }) {
+async function fetchGeneratedNotes({
+  repository,
+  tag,
+  previousTag,
+  token,
+  apiUrl = process.env.GITHUB_API_URL || 'https://api.github.com',
+  fetchImpl = fetch,
+  signalFactory = requestSignal
+}) {
   if (!repository || !tag || !previousTag || !token) {
     throw new Error('repository, current tag, previous tag, and token are required');
   }
 
-  const response = await fetchImpl(`https://api.github.com/repos/${repository}/releases/generate-notes`, {
+  const response = await githubFetch(apiEndpoint(apiUrl, `/repos/${repository}/releases/generate-notes`), {
     method: 'POST',
-    headers: {
-      Accept: 'application/vnd.github+json',
-      Authorization: `Bearer ${token}`,
-      'X-GitHub-Api-Version': '2022-11-28',
-      'User-Agent': 'token-monitor-release-workflow'
-    },
-    body: JSON.stringify({ tag_name: tag, previous_tag_name: previousTag })
-  });
+    headers: requestHeaders(token),
+    body: JSON.stringify({ tag_name: tag, previous_tag_name: previousTag }),
+    signal: signalFactory()
+  }, fetchImpl, 'GitHub release-notes generation');
 
   if (!response.ok) {
     const detail = await response.text();
     throw new Error(`GitHub release-notes generation failed (${response.status}): ${detail}`);
   }
 
-  const payload = await response.json();
+  let payload;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new Error('GitHub release-notes response was not valid JSON');
+  }
   if (typeof payload.body !== 'string') {
     throw new Error('GitHub release-notes response did not contain a body');
   }
   return payload.body;
 }
 
-async function githubJson(url, token, fetchImpl) {
-  const response = await fetchImpl(url, {
-    headers: {
-      Accept: 'application/vnd.github+json',
-      Authorization: `Bearer ${token}`,
-      'X-GitHub-Api-Version': '2022-11-28',
-      'User-Agent': 'token-monitor-release-workflow'
-    }
-  });
+async function githubJson(url, token, fetchImpl, signalFactory) {
+  const response = await githubFetch(url, {
+    headers: requestHeaders(token),
+    signal: signalFactory()
+  }, fetchImpl, 'GitHub changelog lookup');
   if (!response.ok) {
     const detail = await response.text();
     throw new Error(`GitHub changelog lookup failed (${response.status}): ${detail}`);
   }
-  return response.json();
+  try {
+    return await response.json();
+  } catch {
+    throw new Error('GitHub changelog response was not valid JSON');
+  }
 }
 
 function isReleaseCommit(subject, currentTag) {
@@ -123,18 +176,30 @@ async function mapConcurrent(values, concurrency, mapper) {
   return results;
 }
 
-async function fetchDirectCommits({ repository, tag, previousTag, token, fetchImpl = fetch }) {
+async function fetchDirectCommits({
+  repository,
+  tag,
+  previousTag,
+  token,
+  apiUrl = process.env.GITHUB_API_URL || 'https://api.github.com',
+  fetchImpl = fetch,
+  signalFactory = requestSignal
+}) {
   if (!repository || !tag || !previousTag || !token) {
     throw new Error('repository, current tag, previous tag, and token are required');
   }
 
-  const baseUrl = `https://api.github.com/repos/${repository}`;
+  const baseUrl = apiEndpoint(apiUrl, `/repos/${repository}`);
   const commits = [];
   for (let page = 1; ; page += 1) {
+    if (page > MAX_COMPARE_PAGES) {
+      throw new Error(`GitHub compare pagination exceeded ${MAX_COMPARE_PAGES} pages`);
+    }
     const comparison = await githubJson(
       `${baseUrl}/compare/${encodeURIComponent(previousTag)}...${encodeURIComponent(tag)}?per_page=100&page=${page}`,
       token,
-      fetchImpl
+      fetchImpl,
+      signalFactory
     );
     if (!Array.isArray(comparison.commits)) {
       throw new Error('GitHub compare response did not contain commits');
@@ -148,7 +213,7 @@ async function fetchDirectCommits({ repository, tag, previousTag, token, fetchIm
     const subject = commit?.commit?.message?.split('\n')[0]?.trim();
     if (!sha || !subject || isReleaseCommit(subject, tag)) return null;
 
-    const pulls = await githubJson(`${baseUrl}/commits/${sha}/pulls`, token, fetchImpl);
+    const pulls = await githubJson(`${baseUrl}/commits/${sha}/pulls`, token, fetchImpl, signalFactory);
     if (!Array.isArray(pulls)) {
       throw new Error(`GitHub pull-request lookup for ${sha} did not return an array`);
     }
@@ -203,6 +268,7 @@ if (require.main === module) {
 
 module.exports = {
   GENERATED_NOTES_MARKER,
+  apiEndpoint,
   composeReleaseNotes,
   fetchDirectCommits,
   fetchGeneratedNotes,

--- a/scripts/prepare-github-release-notes.js
+++ b/scripts/prepare-github-release-notes.js
@@ -1,0 +1,214 @@
+'use strict';
+
+const fs = require('node:fs/promises');
+
+const GENERATED_NOTES_MARKER = '<!-- github-generated-release-notes -->';
+
+function generatedNotesWithoutFullChangelog(notes) {
+  return String(notes || '')
+    .replace(/^\*\*Full Changelog(?:\*\*:|:\*\*)[^\r\n]*(?:\r?\n)?/gim, '')
+    .trim();
+}
+
+function directCommitLine(repository, commit) {
+  const subject = String(commit.subject || '').trim();
+  const author = commit.authorLogin ? `@${commit.authorLogin}` : commit.authorName;
+  const shortSha = commit.sha.slice(0, 7);
+  return `* ${subject} by ${author} ([${shortSha}](https://github.com/${repository}/commit/${commit.sha}))`;
+}
+
+function notesWithDirectCommits(notes, repository, directCommits) {
+  const body = generatedNotesWithoutFullChangelog(notes);
+  if (directCommits.length === 0) return body;
+
+  const lines = directCommits.map((commit) => directCommitLine(repository, commit)).join('\n');
+  const heading = /^## What's Changed\s*$/m;
+  const headingMatch = heading.exec(body);
+  if (!headingMatch) return `## What's Changed\n${lines}\n\n${body}`.trim();
+
+  const sectionStart = headingMatch.index + headingMatch[0].length;
+  const followingHeading = /^## /m.exec(body.slice(sectionStart));
+  const insertionPoint = followingHeading
+    ? sectionStart + followingHeading.index
+    : body.length;
+  const before = body.slice(0, insertionPoint).trimEnd();
+  const after = body.slice(insertionPoint).trimStart();
+  return after ? `${before}\n${lines}\n\n${after}` : `${before}\n${lines}`;
+}
+
+function generatedChangelogDetails(notes, repository = '', directCommits = []) {
+  return notesWithDirectCommits(notes, repository, directCommits);
+}
+
+function composeReleaseNotes(template, generatedNotes, { repository = '', directCommits = [] } = {}) {
+  const markerCount = template.split(GENERATED_NOTES_MARKER).length - 1;
+  if (markerCount !== 1) {
+    throw new Error(`expected exactly one ${GENERATED_NOTES_MARKER} marker, found ${markerCount}`);
+  }
+
+  const notes = generatedChangelogDetails(generatedNotes, repository, directCommits);
+  return template.replace(GENERATED_NOTES_MARKER, notes);
+}
+
+function fullChangelogRange(template) {
+  const matches = [...template.matchAll(/^<summary><strong>Full Changelog:<\/strong> <a href="https:\/\/github\.com\/Javis603\/token-monitor\/compare\/(v[^.\s"]+(?:\.[^.\s"]+){2})\.\.\.(v[^.\s"]+(?:\.[^.\s"]+){2})">\1\.\.\.\2<\/a><\/summary>$/gm)];
+  if (matches.length !== 1) {
+    throw new Error(`expected exactly one versioned Full Changelog link, found ${matches.length}`);
+  }
+  return { previousTag: matches[0][1], currentTag: matches[0][2] };
+}
+
+async function fetchGeneratedNotes({ repository, tag, previousTag, token, fetchImpl = fetch }) {
+  if (!repository || !tag || !previousTag || !token) {
+    throw new Error('repository, current tag, previous tag, and token are required');
+  }
+
+  const response = await fetchImpl(`https://api.github.com/repos/${repository}/releases/generate-notes`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'token-monitor-release-workflow'
+    },
+    body: JSON.stringify({ tag_name: tag, previous_tag_name: previousTag })
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`GitHub release-notes generation failed (${response.status}): ${detail}`);
+  }
+
+  const payload = await response.json();
+  if (typeof payload.body !== 'string') {
+    throw new Error('GitHub release-notes response did not contain a body');
+  }
+  return payload.body;
+}
+
+async function githubJson(url, token, fetchImpl) {
+  const response = await fetchImpl(url, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'token-monitor-release-workflow'
+    }
+  });
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`GitHub changelog lookup failed (${response.status}): ${detail}`);
+  }
+  return response.json();
+}
+
+function isReleaseCommit(subject, currentTag) {
+  const version = currentTag.replace(/^v/, '');
+  const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`^chore(?:\\([^)]*\\))?: release v?${escapedVersion}$`, 'i')
+    .test(subject.trim());
+}
+
+async function mapConcurrent(values, concurrency, mapper) {
+  const results = new Array(values.length);
+  let nextIndex = 0;
+  async function worker() {
+    while (nextIndex < values.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(values[index], index);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, values.length) }, worker));
+  return results;
+}
+
+async function fetchDirectCommits({ repository, tag, previousTag, token, fetchImpl = fetch }) {
+  if (!repository || !tag || !previousTag || !token) {
+    throw new Error('repository, current tag, previous tag, and token are required');
+  }
+
+  const baseUrl = `https://api.github.com/repos/${repository}`;
+  const commits = [];
+  for (let page = 1; ; page += 1) {
+    const comparison = await githubJson(
+      `${baseUrl}/compare/${encodeURIComponent(previousTag)}...${encodeURIComponent(tag)}?per_page=100&page=${page}`,
+      token,
+      fetchImpl
+    );
+    if (!Array.isArray(comparison.commits)) {
+      throw new Error('GitHub compare response did not contain commits');
+    }
+    commits.push(...comparison.commits);
+    if (comparison.commits.length < 100) break;
+  }
+
+  const direct = await mapConcurrent(commits, 8, async (commit) => {
+    const sha = commit?.sha;
+    const subject = commit?.commit?.message?.split('\n')[0]?.trim();
+    if (!sha || !subject || isReleaseCommit(subject, tag)) return null;
+
+    const pulls = await githubJson(`${baseUrl}/commits/${sha}/pulls`, token, fetchImpl);
+    if (!Array.isArray(pulls)) {
+      throw new Error(`GitHub pull-request lookup for ${sha} did not return an array`);
+    }
+    if (pulls.some((pull) => pull?.merged_at)) return null;
+
+    return {
+      sha,
+      subject,
+      authorLogin: commit.author?.login || null,
+      authorName: commit.commit?.author?.name || 'Unknown contributor'
+    };
+  });
+  return direct.filter(Boolean);
+}
+
+async function main() {
+  const [templatePath, outputPath] = process.argv.slice(2);
+  if (!templatePath || !outputPath) {
+    throw new Error('usage: node scripts/prepare-github-release-notes.js <template> <output>');
+  }
+
+  const template = await fs.readFile(templatePath, 'utf8');
+  const { previousTag, currentTag } = fullChangelogRange(template);
+  if (currentTag !== process.env.GITHUB_REF_NAME) {
+    throw new Error(`Full Changelog ends at ${currentTag}, expected ${process.env.GITHUB_REF_NAME}`);
+  }
+  const generatedNotes = await fetchGeneratedNotes({
+    repository: process.env.GITHUB_REPOSITORY,
+    tag: currentTag,
+    previousTag,
+    token: process.env.GITHUB_TOKEN
+  });
+  const directCommits = await fetchDirectCommits({
+    repository: process.env.GITHUB_REPOSITORY,
+    tag: currentTag,
+    previousTag,
+    token: process.env.GITHUB_TOKEN
+  });
+
+  await fs.writeFile(outputPath, composeReleaseNotes(template, generatedNotes, {
+    repository: process.env.GITHUB_REPOSITORY,
+    directCommits
+  }));
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  GENERATED_NOTES_MARKER,
+  composeReleaseNotes,
+  fetchDirectCommits,
+  fetchGeneratedNotes,
+  fullChangelogRange,
+  generatedChangelogDetails,
+  generatedNotesWithoutFullChangelog,
+  isReleaseCommit,
+  notesWithDirectCommits
+};

--- a/tests/scripts/prepareGithubReleaseNotes.test.js
+++ b/tests/scripts/prepareGithubReleaseNotes.test.js
@@ -141,7 +141,11 @@ test('fetchGeneratedNotes honors GITHUB_API_URL and fails when its timeout signa
       fetchImpl: async (url, options) => {
         assert.equal(url, 'https://github.example/api/v3/repos/Javis603/token-monitor/releases/generate-notes');
         await new Promise((resolve, reject) => {
-          options.signal.addEventListener('abort', () => reject(options.signal.reason), { once: true });
+          const guard = setTimeout(() => reject(new Error('timeout signal did not fire')), 250);
+          options.signal.addEventListener('abort', () => {
+            clearTimeout(guard);
+            reject(options.signal.reason);
+          }, { once: true });
         });
       }
     }),

--- a/tests/scripts/prepareGithubReleaseNotes.test.js
+++ b/tests/scripts/prepareGithubReleaseNotes.test.js
@@ -84,6 +84,18 @@ test('fullChangelogRange locks generated notes to the curated compare range', ()
     ),
     { previousTag: 'v0.42.1', currentTag: 'v0.43.0' }
   );
+  assert.deepEqual(
+    fullChangelogRange(
+      '<summary><strong>Full Changelog:</strong> <a href="https://github.com/Javis603/token-monitor/compare/v1.0.0...v1.1.0-beta.1+build.2">v1.0.0...v1.1.0-beta.1+build.2</a></summary>'
+    ),
+    { previousTag: 'v1.0.0', currentTag: 'v1.1.0-beta.1+build.2' }
+  );
+  assert.throws(
+    () => fullChangelogRange(
+      '<summary><strong>Full Changelog:</strong> <a href="https://github.com/Javis603/token-monitor/compare/v1.0.0...v1.1.0">v1.0.0...v1.2.0</a></summary>'
+    ),
+    /does not match href range/
+  );
   assert.throws(() => fullChangelogRange('missing'), /found 0/);
 });
 
@@ -109,10 +121,55 @@ test('fetchGeneratedNotes requests GitHub generated notes for the pushed tag', a
   assert.equal(request.url, 'https://api.github.com/repos/Javis603/token-monitor/releases/generate-notes');
   assert.equal(request.options.method, 'POST');
   assert.equal(request.options.headers.Authorization, 'Bearer test-token');
+  assert.equal(request.options.headers['X-GitHub-Api-Version'], '2026-03-10');
+  assert.ok(request.options.signal instanceof AbortSignal);
   assert.deepEqual(JSON.parse(request.options.body), {
     tag_name: 'v1.1.0',
     previous_tag_name: 'v1.0.0'
   });
+});
+
+test('fetchGeneratedNotes honors GITHUB_API_URL and fails when its timeout signal fires', async () => {
+  await assert.rejects(
+    fetchGeneratedNotes({
+      repository: 'Javis603/token-monitor',
+      tag: 'v1.1.0',
+      previousTag: 'v1.0.0',
+      token: 'test-token',
+      apiUrl: 'https://github.example/api/v3/',
+      signalFactory: () => AbortSignal.timeout(1),
+      fetchImpl: async (url, options) => {
+        assert.equal(url, 'https://github.example/api/v3/repos/Javis603/token-monitor/releases/generate-notes');
+        await new Promise((resolve, reject) => {
+          options.signal.addEventListener('abort', () => reject(options.signal.reason), { once: true });
+        });
+      }
+    }),
+    /GitHub release-notes generation timed out/
+  );
+});
+
+test('fetchGeneratedNotes rejects GitHub API errors and invalid JSON', async () => {
+  const input = {
+    repository: 'Javis603/token-monitor',
+    tag: 'v1.1.0',
+    previousTag: 'v1.0.0',
+    token: 'test-token'
+  };
+  await assert.rejects(
+    fetchGeneratedNotes({
+      ...input,
+      fetchImpl: async () => ({ ok: false, status: 502, async text() { return 'bad gateway'; } })
+    }),
+    /failed \(502\): bad gateway/
+  );
+  await assert.rejects(
+    fetchGeneratedNotes({
+      ...input,
+      fetchImpl: async () => ({ ok: true, async json() { throw new SyntaxError('bad JSON'); } })
+    }),
+    /was not valid JSON/
+  );
 });
 
 test('fetchDirectCommits keeps only commits without an associated merged PR', async () => {
@@ -146,8 +203,11 @@ test('fetchDirectCommits keeps only commits without an associated merged PR', as
     tag: 'v1.1.0',
     previousTag: 'v1.0.0',
     token: 'test-token',
-    fetchImpl: async (url) => {
+    apiUrl: 'https://github.example/api/v3/',
+    fetchImpl: async (url, options) => {
       requests.push(url);
+      assert.equal(options.headers['X-GitHub-Api-Version'], '2026-03-10');
+      assert.ok(options.signal instanceof AbortSignal);
       const key = url.includes('/compare/')
         ? 'compare'
         : url.includes('111111111111') ? '1111111' : '2222222';
@@ -165,7 +225,10 @@ test('fetchDirectCommits keeps only commits without an associated merged PR', as
     authorName: 'Direct Author'
   }]);
   assert.equal(requests.filter((url) => url.includes('/commits/')).length, 2);
-  assert.match(requests[0], /compare\/v1\.0\.0\.\.\.v1\.1\.0\?per_page=100&page=1$/);
+  assert.equal(
+    requests[0],
+    'https://github.example/api/v3/repos/Javis603/token-monitor/compare/v1.0.0...v1.1.0?per_page=100&page=1'
+  );
 });
 
 test('release commit filtering accepts scoped and unscoped release subjects only', () => {

--- a/tests/scripts/prepareGithubReleaseNotes.test.js
+++ b/tests/scripts/prepareGithubReleaseNotes.test.js
@@ -1,0 +1,177 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  GENERATED_NOTES_MARKER,
+  composeReleaseNotes,
+  fetchDirectCommits,
+  fetchGeneratedNotes,
+  fullChangelogRange,
+  isReleaseCommit
+} = require('../../scripts/prepare-github-release-notes');
+
+test('composeReleaseNotes inserts GitHub notes below the single summary link', () => {
+  const template = [
+    '# User-facing notes',
+    '<details>',
+    '<summary><strong>Full Changelog:</strong> <a href="https://github.com/Javis603/token-monitor/compare/v1.0.0...v1.1.0">v1.0.0...v1.1.0</a></summary>',
+    '',
+    GENERATED_NOTES_MARKER,
+    '</details>'
+  ].join('\n');
+  const generated = [
+    '## What\'s Changed',
+    '* fix: preserve manual notes by @contributor in #123',
+    '',
+    '## New Contributors',
+    '* @contributor made their first contribution in #123',
+    '',
+    '**Full Changelog**: https://example.test/generated-compare'
+  ].join('\n');
+
+  const result = composeReleaseNotes(template, generated);
+
+  assert.match(result, /## What's Changed/);
+  assert.match(result, /@contributor in #123/);
+  assert.match(result, /## New Contributors/);
+  assert.doesNotMatch(result, /## Contributors/);
+  assert.doesNotMatch(result, /generated-compare/);
+  assert.equal(result.match(/Full Changelog:/g)?.length, 1);
+  assert.ok(result.indexOf('Full Changelog:') < result.indexOf("## What's Changed"));
+});
+
+test('composeReleaseNotes adds direct commits to What\'s Changed before New Contributors', () => {
+  const template = `before\n${GENERATED_NOTES_MARKER}\nafter`;
+  const generated = [
+    '## What\'s Changed',
+    '* fix: merged change by @pull-author in #123',
+    '',
+    '## New Contributors',
+    '* @pull-author made their first contribution in #123',
+    '',
+    '**Full Changelog**: https://example.test/compare'
+  ].join('\n');
+
+  const result = composeReleaseNotes(template, generated, {
+    repository: 'Javis603/token-monitor',
+    directCommits: [{
+      sha: 'abcdef1234567890abcdef1234567890abcdef12',
+      subject: 'fix(widget): preserve direct changes',
+      authorLogin: 'direct-author',
+      authorName: 'Direct Author'
+    }]
+  });
+
+  assert.match(result, /fix\(widget\).*by @direct-author \(\[abcdef1\]\(https:\/\/github\.com\/Javis603\/token-monitor\/commit\/abcdef1234567890abcdef1234567890abcdef12\)\)/);
+  assert.ok(result.indexOf('fix(widget)') < result.indexOf('## New Contributors'));
+  assert.doesNotMatch(result, /## Contributors/);
+});
+
+test('composeReleaseNotes rejects a missing or duplicated insertion marker', () => {
+  assert.throws(() => composeReleaseNotes('no marker', 'notes'), /expected exactly one/);
+  assert.throws(
+    () => composeReleaseNotes(`${GENERATED_NOTES_MARKER}\n${GENERATED_NOTES_MARKER}`, 'notes'),
+    /found 2/
+  );
+});
+
+test('fullChangelogRange locks generated notes to the curated compare range', () => {
+  assert.deepEqual(
+    fullChangelogRange(
+      '<summary><strong>Full Changelog:</strong> <a href="https://github.com/Javis603/token-monitor/compare/v0.42.1...v0.43.0">v0.42.1...v0.43.0</a></summary>'
+    ),
+    { previousTag: 'v0.42.1', currentTag: 'v0.43.0' }
+  );
+  assert.throws(() => fullChangelogRange('missing'), /found 0/);
+});
+
+test('fetchGeneratedNotes requests GitHub generated notes for the pushed tag', async () => {
+  let request;
+  const body = await fetchGeneratedNotes({
+    repository: 'Javis603/token-monitor',
+    tag: 'v1.1.0',
+    previousTag: 'v1.0.0',
+    token: 'test-token',
+    fetchImpl: async (url, options) => {
+      request = { url, options };
+      return {
+        ok: true,
+        async json() {
+          return { body: 'generated notes' };
+        }
+      };
+    }
+  });
+
+  assert.equal(body, 'generated notes');
+  assert.equal(request.url, 'https://api.github.com/repos/Javis603/token-monitor/releases/generate-notes');
+  assert.equal(request.options.method, 'POST');
+  assert.equal(request.options.headers.Authorization, 'Bearer test-token');
+  assert.deepEqual(JSON.parse(request.options.body), {
+    tag_name: 'v1.1.0',
+    previous_tag_name: 'v1.0.0'
+  });
+});
+
+test('fetchDirectCommits keeps only commits without an associated merged PR', async () => {
+  const requests = [];
+  const responses = new Map([
+    ['compare', {
+      commits: [
+        {
+          sha: '1111111111111111111111111111111111111111',
+          commit: { message: 'fix: direct change\n\nbody', author: { name: 'Direct Author' } },
+          author: { login: 'direct-author' }
+        },
+        {
+          sha: '2222222222222222222222222222222222222222',
+          commit: { message: 'feat: merged change', author: { name: 'PR Author' } },
+          author: { login: 'pr-author' }
+        },
+        {
+          sha: '3333333333333333333333333333333333333333',
+          commit: { message: 'chore: release v1.1.0', author: { name: 'Maintainer' } },
+          author: { login: 'maintainer' }
+        }
+      ]
+    }],
+    ['1111111', []],
+    ['2222222', [{ number: 42, merged_at: '2026-08-13T00:00:00Z' }]]
+  ]);
+
+  const direct = await fetchDirectCommits({
+    repository: 'Javis603/token-monitor',
+    tag: 'v1.1.0',
+    previousTag: 'v1.0.0',
+    token: 'test-token',
+    fetchImpl: async (url) => {
+      requests.push(url);
+      const key = url.includes('/compare/')
+        ? 'compare'
+        : url.includes('111111111111') ? '1111111' : '2222222';
+      return {
+        ok: true,
+        async json() { return responses.get(key); }
+      };
+    }
+  });
+
+  assert.deepEqual(direct, [{
+    sha: '1111111111111111111111111111111111111111',
+    subject: 'fix: direct change',
+    authorLogin: 'direct-author',
+    authorName: 'Direct Author'
+  }]);
+  assert.equal(requests.filter((url) => url.includes('/commits/')).length, 2);
+  assert.match(requests[0], /compare\/v1\.0\.0\.\.\.v1\.1\.0\?per_page=100&page=1$/);
+});
+
+test('release commit filtering accepts scoped and unscoped release subjects only', () => {
+  assert.equal(isReleaseCommit('chore: release v1.1.0', 'v1.1.0'), true);
+  assert.equal(isReleaseCommit('chore(release): release 1.1.0', 'v1.1.0'), true);
+  assert.equal(isReleaseCommit('chore: release v1.1.0-beta.1+build.2', 'v1.1.0-beta.1+build.2'), true);
+  assert.equal(isReleaseCommit('fix: mention release v1.1.0', 'v1.1.0'), false);
+  assert.equal(isReleaseCommit('chore: release v1.0.0', 'v1.1.0'), false);
+});

--- a/tests/shared/releaseArtifactNames.test.js
+++ b/tests/shared/releaseArtifactNames.test.js
@@ -85,14 +85,16 @@ test('mac release scripts build native Apple Silicon and Intel artifacts', () =>
   assert.equal(intelBullets.length, 5);
   assert.ok(intelBullets.every((line) => line.split(intelDmg).length === 3));
   assert.ok(intelBullets.every((line) => line.includes(`/download/v${rootPackage.version}/`)));
-  const fullChangelogLines = releaseTemplate.split('\n').filter((line) => line.startsWith('**Full Changelog:**'));
-  assert.equal(fullChangelogLines.length, 1);
-  assert.match(fullChangelogLines[0], /\[v\d+\.\d+\.\d+\.\.\.v\d+\.\d+\.\d+\]/);
-  assert.match(fullChangelogLines[0], /https:\/\/github\.com\/Javis603\/token-monitor\/compare\/v\d+\.\d+\.\d+\.\.\.v\d+\.\d+\.\d+/);
-  assert.ok(fullChangelogLines[0].includes(`v${rootPackage.version}`));
+  const fullChangelogSummaries = releaseTemplate
+    .split('\n')
+    .filter((line) => line.startsWith('<summary><strong>Full Changelog:</strong>'));
+  assert.equal(fullChangelogSummaries.length, 1);
+  assert.match(fullChangelogSummaries[0], />v\d+\.\d+\.\d+\.\.\.v\d+\.\d+\.\d+<\/a>/);
+  assert.match(fullChangelogSummaries[0], /https:\/\/github\.com\/Javis603\/token-monitor\/compare\/v\d+\.\d+\.\d+\.\.\.v\d+\.\d+\.\d+/);
+  assert.ok(fullChangelogSummaries[0].includes(`v${rootPackage.version}`));
   assert.match(
     releaseTemplate,
-    /---\s*\*\*Full Changelog:\*\*[\s\S]*<details>\s*<summary>繁體中文 · 한국어 · 日本語<\/summary>/
+    /---\s*<details>\s*<summary><strong>Full Changelog:<\/strong> <a href="[^"]+">v\d+\.\d+\.\d+\.\.\.v\d+\.\d+\.\d+<\/a><\/summary>\s*<!-- github-generated-release-notes -->\s*<\/details>\s*<details>\s*<summary>繁體中文 · 한국어 · 日本語<\/summary>/
   );
 });
 


### PR DESCRIPTION
## Summary

- Keep the curated five-language release notes while placing generated changelog details inside the collapsed Full Changelog section.
- Preserve GitHub-generated pull request and new-contributor notes, and add direct commits that are not associated with a merged pull request while omitting the release commit.
- Assemble a runner-only `release-notes.md` for the template's exact previous/current tag range without modifying the repository or creating another commit; GitHub's native contributor panel remains the sole contributor inventory.
- Fail closed on missing markers, mismatched tags, malformed API responses, or changelog lookup failures.

## Testing

- `npm run verify` (3038 passed, 0 failed, 1 skipped)
- Generated a local `v0.43.0` preview from GitHub's release-notes and compare APIs
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a collapsed Full Changelog details block in release notes populated with GitHub‑generated notes, preserving the curated five‑language sections. Previously we showed only a compare link; now the summary holds the link and expanding shows merged PRs, authors, and new contributors, plus direct commits with links (release commit omitted).

- Inserts a `<!-- github-generated-release-notes -->` marker inside the Full Changelog `<details>`; the workflow replaces it with GitHub’s notes, removes any extra “Full Changelog” line, appends unassociated direct commits, and does not add a Markdown “Contributors” list.
- Builds a runner‑only `release-notes.md` for the exact `vPREVIOUS...vCURRENT` range from the summary link and feeds it to `@softprops/action-gh-release` via `body_path`; repository files are unchanged. The workflow adds a generation step and `pull-requests: read` permission.
- Fails closed on marker count or summary/link mismatches, tag vs `GITHUB_REF_NAME` mismatches, API errors, invalid JSON, or excessive compare pagination; adds request timeouts, `GITHUB_API_URL` validation, and PR‑association checks via `/commits/{sha}/pulls`.
- Updates `.github/RELEASE_NOTES_FORMAT.md` and `.github/RELEASE_TEMPLATE.md`; adds `scripts/prepare-github-release-notes.js` and tests, including a timeout fixture to keep the abort‑signal test stable.

<sup>Written for commit c39085aebd03a04ea143b9aec95e5155af2b5f62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

