### PR TITLE
fix(pricing): fall back to tokscale catalog cache when offline

### DIFF
--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -17,7 +17,7 @@ const {
   deriveClientOverall
 } = require('./clientHealth');
 const { tokscalePackageNameForPlatform, tokscalePlatformKey } = require('./tokscalePlatform');
-const { customPricingPath } = require('./tokscaleConfig');
+const { customPricingPath, tokscaleConfigDir } = require('./tokscaleConfig');
 const {
   applyPeriodDelta,
   emptyPeriod,
@@ -213,6 +213,93 @@ const PROMA_PRICING_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 const PROMA_PRICING_LOOKUP_TIMEOUT_MS = 3000;
 const promaPricingCache = new Map();
 
+// tokscale maintains its own pricing catalog cache under its config dir
+// (cache/pricing-{litellm,openrouter,models-dev}.json): the `tokscale pricing`
+// command refreshes these over the network and falls back to them when offline
+// — but that fallback costs 20-30s of network timeouts, far past the 3s lookup
+// budget (PROMA_PRICING_LOOKUP_TIMEOUT_MS), which is why local clients' costs
+// show zero on machines without catalog access. Read the same local files
+// directly (zero network) as the offline fallback: when the command fails, the
+// catalog it would have fallen back to is already on disk.
+const TOKSCALE_PRICING_CATALOG_FILES = ['pricing-litellm.json', 'pricing-openrouter.json', 'pricing-models-dev.json'];
+
+// Parsed catalog, keyed by model id, invalidated by the files' size+mtime.
+let tokscaleCatalogCache = { revision: '', byModel: null };
+
+function tokscalePricingCatalogDir() {
+  return path.join(tokscaleConfigDir(), 'cache');
+}
+
+// Catalog keys are usually "<provider>/<model>"; usage rows carry the bare
+// model id, so strip any provider prefix (deepseek/deepseek-v4-flash ->
+// deepseek-v4-flash, opencode-go/deepseek-v4-pro -> deepseek-v4-pro).
+function normalizeCatalogModelKey(key) {
+  const raw = String(key || '').trim();
+  if (!raw) return '';
+  const parts = raw.split('/');
+  return (parts[parts.length - 1] || '').trim().toLowerCase();
+}
+
+function normalizeCatalogPricing(value) {
+  const pick = (key) => {
+    const n = Number(value[key]);
+    return Number.isFinite(n) && n >= 0 ? n : undefined;
+  };
+  const pricing = {
+    inputCostPerToken: pick('input_cost_per_token'),
+    outputCostPerToken: pick('output_cost_per_token'),
+    cacheReadInputTokenCost: pick('cache_read_input_token_cost'),
+    cacheCreationInputTokenCost: pick('cache_creation_input_token_cost')
+  };
+  return pricing.inputCostPerToken !== undefined || pricing.outputCostPerToken !== undefined ? pricing : null;
+}
+
+// Parse (once per file-revision) the tokscale pricing catalog cache into a
+// Map<modelId, pricing>. First source wins so litellm stays authoritative.
+function tokscalePricingCatalog(options = {}) {
+  const dir = options.configDir || tokscalePricingCatalogDir();
+  const files = TOKSCALE_PRICING_CATALOG_FILES.map((name) => path.join(dir, name));
+  const revision = files.map((file) => {
+    try {
+      const stat = fs.statSync(file);
+      return `${stat.size}:${stat.mtimeMs}`;
+    } catch (_) {
+      return '';
+    }
+  }).join('|');
+  if (tokscaleCatalogCache.revision === revision && tokscaleCatalogCache.byModel) return tokscaleCatalogCache.byModel;
+  const byModel = new Map();
+  for (const file of files) {
+    let doc;
+    try {
+      doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+    } catch (_) {
+      continue; // missing or malformed cache file
+    }
+    const data = doc && typeof doc === 'object' && doc.data && typeof doc.data === 'object' ? doc.data : null;
+    if (!data) continue;
+    for (const [key, value] of Object.entries(data)) {
+      if (!value || typeof value !== 'object') continue;
+      const modelId = normalizeCatalogModelKey(key);
+      if (!modelId || byModel.has(modelId)) continue;
+      const pricing = normalizeCatalogPricing(value);
+      if (pricing) byModel.set(modelId, pricing);
+    }
+  }
+  tokscaleCatalogCache = { revision, byModel };
+  return byModel;
+}
+
+function readTokscalePricingCatalog(modelId, options = {}) {
+  const key = String(modelId || '').trim().toLowerCase();
+  if (!key) return null;
+  return tokscalePricingCatalog(options).get(key) || null;
+}
+
+function resetTokscaleCatalogCache() {
+  tokscaleCatalogCache = { revision: '', byModel: null };
+}
+
 function promaPricingRevision() {
   try { return fs.statSync(customPricingPath()).mtimeMs; } catch (_) { return 0; }
 }
@@ -254,12 +341,16 @@ async function resolveModelPricing(rows, options = {}) {
       if (cached.pricing) pricingByModel[modelId] = cached.pricing;
       continue;
     }
-    let pricing = null;
+    let pricing;
     try {
       pricing = normalizePromaPricing(await lookup(modelId, commandTimeoutMs));
     } catch (_) {
       // An unknown model, offline lookup, or custom channel must remain
-      // cost-unavailable instead of inheriting an unrelated catalog price.
+      // cost-unavailable instead of inheriting an unrelated catalog price —
+      // but when the lookup itself failed (timeout/offline), the price the
+      // command would have fallen back to is tokscale's local catalog cache,
+      // which is on disk without any network round trip.
+      pricing = readTokscalePricingCatalog(modelId, options);
     }
     promaPricingCache.set(modelId, { at: nowMs, revision, pricing });
     if (pricing) pricingByModel[modelId] = pricing;
@@ -3073,6 +3164,9 @@ module.exports = {
   resolvePlatformBinary,
   resolvePromaPricing,
   resetPromaPricingCache,
+  readTokscalePricingCatalog,
+  resetTokscaleCatalogCache,
+  tokscalePricingCatalog,
   resolveWatchUsePolling,
   selfSyncSourceRootsForClients,
   // The process-wide sync throttle this module drives. Exported so a test can

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -222,6 +222,27 @@ const promaPricingCache = new Map();
 // directly (zero network) as the offline fallback: when the command fails, the
 // catalog it would have fallen back to is already on disk.
 const TOKSCALE_PRICING_CATALOG_FILES = ['pricing-litellm.json', 'pricing-openrouter.json', 'pricing-models-dev.json'];
+const TOKSCALE_MODEL_PRICING_RATE_FIELDS = [
+  'input_cost_per_token',
+  'input_cost_per_token_above_128k_tokens',
+  'input_cost_per_token_above_200k_tokens',
+  'input_cost_per_token_above_256k_tokens',
+  'input_cost_per_token_above_272k_tokens',
+  'output_cost_per_token',
+  'output_cost_per_token_above_128k_tokens',
+  'output_cost_per_token_above_200k_tokens',
+  'output_cost_per_token_above_256k_tokens',
+  'output_cost_per_token_above_272k_tokens',
+  'cache_creation_input_token_cost',
+  'cache_creation_input_token_cost_above_200k_tokens',
+  'cache_read_input_token_cost',
+  'cache_read_input_token_cost_above_200k_tokens',
+  'cache_read_input_token_cost_above_272k_tokens'
+];
+const TOKSCALE_ROUTING_LABELS = new Set(['auto', 'agent_review']);
+const TOKSCALE_TERMINAL_FALLBACK_BLOCKLIST = new Set([
+  'auto', 'mini', 'chat', 'base', 'claude', 'anthropic', 'gemini', 'model', 'router', 'default'
+]);
 const CATALOG_PRICING_FIELDS = [
   'inputCostPerToken',
   'outputCostPerToken',
@@ -229,7 +250,7 @@ const CATALOG_PRICING_FIELDS = [
   'cacheCreationInputTokenCost'
 ];
 
-// Parsed catalog, invalidated by the selected files' path+size+mtime.
+// Parsed catalog, invalidated by every selected candidate's file metadata.
 let tokscaleCatalogCache = { revision: '', catalog: null, recheckAtMs: 0 };
 
 function normalizeCatalogModelKey(key) {
@@ -244,13 +265,7 @@ function terminalCatalogModelKey(key) {
 function normalizePricingRate(value, key) {
   const raw = value?.[key];
   if (raw === null || raw === undefined) return undefined;
-  if (typeof raw !== 'number' && typeof raw !== 'string') return undefined;
-  if (typeof raw === 'string') {
-    const text = raw.trim();
-    if (!/^(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?$/i.test(text)) return undefined;
-  }
-  const n = typeof raw === 'number' ? raw : Number(raw.trim());
-  return Number.isFinite(n) && n >= 0 ? n : undefined;
+  return typeof raw === 'number' && Number.isFinite(raw) && raw >= 0 ? raw : undefined;
 }
 
 function normalizeCatalogPricing(value) {
@@ -275,29 +290,66 @@ function pricingCatalogDirs(options = {}) {
   return tokscaleCacheDirs(options);
 }
 
-function pricingCatalogFile(name, dirs) {
-  for (const dir of dirs) {
-    const file = path.join(dir, name);
-    try {
-      const stat = fs.statSync(file);
-      return { file, revision: `${file}:${stat.size}:${stat.mtimeMs}` };
-    } catch (error) {
-      if (error?.code === 'ENOENT') continue;
-      // Upstream only tries a legacy path when the canonical file is missing;
-      // a permission or I/O error at that path fails this source closed.
-      return { file, revision: `${file}:error:${error?.code || 'unknown'}` };
-    }
+function inspectPricingCatalogFile(file) {
+  try {
+    const stat = fs.statSync(file);
+    return {
+      file,
+      state: 'present',
+      revision: `${file}:${stat.size}:${stat.mtimeMs}:${stat.ctimeMs}:${stat.mode}`
+    };
+  } catch (error) {
+    const code = error?.code || 'unknown';
+    return { file, state: code === 'ENOENT' ? 'missing' : 'error', revision: `${file}:${code}` };
   }
-  return { file: '', revision: `${name}:missing` };
+}
+
+function pricingCatalogSource(name, dirs) {
+  if (dirs.length === 0) return { candidates: [], revision: `${name}:missing` };
+  const canonical = inspectPricingCatalogFile(path.join(dirs[0] || '', name));
+  // Canonical is authoritative whenever it exists or cannot be inspected.
+  // Only ENOENT activates upstream's ordered legacy find_map fallback.
+  const probes = canonical.state === 'missing'
+    ? [canonical, ...dirs.slice(1).map((dir) => inspectPricingCatalogFile(path.join(dir, name)))]
+    : [canonical];
+  return {
+    candidates: probes.filter((entry) => entry.state !== 'missing'),
+    revision: probes.map((entry) => entry.revision).join('|')
+  };
 }
 
 function tokscalePricingCatalogSnapshot(options = {}) {
   const dirs = pricingCatalogDirs(options);
-  const files = TOKSCALE_PRICING_CATALOG_FILES.map((name) => pricingCatalogFile(name, dirs));
+  const files = TOKSCALE_PRICING_CATALOG_FILES.map((name) => pricingCatalogSource(name, dirs));
   return {
     files,
     revision: `${dirs.join('|')}::${files.map((entry) => entry.revision).join('|')}`
   };
+}
+
+function parseTokscalePricingCatalogFile(file) {
+  let doc;
+  try {
+    doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (_) {
+    return null;
+  }
+  if (!doc || typeof doc !== 'object' || Array.isArray(doc)) return null;
+  if (!Number.isSafeInteger(doc.timestamp) || doc.timestamp < 0) return null;
+  if (!doc.data || typeof doc.data !== 'object' || Array.isArray(doc.data)) return null;
+  // Tokscale deserializes the whole HashMap<String, ModelPricing> before using
+  // it. A wrong type in any known Option<f64> field makes that source invalid;
+  // do not salvage rows from a cache Tokscale itself would reject.
+  for (const value of Object.values(doc.data)) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+    for (const field of TOKSCALE_MODEL_PRICING_RATE_FIELDS) {
+      const raw = value[field];
+      if (raw !== null && raw !== undefined && (typeof raw !== 'number' || !Number.isFinite(raw))) {
+        return null;
+      }
+    }
+  }
+  return doc;
 }
 
 // Preserve complete catalog keys. A bare model id may use a terminal-key
@@ -319,25 +371,19 @@ function tokscalePricingCatalog(options = {}) {
   const nowSeconds = Math.floor(nowMs / 1000);
   let recheckAtMs = 0;
   for (const source of snapshot.files) {
-    if (!source.file) continue;
-    let doc;
-    try {
-      doc = JSON.parse(fs.readFileSync(source.file, 'utf8'));
-    } catch (_) {
-      continue; // missing or malformed cache file
+    let doc = null;
+    for (const candidate of source.candidates) {
+      doc = parseTokscalePricingCatalogFile(candidate.file);
+      if (doc) break;
     }
+    if (!doc) continue;
     const timestamp = doc?.timestamp;
-    if (!Number.isSafeInteger(timestamp) || timestamp < 0) continue;
     if (timestamp > nowSeconds) {
       const eligibleAtMs = timestamp * 1000;
       recheckAtMs = recheckAtMs ? Math.min(recheckAtMs, eligibleAtMs) : eligibleAtMs;
       continue;
     }
-    const data = doc && typeof doc === 'object' && !Array.isArray(doc.data)
-      && doc.data && typeof doc.data === 'object' ? doc.data : null;
-    if (!data) continue;
-    for (const [key, value] of Object.entries(data)) {
-      if (!value || typeof value !== 'object') continue;
+    for (const [key, value] of Object.entries(doc.data)) {
       const modelId = normalizeCatalogModelKey(key);
       if (!modelId) continue;
       const pricing = normalizeCatalogPricing(value);
@@ -358,12 +404,16 @@ function tokscalePricingCatalog(options = {}) {
 function readTokscalePricingCatalog(modelId, options = {}) {
   const key = String(modelId || '').trim().toLowerCase();
   if (!key) return null;
+  // Bare router labels never identify the model that actually served usage.
+  // A qualified key such as morph/auto remains eligible for exact lookup.
+  if (TOKSCALE_ROUTING_LABELS.has(key)) return null;
   const catalog = tokscalePricingCatalog(options);
   const exact = catalog.exact.get(key);
   if (exact) return exact;
   // A provider-scoped id that does not exist exactly must not borrow another
   // provider's terminal match.
   if (key.includes('/')) return null;
+  if (TOKSCALE_TERMINAL_FALLBACK_BLOCKLIST.has(key)) return null;
   const candidates = catalog.byTerminal.get(key) || [];
   if (candidates.length === 0) return null;
   const fingerprints = new Set(candidates.map(({ pricing }) => catalogPricingFingerprint(pricing)));

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -17,7 +17,7 @@ const {
   deriveClientOverall
 } = require('./clientHealth');
 const { tokscalePackageNameForPlatform, tokscalePlatformKey } = require('./tokscalePlatform');
-const { customPricingPath, tokscaleConfigDir } = require('./tokscaleConfig');
+const { customPricingPath, tokscaleCacheDirs } = require('./tokscaleConfig');
 const {
   applyPeriodDelta,
   emptyPeriod,
@@ -222,82 +222,168 @@ const promaPricingCache = new Map();
 // directly (zero network) as the offline fallback: when the command fails, the
 // catalog it would have fallen back to is already on disk.
 const TOKSCALE_PRICING_CATALOG_FILES = ['pricing-litellm.json', 'pricing-openrouter.json', 'pricing-models-dev.json'];
+const CATALOG_PRICING_FIELDS = [
+  'inputCostPerToken',
+  'outputCostPerToken',
+  'cacheReadInputTokenCost',
+  'cacheCreationInputTokenCost'
+];
 
-// Parsed catalog, keyed by model id, invalidated by the files' size+mtime.
-let tokscaleCatalogCache = { revision: '', byModel: null };
+// Parsed catalog, invalidated by the selected files' path+size+mtime.
+let tokscaleCatalogCache = { revision: '', catalog: null, recheckAtMs: 0 };
 
-function tokscalePricingCatalogDir() {
-  return path.join(tokscaleConfigDir(), 'cache');
+function normalizeCatalogModelKey(key) {
+  return String(key || '').trim().toLowerCase();
 }
 
-// Catalog keys are usually "<provider>/<model>"; usage rows carry the bare
-// model id, so strip any provider prefix (deepseek/deepseek-v4-flash ->
-// deepseek-v4-flash, opencode-go/deepseek-v4-pro -> deepseek-v4-pro).
-function normalizeCatalogModelKey(key) {
-  const raw = String(key || '').trim();
-  if (!raw) return '';
-  const parts = raw.split('/');
-  return (parts[parts.length - 1] || '').trim().toLowerCase();
+function terminalCatalogModelKey(key) {
+  const parts = String(key || '').split('/');
+  return parts[parts.length - 1] || '';
+}
+
+function normalizePricingRate(value, key) {
+  const raw = value?.[key];
+  if (raw === null || raw === undefined) return undefined;
+  if (typeof raw !== 'number' && typeof raw !== 'string') return undefined;
+  if (typeof raw === 'string') {
+    const text = raw.trim();
+    if (!/^(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?$/i.test(text)) return undefined;
+  }
+  const n = typeof raw === 'number' ? raw : Number(raw.trim());
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
 }
 
 function normalizeCatalogPricing(value) {
-  const pick = (key) => {
-    const n = Number(value[key]);
-    return Number.isFinite(n) && n >= 0 ? n : undefined;
-  };
   const pricing = {
-    inputCostPerToken: pick('input_cost_per_token'),
-    outputCostPerToken: pick('output_cost_per_token'),
-    cacheReadInputTokenCost: pick('cache_read_input_token_cost'),
-    cacheCreationInputTokenCost: pick('cache_creation_input_token_cost')
+    inputCostPerToken: normalizePricingRate(value, 'input_cost_per_token'),
+    outputCostPerToken: normalizePricingRate(value, 'output_cost_per_token'),
+    cacheReadInputTokenCost: normalizePricingRate(value, 'cache_read_input_token_cost'),
+    cacheCreationInputTokenCost: normalizePricingRate(value, 'cache_creation_input_token_cost')
   };
   return pricing.inputCostPerToken !== undefined || pricing.outputCostPerToken !== undefined ? pricing : null;
 }
 
-// Parse (once per file-revision) the tokscale pricing catalog cache into a
-// Map<modelId, pricing>. First source wins so litellm stays authoritative.
-function tokscalePricingCatalog(options = {}) {
-  const dir = options.configDir || tokscalePricingCatalogDir();
-  const files = TOKSCALE_PRICING_CATALOG_FILES.map((name) => path.join(dir, name));
-  const revision = files.map((file) => {
+function catalogPricingFingerprint(pricing) {
+  return JSON.stringify(CATALOG_PRICING_FIELDS.map((field) => (
+    pricing[field] === undefined ? 'missing' : pricing[field]
+  )));
+}
+
+function pricingCatalogDirs(options = {}) {
+  if (Array.isArray(options.catalogDirs)) return options.catalogDirs.map(String).filter(Boolean);
+  if (options.configDir) return [options.configDir];
+  return tokscaleCacheDirs(options);
+}
+
+function pricingCatalogFile(name, dirs) {
+  for (const dir of dirs) {
+    const file = path.join(dir, name);
     try {
       const stat = fs.statSync(file);
-      return `${stat.size}:${stat.mtimeMs}`;
-    } catch (_) {
-      return '';
+      return { file, revision: `${file}:${stat.size}:${stat.mtimeMs}` };
+    } catch (error) {
+      if (error?.code === 'ENOENT') continue;
+      // Upstream only tries a legacy path when the canonical file is missing;
+      // a permission or I/O error at that path fails this source closed.
+      return { file, revision: `${file}:error:${error?.code || 'unknown'}` };
     }
-  }).join('|');
-  if (tokscaleCatalogCache.revision === revision && tokscaleCatalogCache.byModel) return tokscaleCatalogCache.byModel;
-  const byModel = new Map();
-  for (const file of files) {
+  }
+  return { file: '', revision: `${name}:missing` };
+}
+
+function tokscalePricingCatalogSnapshot(options = {}) {
+  const dirs = pricingCatalogDirs(options);
+  const files = TOKSCALE_PRICING_CATALOG_FILES.map((name) => pricingCatalogFile(name, dirs));
+  return {
+    files,
+    revision: `${dirs.join('|')}::${files.map((entry) => entry.revision).join('|')}`
+  };
+}
+
+// Preserve complete catalog keys. A bare model id may use a terminal-key
+// fallback only when every matching entry publishes exactly the same rates;
+// otherwise guessing a provider would turn "cost unavailable" into a wrong
+// cost. Full exact keys and bare exact keys always win before that fallback.
+function tokscalePricingCatalog(options = {}) {
+  const snapshot = tokscalePricingCatalogSnapshot(options);
+  const nowMs = options.nowMs ?? Date.now();
+  if (
+    tokscaleCatalogCache.revision === snapshot.revision
+    && tokscaleCatalogCache.catalog
+    && (!tokscaleCatalogCache.recheckAtMs || nowMs < tokscaleCatalogCache.recheckAtMs)
+  ) {
+    return tokscaleCatalogCache.catalog;
+  }
+  const exact = new Map();
+  const byTerminal = new Map();
+  const nowSeconds = Math.floor(nowMs / 1000);
+  let recheckAtMs = 0;
+  for (const source of snapshot.files) {
+    if (!source.file) continue;
     let doc;
     try {
-      doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+      doc = JSON.parse(fs.readFileSync(source.file, 'utf8'));
     } catch (_) {
       continue; // missing or malformed cache file
     }
-    const data = doc && typeof doc === 'object' && doc.data && typeof doc.data === 'object' ? doc.data : null;
+    const timestamp = doc?.timestamp;
+    if (!Number.isSafeInteger(timestamp) || timestamp < 0) continue;
+    if (timestamp > nowSeconds) {
+      const eligibleAtMs = timestamp * 1000;
+      recheckAtMs = recheckAtMs ? Math.min(recheckAtMs, eligibleAtMs) : eligibleAtMs;
+      continue;
+    }
+    const data = doc && typeof doc === 'object' && !Array.isArray(doc.data)
+      && doc.data && typeof doc.data === 'object' ? doc.data : null;
     if (!data) continue;
     for (const [key, value] of Object.entries(data)) {
       if (!value || typeof value !== 'object') continue;
       const modelId = normalizeCatalogModelKey(key);
-      if (!modelId || byModel.has(modelId)) continue;
+      if (!modelId) continue;
       const pricing = normalizeCatalogPricing(value);
-      if (pricing) byModel.set(modelId, pricing);
+      if (!pricing) continue;
+      if (!exact.has(modelId)) exact.set(modelId, pricing);
+      const terminal = terminalCatalogModelKey(modelId);
+      if (!terminal) continue;
+      if (!byTerminal.has(terminal)) byTerminal.set(terminal, []);
+      byTerminal.get(terminal).push({ modelId, pricing });
     }
   }
-  tokscaleCatalogCache = { revision, byModel };
-  return byModel;
+  const catalogRevision = recheckAtMs ? `${snapshot.revision}:before:${recheckAtMs}` : snapshot.revision;
+  const catalog = { revision: catalogRevision, exact, byTerminal };
+  tokscaleCatalogCache = { revision: snapshot.revision, catalog, recheckAtMs };
+  return catalog;
 }
 
 function readTokscalePricingCatalog(modelId, options = {}) {
   const key = String(modelId || '').trim().toLowerCase();
   if (!key) return null;
-  return tokscalePricingCatalog(options).get(key) || null;
+  const catalog = tokscalePricingCatalog(options);
+  const exact = catalog.exact.get(key);
+  if (exact) return exact;
+  // A provider-scoped id that does not exist exactly must not borrow another
+  // provider's terminal match.
+  if (key.includes('/')) return null;
+  const candidates = catalog.byTerminal.get(key) || [];
+  if (candidates.length === 0) return null;
+  const fingerprints = new Set(candidates.map(({ pricing }) => catalogPricingFingerprint(pricing)));
+  return fingerprints.size === 1 ? candidates[0].pricing : null;
 }
 
 function resetTokscaleCatalogCache() {
-  tokscaleCatalogCache = { revision: '', byModel: null };
+  tokscaleCatalogCache = { revision: '', catalog: null, recheckAtMs: 0 };
+}
+
+function tokscalePricingCatalogRevision(options = {}) {
+  const snapshot = tokscalePricingCatalogSnapshot(options);
+  const nowMs = options.nowMs ?? Date.now();
+  if (tokscaleCatalogCache.revision !== snapshot.revision || !tokscaleCatalogCache.catalog) {
+    return snapshot.revision;
+  }
+  if (tokscaleCatalogCache.recheckAtMs && nowMs >= tokscaleCatalogCache.recheckAtMs) {
+    return `${snapshot.revision}:recheck:${tokscaleCatalogCache.recheckAtMs}`;
+  }
+  return tokscaleCatalogCache.catalog.revision;
 }
 
 function promaPricingRevision() {
@@ -307,23 +393,21 @@ function promaPricingRevision() {
 function normalizePromaPricing(result) {
   const source = result?.pricing;
   if (!source || typeof source !== 'object') return null;
-  const pick = (key) => {
-    const value = Number(source[key]);
-    return Number.isFinite(value) && value >= 0 ? value : undefined;
-  };
   const pricing = {
-    inputCostPerToken: pick('inputCostPerToken'),
-    outputCostPerToken: pick('outputCostPerToken'),
-    cacheReadInputTokenCost: pick('cacheReadInputTokenCost'),
-    cacheCreationInputTokenCost: pick('cacheCreationInputTokenCost')
+    inputCostPerToken: normalizePricingRate(source, 'inputCostPerToken'),
+    outputCostPerToken: normalizePricingRate(source, 'outputCostPerToken'),
+    cacheReadInputTokenCost: normalizePricingRate(source, 'cacheReadInputTokenCost'),
+    cacheCreationInputTokenCost: normalizePricingRate(source, 'cacheCreationInputTokenCost')
   };
   return pricing.inputCostPerToken !== undefined || pricing.outputCostPerToken !== undefined ? pricing : null;
 }
 
 async function resolveModelPricing(rows, options = {}) {
   const lookup = options.lookupModelPricing || lookupModelPricing;
-  const revision = options.pricingRevision ?? promaPricingRevision();
+  const customRevision = options.pricingRevision ?? promaPricingRevision();
   const nowMs = options.nowMs ?? Date.now();
+  const currentRevision = () => `${customRevision}|${tokscalePricingCatalogRevision({ ...options, nowMs })}`;
+  let revision = currentRevision();
   // Pricing is supplementary: never let a missing catalog entry hold up the
   // live usage refresh for the normal tokscale command timeout.
   const commandTimeoutMs = options.commandTimeoutMs || PROMA_PRICING_LOOKUP_TIMEOUT_MS;
@@ -351,6 +435,10 @@ async function resolveModelPricing(rows, options = {}) {
       // command would have fallen back to is tokscale's local catalog cache,
       // which is on disk without any network round trip.
       pricing = readTokscalePricingCatalog(modelId, options);
+      // Parsing a future-dated source adds its time boundary to the catalog
+      // revision, so an unavailable result expires when that source becomes
+      // eligible even if the file itself does not change.
+      revision = currentRevision();
     }
     promaPricingCache.set(modelId, { at: nowMs, revision, pricing });
     if (pricing) pricingByModel[modelId] = pricing;

--- a/src/shared/tokscaleConfig.js
+++ b/src/shared/tokscaleConfig.js
@@ -8,7 +8,21 @@ const path = require('node:path');
 // OS and whether we run via `npm start` (dev) or the packaged app. We read the
 // same process.env the collector passes to the spawned binary, so TOKSCALE_CONFIG_DIR
 // and the per-OS rules stay in lockstep.
-function tokscaleConfigDir({ env = process.env, platform = process.platform, homeDir = os.homedir() } = {}) {
+function windowsNativeAbsolutePath(value) {
+  const raw = typeof value === 'string' ? value.trim() : '';
+  return /^[A-Za-z]:[\\/]/.test(raw) || /^[\\/]{2}[^\\/]+[\\/][^\\/]+/.test(raw);
+}
+
+function tokscaleHomeDir({ env, platform, homeDir }) {
+  if (typeof homeDir === 'string' && homeDir.length > 0) return homeDir;
+  if (platform === 'win32' && windowsNativeAbsolutePath(env.HOME)) return env.HOME.trim();
+  return os.homedir();
+}
+
+function tokscaleConfigDir(options = {}) {
+  const env = options.env || process.env;
+  const platform = options.platform || process.platform;
+  const homeDir = tokscaleHomeDir({ env, platform, homeDir: options.homeDir });
   const override = env.TOKSCALE_CONFIG_DIR;
   if (typeof override === 'string' && override.length > 0) return override;
 
@@ -30,7 +44,10 @@ function tokscaleConfigDir({ env = process.env, platform = process.platform, hom
 // Mirror tokscale-core's canonical cache root plus its two pre-#470 legacy
 // fallbacks. An explicit TOKSCALE_CONFIG_DIR is hermetic upstream, so it must
 // never reach back into a real profile's legacy cache.
-function tokscaleCacheDirs({ env = process.env, platform = process.platform, homeDir = os.homedir() } = {}) {
+function tokscaleCacheDirs(options = {}) {
+  const env = options.env || process.env;
+  const platform = options.platform || process.platform;
+  const homeDir = tokscaleHomeDir({ env, platform, homeDir: options.homeDir });
   const canonical = path.join(tokscaleConfigDir({ env, platform, homeDir }), 'cache');
   const override = env.TOKSCALE_CONFIG_DIR;
   if (typeof override === 'string' && override.length > 0) return [canonical];

--- a/src/shared/tokscaleConfig.js
+++ b/src/shared/tokscaleConfig.js
@@ -13,16 +13,19 @@ function windowsNativeAbsolutePath(value) {
   return /^[A-Za-z]:[\\/]/.test(raw) || /^[\\/]{2}[^\\/]+[\\/][^\\/]+/.test(raw);
 }
 
-function tokscaleHomeDir({ env, platform, homeDir }) {
-  if (typeof homeDir === 'string' && homeDir.length > 0) return homeDir;
+function profileHomeDir(homeDir) {
+  return typeof homeDir === 'string' && homeDir.length > 0 ? homeDir : os.homedir();
+}
+
+function tokscaleHomeDir({ env, platform, profileHome }) {
   if (platform === 'win32' && windowsNativeAbsolutePath(env.HOME)) return env.HOME.trim();
-  return os.homedir();
+  return profileHome;
 }
 
 function tokscaleConfigDir(options = {}) {
   const env = options.env || process.env;
   const platform = options.platform || process.platform;
-  const homeDir = tokscaleHomeDir({ env, platform, homeDir: options.homeDir });
+  const homeDir = profileHomeDir(options.homeDir);
   const override = env.TOKSCALE_CONFIG_DIR;
   if (typeof override === 'string' && override.length > 0) return override;
 
@@ -47,29 +50,30 @@ function tokscaleConfigDir(options = {}) {
 function tokscaleCacheDirs(options = {}) {
   const env = options.env || process.env;
   const platform = options.platform || process.platform;
-  const homeDir = tokscaleHomeDir({ env, platform, homeDir: options.homeDir });
-  const canonical = path.join(tokscaleConfigDir({ env, platform, homeDir }), 'cache');
+  const profileHome = profileHomeDir(options.homeDir);
+  const tokscaleHome = tokscaleHomeDir({ env, platform, profileHome });
+  const canonical = path.join(tokscaleConfigDir({ env, platform, homeDir: profileHome }), 'cache');
   const override = env.TOKSCALE_CONFIG_DIR;
   if (typeof override === 'string' && override.length > 0) return [canonical];
 
   let platformCache;
   if (platform === 'darwin') {
-    platformCache = path.join(homeDir, 'Library', 'Caches', 'tokscale');
+    platformCache = path.join(profileHome, 'Library', 'Caches', 'tokscale');
   } else if (platform === 'win32') {
     const localAppData = (typeof env.LOCALAPPDATA === 'string' && env.LOCALAPPDATA.length > 0)
       ? env.LOCALAPPDATA
-      : path.join(homeDir, 'AppData', 'Local');
+      : path.join(profileHome, 'AppData', 'Local');
     platformCache = path.join(localAppData, 'tokscale');
   } else {
     const xdg = env.XDG_CACHE_HOME;
-    const cacheHome = (typeof xdg === 'string' && path.isAbsolute(xdg)) ? xdg : path.join(homeDir, '.cache');
+    const cacheHome = (typeof xdg === 'string' && path.isAbsolute(xdg)) ? xdg : path.join(profileHome, '.cache');
     platformCache = path.join(cacheHome, 'tokscale');
   }
 
   return [...new Set([
     canonical,
     platformCache,
-    path.join(homeDir, '.cache', 'tokscale')
+    path.join(tokscaleHome, '.cache', 'tokscale')
   ])];
 }
 

--- a/src/shared/tokscaleConfig.js
+++ b/src/shared/tokscaleConfig.js
@@ -27,8 +27,37 @@ function tokscaleConfigDir({ env = process.env, platform = process.platform, hom
   return path.join(configHome, 'tokscale');
 }
 
+// Mirror tokscale-core's canonical cache root plus its two pre-#470 legacy
+// fallbacks. An explicit TOKSCALE_CONFIG_DIR is hermetic upstream, so it must
+// never reach back into a real profile's legacy cache.
+function tokscaleCacheDirs({ env = process.env, platform = process.platform, homeDir = os.homedir() } = {}) {
+  const canonical = path.join(tokscaleConfigDir({ env, platform, homeDir }), 'cache');
+  const override = env.TOKSCALE_CONFIG_DIR;
+  if (typeof override === 'string' && override.length > 0) return [canonical];
+
+  let platformCache;
+  if (platform === 'darwin') {
+    platformCache = path.join(homeDir, 'Library', 'Caches', 'tokscale');
+  } else if (platform === 'win32') {
+    const localAppData = (typeof env.LOCALAPPDATA === 'string' && env.LOCALAPPDATA.length > 0)
+      ? env.LOCALAPPDATA
+      : path.join(homeDir, 'AppData', 'Local');
+    platformCache = path.join(localAppData, 'tokscale');
+  } else {
+    const xdg = env.XDG_CACHE_HOME;
+    const cacheHome = (typeof xdg === 'string' && path.isAbsolute(xdg)) ? xdg : path.join(homeDir, '.cache');
+    platformCache = path.join(cacheHome, 'tokscale');
+  }
+
+  return [...new Set([
+    canonical,
+    platformCache,
+    path.join(homeDir, '.cache', 'tokscale')
+  ])];
+}
+
 function customPricingPath(opts) {
   return path.join(tokscaleConfigDir(opts), 'custom-pricing.json');
 }
 
-module.exports = { tokscaleConfigDir, customPricingPath };
+module.exports = { tokscaleCacheDirs, tokscaleConfigDir, customPricingPath };

--- a/tests/shared/tokscaleConfig.test.js
+++ b/tests/shared/tokscaleConfig.test.js
@@ -4,7 +4,7 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 const path = require('node:path');
 
-const { tokscaleConfigDir, customPricingPath } = require('../../src/shared/tokscaleConfig');
+const { tokscaleCacheDirs, tokscaleConfigDir, customPricingPath } = require('../../src/shared/tokscaleConfig');
 
 test('TOKSCALE_CONFIG_DIR override wins verbatim on every platform', () => {
   for (const platform of ['darwin', 'win32', 'linux']) {
@@ -61,5 +61,53 @@ test('customPricingPath appends the filename', () => {
   assert.equal(
     customPricingPath({ platform: 'darwin', homeDir: '/Users/u', env: {} }),
     path.join('/Users/u', '.config', 'tokscale', 'custom-pricing.json')
+  );
+});
+
+test('explicit config override keeps cache discovery hermetic', () => {
+  assert.deepEqual(
+    tokscaleCacheDirs({ platform: 'linux', homeDir: '/home/u', env: { TOKSCALE_CONFIG_DIR: '/tmp/iso' } }),
+    [path.join('/tmp/iso', 'cache')]
+  );
+});
+
+test('macOS cache discovery includes both upstream legacy roots', () => {
+  assert.deepEqual(
+    tokscaleCacheDirs({ platform: 'darwin', homeDir: '/Users/u', env: {} }),
+    [
+      path.join('/Users/u', '.config', 'tokscale', 'cache'),
+      path.join('/Users/u', 'Library', 'Caches', 'tokscale'),
+      path.join('/Users/u', '.cache', 'tokscale')
+    ]
+  );
+});
+
+test('Linux cache discovery honors XDG_CACHE_HOME and keeps dot-cache fallback', () => {
+  assert.deepEqual(
+    tokscaleCacheDirs({
+      platform: 'linux',
+      homeDir: '/home/u',
+      env: { XDG_CONFIG_HOME: '/config', XDG_CACHE_HOME: '/cache' }
+    }),
+    [
+      path.join('/config', 'tokscale', 'cache'),
+      path.join('/cache', 'tokscale'),
+      path.join('/home/u', '.cache', 'tokscale')
+    ]
+  );
+});
+
+test('Windows cache discovery uses LocalAppData for the dirs cache root', () => {
+  assert.deepEqual(
+    tokscaleCacheDirs({
+      platform: 'win32',
+      homeDir: 'C:\\Users\\u',
+      env: { APPDATA: 'C:\\Users\\u\\AppData\\Roaming', LOCALAPPDATA: 'C:\\Users\\u\\AppData\\Local' }
+    }),
+    [
+      path.join('C:\\Users\\u\\AppData\\Roaming', 'tokscale', 'cache'),
+      path.join('C:\\Users\\u\\AppData\\Local', 'tokscale'),
+      path.join('C:\\Users\\u', '.cache', 'tokscale')
+    ]
   );
 });

--- a/tests/shared/tokscaleConfig.test.js
+++ b/tests/shared/tokscaleConfig.test.js
@@ -43,6 +43,24 @@ test('Windows falls back to <home>/AppData/Roaming when APPDATA unset', () => {
   );
 });
 
+test('Windows honors a native absolute HOME override when no home is injected', () => {
+  assert.deepEqual(
+    tokscaleCacheDirs({ platform: 'win32', env: { HOME: 'D:\\sandbox\\home' } }),
+    [
+      path.join('D:\\sandbox\\home', 'AppData', 'Roaming', 'tokscale', 'cache'),
+      path.join('D:\\sandbox\\home', 'AppData', 'Local', 'tokscale'),
+      path.join('D:\\sandbox\\home', '.cache', 'tokscale')
+    ]
+  );
+});
+
+test('Windows ignores POSIX-shaped and drive-relative HOME overrides', () => {
+  for (const home of ['/home/u', 'C:relative']) {
+    const dirs = tokscaleCacheDirs({ platform: 'win32', env: { HOME: home } });
+    assert.equal(dirs.some((dir) => dir.includes(home)), false);
+  }
+});
+
 test('Linux honors absolute XDG_CONFIG_HOME', () => {
   assert.equal(
     tokscaleConfigDir({ platform: 'linux', homeDir: '/home/u', env: { XDG_CONFIG_HOME: '/xdg' } }),

--- a/tests/shared/tokscaleConfig.test.js
+++ b/tests/shared/tokscaleConfig.test.js
@@ -43,12 +43,16 @@ test('Windows falls back to <home>/AppData/Roaming when APPDATA unset', () => {
   );
 });
 
-test('Windows honors a native absolute HOME override when no home is injected', () => {
+test('Windows native HOME redirects only the home-rooted legacy cache', () => {
   assert.deepEqual(
-    tokscaleCacheDirs({ platform: 'win32', env: { HOME: 'D:\\sandbox\\home' } }),
+    tokscaleCacheDirs({
+      platform: 'win32',
+      homeDir: 'C:\\Users\\u',
+      env: { HOME: 'D:\\sandbox\\home' }
+    }),
     [
-      path.join('D:\\sandbox\\home', 'AppData', 'Roaming', 'tokscale', 'cache'),
-      path.join('D:\\sandbox\\home', 'AppData', 'Local', 'tokscale'),
+      path.join('C:\\Users\\u', 'AppData', 'Roaming', 'tokscale', 'cache'),
+      path.join('C:\\Users\\u', 'AppData', 'Local', 'tokscale'),
       path.join('D:\\sandbox\\home', '.cache', 'tokscale')
     ]
   );
@@ -56,8 +60,14 @@ test('Windows honors a native absolute HOME override when no home is injected', 
 
 test('Windows ignores POSIX-shaped and drive-relative HOME overrides', () => {
   for (const home of ['/home/u', 'C:relative']) {
-    const dirs = tokscaleCacheDirs({ platform: 'win32', env: { HOME: home } });
-    assert.equal(dirs.some((dir) => dir.includes(home)), false);
+    assert.deepEqual(
+      tokscaleCacheDirs({ platform: 'win32', homeDir: 'C:\\Users\\u', env: { HOME: home } }),
+      [
+        path.join('C:\\Users\\u', 'AppData', 'Roaming', 'tokscale', 'cache'),
+        path.join('C:\\Users\\u', 'AppData', 'Local', 'tokscale'),
+        path.join('C:\\Users\\u', '.cache', 'tokscale')
+      ]
+    );
   }
 });
 

--- a/tests/shared/tokscalePricingCatalog.test.js
+++ b/tests/shared/tokscalePricingCatalog.test.js
@@ -70,7 +70,7 @@ test('catalog parsing preserves full keys and keeps null rates unavailable', (t)
   });
 });
 
-test('catalog parsing rejects coercive rate values', (t) => {
+test('catalog parsing rejects a source with coercive rate values', (t) => {
   resetPricingCaches(t);
   const dir = catalogDir(t);
   writeCatalog(dir, 'pricing-litellm.json', {
@@ -79,20 +79,12 @@ test('catalog parsing rejects coercive rate values', (t) => {
       boolean: { input_cost_per_token: true, output_cost_per_token: false },
       whitespace: { input_cost_per_token: '   ', output_cost_per_token: [] },
       object: { input_cost_per_token: {}, output_cost_per_token: [2] },
-      numeric: { input_cost_per_token: '1.5e-7', output_cost_per_token: 2e-7 }
+      numericString: { input_cost_per_token: '1.5e-7', output_cost_per_token: 2e-7 }
     }
   });
 
   const catalog = tokscalePricingCatalog({ configDir: dir });
-  assert.equal(catalog.exact.has('boolean'), false);
-  assert.equal(catalog.exact.has('whitespace'), false);
-  assert.equal(catalog.exact.has('object'), false);
-  assert.deepEqual(catalog.exact.get('numeric'), {
-    inputCostPerToken: 1.5e-7,
-    outputCostPerToken: 2e-7,
-    cacheReadInputTokenCost: undefined,
-    cacheCreationInputTokenCost: undefined
-  });
+  assert.equal(catalog.exact.size, 0);
 });
 
 test('bare exact key wins over earlier reseller terminal collisions', (t) => {
@@ -153,6 +145,39 @@ test('provider-scoped ids require their own full exact key', (t) => {
     1.4e-7
   );
   assert.equal(readTokscalePricingCatalog('reseller/deepseek-v4-flash', { configDir: dir }), null);
+});
+
+test('bare routing labels never resolve through terminal matches', (t) => {
+  resetPricingCaches(t);
+  const dir = catalogDir(t);
+  writeCatalog(dir, 'pricing-litellm.json', {
+    timestamp: 0,
+    data: {
+      'morph/auto': { input_cost_per_token: 8.5e-7, output_cost_per_token: 1.55e-6 },
+      'someone/agent_review': { input_cost_per_token: 1e-7, output_cost_per_token: 2e-7 }
+    }
+  });
+
+  assert.equal(readTokscalePricingCatalog('auto', { configDir: dir }), null);
+  assert.equal(readTokscalePricingCatalog('agent_review', { configDir: dir }), null);
+  assert.equal(readTokscalePricingCatalog('morph/auto', { configDir: dir }).inputCostPerToken, 8.5e-7);
+});
+
+test('generic bare ids do not borrow provider terminal matches', (t) => {
+  resetPricingCaches(t);
+  const dir = catalogDir(t);
+  writeCatalog(dir, 'pricing-litellm.json', {
+    timestamp: 0,
+    data: {
+      default: { input_cost_per_token: 3e-7, output_cost_per_token: 4e-7 },
+      'vendor/default': { input_cost_per_token: 1e-7, output_cost_per_token: 2e-7 },
+      'vendor/router': { input_cost_per_token: 5e-7, output_cost_per_token: 6e-7 }
+    }
+  });
+
+  assert.equal(readTokscalePricingCatalog('default', { configDir: dir }).inputCostPerToken, 3e-7);
+  assert.equal(readTokscalePricingCatalog('router', { configDir: dir }), null);
+  assert.equal(readTokscalePricingCatalog('vendor/router', { configDir: dir }).inputCostPerToken, 5e-7);
 });
 
 test('catalog parsing skips malformed and future-dated sources', (t) => {
@@ -217,6 +242,27 @@ test('catalog discovery uses a legacy root only when the canonical file is missi
   writeRawCatalog(canonical, 'pricing-litellm.json', 'not json {');
   resetTokscaleCatalogCache();
   assert.equal(readTokscalePricingCatalog('legacy', { catalogDirs: [canonical, legacy] }), null);
+});
+
+test('catalog discovery skips a malformed legacy source and tracks every candidate revision', (t) => {
+  resetPricingCaches(t);
+  const canonical = catalogDir(t);
+  const firstLegacy = catalogDir(t);
+  const secondLegacy = catalogDir(t);
+  writeRawCatalog(firstLegacy, 'pricing-litellm.json', 'not json {');
+  writeCatalog(secondLegacy, 'pricing-litellm.json', {
+    timestamp: 0,
+    data: { model: { input_cost_per_token: 2, output_cost_per_token: 2 } }
+  });
+  const options = { catalogDirs: [canonical, firstLegacy, secondLegacy] };
+
+  assert.equal(readTokscalePricingCatalog('model', options).inputCostPerToken, 2);
+
+  writeCatalog(firstLegacy, 'pricing-litellm.json', {
+    timestamp: 0,
+    data: { model: { input_cost_per_token: 111, output_cost_per_token: 111 } }
+  });
+  assert.equal(readTokscalePricingCatalog('model', options).inputCostPerToken, 111);
 });
 
 test('resolvePromaPricing falls back to the local catalog when the lookup fails offline', async (t) => {
@@ -332,6 +378,13 @@ test('normalizePromaPricing rejects coercive command rates', () => {
     outputCostPerToken: [],
     cacheReadInputTokenCost: ' ',
     cacheCreationInputTokenCost: {}
+  } }), null);
+});
+
+test('normalizePromaPricing rejects numeric-string command rates', () => {
+  assert.equal(normalizePromaPricing({ pricing: {
+    inputCostPerToken: '1.5e-7',
+    outputCostPerToken: '2e-7'
   } }), null);
 });
 

--- a/tests/shared/tokscalePricingCatalog.test.js
+++ b/tests/shared/tokscalePricingCatalog.test.js
@@ -1,10 +1,9 @@
 'use strict';
 
-// Local clients' (e.g. Proma) costs fall back to tokscale's own pricing catalog cache
-// (cache/pricing-{litellm,openrouter,models-dev}.json) when the `tokscale
-// pricing` lookup fails — e.g. offline, where the command itself would wait
-// 20-30s of network timeouts before using that same cache. These tests pin the
-// local-cache parsing and the fallback wiring in resolvePromaPricing.
+// Proma costs may fall back to tokscale's on-disk pricing datasets when the
+// bounded `tokscale pricing` command cannot finish. The fallback deliberately
+// resolves less than tokscale: exact matches are safe, while ambiguous
+// provider-stripped matches fail closed instead of guessing a price.
 
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
@@ -13,12 +12,14 @@ const path = require('node:path');
 const test = require('node:test');
 
 const {
+  normalizePromaPricing,
   readTokscalePricingCatalog,
   resetPromaPricingCache,
   resetTokscaleCatalogCache,
   resolvePromaPricing,
   tokscalePricingCatalog
 } = require('../../src/shared/collector');
+const { buildPromaPeriods } = require('../../src/shared/promaUsage');
 
 function catalogDir(t) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tokscale-pricing-catalog-'));
@@ -31,18 +32,26 @@ function writeCatalog(dir, fileName, data) {
   fs.writeFileSync(path.join(dir, fileName), JSON.stringify(data));
 }
 
-test('tokscalePricingCatalog parses litellm cache and strips provider prefixes', (t) => {
+function writeRawCatalog(dir, fileName, data) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, fileName), data);
+}
+
+function resetPricingCaches(t) {
+  resetPromaPricingCache();
   resetTokscaleCatalogCache();
+  t.after(() => {
+    resetPromaPricingCache();
+    resetTokscaleCatalogCache();
+  });
+}
+
+test('catalog parsing preserves full keys and keeps null rates unavailable', (t) => {
+  resetPricingCaches(t);
   const dir = catalogDir(t);
   writeCatalog(dir, 'pricing-litellm.json', {
     timestamp: 0,
     data: {
-      'deepseek/deepseek-v4-flash': {
-        input_cost_per_token: 1.4e-7,
-        output_cost_per_token: 2.8e-7,
-        cache_read_input_token_cost: 2.8e-9,
-        cache_creation_input_token_cost: 0
-      },
       'opencode-go/deepseek-v4-pro': {
         input_cost_per_token: 4.35e-7,
         output_cost_per_token: 8.7e-7,
@@ -53,31 +62,165 @@ test('tokscalePricingCatalog parses litellm cache and strips provider prefixes',
   });
 
   const catalog = tokscalePricingCatalog({ configDir: dir });
-  assert.deepEqual(catalog.get('deepseek-v4-flash'), {
-    inputCostPerToken: 1.4e-7,
-    outputCostPerToken: 2.8e-7,
-    cacheReadInputTokenCost: 2.8e-9,
-    cacheCreationInputTokenCost: 0
+  assert.deepEqual(catalog.exact.get('opencode-go/deepseek-v4-pro'), {
+    inputCostPerToken: 4.35e-7,
+    outputCostPerToken: 8.7e-7,
+    cacheReadInputTokenCost: 3.625e-9,
+    cacheCreationInputTokenCost: undefined
   });
-  assert.equal(catalog.get('deepseek-v4-pro').outputCostPerToken, 8.7e-7);
-  assert.equal(readTokscalePricingCatalog('DeepSeek-V4-Flash', { configDir: dir }).inputCostPerToken, 1.4e-7);
-  resetTokscaleCatalogCache();
 });
 
-test('tokscalePricingCatalog skips missing or malformed cache files', (t) => {
-  resetTokscaleCatalogCache();
+test('catalog parsing rejects coercive rate values', (t) => {
+  resetPricingCaches(t);
   const dir = catalogDir(t);
-  writeCatalog(dir, 'pricing-litellm.json', 'not json {');
-  writeCatalog(dir, 'pricing-openrouter.json', { timestamp: 0, data: { 'openai/gpt-4o': { input_cost_per_token: 2.5e-6 } } });
+  writeCatalog(dir, 'pricing-litellm.json', {
+    timestamp: 0,
+    data: {
+      boolean: { input_cost_per_token: true, output_cost_per_token: false },
+      whitespace: { input_cost_per_token: '   ', output_cost_per_token: [] },
+      object: { input_cost_per_token: {}, output_cost_per_token: [2] },
+      numeric: { input_cost_per_token: '1.5e-7', output_cost_per_token: 2e-7 }
+    }
+  });
+
   const catalog = tokscalePricingCatalog({ configDir: dir });
-  assert.equal(catalog.get('gpt-4o').inputCostPerToken, 2.5e-6);
-  assert.equal(catalog.size, 1);
+  assert.equal(catalog.exact.has('boolean'), false);
+  assert.equal(catalog.exact.has('whitespace'), false);
+  assert.equal(catalog.exact.has('object'), false);
+  assert.deepEqual(catalog.exact.get('numeric'), {
+    inputCostPerToken: 1.5e-7,
+    outputCostPerToken: 2e-7,
+    cacheReadInputTokenCost: undefined,
+    cacheCreationInputTokenCost: undefined
+  });
+});
+
+test('bare exact key wins over earlier reseller terminal collisions', (t) => {
+  resetPricingCaches(t);
+  const dir = catalogDir(t);
+  writeCatalog(dir, 'pricing-litellm.json', {
+    timestamp: 0,
+    data: {
+      'libertai/deepseek-v4-flash': { input_cost_per_token: 2.5e-7, output_cost_per_token: 1.75e-6 },
+      'deepseek-v4-flash': { input_cost_per_token: 1.4e-7, output_cost_per_token: 2.8e-7 },
+      'deepseek/deepseek-v4-flash': { input_cost_per_token: 1.4e-7, output_cost_per_token: 2.8e-7 }
+    }
+  });
+
+  assert.equal(readTokscalePricingCatalog('deepseek-v4-flash', { configDir: dir }).outputCostPerToken, 2.8e-7);
+});
+
+test('ambiguous terminal matches with different rates fail closed', (t) => {
+  resetPricingCaches(t);
+  const dir = catalogDir(t);
+  writeCatalog(dir, 'pricing-litellm.json', {
+    timestamp: 0,
+    data: {
+      'provider-a/model-x': { input_cost_per_token: 1e-7, output_cost_per_token: 2e-7 },
+      'provider-b/model-x': { input_cost_per_token: 3e-7, output_cost_per_token: 4e-7 }
+    }
+  });
+
+  assert.equal(readTokscalePricingCatalog('model-x', { configDir: dir }), null);
+});
+
+test('terminal matches with identical rates remain safe without a bare key', (t) => {
+  resetPricingCaches(t);
+  const dir = catalogDir(t);
+  writeCatalog(dir, 'pricing-litellm.json', {
+    timestamp: 0,
+    data: {
+      'provider-a/model-x': { input_cost_per_token: 1e-7, output_cost_per_token: 2e-7 },
+      'provider-b/model-x': { input_cost_per_token: 1e-7, output_cost_per_token: 2e-7 }
+    }
+  });
+
+  assert.equal(readTokscalePricingCatalog('model-x', { configDir: dir }).inputCostPerToken, 1e-7);
+});
+
+test('provider-scoped ids require their own full exact key', (t) => {
+  resetPricingCaches(t);
+  const dir = catalogDir(t);
+  writeCatalog(dir, 'pricing-litellm.json', {
+    timestamp: 0,
+    data: {
+      'deepseek/deepseek-v4-flash': { input_cost_per_token: 1.4e-7, output_cost_per_token: 2.8e-7 }
+    }
+  });
+
+  assert.equal(
+    readTokscalePricingCatalog('deepseek/deepseek-v4-flash', { configDir: dir }).inputCostPerToken,
+    1.4e-7
+  );
+  assert.equal(readTokscalePricingCatalog('reseller/deepseek-v4-flash', { configDir: dir }), null);
+});
+
+test('catalog parsing skips malformed and future-dated sources', (t) => {
+  resetPricingCaches(t);
+  const dir = catalogDir(t);
+  writeRawCatalog(dir, 'pricing-litellm.json', 'not json {');
+  writeCatalog(dir, 'pricing-openrouter.json', {
+    timestamp: 2,
+    data: { 'openai/future': { input_cost_per_token: 1e-7, output_cost_per_token: 2e-7 } }
+  });
+  writeCatalog(dir, 'pricing-models-dev.json', {
+    timestamp: 0,
+    data: { 'openai/known': { input_cost_per_token: 2.5e-6, output_cost_per_token: 1e-5 } }
+  });
+
+  const catalog = tokscalePricingCatalog({ configDir: dir, nowMs: 1000 });
+  assert.equal(catalog.exact.has('openai/future'), false);
+  assert.equal(catalog.exact.get('openai/known').inputCostPerToken, 2.5e-6);
+});
+
+test('future-dated catalog becomes eligible without a file revision change', async (t) => {
+  resetPricingCaches(t);
+  const dir = catalogDir(t);
+  writeCatalog(dir, 'pricing-litellm.json', {
+    timestamp: 2,
+    data: { model: { input_cost_per_token: 1e-7, output_cost_per_token: 2e-7 } }
+  });
+  let lookupCalls = 0;
+  const lookupModelPricing = async () => {
+    lookupCalls += 1;
+    throw new Error('offline');
+  };
+
+  const before = await resolvePromaPricing(
+    [{ model: 'model' }],
+    { lookupModelPricing, pricingRevision: 1, nowMs: 1000, configDir: dir }
+  );
+  const after = await resolvePromaPricing(
+    [{ model: 'model' }],
+    { lookupModelPricing, pricingRevision: 1, nowMs: 2000, configDir: dir }
+  );
+
+  assert.deepEqual(before, {});
+  assert.equal(after.model.inputCostPerToken, 1e-7);
+  assert.equal(lookupCalls, 2);
+});
+
+test('catalog discovery uses a legacy root only when the canonical file is missing', (t) => {
+  resetPricingCaches(t);
+  const canonical = catalogDir(t);
+  const legacy = catalogDir(t);
+  writeCatalog(legacy, 'pricing-litellm.json', {
+    timestamp: 0,
+    data: { 'openai/legacy': { input_cost_per_token: 1e-7, output_cost_per_token: 2e-7 } }
+  });
+
+  assert.equal(
+    readTokscalePricingCatalog('legacy', { catalogDirs: [canonical, legacy] }).inputCostPerToken,
+    1e-7
+  );
+
+  writeRawCatalog(canonical, 'pricing-litellm.json', 'not json {');
   resetTokscaleCatalogCache();
+  assert.equal(readTokscalePricingCatalog('legacy', { catalogDirs: [canonical, legacy] }), null);
 });
 
 test('resolvePromaPricing falls back to the local catalog when the lookup fails offline', async (t) => {
-  resetPromaPricingCache();
-  resetTokscaleCatalogCache();
+  resetPricingCaches(t);
   const dir = catalogDir(t);
   writeCatalog(dir, 'pricing-litellm.json', {
     timestamp: 0,
@@ -107,13 +250,93 @@ test('resolvePromaPricing falls back to the local catalog when the lookup fails 
     cacheCreationInputTokenCost: 0
   });
   assert.equal(lookupCalls, 1);
-  resetPromaPricingCache();
-  resetTokscaleCatalogCache();
+});
+
+test('catalog changes invalidate the outer Proma pricing cache', async (t) => {
+  resetPricingCaches(t);
+  const dir = catalogDir(t);
+  const writePrice = (value) => writeCatalog(dir, 'pricing-litellm.json', {
+    timestamp: 0,
+    data: { model: { input_cost_per_token: value, output_cost_per_token: value } }
+  });
+  let lookupCalls = 0;
+  const lookupModelPricing = async () => {
+    lookupCalls += 1;
+    throw new Error('offline');
+  };
+
+  writePrice(1);
+  const first = await resolvePromaPricing(
+    [{ model: 'model' }],
+    { lookupModelPricing, pricingRevision: 1, nowMs: 1000, configDir: dir }
+  );
+  writePrice(22);
+  const second = await resolvePromaPricing(
+    [{ model: 'model' }],
+    { lookupModelPricing, pricingRevision: 1, nowMs: 2000, configDir: dir }
+  );
+
+  assert.equal(first.model.inputCostPerToken, 1);
+  assert.equal(second.model.inputCostPerToken, 22);
+  assert.equal(lookupCalls, 2);
+});
+
+test('missing cache-write rate keeps a partially priced Proma row unavailable', (t) => {
+  resetPricingCaches(t);
+  const dir = catalogDir(t);
+  writeCatalog(dir, 'pricing-litellm.json', {
+    timestamp: 0,
+    data: {
+      'provider/model-x': {
+        input_cost_per_token: 1,
+        output_cost_per_token: 2,
+        cache_creation_input_token_cost: null
+      }
+    }
+  });
+  const pricing = readTokscalePricingCatalog('model-x', { configDir: dir });
+  const periods = buildPromaPeriods({
+    now: new Date(),
+    rows: [{
+      sessionId: 'session',
+      model: 'model-x',
+      input: 10,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 10,
+      messages: 1,
+      createdAt: Date.now()
+    }],
+    pricingByModel: { 'model-x': pricing }
+  });
+
+  assert.equal(pricing.cacheCreationInputTokenCost, undefined);
+  assert.equal(periods.today.entries[0].cost, 0);
+});
+
+test('normalizePromaPricing keeps null command rates unavailable', () => {
+  assert.deepEqual(
+    normalizePromaPricing({ pricing: { inputCostPerToken: 1e-7, outputCostPerToken: 2e-7, cacheReadInputTokenCost: null } }),
+    {
+      inputCostPerToken: 1e-7,
+      outputCostPerToken: 2e-7,
+      cacheReadInputTokenCost: undefined,
+      cacheCreationInputTokenCost: undefined
+    }
+  );
+});
+
+test('normalizePromaPricing rejects coercive command rates', () => {
+  assert.equal(normalizePromaPricing({ pricing: {
+    inputCostPerToken: true,
+    outputCostPerToken: [],
+    cacheReadInputTokenCost: ' ',
+    cacheCreationInputTokenCost: {}
+  } }), null);
 });
 
 test('resolvePromaPricing keeps the command result when the lookup succeeds', async (t) => {
-  resetPromaPricingCache();
-  resetTokscaleCatalogCache();
+  resetPricingCaches(t);
   const dir = catalogDir(t);
   writeCatalog(dir, 'pricing-litellm.json', {
     timestamp: 0,
@@ -125,17 +348,16 @@ test('resolvePromaPricing keeps the command result when the lookup succeeds', as
     [{ model: 'deepseek-v4-flash' }],
     { lookupModelPricing, pricingRevision: 1, nowMs: 1000, configDir: dir }
   );
-  // The successful (fresher) command result wins over the local catalog.
   assert.equal(pricing['deepseek-v4-flash'].inputCostPerToken, 9e-7);
-  resetPromaPricingCache();
-  resetTokscaleCatalogCache();
 });
 
 test('resolvePromaPricing stays cost-unavailable when neither lookup nor catalog know the model', async (t) => {
-  resetPromaPricingCache();
-  resetTokscaleCatalogCache();
+  resetPricingCaches(t);
   const dir = catalogDir(t);
-  writeCatalog(dir, 'pricing-litellm.json', { timestamp: 0, data: { 'x/known': { input_cost_per_token: 1e-7 } } });
+  writeCatalog(dir, 'pricing-litellm.json', {
+    timestamp: 0,
+    data: { 'x/known': { input_cost_per_token: 1e-7, output_cost_per_token: 2e-7 } }
+  });
 
   const lookupModelPricing = async () => { throw new Error('offline'); };
   const pricing = await resolvePromaPricing(
@@ -143,6 +365,4 @@ test('resolvePromaPricing stays cost-unavailable when neither lookup nor catalog
     { lookupModelPricing, pricingRevision: 1, nowMs: 1000, configDir: dir }
   );
   assert.deepEqual(pricing, {});
-  resetPromaPricingCache();
-  resetTokscaleCatalogCache();
 });

--- a/tests/shared/tokscalePricingCatalog.test.js
+++ b/tests/shared/tokscalePricingCatalog.test.js
@@ -1,0 +1,148 @@
+'use strict';
+
+// Local clients' (e.g. Proma) costs fall back to tokscale's own pricing catalog cache
+// (cache/pricing-{litellm,openrouter,models-dev}.json) when the `tokscale
+// pricing` lookup fails — e.g. offline, where the command itself would wait
+// 20-30s of network timeouts before using that same cache. These tests pin the
+// local-cache parsing and the fallback wiring in resolvePromaPricing.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  readTokscalePricingCatalog,
+  resetPromaPricingCache,
+  resetTokscaleCatalogCache,
+  resolvePromaPricing,
+  tokscalePricingCatalog
+} = require('../../src/shared/collector');
+
+function catalogDir(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tokscale-pricing-catalog-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function writeCatalog(dir, fileName, data) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, fileName), JSON.stringify(data));
+}
+
+test('tokscalePricingCatalog parses litellm cache and strips provider prefixes', (t) => {
+  resetTokscaleCatalogCache();
+  const dir = catalogDir(t);
+  writeCatalog(dir, 'pricing-litellm.json', {
+    timestamp: 0,
+    data: {
+      'deepseek/deepseek-v4-flash': {
+        input_cost_per_token: 1.4e-7,
+        output_cost_per_token: 2.8e-7,
+        cache_read_input_token_cost: 2.8e-9,
+        cache_creation_input_token_cost: 0
+      },
+      'opencode-go/deepseek-v4-pro': {
+        input_cost_per_token: 4.35e-7,
+        output_cost_per_token: 8.7e-7,
+        cache_read_input_token_cost: 3.625e-9,
+        cache_creation_input_token_cost: null
+      }
+    }
+  });
+
+  const catalog = tokscalePricingCatalog({ configDir: dir });
+  assert.deepEqual(catalog.get('deepseek-v4-flash'), {
+    inputCostPerToken: 1.4e-7,
+    outputCostPerToken: 2.8e-7,
+    cacheReadInputTokenCost: 2.8e-9,
+    cacheCreationInputTokenCost: 0
+  });
+  assert.equal(catalog.get('deepseek-v4-pro').outputCostPerToken, 8.7e-7);
+  assert.equal(readTokscalePricingCatalog('DeepSeek-V4-Flash', { configDir: dir }).inputCostPerToken, 1.4e-7);
+  resetTokscaleCatalogCache();
+});
+
+test('tokscalePricingCatalog skips missing or malformed cache files', (t) => {
+  resetTokscaleCatalogCache();
+  const dir = catalogDir(t);
+  writeCatalog(dir, 'pricing-litellm.json', 'not json {');
+  writeCatalog(dir, 'pricing-openrouter.json', { timestamp: 0, data: { 'openai/gpt-4o': { input_cost_per_token: 2.5e-6 } } });
+  const catalog = tokscalePricingCatalog({ configDir: dir });
+  assert.equal(catalog.get('gpt-4o').inputCostPerToken, 2.5e-6);
+  assert.equal(catalog.size, 1);
+  resetTokscaleCatalogCache();
+});
+
+test('resolvePromaPricing falls back to the local catalog when the lookup fails offline', async (t) => {
+  resetPromaPricingCache();
+  resetTokscaleCatalogCache();
+  const dir = catalogDir(t);
+  writeCatalog(dir, 'pricing-litellm.json', {
+    timestamp: 0,
+    data: {
+      'deepseek/deepseek-v4-flash': {
+        input_cost_per_token: 1.4e-7,
+        output_cost_per_token: 2.8e-7,
+        cache_read_input_token_cost: 2.8e-9,
+        cache_creation_input_token_cost: 0
+      }
+    }
+  });
+
+  let lookupCalls = 0;
+  const lookupModelPricing = async () => {
+    lookupCalls += 1;
+    throw new Error('tokscale pricing timed out after 3000ms');
+  };
+  const pricing = await resolvePromaPricing(
+    [{ model: 'deepseek-v4-flash' }],
+    { lookupModelPricing, pricingRevision: 1, nowMs: 1000, configDir: dir }
+  );
+  assert.deepEqual(pricing['deepseek-v4-flash'], {
+    inputCostPerToken: 1.4e-7,
+    outputCostPerToken: 2.8e-7,
+    cacheReadInputTokenCost: 2.8e-9,
+    cacheCreationInputTokenCost: 0
+  });
+  assert.equal(lookupCalls, 1);
+  resetPromaPricingCache();
+  resetTokscaleCatalogCache();
+});
+
+test('resolvePromaPricing keeps the command result when the lookup succeeds', async (t) => {
+  resetPromaPricingCache();
+  resetTokscaleCatalogCache();
+  const dir = catalogDir(t);
+  writeCatalog(dir, 'pricing-litellm.json', {
+    timestamp: 0,
+    data: { 'deepseek/deepseek-v4-flash': { input_cost_per_token: 1.4e-7, output_cost_per_token: 2.8e-7 } }
+  });
+
+  const lookupModelPricing = async () => ({ pricing: { inputCostPerToken: 9e-7, outputCostPerToken: 9e-7 } });
+  const pricing = await resolvePromaPricing(
+    [{ model: 'deepseek-v4-flash' }],
+    { lookupModelPricing, pricingRevision: 1, nowMs: 1000, configDir: dir }
+  );
+  // The successful (fresher) command result wins over the local catalog.
+  assert.equal(pricing['deepseek-v4-flash'].inputCostPerToken, 9e-7);
+  resetPromaPricingCache();
+  resetTokscaleCatalogCache();
+});
+
+test('resolvePromaPricing stays cost-unavailable when neither lookup nor catalog know the model', async (t) => {
+  resetPromaPricingCache();
+  resetTokscaleCatalogCache();
+  const dir = catalogDir(t);
+  writeCatalog(dir, 'pricing-litellm.json', { timestamp: 0, data: { 'x/known': { input_cost_per_token: 1e-7 } } });
+
+  const lookupModelPricing = async () => { throw new Error('offline'); };
+  const pricing = await resolvePromaPricing(
+    [{ model: 'private-channel-alias' }],
+    { lookupModelPricing, pricingRevision: 1, nowMs: 1000, configDir: dir }
+  );
+  assert.deepEqual(pricing, {});
+  resetPromaPricingCache();
+  resetTokscaleCatalogCache();
+});


### PR DESCRIPTION
## What

`tokscale pricing` refreshes its catalog over the network and only falls back to its local cache after 20-30s of network timeouts. The collector's pricing lookup budget is 3s, so on offline/restricted machines locally parsed clients (Proma) showed zero cost even when the price was already on disk.

This change reads tokscale's own catalog cache files (`~/.config/tokscale/cache/pricing-{litellm,openrouter,models-dev}.json`) directly when the pricing command fails — zero network, zero wait.

## Why

- The command is authoritative when it succeeds (fresher, better matching) and still runs first; the fallback only fires on timeout/offline failure.
- The fallback is an exact model-id lookup, so it can never substitute one model's price for another — worst case it stays cost-unavailable (the previous behaviour), never a wrong price.
- It parses once per file revision (size+mtime), so repeated ticks don't re-parse ~8.7K catalog entries.

## Scope

- `src/shared/collector.js`: local catalog cache parsing + fallback in `resolveModelPricing`
- `tests/shared/tokscalePricingCatalog.test.js`: 5 tests (parse, provider-prefix strip, malformed-file tolerance, offline fallback integration, command-still-wins)

No new dependencies; `collector.js` is not part of the Worker closure, so no `sync:worker`.

## Verification

`npm run verify` — lint clean, 3205/3206 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Falls back to `tokscale`’s local pricing catalog when the network lookup fails, so offline machines compute model costs within the 3s budget. Previously the command waited ~20–30s and returned zero cost; now we read `~/.config/tokscale/cache/pricing-*.json` immediately on failure.

- Aligns fallback rules with `tokscale`: exact keys win; bare ids use terminal-key matches only when all candidates publish identical rates; provider-scoped ids and routing labels (`auto`, `agent_review`) never borrow terminal matches.
- Discovers the catalog in canonical cache and legacy roots; honors `TOKSCALE_CONFIG_DIR` with canonical-first, hermetic discovery; on Windows, `HOME` overrides affect only the legacy home-rooted cache.
- Memoizes by file path/size/mtime and defers future-dated sources; any catalog change or eligibility shift invalidates the Proma pricing cache.
- Normalizes and validates rates; tolerates missing/malformed files and nulls; if no safe match, price stays unavailable. Command results still win when available.

<sup>Written for commit e425dc0a025e1ddf87259761e75632a8588b7bb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

