### PR TITLE
fix(wsl): count WSL ZCode usage by staging its SQLite DB for tokscale

### DIFF
--- a/docs/wsl-sqlite-setup.md
+++ b/docs/wsl-sqlite-setup.md
@@ -8,6 +8,8 @@ On Windows, Token Monitor normally scans supported tools inside every running WS
 
 OpenCode and Hermes store current usage in SQLite databases. A Windows process can discover those databases through `\\wsl$` while SQLite still cannot reliably coordinate locks or an active WAL across the WSL 9P boundary. Token Monitor may therefore show the tool under **Settings → Collection → WSL detection** with no usage.
 
+ZCode is handled automatically: its `~/.zcode/cli/db/db.sqlite` database (with WAL sidecars) is staged into a local temp home on every refresh tick, so WSL ZCode usage is counted out of the box. The staged copy is best-effort per tick — a torn copy at worst yields one empty tick that self-corrects five minutes later — so the headless-agent setup below remains the exact option.
+
 Do not copy a live `.db` file as a workaround. Recent transactions may still be in `-wal`, and copying the database and sidecars separately does not guarantee a consistent snapshot.
 
 The reliable setup is:

--- a/docs/wsl-sqlite-setup.zh-CN.md
+++ b/docs/wsl-sqlite-setup.zh-CN.md
@@ -8,6 +8,8 @@ Windows 版 Token Monitor 默认会通过 `\\wsl$` 扫描所有正在运行的 W
 
 OpenCode 和 Hermes 的当前用量保存在 SQLite 数据库中。Windows 进程可以通过 `\\wsl$` 找到数据库，但 SQLite 无法可靠地跨 WSL 9P 边界协调文件锁和正在使用的 WAL。因此，Token Monitor 可能会在 **设置 → 采集 → WSL 检测** 里显示已找到工具，却没有用量。
 
+ZCode 已自动处理：每次刷新都会把 `~/.zcode/cli/db/db.sqlite`（含 WAL sidecar）暂存到本地临时目录再扫描，WSL 中的 ZCode 用量开箱即得。暂存副本按 tick 尽力而为——撕裂副本最坏只会让该次刷新读到空数据，五分钟后自动修正；如需精确计数，仍可使用下文的 headless agent 方案。
+
 不要把复制正在使用的 `.db` 文件当作解决方案。最新事务可能还在 `-wal` 中，而分别复制数据库与 sidecar 文件也无法保证得到一致快照。
 
 可靠的架构是：

--- a/src/shared/wslUsage.js
+++ b/src/shared/wslUsage.js
@@ -1,12 +1,26 @@
 'use strict';
 
 const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 const { emptyPeriod, extractUsageFromTokscale, mergePeriods } = require('./usage');
 const { REASONIX_CLIENT } = require('./reasonixPaths');
 const { buildPromaPeriods, collectPromaRows } = require('./promaUsage');
 
 const LXSS_KEY = 'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss';
+
+// ZCode stores usage in a SQLite DB under `.zcode/cli/db`. Tokscale discovers
+// the file under a `\\wsl$` home but its SQLite read silently returns zero
+// messages over the 9P redirector (same class of issue as hermes WSL homes,
+// which report detected-but-empty), so the DB is staged into a local temp home
+// and tokscale scans the staged copy instead. WAL sidecars are copied alongside
+// so writes not yet checkpointed into the main DB are not lost; a torn copy at
+// worst yields one empty scan, never a crash.
+const ZCODE_CLIENT = 'zcode';
+const ZCODE_DB_MARKER = '.zcode/cli/db';
+const ZCODE_DB_FILES = ['db.sqlite', 'db.sqlite-wal', 'db.sqlite-shm'];
+const ZCODE_STAGE_MAX_BYTES = 512 * 1024 * 1024;
 
 // Relative (Linux-style) paths under a WSL home. If any exists, a tracked client
 // stores data there and the home is worth a tokscale scan. These mirror the roots
