### PR TITLE
docs(readme): mark Reasonix session details as supported

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -57,7 +57,7 @@ Token Monitor は **トークン使用量**、**アカウント制限**、**セ�
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`, `~/.workbuddy/workbuddy.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/proma.png" width="28" alt="Proma" /> | Proma | `~/.proma/agent-sessions/*.jsonl` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/qoder.png" width="28" alt="Qoder" /> | Qoder | `<platform-app-data>/QoderCN/SharedClientCache/cache/db/local.db`（中国版のみ）；Qoder dashboard cookie（Qoder usage API で big-model credits 取得） | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/reasonix.png" width="28" alt="Reasonix" /> | Reasonix | `~/.reasonix/`（`stats/`、`sessions/`、`projects/*/sessions/`） | ✅ | — | — |
+| <img src=".github/assets/tools-icon/reasonix.png" width="28" alt="Reasonix" /> | Reasonix | `~/.reasonix/`（`stats/`、`sessions/`、`projects/*/sessions/`） | ✅ | — | ✅ |
 | <img src=".github/assets/tools-icon/deepseek.png" width="28" alt="DeepSeek" /> | DeepSeek | DeepSeek API キー（DeepSeek API で残高取得） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/openrouter.png" width="28" alt="OpenRouter" /> | OpenRouter | OpenRouter API キー（使用量／キー上限。creditsアクセス許可時は残高も表示。公式文書ではManagementキーを指定） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/minimax.png" width="28" alt="Minimax" /> | Minimax | Minimax API キー（Minimax API で Token Plan クォータ取得） | — | ✅ | — |
@@ -114,7 +114,7 @@ Qoder CN のトークン使用量は API ではなくアプリのローカル SQ
 ### 使用量の追跡
 
 - **リアルタイムトークン追跡** — Claude Code、Codex、Cursor、GitHub Copilot、Antigravity、OpenCode など 24+ 種類の AI ツール、各ターンから数秒以内に UI 更新（全リストは上の表を参照）
-- **セッション別詳細** — Claude Code、Codex、OpenCode セッションでプロンプトごとのトークン、各応答のトークン分割・使用ツールまで展開（ローカル transcript/DB を必要時のみ読み込み、同期しない）
+- **セッション別詳細** — Claude Code、Codex、OpenCode、Reasonix セッションでプロンプトごとのトークン、各応答のトークン分割・使用ツールまで展開（ローカル transcript/DB を必要時のみ読み込み、同期しない）
 - **キャッシュヒット統計** — ツール・モデルをクリックすると入力トークン（キャッシュ hit/miss）、出力トークン、ヒット率の詳細
 - **コストと通貨** — トークン数とともにコストを表示。USD、TWD、HKD、CNY に対応し、為替レートは毎日自動更新、設定で手動上書き可能
 - **WSL 使用量 (Windows)** — 実行中の WSL ディストリビューションにあるファイルベースの使用量を約 5 分ごとに自動検出して合算。OpenCode や Hermes など SQLite ベースのツールでは、[WSL 内のヘッドレスエージェント](docs/wsl-sqlite-setup.md)が必要になる場合があります

