### PR TITLE
fix(limits): derive merged OpenCode provenance from winning components

### DIFF
--- a/src/shared/hubBuildRegistry.json
+++ b/src/shared/hubBuildRegistry.json
@@ -13,6 +13,10 @@
       {
         "revision": 3,
         "buildId": "sha256:ef3b4bc1b1f69413e4ed12090aae4a638826bf7b064b7e97ae0e0b89125708dd"
+      },
+      {
+        "revision": 4,
+        "buildId": "sha256:6ca66e4e1047c7116064764cb69ab9ccd8f7ea3673d863d16903bea8a0dc71aa"
       }
     ],
     "node-hub": [

--- a/src/shared/limits.js
+++ b/src/shared/limits.js
@@ -616,6 +616,24 @@ function openCodeWindowKey(window) {
     .join(':');
 }
 
+// Authority of one quota observation: a server reading outranks a local
+// estimate, and nothing finer than that. Deliberately.
+//
+// Go quota reaches the wire from three places, but only the estimate is a
+// different *kind* of answer: the usage API and the go-page scrape read the same
+// server-side counters and emit the same window kinds, so two of them differ
+// only in when they were read. Freshness below is what separates those.
+//
+// A finer api tier does not belong here. It could only be read off the provider
+// — an API window is tagged `web` on the wire, since that field is a two-value
+// enum a Hub predating it would strip and then rank below a local estimate — and
+// the provider does not describe every window under it: a provider whose Go
+// quota came from the API still carries Zen windows that were scraped. Ranking
+// on it therefore promotes a scraped window on the strength of a key that read
+// something else. The collector's own api → web precedence is a fallback chain
+// for choosing between two credentials on one machine at one moment; it is not
+// a claim that an older API reading beats a newer scraped one, and generalizing
+// it that way pinned readings up to the full staleness threshold old.
 function openCodeWindowSourceRank(window) {
   if (window?.source === 'web') return 2;
   if (window?.source === 'local') return 1;
@@ -723,6 +741,30 @@ function mergeOpenCodeProviderComponents(candidates) {
   const balanceUsd = balanceProvider ? balanceProvider.balanceUsd : winner.balanceUsd;
   const hasWebComponent = windows.some((window) => window.source === 'web')
     || balanceUsd !== null && balanceUsd !== undefined;
+  // Provenance describes the components that actually won, not whichever
+  // device's snapshot ranked highest. Read off `winner` the two could disagree:
+  // a device whose every window lost still named the merged row's source, so a
+  // cookie poll arriving a second after an API one relabelled the whole row.
+  //
+  // The envelope rule is the collector's, and the merge has to keep it: this
+  // field is what a Hub predating windows[].source ranks on, so it may not
+  // claim a server reading while a local estimate is in the row. One local
+  // window makes the row an estimate however fresh the Web observation beside
+  // it is. Above that line 'api' and 'web' say which server source produced the
+  // Go quota, in the collector's own sense of the words rather than a stronger
+  // one — an `api` provider can carry scraped Zen windows too — so 'api' holds
+  // only while every winning component came from a collector that read the
+  // usage endpoint. A Zen balance does not weaken either claim, because both
+  // are about the quota windows.
+  const anyLocalWindow = windows.some((window) => window.source === 'local');
+  const componentProviders = Array.from(entries.values()).map((entry) => entry.provider);
+  const everyWindowFromApi = componentProviders.length > 0
+    && componentProviders.every((provider) => provider.source === 'api');
+  const mergedSource = anyLocalWindow
+    ? 'local'
+    : everyWindowFromApi
+      ? 'api'
+      : hasWebComponent ? 'web' : winner.source;
   const canonicalWebAccountKey = [...new Set(candidates
     .map((provider) => String(provider.webAccountKey || '').trim())
     .filter(Boolean))].sort()[0] || '';
@@ -736,11 +778,7 @@ function mergeOpenCodeProviderComponents(candidates) {
     accountKey,
     ...(canonicalWebAccountKey ? { webAccountKey: canonicalWebAccountKey } : {}),
     ...(accountKeyAliases.length > 0 ? { accountKeyAliases } : {}),
-    // The Web envelope exists so an old Hub cannot turn a local estimate into a
-    // Web observation. 'api' is a strictly stronger claim than 'web' and is only
-    // ever set by a collector that read the official usage endpoint, so it keeps
-    // its own label instead of being flattened by a Web window or balance.
-    source: hasWebComponent && winner.source !== 'api' ? 'web' : winner.source,
+    source: mergedSource,
     windows,
     balanceUsd
   };

--- a/tests/shared/limits.test.js
+++ b/tests/shared/limits.test.js
@@ -1348,3 +1348,153 @@ test('window metric accepts only the documented machine-readable roles', () => {
   // Anything else is dropped rather than carried onto the wire as a free-form tag.
   assert.equal('metric' in normalizeLimitWindow({ kind: 'billing', metric: 'whatever' }), false);
 });
+
+// Two devices reading the same account, one through the usage API and one
+// through the go-page scrape. Both read the same server-side counters, so the
+// newer reading is the better one and the merged row's provenance follows
+// whichever it was.
+function openCodeServerObservationDevices({ apiAt, webAt }) {
+  const window = (percent, source) => ({ kind: 'weekly', source, usedPercent: percent });
+  return [
+    {
+      deviceId: 'api-device',
+      limits: {
+        updatedAt: apiAt,
+        providers: [{
+          provider: 'opencode',
+          accountKey: 'sha256:shared',
+          webAccountKey: 'sha256:shared',
+          status: 'ok',
+          // API windows are tagged `web` on the wire so a Hub predating that
+          // value cannot rank them below a local estimate; the provider-level
+          // field is the only thing that says which server source produced them.
+          source: 'api',
+          updatedAt: apiAt,
+          windows: [window(57, 'web')],
+          balanceUsd: null
+        }]
+      }
+    },
+    {
+      deviceId: 'cookie-device',
+      limits: {
+        updatedAt: webAt,
+        providers: [{
+          provider: 'opencode',
+          accountKey: 'sha256:shared',
+          webAccountKey: 'sha256:shared',
+          status: 'ok',
+          source: 'web',
+          updatedAt: webAt,
+          windows: [window(11, 'web')],
+          balanceUsd: 4
+        }]
+      }
+    }
+  ];
+}
+
+test('aggregateLimits shows the freshest OpenCode server reading whichever source took it', () => {
+  const apiNewer = aggregateLimits(openCodeServerObservationDevices({
+    apiAt: '2026-08-09T08:00:01.000Z',
+    webAt: '2026-08-09T08:00:00.000Z'
+  }), 0, Date.parse('2026-08-09T08:00:10.000Z'));
+  const fromApi = apiNewer.providers.find((entry) => entry.provider === 'opencode');
+  assert.equal(fromApi.windows.find((window) => window.kind === 'weekly').remainingPercent, 43);
+  assert.equal(fromApi.source, 'api');
+  // The cookie is still the only source for the balance.
+  assert.equal(fromApi.balanceUsd, 4);
+
+  const cookieNewer = aggregateLimits(openCodeServerObservationDevices({
+    apiAt: '2026-08-09T08:00:00.000Z',
+    webAt: '2026-08-09T08:00:01.000Z'
+  }), 0, Date.parse('2026-08-09T08:00:10.000Z'));
+  const fromWeb = cookieNewer.providers.find((entry) => entry.provider === 'opencode');
+  assert.equal(fromWeb.windows.find((window) => window.kind === 'weekly').remainingPercent, 89);
+  assert.equal(fromWeb.source, 'web');
+});
+
+// A device is live until the staleness threshold, which reaches an hour on the
+// longest refresh interval. Preferring the API within that whole span would show
+// an hour-old reading beside a current one, so the skew has to lose to freshness
+// well before the API device goes stale.
+test('aggregateLimits prefers a current OpenCode cookie reading over a much older live API one', () => {
+  const devices = openCodeServerObservationDevices({
+    apiAt: '2026-08-09T07:32:00.000Z',
+    webAt: '2026-08-09T08:00:00.000Z'
+  });
+  for (const device of devices) device.limits.refreshMs = 30 * 60 * 1000;
+  devices[0].receivedAt = Date.parse('2026-08-09T07:32:00.000Z');
+  devices[1].receivedAt = Date.parse('2026-08-09T08:00:00.000Z');
+  const aggregate = aggregateLimits(devices, 10 * 60 * 1000, Date.parse('2026-08-09T08:00:10.000Z'));
+  const provider = aggregate.providers.find((entry) => entry.provider === 'opencode');
+  assert.equal(provider.windows.find((window) => window.kind === 'weekly').remainingPercent, 89);
+  assert.equal(provider.source, 'web');
+});
+
+test('aggregateLimits resolves the OpenCode merge independently of device order', () => {
+  const forward = openCodeServerObservationDevices({
+    apiAt: '2026-08-09T08:00:01.000Z',
+    webAt: '2026-08-09T08:00:00.000Z'
+  });
+  const aggregate = aggregateLimits(forward, 0, Date.parse('2026-08-09T08:00:10.000Z'));
+  const provider = aggregate.providers.find((entry) => entry.provider === 'opencode');
+  assert.equal(provider.windows.find((window) => window.kind === 'weekly').remainingPercent, 43);
+  assert.equal(provider.source, 'api');
+
+  const reversed = aggregateLimits([...forward].reverse(), 0, Date.parse('2026-08-09T08:00:10.000Z'));
+  const reversedProvider = reversed.providers.find((entry) => entry.provider === 'opencode');
+  assert.equal(reversedProvider.windows.find((window) => window.kind === 'weekly').remainingPercent, 43);
+  assert.equal(reversedProvider.source, 'api');
+});
+
+// Freshness decides between two server readings, but only among devices still
+// reporting: the merge drops stale providers first, so an API device that went
+// away cannot hold the row against a live cookie one.
+test('aggregateLimits lets a live OpenCode cookie observation beat a stale API one', () => {
+  const devices = openCodeServerObservationDevices({
+    apiAt: '2026-08-09T07:00:00.000Z',
+    webAt: '2026-08-09T08:00:00.000Z'
+  });
+  devices[0].receivedAt = Date.parse('2026-08-09T07:00:00.000Z');
+  devices[1].receivedAt = Date.parse('2026-08-09T08:00:00.000Z');
+  const aggregate = aggregateLimits(devices, 10 * 60 * 1000, Date.parse('2026-08-09T08:00:10.000Z'));
+  const provider = aggregate.providers.find((entry) => entry.provider === 'opencode');
+  assert.equal(provider.windows.find((window) => window.kind === 'weekly').remainingPercent, 89);
+  assert.equal(provider.source, 'web');
+});
+
+// The provider-level source is the envelope a Hub predating windows[].source
+// ranks on, so it may not claim a server reading while an estimate is in the
+// row. One local window makes the whole row an estimate, however fresh the Web
+// observation beside it is — the collector already states that rule for a
+// single device, and the merge has to keep it.
+test('aggregateLimits never labels a merged OpenCode row Web while a local window is in it', () => {
+  const aggregate = aggregateLimits([
+    {
+      deviceId: 'web-device',
+      limits: {
+        updatedAt: '2026-08-09T08:00:00.000Z',
+        providers: [{
+          provider: 'opencode', accountKey: 'sha256:shared', webAccountKey: 'sha256:shared',
+          status: 'ok', source: 'web', updatedAt: '2026-08-09T08:00:00.000Z',
+          windows: [{ kind: 'weekly', source: 'web', usedPercent: 20 }], balanceUsd: null
+        }]
+      }
+    },
+    {
+      deviceId: 'local-device',
+      limits: {
+        updatedAt: '2026-08-09T08:00:01.000Z',
+        providers: [{
+          provider: 'opencode', accountKey: 'sha256:shared', webAccountKey: 'sha256:shared',
+          status: 'ok', source: 'local', updatedAt: '2026-08-09T08:00:01.000Z',
+          windows: [{ kind: 'session', source: 'local', usedPercent: 90 }], balanceUsd: null
+        }]
+      }
+    }
+  ], 0, Date.parse('2026-08-09T08:00:10.000Z'));
+  const provider = aggregate.providers.find((entry) => entry.provider === 'opencode');
+  assert.equal(provider.windows.length, 2);
+  assert.equal(provider.source, 'local');
+});

--- a/worker/src/shared/hubBuildRegistry.json
+++ b/worker/src/shared/hubBuildRegistry.json
@@ -13,6 +13,10 @@
       {
         "revision": 3,
         "buildId": "sha256:ef3b4bc1b1f69413e4ed12090aae4a638826bf7b064b7e97ae0e0b89125708dd"
+      },
+      {
+        "revision": 4,
+        "buildId": "sha256:6ca66e4e1047c7116064764cb69ab9ccd8f7ea3673d863d16903bea8a0dc71aa"
       }
     ],
     "node-hub": [

--- a/worker/src/shared/limits.js
+++ b/worker/src/shared/limits.js
@@ -619,6 +619,24 @@ function openCodeWindowKey(window) {
     .join(':');
 }
 
+// Authority of one quota observation: a server reading outranks a local
+// estimate, and nothing finer than that. Deliberately.
+//
+// Go quota reaches the wire from three places, but only the estimate is a
+// different *kind* of answer: the usage API and the go-page scrape read the same
+// server-side counters and emit the same window kinds, so two of them differ
+// only in when they were read. Freshness below is what separates those.
+//
+// A finer api tier does not belong here. It could only be read off the provider
+// — an API window is tagged `web` on the wire, since that field is a two-value
+// enum a Hub predating it would strip and then rank below a local estimate — and
+// the provider does not describe every window under it: a provider whose Go
+// quota came from the API still carries Zen windows that were scraped. Ranking
+// on it therefore promotes a scraped window on the strength of a key that read
+// something else. The collector's own api → web precedence is a fallback chain
+// for choosing between two credentials on one machine at one moment; it is not
+// a claim that an older API reading beats a newer scraped one, and generalizing
+// it that way pinned readings up to the full staleness threshold old.
 function openCodeWindowSourceRank(window) {
   if (window?.source === 'web') return 2;
   if (window?.source === 'local') return 1;
@@ -726,6 +744,30 @@ function mergeOpenCodeProviderComponents(candidates) {
   const balanceUsd = balanceProvider ? balanceProvider.balanceUsd : winner.balanceUsd;
   const hasWebComponent = windows.some((window) => window.source === 'web')
     || balanceUsd !== null && balanceUsd !== undefined;
+  // Provenance describes the components that actually won, not whichever
+  // device's snapshot ranked highest. Read off `winner` the two could disagree:
+  // a device whose every window lost still named the merged row's source, so a
+  // cookie poll arriving a second after an API one relabelled the whole row.
+  //
+  // The envelope rule is the collector's, and the merge has to keep it: this
+  // field is what a Hub predating windows[].source ranks on, so it may not
+  // claim a server reading while a local estimate is in the row. One local
+  // window makes the row an estimate however fresh the Web observation beside
+  // it is. Above that line 'api' and 'web' say which server source produced the
+  // Go quota, in the collector's own sense of the words rather than a stronger
+  // one — an `api` provider can carry scraped Zen windows too — so 'api' holds
+  // only while every winning component came from a collector that read the
+  // usage endpoint. A Zen balance does not weaken either claim, because both
+  // are about the quota windows.
+  const anyLocalWindow = windows.some((window) => window.source === 'local');
+  const componentProviders = Array.from(entries.values()).map((entry) => entry.provider);
+  const everyWindowFromApi = componentProviders.length > 0
+    && componentProviders.every((provider) => provider.source === 'api');
+  const mergedSource = anyLocalWindow
+    ? 'local'
+    : everyWindowFromApi
+      ? 'api'
+      : hasWebComponent ? 'web' : winner.source;
   const canonicalWebAccountKey = [...new Set(candidates
     .map((provider) => String(provider.webAccountKey || '').trim())
     .filter(Boolean))].sort()[0] || '';
@@ -739,11 +781,7 @@ function mergeOpenCodeProviderComponents(candidates) {
     accountKey,
     ...(canonicalWebAccountKey ? { webAccountKey: canonicalWebAccountKey } : {}),
     ...(accountKeyAliases.length > 0 ? { accountKeyAliases } : {}),
-    // The Web envelope exists so an old Hub cannot turn a local estimate into a
-    // Web observation. 'api' is a strictly stronger claim than 'web' and is only
-    // ever set by a collector that read the official usage endpoint, so it keeps
-    // its own label instead of being flattened by a Web window or balance.
-    source: hasWebComponent && winner.source !== 'api' ? 'web' : winner.source,
+    source: mergedSource,
     windows,
     balanceUsd
   };


### PR DESCRIPTION
Follow-up to #406, found while reviewing the merged result. Nothing here has shipped: #406 is on `main` and unreleased.

## Provenance was derived from the wrong thing

A merged OpenCode row picked its windows one way and its `source` another: the windows were ranked per key, while `source` was read off whichever device's snapshot ranked highest. The two could disagree, so a device whose every window lost still named the row's provenance, and a cookie poll arriving a second after an API one relabelled the whole row. It is now derived from the components that actually won.

That also restores a rule the collector states and the merge had been breaking, pre-existing and not introduced by #406:

> The provider-level source is the compatibility envelope used by Hubs that predate `windows[].source`. It may claim Web only when every quota window is Web; otherwise an old Hub could turn a local estimate into a Web observation when it strips component provenance.

| Merged row | Before | After |
|---|---|---|
| Web weekly + local session | **`web`** | `local` |
| Source named by a device whose windows all lost | that device's | the winning components' |

## Window ranking stays coarse on purpose

Server reading over local estimate, and nothing finer. Go quota reaches the wire from the usage API, the go-page scrape, and the local database, but only the estimate is a different kind of answer: the API and the scrape read the same server-side counters and emit the same window kinds, so two of them differ only in when they were read.

A finer `api` tier could only be read off the provider, since an API window is tagged `windows[].source === 'web'` so a Hub predating that value cannot rank it below a local estimate. The provider does not describe every window under it: a provider whose Go quota came from the API still carries Zen windows that were scraped, so ranking on it would promote a scraped window on the strength of a key that read something else. And the collector's own `api → web` precedence is a fallback chain for choosing between two credentials on one machine at one moment, not a claim that an older API reading beats a newer scraped one. Generalizing it that way would pin a reading up to the full staleness threshold old, which reaches an hour on the longest refresh interval.

## Verification

`npm run verify` — 3192 passing, 0 failing. `src/shared/limits.js` is part of the portable Hub core, so `npm run sync:worker` and `npm run update:hub-build` were re-run.

Five tests, each confirmed to fail against the previous behaviour: the freshest server reading wins whichever source took it, a current cookie reading beats a much older but still live API one, the same result independent of device order, a live cookie observation still beating a stale API one, and the envelope rule for a merged row containing a local window.