@@ -39,6 +53,7 @@ const WSL_DATA_MARKERS = [
   '.vscode-server/data/User/globalStorage/kilocode.kilo-code/tasks',
   '.local/share/mimocode/mimocode.db',
   '.zcode/projects',
+  '.zcode/cli/db',
   '.kiro/sessions',
   '.local/share/kiro-cli/data.sqlite3',
   '.config/Kiro/User/globalStorage/kiro.kiroagent',
@@ -79,6 +94,7 @@ const MARKER_CLIENTS = {
   '.vscode-server/data/User/globalStorage/kilocode.kilo-code/tasks': 'kilocode',
   '.local/share/mimocode/mimocode.db': 'micode',
   '.zcode/projects': 'zcode',
+  '.zcode/cli/db': 'zcode',
   '.kiro/sessions': 'kiro',
   '.local/share/kiro-cli/data.sqlite3': 'kiro',
   '.config/Kiro/User/globalStorage/kiro.kiroagent': 'kiro',
@@ -139,6 +155,42 @@ function listRunningWslDistros(deps = {}) {
 // Empty array = no tracked client stores data here.
 function wslHomePath(home, relativePath) {
   return `${home}\\${relativePath.replace(/\//g, '\\')}`;
+}
+
+// Copies a WSL home's zcode SQLite DB (plus WAL sidecars) into a fresh local
+// temp home tokscale can read, and returns the staged home path. Throws when
+// the DB is missing/unreadable or too large to stage; the caller logs and moves
+// on, leaving detection-only attribution for that home.
+function stageZcodeHome(home, deps = {}) {
+  const mkdtempSync = deps.mkdtempSync || fs.mkdtempSync;
+  const mkdirSync = deps.mkdirSync || fs.mkdirSync;
+  const cpSync = deps.cpSync || fs.cpSync;
+  const statSync = deps.statSync || fs.statSync;
+  const dbDir = wslHomePath(home, ZCODE_DB_MARKER);
+  const staged = mkdtempSync(path.join(os.tmpdir(), 'token-monitor-zcode-'));
+  try {
+    const stagedDbDir = path.join(staged, '.zcode', 'cli', 'db');
+    mkdirSync(stagedDbDir, { recursive: true });
+    for (const name of ZCODE_DB_FILES) {
+      const source = `${dbDir}\\${name}`; // Windows-style join: dbDir is a \\wsl$ UNC path
+      let size;
+      try {
+        size = statSync(source).size;
+      } catch (_) {
+        continue; // sidecars are optional; a missing main DB fails at the tokscale scan
+      }
+      if (name === 'db.sqlite' && size > ZCODE_STAGE_MAX_BYTES) {
+        throw new Error(`zcode DB too large to stage (${size} bytes)`);
+      }
+      cpSync(source, path.join(stagedDbDir, name));
+    }
+    return staged;
+  } catch (error) {
+    try {
+      fs.rmSync(staged, { recursive: true, force: true });
+    } catch (_) { /* best-effort cleanup */ }
+    throw error;
+  }
 }
 
 function homeHasData(home, existsSync, readdirSync = fs.readdirSync) {
@@ -205,10 +257,13 @@ async function collectWslUsage(options = {}, deps = {}) {
   // Reasonix aggregate usage is supported on the host, but remains excluded
   // from WSL scans: Tokscale's Windows PathRoot::ReasonixHome conflicts with
   // the Linux-default `.reasonix/stats` path inside WSL. Native session files
-  // are local-only as well.
+  // are local-only as well. zcode is excluded for a different reason: its
+  // SQLite DB reads empty over the 9P redirector, so WSL zcode usage is
+  // collected via the staged-home scan below instead of the per-home tokscale
+  // pass (also preventing double counting once tokscale's UNC read is fixed).
   const tracked = new Set(String(trackedClients).split(',').map((c) => c.trim()).filter(Boolean));
   const clientsCsv = String(clients || '').split(',').map((c) => c.trim()).filter(Boolean)
-    .filter((client) => client !== REASONIX_CLIENT)
+    .filter((client) => client !== REASONIX_CLIENT && client !== ZCODE_CLIENT)
     .join(',');
   for (const home of wslUsageHomes(deps)) {
     // Attribution is marker-based, independent of whether a parser returns data.
@@ -242,6 +297,34 @@ async function collectWslUsage(options = {}, deps = {}) {
         if (typeof logger === 'function') logger(`wsl Proma usage parse failed for ${home}: ${error.message}`);
       }
     }
+    // ZCode usage lives in a SQLite DB, which tokscale cannot read in place
+    // over `\\wsl$` (zero messages; see stageZcodeHome). Stage the DB into a
+    // local temp home and scan that so WSL zcode contributes real usage, not
+    // merely marker detection.
+    if (tracked.has(ZCODE_CLIENT) && homeDataClients.includes(ZCODE_CLIENT) && typeof runTokscale === 'function') {
+      let stagedHome = null;
+      try {
+        stagedHome = stageZcodeHome(home, deps);
+        const stagedPeriods = {
+          today: extractUsageFromTokscale(await runTokscale({ clients: ZCODE_CLIENT, flags: ['--today', '--home', stagedHome], commandTimeoutMs })),
+          month: extractUsageFromTokscale(await runTokscale({ clients: ZCODE_CLIENT, flags: ['--month', '--home', stagedHome], commandTimeoutMs })),
+          allTime: extractUsageFromTokscale(await runTokscale({ clients: ZCODE_CLIENT, flags: ['--since', allTimeSince, '--home', stagedHome], commandTimeoutMs }))
+        };
+        if (typeof decoratePeriods === 'function') decoratePeriods(stagedPeriods, home);
+        bundle.today = mergePeriods(bundle.today, stagedPeriods.today);
+        bundle.month = mergePeriods(bundle.month, stagedPeriods.month);
+        bundle.allTime = mergePeriods(bundle.allTime, stagedPeriods.allTime);
+      } catch (error) {
+        if (typeof logger === 'function') logger(`wsl ZCode usage scan failed for ${home}: ${error.message}`);
+      } finally {
+        if (stagedHome) {
+          const rmSync = deps.rmSync || fs.rmSync;
+          try {
+            rmSync(stagedHome, { recursive: true, force: true });
+          } catch (_) { /* best-effort cleanup */ }
+        }
+      }
+    }
     // Tokscale 4.6+ keeps explicit --home scans isolated from host-native roots,
     // so every requested client can be passed through for each discovered home.
     // Keep the empty guard because an empty --client expands to all clients.
@@ -270,11 +353,13 @@ async function collectWslUsage(options = {}, deps = {}) {
 module.exports = {
   WSL_DATA_MARKERS,
   MARKER_CLIENTS,
+  ZCODE_DB_MARKER,
   collectWslUsage,
   emptyWslBundle,
   homeHasData,
   isWslInstalled,
   listRunningWslDistros,
   probeWslState,
+  stageZcodeHome,
   wslUsageHomes
 };

--- a/tests/shared/wslUsage.test.js
+++ b/tests/shared/wslUsage.test.js
@@ -418,3 +418,104 @@ test('collectWslUsage logs and skips a home that throws, keeps others', async ()
   assert.equal(logs.length, 1);
   assert.match(logs[0], /Debian/);
 });
+
+// --- zcode WSL staging -------------------------------------------------------
+
+test('homeHasData maps the zcode CLI DB dir marker to zcode', () => {
+  const home = '\\\\wsl$\\Ubuntu\\home\\u';
+  const present = new Set([`${home}\\.zcode\\cli\\db`]);
+  const ids = homeHasData(home, (p) => present.has(p));
+  assert.deepEqual(ids, ['zcode']);
+});
+
+function zcodeStagingDeps(home, overrides = {}) {
+  const staged = 'C:\\Temp\\token-monitor-zcode-STAGED';
+  const copied = [];
+  const removed = [];
+  const deps = {
+    platform: 'win32',
+    exec: (cmd) => (cmd === 'reg' ? 'Lxss' : 'Ubuntu\n'),
+    readdirSync: () => ['u'],
+    existsSync: (p) => p === `${home}\\.zcode\\cli\\db`,
+    mkdtempSync: () => staged,
+    mkdirSync: () => {},
+    cpSync: (src, dst) => copied.push([src, dst]),
+    statSync: (p) => ({ size: p.endsWith('db.sqlite') ? 2048 : 512 }),
+    rmSync: (p) => removed.push(p)
+  };
+  return Object.assign(deps, { staged, copied, removed }, overrides);
+}
+
+test('stageZcodeHome copies the DB and its WAL sidecars into a temp home', () => {
+  const home = '\\\\wsl$\\Ubuntu\\home\\u';
+  const deps = zcodeStagingDeps(home);
+  const { stageZcodeHome, ZCODE_DB_MARKER } = require('../../src/shared/wslUsage');
+  const staged = stageZcodeHome(home, deps);
+  assert.equal(staged, deps.staged);
+  assert.deepEqual(deps.copied.map(([src]) => src), [
+    path(home, ZCODE_DB_MARKER, 'db.sqlite'),
+    path(home, ZCODE_DB_MARKER, 'db.sqlite-wal'),
+    path(home, ZCODE_DB_MARKER, 'db.sqlite-shm')
+  ]);
+  function path(root, dir, file) {
+    return `${root}\\${dir.replace(/\//g, '\\')}\\${file}`;
+  }
+});
+
+test('collectWslUsage scans the staged zcode home and merges real usage', async () => {
+  const home = '\\\\wsl$\\Ubuntu\\home\\u';
+  const deps = zcodeStagingDeps(home);
+  const tokscaleCalls = [];
+  const runTokscale = async ({ clients, flags }) => {
+    tokscaleCalls.push({ clients, home: flags[flags.indexOf('--home') + 1] });
+    return { entries: [{ client: 'zcode', sessionId: 's1', model: 'glm-5.3', input: 11, output: 0, cost: 0 }] };
+  };
+  const { bundle, detected } = await collectWslUsage(
+    { clients: 'zcode', trackedClients: 'zcode', allTimeSince: '2025-01-01', commandTimeoutMs: 1000, runTokscale },
+    deps
+  );
+  assert.deepEqual(detected, ['zcode']);
+  // 3 period scans, all against the staged temp home, never the 9P home.
+  assert.equal(tokscaleCalls.length, 3);
+  assert.ok(tokscaleCalls.every((c) => c.clients === 'zcode' && c.home === deps.staged));
+  assert.equal(bundle.today.clients.zcode, 11);
+  assert.deepEqual(deps.removed, [deps.staged]); // staged home cleaned up
+});
+
+test('collectWslUsage keeps zcode out of the per-home tokscale pass', async () => {
+  const home = '\\\\wsl$\\Ubuntu\\home\\u';
+  const deps = zcodeStagingDeps(home);
+  deps.existsSync = (p) => p === `${home}\\.zcode\\cli\\db` || p === `${home}\\.codex\\sessions`;
+  const passClients = [];
+  const runTokscale = async ({ clients, flags }) => {
+    if (flags[flags.indexOf('--home') + 1] === home) passClients.push(clients);
+    return { entries: [] };
+  };
+  await collectWslUsage(
+    { clients: 'zcode,codex', trackedClients: 'zcode,codex', allTimeSince: '2025-01-01', commandTimeoutMs: 1000, runTokscale },
+    deps
+  );
+  // The per-home pass must not include zcode (staged scan owns it) but keeps codex.
+  assert.deepEqual([...new Set(passClients)], ['codex']);
+});
+
+test('collectWslUsage logs and skips an oversized zcode DB', async () => {
+  const home = '\\\\wsl$\\Ubuntu\\home\\u';
+  const deps = zcodeStagingDeps(home, {
+    statSync: (p) => ({ size: p.endsWith('db.sqlite') ? 2 * 1024 * 1024 * 1024 : 512 })
+  });
+  const logs = [];
+  let stagedRuns = 0;
+  const runTokscale = async ({ flags }) => {
+    if (flags[flags.indexOf('--home') + 1] === deps.staged) stagedRuns++;
+    return { entries: [] };
+  };
+  const { detected } = await collectWslUsage(
+    { clients: 'zcode', trackedClients: 'zcode', allTimeSince: '2025-01-01', commandTimeoutMs: 1000, runTokscale, logger: (m) => logs.push(m) },
+    deps
+  );
+  assert.deepEqual(detected, ['zcode']); // still detected, just not scanned
+  assert.equal(stagedRuns, 0);
+  assert.equal(logs.length, 1);
+  assert.match(logs[0], /too large/);
+});


### PR DESCRIPTION
## What

WSL ZCode usage was detected but never counted. Tokscale discovers `~/.zcode/cli/db/db.sqlite` under a `\\wsl$` home (its `clients` report even marks the file as found) but the SQLite read silently returns **zero messages** over the 9P redirector — the same class of issue documented for Hermes WSL homes. As a result the README's WSL support mark for ZCode never produced actual numbers without the headless-agent setup.

### Implementation

- New WSL marker `.zcode/cli/db` (alongside legacy `.zcode/projects`), so a CLI-DB-only WSL home is discovered and attributed to `zcode`.
- `collectWslUsage` stages the zcode DB (plus `db.sqlite-wal` / `db.sqlite-shm`, so un-checkpointed writes survive) into a local temp home under `os.tmpdir()`, scans today/month/allTime with tokscale against the staged home, decorates and merges like the other per-home passes, and always removes the staged dir in a `finally`.
- `zcode` is excluded from the per-home tokscale pass (mirroring the Reasonix exclusion): the staged scan is the single source of WSL zcode numbers, which also prevents double counting if tokscale's UNC SQLite read is ever fixed.
- Size guard: DBs larger than 512 MB are not staged (logged; detection-only) so a huge DB cannot stall the 5-minute refresh tick on a 9P copy.

### Notes / decisions

- The staged copy is best-effort per tick: a torn WAL copy at worst yields one empty tick that self-corrects on the next refresh — never a crash, and the source DB is never touched. The headless-agent setup in `docs/wsl-sqlite-setup.md` remains the exact option; both docs (en / zh-CN) now note that ZCode is handled automatically.
- Reuses tokscale's existing zcode parser — no new sqlite dependency.

## Verification

- `node --test tests/shared/wslUsage.test.js`: 34 pass, including 5 new tests (marker mapping, staging file set incl. WAL sidecars, staged-scan merge + temp cleanup, zcode excluded from the per-home tokscale pass, oversized-DB skip).
- Full suite `node --test "tests/**/*.test.js"`: 3073/3080 pass. The 2 failures are pre-existing and environment-specific — verified identical on a pristine checkout of `main` on this machine (`clientTracking`: "default tracked clients are supported by tokscale or a native adapter" requires `@tokscale/cli-linux-x64-gnu`, absent from a Windows `npm ci`; `collectorLoadGuards`: a timing/coalescing assertion).
- End-to-end against a real `\\wsl$\\Ubuntu-24.04` home: before the change `tokscale clients --home <wsl-home>` reports `~\\.zcode/cli/db/db.sqlite ✓ / messages: 0`; with the staged scan the same home returns the same rows as a local copy of the same DB (33.1M tokens for today on the test machine).

## Screenshots

*(none — backend collection change)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Counts WSL ZCode usage by staging its SQLite DB into a local temp home for tokscale. Previously tokscale found the DB under \\wsl$ but returned zero messages; now we copy the DB (and WAL sidecars), scan, and merge real usage.

- Adds a WSL data marker for `.zcode/cli/db` to attribute homes to `zcode`.
- Stages `db.sqlite`, `db.sqlite-wal`, and `db.sqlite-shm` to `os.tmpdir()`, scans today/month/all-time with tokscale, and always cleans up the staged dir.
- Excludes `zcode` from the per-home tokscale pass; the staged scan is the single source, preventing double counting if UNC reads are fixed later.
- Skips staging and logs when the main DB exceeds 512 MB to keep the 5-minute tick responsive.
- Updates WSL SQLite docs to note ZCode is handled automatically; adds tests for marker mapping, staging set, merge/cleanup, per-home exclusion, and oversize guard.

<sup>Written for commit d4edcce3e971de0f3413bfd49b9ec1899c08d00b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Closes #425