--- a/README.ko.md
+++ b/README.ko.md
@@ -57,7 +57,7 @@ Token Monitor는 **토큰 사용량**, **계정 한도**, **세션 상세**를 �
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`, `~/.workbuddy/workbuddy.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/proma.png" width="28" alt="Proma" /> | Proma | `~/.proma/agent-sessions/*.jsonl` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/qoder.png" width="28" alt="Qoder" /> | Qoder | `<platform-app-data>/QoderCN/SharedClientCache/cache/db/local.db`(중국판 전용); Qoder dashboard cookie (Qoder usage API로 big-model credits 조회) | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/reasonix.png" width="28" alt="Reasonix" /> | Reasonix | `~/.reasonix/` (`stats/`, `sessions/`, `projects/*/sessions/`) | ✅ | — | — |
+| <img src=".github/assets/tools-icon/reasonix.png" width="28" alt="Reasonix" /> | Reasonix | `~/.reasonix/` (`stats/`, `sessions/`, `projects/*/sessions/`) | ✅ | — | ✅ |
 | <img src=".github/assets/tools-icon/deepseek.png" width="28" alt="DeepSeek" /> | DeepSeek | DeepSeek API 키 (DeepSeek API로 잔액 조회) | — | ✅ | — |
 | <img src=".github/assets/tools-icon/openrouter.png" width="28" alt="OpenRouter" /> | OpenRouter | OpenRouter API 키 (사용량/키 한도, credits 접근 승인 시 잔액 표시; 공식 문서는 Management 키 지정) | — | ✅ | — |
 | <img src=".github/assets/tools-icon/minimax.png" width="28" alt="Minimax" /> | Minimax | Minimax API 키 (Minimax API로 Token Plan 할당량 조회) | — | ✅ | — |
@@ -114,7 +114,7 @@ Qoder CN 토큰 사용량은 API가 아닌 앱의 로컬 SQLite 데이터베이�
 ### 사용량 추적
 
 - **실시간 토큰 추적** — Claude Code, Codex, Cursor, GitHub Copilot, Antigravity, OpenCode 등 24개 이상의 AI 도구, 턴당 수 초 내 UI 갱신 (전체 목록은 위 표 참고)
-- **세션별 상세** — Claude Code, Codex, OpenCode 세션에서 프롬프트별 토큰, 응답별 토큰 분할·사용 도구까지 확장 (로컬 transcript/DB를 필요할 때만 읽으며 동기화하지 않음)
+- **세션별 상세** — Claude Code, Codex, OpenCode, Reasonix 세션에서 프롬프트별 토큰, 응답별 토큰 분할·사용 도구까지 확장 (로컬 transcript/DB를 필요할 때만 읽으며 동기화하지 않음)
 - **캐시 히트 통계** — 도구·모델 클릭 시 입력 토큰(캐시 hit/miss), 출력 토큰, 히트율 상세
 - **비용과 통화** — 토큰 수와 함께 비용 표시. USD, TWD, HKD, CNY 지원, 환율은 매일 자동 갱신, 설정에서 수동 덮어쓰기 가능
 - **WSL 사용량 (Windows)** — 실행 중인 WSL 배포판의 파일 기반 사용량을 약 5분마다 자동 감지해 합산합니다. OpenCode와 Hermes 같은 SQLite 기반 도구는 [WSL 내부 헤드리스 에이전트](docs/wsl-sqlite-setup.md)가 필요할 수 있습니다

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Token Monitor supports token usage, account-limit checks, and session details se
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`, `~/.workbuddy/workbuddy.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/proma.png" width="28" alt="Proma" /> | Proma | `~/.proma/agent-sessions/*.jsonl` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/qoder.png" width="28" alt="Qoder" /> | Qoder | `<platform-app-data>/QoderCN/SharedClientCache/cache/db/local.db` (CN only); Qoder dashboard cookie (big-model credits via Qoder usage API) | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/reasonix.png" width="28" alt="Reasonix" /> | Reasonix | `~/.reasonix/` (`stats/`, `sessions/`, `projects/*/sessions/`) | ✅ | — | — |
+| <img src=".github/assets/tools-icon/reasonix.png" width="28" alt="Reasonix" /> | Reasonix | `~/.reasonix/` (`stats/`, `sessions/`, `projects/*/sessions/`) | ✅ | — | ✅ |
 | <img src=".github/assets/tools-icon/deepseek.png" width="28" alt="DeepSeek" /> | DeepSeek | DeepSeek API key (balance via DeepSeek API) | — | ✅ | — |
 | <img src=".github/assets/tools-icon/openrouter.png" width="28" alt="OpenRouter" /> | OpenRouter | OpenRouter API key (usage/key limit; balance when credits access is authorized, documented for Management keys) | — | ✅ | — |
 | <img src=".github/assets/tools-icon/minimax.png" width="28" alt="Minimax" /> | Minimax | Minimax API key (Token Plan quota via Minimax API) | — | ✅ | — |
