### PR TITLE
fix(limits): guard OpenCode supplemental windows against every Go source

### DIFF
--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -3150,15 +3150,20 @@ const OPENCODE_REMOTE_FAIL_STATUSES = ['unauthorized', 'sourceRateLimited', 'una
 // renderer localizes this exact string.
 const OPENCODE_AMBIENT_ACCOUNT_NAME = 'Auto-detected';
 
-function openCodeSupplementalZenWindows(goWeb, zen) {
-  const goWindowKeys = new Set(
-    (goWeb?.status === 'ok' ? goWeb.windows || [] : [])
+// Supplemental windows fill kinds the Go source did not answer, and are dropped
+// for any kind it did. The comparison is against the windows actually taken
+// rather than against one candidate source: Go quota resolves api → web → local,
+// so naming a single source there leaves the other two unguarded and the account
+// reports one window kind twice, from two sources and with two different numbers.
+function openCodeSupplementalZenWindows(takenWindows, zen) {
+  const takenKeys = new Set(
+    (Array.isArray(takenWindows) ? takenWindows : [])
       .map(openCodeWindowKey)
       .filter(Boolean)
   );
   return (zen?.windows || []).filter((window) => {
     const key = openCodeWindowKey(window);
-    return !key || !goWindowKeys.has(key);
+    return !key || !takenKeys.has(key);
   });
 }
 
@@ -3299,8 +3304,9 @@ async function fetchOpenCodeLimits(options = {}, deps = {}) {
     }
 
     if (zen && webIdentity.includeZen) {
-      windows.push(...openCodeSupplementalZenWindows(goWeb, zen)
-        .map((window) => ({ ...window, source: 'web' })));
+      const supplemental = openCodeSupplementalZenWindows(windows, zen)
+        .map((window) => ({ ...window, source: 'web' }));
+      windows.push(...supplemental);
       status = 'ok';
       // The provider-level source is the compatibility envelope used by Hubs
       // that predate windows[].source. It may claim Web only when every quota
@@ -3436,8 +3442,9 @@ async function fetchOpenCodeProfile(name, cookie, fetchGoWeb, fetchZen, nowMs, u
 
     const webIdentity = openCodeWebIdentity(goWeb, zen, cookie);
     if (zen && webIdentity.includeZen) {
-      windows.push(...openCodeSupplementalZenWindows(goWeb, zen)
-        .map((window) => ({ ...window, source: 'web' })));
+      const supplemental = openCodeSupplementalZenWindows(windows, zen)
+        .map((window) => ({ ...window, source: 'web' }));
+      windows.push(...supplemental);
       status = 'ok';
       if (!planLabel) planLabel = 'Zen';
       if (typeof zen.balanceUsd === 'number' && Number.isFinite(zen.balanceUsd)) balanceUsd = zen.balanceUsd;

--- a/tests/shared/limitCollector.opencode.test.js
+++ b/tests/shared/limitCollector.opencode.test.js
@@ -1358,3 +1358,87 @@ test('a failed API probe reports API provenance whether or not other accounts ex
   assert.strictEqual(personal.status, 'unauthorized');
   assert.strictEqual(personal.source, 'web');
 });
+
+// Supplemental windows fill kinds the Go source did not answer. The guard used
+// to compare against the go-page scrape alone, so it only held while that scrape
+// was the Go source: whenever the usage API answered and the scrape did not, the
+// account reported one window kind twice, from two sources and with two
+// different numbers. Go quota resolves api → web → local, so the comparison has
+// to be against whatever was actually taken.
+test('opencode drops a supplemental window whose kind the usage API answered', async () => {
+  const now = Date.UTC(2026, 7, 14, 12, 0, 0);
+  const summary = await collectLimitsOnce(
+    {
+      limitProviders: 'opencode',
+      limitsEnabled: true,
+      opencodeProfiles: { mine: { enabled: true, cookie: 'sess=1', apiKey: 'sk-mine' } }
+    },
+    {
+      now: () => now,
+      opencodeCollectGoApi: async () => ({
+        status: 'ok',
+        identity: 'go-api:mine',
+        entitled: true,
+        windows: [
+          { kind: 'session', usedPercent: 40, windowMinutes: 300 },
+          { kind: 'weekly', usedPercent: 55, windowMinutes: 10080 }
+        ]
+      }),
+      opencodeFetchGoWeb: async () => ({ status: 'unavailable', windows: [], workspaceId: 'wrk_1' }),
+      opencodeFetchZen: async () => ({
+        status: 'ok',
+        workspaceId: 'wrk_1',
+        balanceUsd: 7.5,
+        windows: [
+          { kind: 'session', usedPercent: 11, windowMinutes: 300 },
+          { kind: 'weekly', usedPercent: 12, windowMinutes: 10080 }
+        ]
+      })
+    }
+  );
+  const provider = summary.providers.find((p) => p.provider === 'opencode');
+  assert.strictEqual(provider.status, 'ok');
+  assert.deepStrictEqual(
+    provider.windows.map((window) => `${window.kind}:${window.usedPercent}`),
+    ['session:40', 'weekly:55']
+  );
+  // The cookie is still what produced the balance.
+  assert.strictEqual(provider.balanceUsd, 7.5);
+});
+
+// Same guard for the local estimate, which is the other Go source the previous
+// comparison did not cover, and had the gap before the usage API existed.
+test('opencode drops a supplemental window whose kind the local estimate answered', async () => {
+  const now = Date.UTC(2026, 7, 14, 12, 0, 0);
+  const summary = await collectLimitsOnce(
+    {
+      limitProviders: 'opencode',
+      limitsEnabled: true,
+      opencodeLocalLimitsEnabled: true,
+      opencodeCookie: 'sess=1'
+    },
+    {
+      now: () => now,
+      opencodeCollectGo: () => ({
+        status: 'ok',
+        identity: 'go:/x',
+        windows: [{ kind: 'session', used: 1, limit: 12, usedPercent: 8.3, windowMinutes: 300 }]
+      }),
+      opencodeFetchGoWeb: async () => ({ status: 'unavailable', windows: [], workspaceId: 'wrk_1' }),
+      opencodeFetchZen: async () => ({
+        status: 'ok',
+        workspaceId: 'wrk_1',
+        balanceUsd: 3,
+        windows: [
+          { kind: 'session', usedPercent: 90, windowMinutes: 300 },
+          { kind: 'weekly', usedPercent: 20, windowMinutes: 10080 }
+        ]
+      })
+    }
+  );
+  const provider = summary.providers.find((p) => p.provider === 'opencode');
+  assert.deepStrictEqual(
+    provider.windows.map((window) => `${window.kind}:${window.usedPercent}:${window.source}`),
+    ['session:8.3:local', 'weekly:20:web']
+  );
+});


### PR DESCRIPTION
Follow-up to #406, found while reviewing the merged result. Nothing here has shipped: #406 is on `main` and unreleased. Independent of #414, which is on the aggregation side.

## What happens

An OpenCode account's supplemental windows exist to fill window kinds the Go source did not answer, and are dropped for any kind it did. The guard that enforced this compared against the go-page scrape alone, so it only held while that scrape was the Go source. Go quota resolves api → web → local, so the other two paths met an empty comparison set.

An account holding both a key and a cookie, where the usage API answers and the page scrape does not:

| Window kind | Before | After |
|---|---|---|
| session | **two rows, 40% and 11%** | one row, 40% |
| weekly | **two rows, 55% and 12%** | one row, 55% |

The comparison is now against the windows actually taken, which is the rule the scrape path has always had rather than a new one. The local estimate had the same gap before the usage API existed, so this is not only a regression from that change, and it is covered by the same fix.

## Reachability

The two web probes fail independently: they share a cookie and a host but not an endpoint, and the go path is a regex scrape of a page, which is the fragile one of the pair. Making the Go quota independent of that fragility is what #406 was for.

On a Hub the two rows collapse back to one, but by the deterministic tie-break rather than by provenance, since they carry the same provider, timestamp and `windows[].source`. Which number survived was not a decision anything made.

## Verification

`npm run verify` — 3189 passing, 0 failing. `limitCollector.js` is not part of the portable Hub core, so no Worker sync is involved.

Two tests, both confirmed to fail against the previous behaviour: the usage API case and the local-estimate case.
