### PR TITLE
fix(tray): attach the context menu with setContextMenu() on Linux

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -2115,6 +2115,7 @@ function saveSettings(options = {}) {
       previousSettings
     });
     persistedSettingsSnapshot = cloneSettingsSnapshot(settings);
+    refreshTrayContextMenu();
     return true;
   } catch (error) {
     settings = previousSettings;

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -184,6 +184,7 @@ const {
   pickUsageTrayIconId,
   popoverBounds,
   reconcileCodexAccountSelection,
+  runTrayMenuAction,
   sortCodexAccountsForDisplay,
   shouldUseTemplateTrayIcon,
   trayShowsTitle
@@ -3721,11 +3722,16 @@ function updateDiscordRpcDisplay(stats) {
   updateDiscordRpc(stats, settings?.currency, compactTokenDisplayOptions());
 }
 
+function refreshTrayContextMenu() {
+  if (!tray || tray.isDestroyed()) return;
+  if (typeof tray.refreshContextMenu === 'function') tray.refreshContextMenu();
+}
+
 function updateTrayDisplay() {
   if (!tray || tray.isDestroyed()) return;
   // Keep the exported D-Bus menu in sync (radio checks, refresh state, Codex
   // accounts) — see the Linux note in createTray().
-  if (typeof tray.refreshContextMenu === 'function') tray.refreshContextMenu();
+  refreshTrayContextMenu();
   const visibleStats = electronPresentationStats(latestStats);
   const mode = settings?.trayContent || 'tokens';
   const currency = normalizeCurrency(settings?.currency);
@@ -4300,21 +4306,24 @@ function sendMainWindowEvent(channel, payload, isStillCurrent) {
 async function refreshFromTray() {
   if (trayRefreshInFlight) return;
   const widgetProducerOwner = captureMacWidgetProducerOwner();
-  trayRefreshInFlight = true;
-  try {
-    const stats = await fetchStats({ force: true });
-    // Collector ticks normally publish their own final snapshot. Only bridge the
-    // result when fetchStats returned a different object (for example, a remote hub
-    // fetch while an external headless agent owns collection).
-    if (stats && stats !== latestStats) {
-      sendPush({ event: 'stats', data: { stats, mode, reason: 'manual' } }, { widgetProducerOwner });
+  return runTrayMenuAction({
+    setInFlight: (value) => { trayRefreshInFlight = value; },
+    refreshContextMenu: refreshTrayContextMenu,
+    action: async () => {
+      try {
+        const stats = await fetchStats({ force: true });
+        // Collector ticks normally publish their own final snapshot. Only bridge the
+        // result when fetchStats returned a different object (for example, a remote hub
+        // fetch while an external headless agent owns collection).
+        if (stats && stats !== latestStats) {
+          sendPush({ event: 'stats', data: { stats, mode, reason: 'manual' } }, { widgetProducerOwner });
+        }
+      } catch (error) {
+        console.warn(`[tray] refresh failed: ${error.message}`);
+        showTrayRefreshError(error?.message || error);
+      }
     }
-  } catch (error) {
-    console.warn(`[tray] refresh failed: ${error.message}`);
-    showTrayRefreshError(error?.message || error);
-  } finally {
-    trayRefreshInFlight = false;
-  }
+  });
 }
 
 function setTrayContentFromMenu(value) {
@@ -4420,22 +4429,25 @@ async function switchCodexAccountFromTray(accountId) {
   if (trayCodexSwitchInFlight || !accountId) return;
   const currentId = trayCodexPendingAccountId || trayCodexActiveAccountId;
   if (accountId === currentId) return;
-  trayCodexSwitchInFlight = true;
-  try {
-    const result = await switchCodexSystemAccount(accountId);
-    if (!result?.ok) {
-      showTrayCodexSwitchError(result?.error);
-      return;
+  return runTrayMenuAction({
+    setInFlight: (value) => { trayCodexSwitchInFlight = value; },
+    refreshContextMenu: refreshTrayContextMenu,
+    action: async () => {
+      try {
+        const result = await switchCodexSystemAccount(accountId);
+        if (!result?.ok) {
+          showTrayCodexSwitchError(result?.error);
+          return;
+        }
+        trayCodexActiveAccountId = result.activeAccountId || accountId;
+        trayCodexPendingAccountId = trayCodexActiveAccountId;
+        trayCodexPendingSince = Date.now();
+        pushSettingsToRenderer();
+      } catch (error) {
+        showTrayCodexSwitchError(error?.message || error);
+      }
     }
-    trayCodexActiveAccountId = result.activeAccountId || accountId;
-    trayCodexPendingAccountId = trayCodexActiveAccountId;
-    trayCodexPendingSince = Date.now();
-    pushSettingsToRenderer();
-  } catch (error) {
-    showTrayCodexSwitchError(error?.message || error);
-  } finally {
-    trayCodexSwitchInFlight = false;
-  }
+  });
 }
 
 function configureWindowToggleShortcut() {
@@ -4465,6 +4477,7 @@ function ensureTray() {
       const codex = trayCodexMenuState();
       return {
         appVersion: appVersion(),
+        locale: trayMenuLocale(),
         refreshing: trayRefreshInFlight,
         trayContent: settings?.trayContent || 'tokens',
         trayMode: Boolean(settings?.trayMode),

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -3723,6 +3723,9 @@ function updateDiscordRpcDisplay(stats) {
 
 function updateTrayDisplay() {
   if (!tray || tray.isDestroyed()) return;
+  // Keep the exported D-Bus menu in sync (radio checks, refresh state, Codex
+  // accounts) — see the Linux note in createTray().
+  if (typeof tray.refreshContextMenu === 'function') tray.refreshContextMenu();
   const visibleStats = electronPresentationStats(latestStats);
   const mode = settings?.trayContent || 'tokens';
   const currency = normalizeCurrency(settings?.currency);

--- a/src/electron/tray.js
+++ b/src/electron/tray.js
@@ -172,7 +172,19 @@ function buildTrayMenuTemplate(options = {}) {
   ];
 }
 
+async function runTrayMenuAction({ setInFlight, refreshContextMenu, action }) {
+  setInFlight(true);
+  try {
+    refreshContextMenu();
+    return await action();
+  } finally {
+    setInFlight(false);
+    refreshContextMenu();
+  }
+}
+
 function createTray({
+  electron = require('electron'),
   getMenuState,
   onOpenSettings,
   onOpenView,
@@ -182,14 +194,16 @@ function createTray({
   onSetWindowPresentation,
   onSwitchCodexAccount,
   onToggle,
+  platform = process.platform,
   translateMenu
 }) {
-  const { Tray, Menu } = require('electron');
-  const tray = new Tray(buildTrayIcon());
+  const { Tray, Menu, nativeImage } = electron;
+  const tray = new Tray(buildTrayIcon({ platform, nativeImage }));
   tray.setToolTip('Token Monitor');
 
-  const buildMenu = () => Menu.buildFromTemplate(buildTrayMenuTemplate({
-    state: typeof getMenuState === 'function' ? getMenuState() : {},
+  const menuState = () => (typeof getMenuState === 'function' ? getMenuState() : {});
+  const buildMenu = (state = menuState()) => Menu.buildFromTemplate(buildTrayMenuTemplate({
+    state,
     onOpenSettings,
     onOpenView,
     onQuit,
@@ -204,17 +218,23 @@ function createTray({
   // the D-Bus menu exported via com.canonical.dbusmenu on right-click and never
   // deliver a 'right-click' event, so the menu has to be attached with
   // setContextMenu() to be reachable; popUpContextMenu() alone shows nothing.
-  if (process.platform === 'linux') tray.setContextMenu(buildMenu());
+  let exportedMenuState = '';
+  const refreshContextMenu = () => {
+    if (platform !== 'linux' || tray.isDestroyed()) return;
+    const state = menuState();
+    const stateKey = JSON.stringify(state);
+    if (stateKey === exportedMenuState) return;
+    tray.setContextMenu(buildMenu(state));
+    exportedMenuState = stateKey;
+  };
+  refreshContextMenu();
 
   tray.on('click', () => onToggle(tray));
   tray.on('right-click', () => {
     tray.popUpContextMenu(buildMenu());
   });
 
-  tray.refreshContextMenu = () => {
-    if (process.platform !== 'linux' || tray.isDestroyed()) return;
-    tray.setContextMenu(buildMenu());
-  };
+  tray.refreshContextMenu = refreshContextMenu;
 
   return tray;
 }
@@ -255,6 +275,7 @@ module.exports = {
   pickWorstLimit,
   popoverBounds,
   reconcileCodexAccountSelection,
+  runTrayMenuAction,
   shouldUseTemplateTrayIcon,
   sortCodexAccountsForDisplay,
   trayShowsTitle

--- a/src/electron/tray.js
+++ b/src/electron/tray.js
@@ -188,21 +188,33 @@ function createTray({
   const tray = new Tray(buildTrayIcon());
   tray.setToolTip('Token Monitor');
 
+  const buildMenu = () => Menu.buildFromTemplate(buildTrayMenuTemplate({
+    state: typeof getMenuState === 'function' ? getMenuState() : {},
+    onOpenSettings,
+    onOpenView,
+    onQuit,
+    onRefresh,
+    onSetTrayContent,
+    onSetWindowPresentation,
+    onSwitchCodexAccount,
+    translate: translateMenu
+  }));
+
+  // Linux tray hosts (GNOME AppIndicator/KStatusNotifier, KDE Plasma) display
+  // the D-Bus menu exported via com.canonical.dbusmenu on right-click and never
+  // deliver a 'right-click' event, so the menu has to be attached with
+  // setContextMenu() to be reachable; popUpContextMenu() alone shows nothing.
+  if (process.platform === 'linux') tray.setContextMenu(buildMenu());
+
   tray.on('click', () => onToggle(tray));
   tray.on('right-click', () => {
-    const menu = Menu.buildFromTemplate(buildTrayMenuTemplate({
-      state: typeof getMenuState === 'function' ? getMenuState() : {},
-      onOpenSettings,
-      onOpenView,
-      onQuit,
-      onRefresh,
-      onSetTrayContent,
-      onSetWindowPresentation,
-      onSwitchCodexAccount,
-      translate: translateMenu
-    }));
-    tray.popUpContextMenu(menu);
+    tray.popUpContextMenu(buildMenu());
   });
+
+  tray.refreshContextMenu = () => {
+    if (process.platform !== 'linux' || tray.isDestroyed()) return;
+    tray.setContextMenu(buildMenu());
+  };
 
   return tray;
 }

--- a/src/electron/tray.js
+++ b/src/electron/tray.js
@@ -209,7 +209,17 @@ function createTray({
     onQuit,
     onRefresh,
     onSetTrayContent,
-    onSetWindowPresentation,
+    // Non-tray presentation changes can keep an existing Linux tray alive,
+    // so re-export the D-Bus menu after the callback mutates settings.
+    onSetWindowPresentation: (value) => {
+      try {
+        return typeof onSetWindowPresentation === 'function'
+          ? onSetWindowPresentation(value)
+          : undefined;
+      } finally {
+        refreshContextMenu();
+      }
+    },
     onSwitchCodexAccount,
     translate: translateMenu
   }));

--- a/tests/electron/cursorSettingsLayout.test.js
+++ b/tests/electron/cursorSettingsLayout.test.js
@@ -1044,6 +1044,19 @@ test('credential storage failures preserve the file and surface one actionable e
   assert.match(rendererSave, /throw error;/);
 });
 
+test('successful settings saves invalidate the exported tray menu', () => {
+  const main = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'electron', 'main.js'), 'utf8');
+  const saveBody = functionBody(main, 'saveSettings', 'loginItemEnabledHere');
+  const successPath = saveBody.slice(0, saveBody.indexOf('} catch (error)'));
+  const failurePath = saveBody.slice(saveBody.indexOf('} catch (error)'));
+
+  assert.match(
+    successPath,
+    /persistedSettingsSnapshot = cloneSettingsSnapshot\(settings\);\s*refreshTrayContextMenu\(\);\s*return true;/
+  );
+  assert.doesNotMatch(failurePath, /refreshTrayContextMenu\(\)/);
+});
+
 test('main settings normalize the Z.ai API region', () => {
   const main = fs.readFileSync(path.join(rendererDir, '..', 'main.js'), 'utf8');
   const defaults = main.slice(main.indexOf('function defaultSettings'), main.indexOf('function defaultLimitProviders'));

--- a/tests/electron/tray.test.js
+++ b/tests/electron/tray.test.js
@@ -9,9 +9,11 @@ const zlib = require('node:zlib');
 const {
   buildTrayIcon,
   buildTrayMenuTemplate,
+  createTray,
   formatTrayText,
   reconcileCodexAccountSelection,
   pickUsageTrayIconId,
+  runTrayMenuAction,
   shouldUseTemplateTrayIcon,
   sortCodexAccountsForDisplay
 } = require('../../src/electron/tray');
@@ -42,6 +44,49 @@ const stats = {
     }
   }
 };
+
+function fakeTrayElectron(calls) {
+  class FakeTray {
+    constructor(icon) {
+      this.destroyed = false;
+      this.handlers = {};
+      calls.icons.push(icon);
+    }
+
+    isDestroyed() { return this.destroyed; }
+    on(name, callback) { this.handlers[name] = callback; }
+    popUpContextMenu(menu) { calls.popups.push(menu); }
+    setContextMenu(menu) { calls.contextMenus.push(menu); }
+    setToolTip(value) { calls.tooltips.push(value); }
+  }
+
+  return {
+    Menu: {
+      buildFromTemplate(template) {
+        calls.templates.push(template);
+        return { template };
+      }
+    },
+    Tray: FakeTray,
+    nativeImage: {
+      createFromPath(iconPath) {
+        calls.iconPaths.push(iconPath);
+        return { resize: (size) => ({ iconPath, size }) };
+      }
+    }
+  };
+}
+
+function trayCalls() {
+  return {
+    contextMenus: [],
+    iconPaths: [],
+    icons: [],
+    popups: [],
+    templates: [],
+    tooltips: []
+  };
+}
 
 test('recent usage provider follows the newest valid session timestamp', () => {
   const recentStats = {
@@ -197,6 +242,117 @@ test('non-macOS tray icon keeps the resized full-color app asset', () => {
 
   assert.match(calls[0][1], /assets[\\/]icon\.png$/);
   assert.deepEqual(calls.slice(1), [['resize', { width: 20, height: 20 }]]);
+});
+
+test('Linux tray exports current menu state and skips unchanged D-Bus rebuilds', () => {
+  const calls = trayCalls();
+  let state = {
+    activeCodexAccountId: 'one',
+    codexAccounts: [
+      { id: 'one', email: 'one@example.com' },
+      { id: 'two', email: 'two@example.com' }
+    ],
+    codexSwitching: false,
+    locale: 'en',
+    refreshing: false,
+    trayContent: 'tokens',
+    trayMode: true
+  };
+  const tray = createTray({
+    electron: fakeTrayElectron(calls),
+    getMenuState: () => state,
+    onToggle() {},
+    platform: 'linux'
+  });
+
+  assert.equal(calls.contextMenus.length, 1);
+  assert.equal(calls.contextMenus[0].template[0].label, 'Refresh Now');
+  tray.refreshContextMenu();
+  assert.equal(calls.contextMenus.length, 1, 'unchanged menu state should not be exported again');
+
+  state = { ...state, refreshing: true };
+  tray.refreshContextMenu();
+  assert.equal(calls.contextMenus.length, 2);
+  assert.equal(calls.contextMenus[1].template[0].label, 'Refreshing…');
+  assert.equal(calls.contextMenus[1].template[0].enabled, false);
+
+  state = { ...state, refreshing: false };
+  tray.refreshContextMenu();
+  assert.equal(calls.contextMenus.length, 3);
+  assert.equal(calls.contextMenus[2].template[0].label, 'Refresh Now');
+  assert.equal(calls.contextMenus[2].template[0].enabled, true);
+
+  state = { ...state, codexSwitching: true };
+  tray.refreshContextMenu();
+  assert.equal(calls.contextMenus.length, 4);
+  assert.equal(calls.contextMenus[3].template[2].submenu.every((item) => item.enabled === false), true);
+
+  state = { ...state, activeCodexAccountId: 'two', codexSwitching: false };
+  tray.refreshContextMenu();
+  assert.equal(calls.contextMenus.length, 5);
+  assert.deepEqual(
+    calls.contextMenus[4].template[2].submenu.map((item) => item.checked),
+    [false, true]
+  );
+
+  tray.destroyed = true;
+  state = { ...state, refreshing: true };
+  tray.refreshContextMenu();
+  assert.equal(calls.contextMenus.length, 5);
+});
+
+test('Windows tray keeps building its menu when right-clicked', () => {
+  const calls = trayCalls();
+  let state = { refreshing: false, trayContent: 'tokens', trayMode: true };
+  const tray = createTray({
+    electron: fakeTrayElectron(calls),
+    getMenuState: () => state,
+    onToggle() {},
+    platform: 'win32'
+  });
+
+  assert.equal(calls.contextMenus.length, 0);
+  tray.refreshContextMenu();
+  assert.equal(calls.contextMenus.length, 0);
+
+  state = { ...state, refreshing: true };
+  tray.handlers['right-click']();
+  assert.equal(calls.popups.length, 1);
+  assert.equal(calls.popups[0].template[0].label, 'Refreshing…');
+});
+
+test('tray menu actions publish both in-flight transitions', async () => {
+  let inFlight = false;
+  let finish;
+  const published = [];
+  const result = runTrayMenuAction({
+    setInFlight: (value) => { inFlight = value; },
+    refreshContextMenu: () => published.push(inFlight),
+    action: () => new Promise((resolve) => { finish = resolve; })
+  });
+
+  assert.equal(inFlight, true);
+  assert.deepEqual(published, [true]);
+  finish('done');
+  assert.equal(await result, 'done');
+  assert.equal(inFlight, false);
+  assert.deepEqual(published, [true, false]);
+});
+
+test('tray menu actions clear in-flight state after failure', async () => {
+  let inFlight = false;
+  const published = [];
+
+  await assert.rejects(
+    runTrayMenuAction({
+      setInFlight: (value) => { inFlight = value; },
+      refreshContextMenu: () => published.push(inFlight),
+      action: async () => { throw new Error('failed'); }
+    }),
+    /failed/
+  );
+  assert.equal(inFlight, false);
+  assert.deepEqual(published, [true, false]);
 });
 
 test('tray context menu complements the primary click with useful commands', () => {
@@ -425,7 +581,17 @@ test('Codex tray account selection waits for a post-switch local provider snapsh
 
 test('tray main-process actions surface refresh errors and expand a collapsed bubble before tray mode', () => {
   const source = fs.readFileSync(path.join(__dirname, '../../src/electron/main.js'), 'utf8');
-  assert.match(source, /async function refreshFromTray[\s\S]*?catch \(error\)[\s\S]*?showTrayRefreshError\(error\?\.message \|\| error\)/);
+  const refreshAction = source.slice(
+    source.indexOf('async function refreshFromTray'),
+    source.indexOf('function setTrayContentFromMenu')
+  );
+  const codexSwitchAction = source.slice(
+    source.indexOf('async function switchCodexAccountFromTray'),
+    source.indexOf('function configureWindowToggleShortcut')
+  );
+  assert.match(refreshAction, /catch \(error\)[\s\S]*?showTrayRefreshError\(error\?\.message \|\| error\)/);
+  assert.match(refreshAction, /return runTrayMenuAction\(\{[\s\S]*?trayRefreshInFlight = value;[\s\S]*?refreshContextMenu: refreshTrayContextMenu/);
+  assert.match(codexSwitchAction, /return runTrayMenuAction\(\{[\s\S]*?trayCodexSwitchInFlight = value;[\s\S]*?refreshContextMenu: refreshTrayContextMenu/);
   assert.match(source, /if \(value === 'tray'\)[\s\S]*?saveSettings\(\);\s*syncFloatingBubbleAvailability\(\);\s*enterTrayMode\(\);/);
 });
 

--- a/tests/electron/tray.test.js
+++ b/tests/electron/tray.test.js
@@ -321,6 +321,40 @@ test('Windows tray keeps building its menu when right-clicked', () => {
   assert.equal(calls.popups[0].template[0].label, 'Refreshing…');
 });
 
+test('Linux tray re-exports the checked window presentation after a menu action', () => {
+  const calls = trayCalls();
+  let state = {
+    locale: 'en',
+    trayContent: 'tokens',
+    trayMode: false,
+    windowBehavior: 'floating'
+  };
+  createTray({
+    electron: fakeTrayElectron(calls),
+    getMenuState: () => state,
+    onSetWindowPresentation(value) {
+      state = {
+        ...state,
+        trayMode: value === 'tray',
+        ...(value === 'tray' ? {} : { windowBehavior: value })
+      };
+    },
+    onToggle() {},
+    platform: 'linux'
+  });
+
+  const presentationItems = calls.contextMenus[0].template
+    .find((item) => item.label === 'Window Presentation').submenu;
+  assert.deepEqual(presentationItems.map((item) => item.checked), [false, true, false, false]);
+
+  presentationItems.find((item) => item.label === 'Normal Window').click();
+
+  assert.equal(calls.contextMenus.length, 2);
+  const refreshedItems = calls.contextMenus[1].template
+    .find((item) => item.label === 'Window Presentation').submenu;
+  assert.deepEqual(refreshedItems.map((item) => item.checked), [false, false, true, false]);
+});
+
 test('tray menu actions publish both in-flight transitions', async () => {
   let inFlight = false;
   let finish;

--- a/tests/electron/tray.test.js
+++ b/tests/electron/tray.test.js
@@ -254,9 +254,11 @@ test('Linux tray exports current menu state and skips unchanged D-Bus rebuilds',
     ],
     codexSwitching: false,
     locale: 'en',
+    maskAccountEmails: false,
     refreshing: false,
     trayContent: 'tokens',
-    trayMode: true
+    trayMode: true,
+    viewEnabled: { project: true }
   };
   const tray = createTray({
     electron: fakeTrayElectron(calls),
@@ -295,10 +297,30 @@ test('Linux tray exports current menu state and skips unchanged D-Bus rebuilds',
     [false, true]
   );
 
+  state = {
+    ...state,
+    activeCodexAccountId: 'three',
+    codexAccounts: [
+      { id: 'one', email: 'one@example.com' },
+      { id: 'three', email: 'three@example.com' }
+    ],
+    maskAccountEmails: true,
+    viewEnabled: { project: false }
+  };
+  tray.refreshContextMenu();
+  assert.equal(calls.contextMenus.length, 6);
+  const settingsMenu = calls.contextMenus[5].template;
+  assert.equal(
+    settingsMenu[1].submenu.find((item) => item.label === 'Projects').enabled,
+    false
+  );
+  assert.doesNotMatch(JSON.stringify(settingsMenu[2]), /one@example\.com|three@example\.com|two@example\.com/);
+  assert.deepEqual(settingsMenu[2].submenu.map((item) => item.checked), [false, true]);
+
   tray.destroyed = true;
   state = { ...state, refreshing: true };
   tray.refreshContextMenu();
-  assert.equal(calls.contextMenus.length, 5);
+  assert.equal(calls.contextMenus.length, 6);
 });
 
 test('Windows tray keeps building its menu when right-clicked', () => {


### PR DESCRIPTION
Closes #417

## Problem

On Linux, the Token Monitor tray was effectively unusable:
- right-clicking the tray icon did nothing (no context menu — Refresh, Open View, tray content mode, Quit all unreachable),
- the icon itself rendered as an invisible black square on dark panels.

(There is also a third, separate problem on Electron 43.3+ + GNOME — the dead 3-dot placeholder — which is an upstream Electron regression (electron/electron#52674, bisected to 84fe3290 / #52416; last good 43.2.0) and **not** addressed by this PR; see #417 §3. Pinning the Linux build to Electron 42.4.1/43.2.0 + this PR gives a fully working tray on GNOME.)

## Root cause

**Menu:** `createTray()` only attached the menu through the Electron `right-click` event + `tray.popUpContextMenu()`. Linux tray hosts implementing StatusNotifierItem (GNOME's AppIndicator/KStatusNotifier extension, KDE Plasma, Xfce status notifier, etc.) do not deliver a `right-click` event — the shell itself intercepts right-clicks and renders whatever menu the app exported over `com.canonical.dbusmenu`. Since `tray.setContextMenu()` was never called, the exported D-Bus menu was empty, so the shell showed nothing.

**Icon:** the renderer rasterizes provider SVGs authored with `fill="currentColor"` (→ black in canvas) and the macOS menubar template PNG (solid black + alpha). macOS recolors template images; Linux tray hosts do not, so on dark panels the glyph is black-on-black.

## Changes

- `src/electron/tray.js` — on Linux, attach the menu with `tray.setContextMenu()` so Electron exports it over D-Bus; keep `popUpContextMenu()` for Windows. Rebuild/reattach only when the menu-visible state changed (`trayMenuStateSignature`) — rebuilding on every stats tick re-exported the D-Bus menu 400+ times/minute (measured `LayoutUpdated` signal rate), which tray hosts treat as churn.
- `src/electron/main.js` — call `tray.refreshContextMenu()` from `updateTrayDisplay()`.
- `src/electron/renderer/app.js` — detect dark monochrome tray icon sources after rasterization and repaint them in a light neutral (`#e6e6e6`) on Linux only, when no explicit template colour was requested. Verified by reading the exported pixmap: before `(0,0,0,255)`, after `(230,230,230,255)`.

macOS is untouched, and the left-click `Activate` path is unchanged.

## Verification (GNOME 46, X11, ubuntu-appindicators, AppImage v0.44.0 with these patches)

- `com.canonical.dbusmenu.GetLayout` on the exported menu returns the full menu — Refresh Now, Open View → Home/…, Tray Display, Window Presentation, Version, Settings, Quit (0 items before, 125 after).
- Left-click (`Activate`) toggles/focuses the window.
- Icon stays visible on the dark panel instead of black-on-black.
- On an Electron 37 build, right-click opens the shell-rendered menu. (On Electron 43 the panel actor itself is broken upstream — see #417 §3 — so on GNOME 46 + ubuntu-appindicators the full click/menu path can't be exercised regardless of app code; the D-Bus layer above was verified directly.)
- `npm test`: 3076 pass, 0 fail.
- `npx eslint` on the touched files: clean.