@@ -114,7 +114,7 @@ Most usage monitors are useful on the machine they run on. Token Monitor is buil
 ### Tracking usage
 
 - **Live token tracking** — Claude Code, Codex, Cursor, GitHub Copilot, Antigravity, OpenCode, and 24+ AI tools, with the UI updating within seconds of each turn (full list in the table above)
-- **Per-session detail** — open a Claude Code, Codex, or OpenCode session to see tokens per prompt, expandable to each reply's exact token split and tools used (read on-demand from local transcripts or databases, never synced)
+- **Per-session detail** — open a Claude Code, Codex, OpenCode, or Reasonix session to see tokens per prompt, expandable to each reply's exact token split and tools used (read on-demand from local transcripts or databases, never synced)
 - **Cache hit statistics** — click any tool or model to expand a detailed breakdown of input tokens (cache hit vs miss), output tokens, and hit-rate percentages
 - **Cost & currency** — cost alongside token counts, shown in USD, TWD, HKD, or CNY; exchange rates auto-update daily and can be manually overridden in Settings
 - **WSL usage (Windows)** — file-based usage from a running WSL distro is detected automatically and merged about every 5 minutes; SQLite-backed tools such as OpenCode and Hermes may require a [headless agent inside WSL](docs/wsl-sqlite-setup.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,7 +57,7 @@ Token Monitor 对 Token 用量、账户额度和 session 明细分别支持：
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`、`~/.workbuddy/workbuddy.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/proma.png" width="28" alt="Proma" /> | Proma | `~/.proma/agent-sessions/*.jsonl` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/qoder.png" width="28" alt="Qoder" /> | Qoder | `<platform-app-data>/QoderCN/SharedClientCache/cache/db/local.db`（仅限中国版）；Qoder dashboard cookie（通过 Qoder usage API 查询 big-model credits） | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/reasonix.png" width="28" alt="Reasonix" /> | Reasonix | `~/.reasonix/`（`stats/`、`sessions/`、`projects/*/sessions/`） | ✅ | — | — |
+| <img src=".github/assets/tools-icon/reasonix.png" width="28" alt="Reasonix" /> | Reasonix | `~/.reasonix/`（`stats/`、`sessions/`、`projects/*/sessions/`） | ✅ | — | ✅ |
 | <img src=".github/assets/tools-icon/deepseek.png" width="28" alt="DeepSeek" /> | DeepSeek | DeepSeek API 密钥（通过 DeepSeek API 查询余额） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/openrouter.png" width="28" alt="OpenRouter" /> | OpenRouter | OpenRouter API 密钥（查询用量／密钥上限；获授权访问 credits 时显示余额，官方文档指定 Management 密钥） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/minimax.png" width="28" alt="Minimax" /> | Minimax | Minimax API 密钥（通过 Minimax API 查询 Token Plan 额度） | — | ✅ | — |
@@ -114,7 +114,7 @@ Qoder CN 的 Token 用量来自应用本地 SQLite 数据库，而非 API ——
 ### 用量追踪
 
 - **实时 Token 追踪**：Claude Code、Codex、Cursor、GitHub Copilot、Antigravity、OpenCode 等 24+ 种 AI 工具，每轮对话后 UI 在数秒内刷新（完整列表见上方表格）
-- **单个 session 明细**：点进 Claude Code、Codex 或 OpenCode 的 session，可看每条提问的 Token 消耗，并展开查看每次回复的 Token 拆分与用到的工具（打开时才实时读取本机 transcript 或数据库，绝不同步）
+- **单个 session 明细**：点进 Claude Code、Codex、OpenCode 或 Reasonix 的 session，可看每条提问的 Token 消耗，并展开查看每次回复的 Token 拆分与用到的工具（打开时才实时读取本机 transcript 或数据库，绝不同步）
 - **缓存命中统计**：点击任何工具或模型，展开查看输入 Token（缓存命中与未命中）、输出 Token 的详细分类及命中率百分比
 - **成本与币别**：Token 数量旁附带成本；可用 USD、TWD、HKD 或 CNY 显示，汇率每日自动更新，也可在设置中手动覆写
 - **WSL 用量（Windows）**：运行中 WSL 发行版里的文件型用量会自动识别，约每 5 分钟并入总量；OpenCode、Hermes 等 SQLite 来源可能需要按照[指南](docs/wsl-sqlite-setup.zh-CN.md)在 WSL 内运行 headless agent

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -57,7 +57,7 @@ Token Monitor 對 Token 用量、帳戶額度與 session 明細分別支援：
 | <img src=".github/assets/tools-icon/workbuddy.png" width="28" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/`、`~/.workbuddy/workbuddy.db` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/proma.png" width="28" alt="Proma" /> | Proma | `~/.proma/agent-sessions/*.jsonl` | ✅ | — | — |
 | <img src=".github/assets/tools-icon/qoder.png" width="28" alt="Qoder" /> | Qoder | `<platform-app-data>/QoderCN/SharedClientCache/cache/db/local.db`（僅限中國版）；Qoder dashboard cookie（透過 Qoder usage API 查詢 big-model credits） | ✅ | ✅ | — |
-| <img src=".github/assets/tools-icon/reasonix.png" width="28" alt="Reasonix" /> | Reasonix | `~/.reasonix/`（`stats/`、`sessions/`、`projects/*/sessions/`） | ✅ | — | — |
+| <img src=".github/assets/tools-icon/reasonix.png" width="28" alt="Reasonix" /> | Reasonix | `~/.reasonix/`（`stats/`、`sessions/`、`projects/*/sessions/`） | ✅ | — | ✅ |
 | <img src=".github/assets/tools-icon/deepseek.png" width="28" alt="DeepSeek" /> | DeepSeek | DeepSeek API 金鑰（透過 DeepSeek API 查詢餘額） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/openrouter.png" width="28" alt="OpenRouter" /> | OpenRouter | OpenRouter API 金鑰（查詢用量／金鑰上限；獲授權存取 credits 時顯示餘額，官方文件指定 Management 金鑰） | — | ✅ | — |
 | <img src=".github/assets/tools-icon/minimax.png" width="28" alt="Minimax" /> | Minimax | Minimax API 金鑰（透過 Minimax API 查詢 Token Plan 額度） | — | ✅ | — |
@@ -114,7 +114,7 @@ Qoder CN 的 Token 用量來自應用程式本機 SQLite 資料庫，而非 API 
 ### 用量追蹤
 
 - **即時 Token 追蹤**：Claude Code、Codex、Cursor、GitHub Copilot、Antigravity、OpenCode 等 24+ 種 AI 工具，每輪對話後 UI 在數秒內更新（完整清單見上方表格）
-- **單一 session 明細**：點進 Claude Code、Codex 或 OpenCode 的 session，可看每則提問的 Token 消耗，並展開查看每次回覆的 Token 拆分與用到的工具（開啟時才即時讀取本機 transcript 或資料庫，絕不同步）
+- **單一 session 明細**：點進 Claude Code、Codex、OpenCode 或 Reasonix 的 session，可看每則提問的 Token 消耗，並展開查看每次回覆的 Token 拆分與用到的工具（開啟時才即時讀取本機 transcript 或資料庫，絕不同步）
 - **快取命中統計**：點擊任何工具或模型，展開查看輸入 Token（快取命中與未命中）、輸出 Token 的詳細分類及命中率百分比
 - **成本與幣別**：Token 數量旁附帶成本；可用 USD、TWD、HKD 或 CNY 顯示，匯率每日自動更新，也可在設定中手動覆寫
 - **WSL 用量（Windows）**：執行中 WSL 發行版裡的檔案型用量會自動偵測，約每 5 分鐘併入總量；OpenCode、Hermes 等 SQLite 來源可能需要依照[指南](docs/wsl-sqlite-setup.zh-CN.md)在 WSL 內執行 headless agent

--- a/src/shared/sessionDetail.js
+++ b/src/shared/sessionDetail.js
@@ -277,10 +277,12 @@ function distributeCost(exchanges, sessionCost) {
   return exchanges;
 }
 
+// Clients whose detail is parsed out of a transcript file located by `resolveSessionFile`.
+const TRANSCRIPT_PARSERS = { claude: parseClaudeTranscript, codex: parseCodexTranscript };
+
 function parseByClient(client, text) {
-  if (client === 'claude') return parseClaudeTranscript(text);
-  if (client === 'codex') return parseCodexTranscript(text);
-  return [];
+  const parse = TRANSCRIPT_PARSERS[client];
+  return parse ? parse(text) : [];
 }
 
 function totalsOf(exchanges, sessionCost) {
@@ -338,9 +340,21 @@ function readReasonixSessionDetail({ sessionId, period = 'total', home, deps = {
   };
 }
 
+// Clients that own their whole read — a database or a native sidecar — instead of a
+// transcript file.
+const SESSION_READERS = { opencode: readOpenCodeSessionDetail, reasonix: readReasonixSessionDetail };
+
+// Every client Session Detail can open, derived from the two dispatch tables above so it
+// cannot drift from them. The README's "Session Details" column is checked against this
+// list (tests/docs/readmeConsistency.test.js).
+const SESSION_DETAIL_CLIENTS = Object.freeze([
+  ...Object.keys(TRANSCRIPT_PARSERS),
+  ...Object.keys(SESSION_READERS)
+]);
+
 function readSessionDetail({ client, sessionId, period = 'total', sessionCost = 0, home, deps = {} }) {
-  if (client === 'opencode') return readOpenCodeSessionDetail({ sessionId, period, deps });
-  if (client === 'reasonix') return readReasonixSessionDetail({ sessionId, period, home, deps });
+  const readForClient = SESSION_READERS[client];
+  if (readForClient) return readForClient({ sessionId, period, home, deps });
   const filePath = resolveSessionFile(client, sessionId, home);
   if (!filePath) return { found: false, client, sessionId, period, exchanges: [], totals: totalsOf([], sessionCost) };
   let text;
@@ -361,5 +375,6 @@ module.exports = {
   filterExchangesByPeriod,
   distributeCost,
   readReasonixSessionDetail,
-  readSessionDetail
+  readSessionDetail,
+  SESSION_DETAIL_CLIENTS
 };

--- a/tests/docs/readmeConsistency.test.js
+++ b/tests/docs/readmeConsistency.test.js
@@ -5,6 +5,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
 const { LIMIT_PROVIDER_IDS } = require('../../src/shared/limitProviders');
+const { SESSION_DETAIL_CLIENTS } = require('../../src/shared/sessionDetail');
 
 const rootDir = path.join(__dirname, '..', '..');
 const read = (file) => fs.readFileSync(path.join(rootDir, file), 'utf8');
@@ -190,6 +191,30 @@ test('limit provider order follows the supported-tools table', () => {
     });
 
   assert.deepEqual(fromReadme, [...LIMIT_PROVIDER_IDS]);
+});
+
+// The "Session Details" column is the one cell a reader cannot check against the row's own
+// data path: it claims a feature, not a file. Pin it to the dispatch tables in
+// sessionDetail.js, since nothing else did — Reasonix shipped its reader and a `—` in the
+// same commit (#365), and the cross-locale checks above pass happily on an error all five
+// files agree on.
+//
+// Compared as sets: unlike the limits column, no UI order depends on this one. Every id
+// here currently equals its icon id; bridge them like README_ICON_TO_LIMIT_PROVIDERS above
+// if that stops being true.
+test('README session-detail column matches the clients Session Detail can open', () => {
+  const expected = [...SESSION_DETAIL_CLIENTS].sort();
+  assert.ok(expected.length > 0, 'SESSION_DETAIL_CLIENTS should not be empty');
+
+  for (const file of localizedReadmes) {
+    const fromReadme = read(file)
+      .split('\n')
+      .filter((line) => line.startsWith('| <img'))
+      .filter((row) => row.split('|').map((cell) => cell.trim())[6] === '✅')
+      .map((row) => row.match(/tools-icon\/([^".]+)\.[a-z]+"/i)[1])
+      .sort();
+    assert.deepEqual(fromReadme, expected, file);
+  }
 });
 
 test('README tool and provider counts match the supported-tools table', () => {


### PR DESCRIPTION
## Summary

The README's supported-tools table claimed Reasonix has no Session Details, but it has had a reader since #365 — `readSessionDetail` dispatches `reasonix` to `readReasonixSessionDetail` alongside Claude Code, Codex and OpenCode, and the renderer opens it. The same commit that shipped the reader wrote the `—`, and the per-session detail feature bullet was never updated either.

All five locales carried the identical mistake, which is why nothing caught it: `tests/docs/readmeConsistency.test.js` checks that the locales agree with each other and that the row has eight cells, not that a ✅ means anything.

## Changes

- README ×5: Reasonix "Session Details" `—` → `✅`, and Reasonix added to the per-session detail feature bullet.
- `src/shared/sessionDetail.js`: the two `if` chains become dispatch tables (`TRANSCRIPT_PARSERS`, `SESSION_READERS`), and `SESSION_DETAIL_CLIENTS` is derived from them. Deriving it matters — a hand-written list would just move the staleness from the README to the constant.
- New guard test: the set of clients marked ✅ in the Session Details column must equal `SESSION_DETAIL_CLIENTS`, in every locale. Compared as sets, since unlike the limits column no UI order depends on this one.

## Behaviour

Unchanged. An unsupported client already fell through to `resolveSessionFile` returning an empty path and a `found: false` result, which is exactly what the table lookup now produces. `readOpenCodeSessionDetail` receives a `home` property it does not destructure.

One thing deliberately not encoded: Reasonix's session detail is conditional on the native sidecar carrying token data (`sessionDetailAvailable` in `reasonixSessions.js`), unlike the other three. The column is binary and the app already blocks the row when the data is absent, so this is treated as a runtime state rather than a capability gap — the same way an uninstalled tool is.

## Verification

`npm run verify` — lint clean, 3290 pass / 0 fail.

The guard was checked in both directions: reverting the Reasonix cell to `—` fails it, and adding a spurious ✅ to an unrelated row (Proma) fails it too.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects all README locales to show Reasonix Session Details as supported and adds a guard test that keeps the docs aligned with the code. The old docs showed an em dash; the new docs show a checkmark and include Reasonix in the per‑session detail bullet. Runtime behavior is unchanged.

**Key changes**
- READMEs (5 locales): Reasonix Session Details `—` → `✅`; add Reasonix to the per‑session detail bullet.
- `src/shared/sessionDetail.js`: replace `if` chains with dispatch tables (`TRANSCRIPT_PARSERS`, `SESSION_READERS`); derive and export `SESSION_DETAIL_CLIENTS`; `readSessionDetail` now dispatches via the table; unsupported clients still return `{ found: false }`; `readOpenCodeSessionDetail` now receives `home` (ignored).
- `tests/docs/readmeConsistency.test.js`: new test pins the set of `✅` clients in the Session Details column to `SESSION_DETAIL_CLIENTS` across all locales (compared as sets).

<sup>Written for commit 885250e52ac7f68bdf4ab3d55c1c58e5c5b4e024. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

