### PR TITLE
fix(history): derive the aggregate day boundary from producer calendars

### DIFF
--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -29,7 +29,7 @@ const {
 } = require('./usage');
 const { collectWslUsage: collectWslUsageImpl, emptyWslBundle, probeWslState: probeWslStateImpl } = require('./wslUsage');
 const { hermesProfileWatchDirs, resolveHermesHome } = require('./hermesProfiles');
-const { mergeHistories, parseGraphResult, normalizeHistory } = require('./history');
+const { localDayKey, mergeHistories, parseGraphResult, normalizeHistory } = require('./history');
 const { retainDailyHistory, retainLiveDailyHistory } = require('./dailyHistoryArchive');
 const cursorAuth = require('./cursorAuth');
 const { findSessionFiles, codexSessionFile } = require('./sessionFiles');
@@ -511,12 +511,11 @@ function resetPromaPricingCache() {
   promaPricingCache.clear();
 }
 
-function localTodayKey(date = new Date()) {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, '0');
-  const d = String(date.getDate()).padStart(2, '0');
-  return `${y}-${m}-${d}`;
-}
+// The collector's stamp and history.js's window/streak boundary have to be the same
+// calendar day or the aggregate re-keys what the collector wrote, so there is one
+// implementation rather than two formatters free to drift. Kept under the collector's
+// own name: it is exported and reads as the stamping side at its call sites.
+const localTodayKey = localDayKey;
 
 function collectionDate(now) {
   const value = typeof now === 'function' ? now() : now;

--- a/src/shared/history.js
+++ b/src/shared/history.js
@@ -522,7 +522,7 @@ function deviceHistoryRevision(devices) {
 }
 
 module.exports = {
-  num, sumTokens, parseGraphResult, computeIntensities, localDayKey,
+  num, sumTokens, parseGraphResult, computeIntensities, localDayKey, dayKeyAddDays,
   computeStreaks, monthlyRollup, normalizeHistory, mergeHistories,
   coerceHistory, historyPreview, historyRevision, deviceHistoryRevision
 };

--- a/src/shared/history.js
+++ b/src/shared/history.js
@@ -212,6 +212,18 @@ function dayKeyAddDays(key, delta) {
   return new Date(ms).toISOString().slice(0, 10);
 }
 
+// Every day key reaching this module is a local calendar day: the collector stamps
+// contributions with `localTodayKey()` and `computePeriodWindows` ends each window at
+// the next *local* midnight. Resolving "today" from `toISOString()` instead keys the
+// boundary in UTC, which east of UTC drops the current local day out of the rolling
+// window and west of UTC starts the streak walk on a day that holds no data.
+function localDayKey(date = new Date()) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
 // A day is "active" when tokens > 0. currentStreak = consecutive active days ending at
 // todayKey (0 if today is inactive). longestStreak = longest run anywhere.
 function computeStreaks(days, todayKey) {
@@ -328,7 +340,7 @@ function favoriteModelOf(contributions) {
 // never affects lifetime totals.
 function normalizeHistory(graphData, options = {}) {
   const capDays = Number.isFinite(options.capDays) ? options.capDays : DEFAULT_CAP_DAYS;
-  const todayKey = String(options.todayKey || new Date().toISOString().slice(0, 10)).slice(0, 10);
+  const todayKey = String(options.todayKey || localDayKey()).slice(0, 10);
   const full = (graphData && Array.isArray(graphData.contributions) ? graphData.contributions : [])
     .slice()
     .sort((a, b) => a.date.localeCompare(b.date));
@@ -402,7 +414,7 @@ function mergeMonthlyMaps(histories) {
 // stats (active days / peak / streaks) come from the merged daily window.
 function mergeHistories(histories, options = {}) {
   const list = Array.isArray(histories) ? histories : [];
-  const todayKey = String(options.todayKey || new Date().toISOString().slice(0, 10)).slice(0, 10);
+  const todayKey = String(options.todayKey || localDayKey()).slice(0, 10);
   const capDays = Number.isFinite(options.capDays) ? options.capDays : DEFAULT_CAP_DAYS;
 
   // Re-cap after merging: an offline device's persisted daily tier no longer
@@ -510,7 +522,7 @@ function deviceHistoryRevision(devices) {
 }
 
 module.exports = {
-  num, sumTokens, parseGraphResult, computeIntensities,
+  num, sumTokens, parseGraphResult, computeIntensities, localDayKey,
   computeStreaks, monthlyRollup, normalizeHistory, mergeHistories,
   coerceHistory, historyPreview, historyRevision, deviceHistoryRevision
 };

--- a/src/shared/hubBuildRegistry.json
+++ b/src/shared/hubBuildRegistry.json
@@ -28,7 +28,7 @@
       },
       {
         "revision": 7,
-        "buildId": "sha256:d9704d5dd1fbf8adbebf76a5395c8c1c4eceeadd69403278490f136df9665927"
+        "buildId": "sha256:c11547ddf7ae9ba6b950fbda7d539e0f092d4776c0e6183bc426a704e97c295e"
       }
     ],
     "node-hub": [

--- a/src/shared/hubBuildRegistry.json
+++ b/src/shared/hubBuildRegistry.json
@@ -28,7 +28,7 @@
       },
       {
         "revision": 7,
-        "buildId": "sha256:c11547ddf7ae9ba6b950fbda7d539e0f092d4776c0e6183bc426a704e97c295e"
+        "buildId": "sha256:56beeaa8bb294264ec399cf6a93b246a2dc7068a9b666c9b617d584b783648f1"
       }
     ],
     "node-hub": [

--- a/src/shared/hubBuildRegistry.json
+++ b/src/shared/hubBuildRegistry.json
@@ -28,7 +28,7 @@
       },
       {
         "revision": 7,
-        "buildId": "sha256:56beeaa8bb294264ec399cf6a93b246a2dc7068a9b666c9b617d584b783648f1"
+        "buildId": "sha256:b08b43274dd4a3086e99e37f6166cf40004885adf1b5733d5dbec245d1cbce85"
       }
     ],
     "node-hub": [

--- a/src/shared/hubBuildRegistry.json
+++ b/src/shared/hubBuildRegistry.json
@@ -25,6 +25,10 @@
       {
         "revision": 6,
         "buildId": "sha256:006ab65f658958e8f11ac8b5646e86531ce8d142321dccbe92db8edbc727ae94"
+      },
+      {
+        "revision": 7,
+        "buildId": "sha256:5419f897d8f6114c1ef38821ed0a6906fd92506cbcb838b6af4a90eafa56bab5"
       }
     ],
     "node-hub": [

--- a/src/shared/hubBuildRegistry.json
+++ b/src/shared/hubBuildRegistry.json
@@ -28,7 +28,7 @@
       },
       {
         "revision": 7,
-        "buildId": "sha256:5419f897d8f6114c1ef38821ed0a6906fd92506cbcb838b6af4a90eafa56bab5"
+        "buildId": "sha256:d9704d5dd1fbf8adbebf76a5395c8c1c4eceeadd69403278490f136df9665927"
       }
     ],
     "node-hub": [

--- a/src/shared/usage.js
+++ b/src/shared/usage.js
@@ -1181,8 +1181,12 @@ function isPlausibleProducerDay(key, nowMs) {
 // fleet of those keeps the best-effort local-day behaviour it has always had.
 function aggregateHistory(devices, options = {}) {
   const explicitToday = calendarDayKey(options.todayKey);
-  const clockToday = localDayKey();
-  const nowMs = Date.now();
+  // One instant for the whole pass. Reading the clock twice lets a local midnight fall
+  // between them, which would date the fallback a day behind the expiry and
+  // plausibility tests it is meant to back up.
+  const now = new Date();
+  const nowMs = now.getTime();
+  const clockToday = localDayKey(now);
   const histories = [];
   let reportedToday = '';
   for (const record of devices) {

--- a/src/shared/usage.js
+++ b/src/shared/usage.js
@@ -1117,17 +1117,18 @@ function calendarDayKey(value) {
     : '';
 }
 
-// Could a correct clock somewhere on Earth be naming this day right now? The bound is
-// the real UTC-offset envelope, not a tolerance: every legal zone sits within
-// [-12h, +14h] of UTC, and both are under 24h, so at any instant a correct clock names
-// the UTC day, the one before it, or the one after. Anchored on UTC precisely because
-// the ends of that envelope are 26 hours apart — a UTC-12 reader and a UTC+14 producer
-// are both right and name days two apart, so the reader's own calendar day is not a
-// reference either end can be measured from. `key` is calendarDayKey() output, so the
-// parse cannot fail.
+// Could a correct clock somewhere on Earth be naming this day right now? A zone at
+// offset o reads the UTC day of now+o, and every legal o sits within [-12h, +14h], so
+// the answer is exactly the UTC days this 26-hour interval touches — an envelope read
+// off the offset range itself, not a tolerance around a reference day. Which is why
+// neither end is a reference: the ends are 26 hours apart, so a UTC-12 reader and a
+// UTC+14 producer are both correct and name days two apart. Measuring ±1 day from
+// either would be both too loose and too tight — at 00:30 UTC the interval covers only
+// two days, and admitting the third lets a producer one day fast take the boundary and
+// zero the streak of every device that is on time.
 function isPlausibleProducerDay(key, nowMs) {
-  const utcMidnight = Date.parse(`${utcDayKey(new Date(nowMs))}T00:00:00.000Z`);
-  return Math.abs(Date.parse(`${key}T00:00:00.000Z`) - utcMidnight) <= 86400000;
+  return key >= utcDayKey(new Date(nowMs - 12 * 3600000))
+    && key <= utcDayKey(new Date(nowMs + 14 * 3600000));
 }
 
 // History is durable device data, not live presence. Keep a stored device's

--- a/src/shared/usage.js
+++ b/src/shared/usage.js
@@ -3,7 +3,7 @@
 const PERIODS = ['today', 'month', 'allTime'];
 const { aggregateLimits, normalizeLimitsSummary } = require('./limits');
 const { normalizeClientHealth } = require('./clientHealth');
-const { coerceHistory, localDayKey, mergeHistories } = require('./history');
+const { coerceHistory, dayKeyAddDays, localDayKey, mergeHistories } = require('./history');
 const { REASONIX_CLIENT } = require('./reasonixPaths');
 const { filterReasonixSyntheticSessions, isReasonixSyntheticSession } = require('./reasonixSessionGuard');
 const { canonicalProjectKey, deterministicProjectLabel } = require('./projectKey');
@@ -1149,23 +1149,32 @@ function isPlausibleProducerDay(key, nowMs) {
 // was told about — the only end key that cannot cut off a device's own current day.
 // A caller that knows better (a widget aggregating its own record) may pass todayKey.
 //
-// Three conditions narrow which producers get that vote, and each is load-bearing.
-// Only a device that actually contributes a History may move the boundary: one that
-// merely reports a window would otherwise push the end past every contributing
+// Two conditions narrow which producers get that vote, and each is load-bearing.
+//
+// Only a device that puts days into the merge may move the boundary. One that reports
+// a window but contributes nothing would otherwise push the end past every real
 // device's day and zero their streak — the very failure this function exists to
-// prevent. Both spellings of "no History" are excluded, and they are different
-// records: an omitted field means this tick carried no History update, while an
-// explicit null is the sentinel for History disabled or unavailable. Hence the
-// `=== null` test rather than a truthiness check — the distinction is contractual.
+// prevent — so the test is that its daily tier is non-empty, not that a `history`
+// field arrived. Those are far apart on the wire: coerceHistory() turns a string, an
+// array, a number and `{}` alike into an empty History, so a presence check hands a
+// vote to records that describe no day at all. The `=== null` test above is still
+// contractual and separate: an omitted field means this tick carried no History
+// update, while an explicit null is the disabled/unavailable sentinel.
 //
-// Only a window that has not closed yet counts, because a device offline since last
-// year still reports last year's day, and without that gate a dormant fleet pins the
-// rolling window and keeps serving a streak that ended with it.
+// And only a day some correct clock could be naming right now, because the key is a
+// lexical maximum and one device with a dead RTC reporting 2099 would drag the window
+// there and blank every other device's daily tier. That bound never re-keys the day —
+// the whole point is that no clock here can — it only rejects what no zone explains.
 //
-// And only a day some correct clock could be naming right now, because one device
-// with a dead RTC reporting 2099 is a lexical maximum that drags the window there and
-// blanks every other device's daily tier. That bound never re-keys the day — the
-// whole point is that no clock here can — it only rejects what no zone explains.
+// What each producer contributes is a lower bound on its own current day, which its
+// window states in one of two ways. While the window is open that day is exactly the
+// reported key. Once endsAt has passed the device has rolled over to at least the day
+// after, and dropping the key there rather than advancing it is not neutral: the
+// fallback would re-select the very day the window just declared finished, which is
+// how a UTC+14 laptop asleep across its own midnight kept feeding a live streak to a
+// UTC Worker for the next fourteen hours. Advancing it also retires a dormant fleet on
+// its own, since a window closed long enough ago has a successor no zone has been on
+// for years, and the plausibility bound drops it.
 //
 // When no producer passes, nothing on the wire describes today and this machine's
 // clock is all there is. That is also all a pre-periodWindows agent ever offers, so a
@@ -1180,12 +1189,13 @@ function aggregateHistory(devices, options = {}) {
     const normalized = normalizeDeviceRecord(record);
     if (!hasOwn(normalized, 'history') || normalized.history === null) continue;
     histories.push(normalized.history);
+    if (!normalized.history.daily.length) continue;
     const reported = calendarDayKey(normalized.periodWindows?.today?.key);
-    if (reported > reportedToday
-      && isPlausibleProducerDay(reported, nowMs)
-      && !isPeriodExpired(normalized, 'today', nowMs)) {
-      reportedToday = reported;
-    }
+    if (!reported) continue;
+    const floor = isPeriodExpired(normalized, 'today', nowMs)
+      ? dayKeyAddDays(reported, 1)
+      : reported;
+    if (floor > reportedToday && isPlausibleProducerDay(floor, nowMs)) reportedToday = floor;
   }
   return mergeHistories(histories, {
     todayKey: explicitToday || reportedToday || clockToday

--- a/src/shared/usage.js
+++ b/src/shared/usage.js
@@ -3,7 +3,7 @@
 const PERIODS = ['today', 'month', 'allTime'];
 const { aggregateLimits, normalizeLimitsSummary } = require('./limits');
 const { normalizeClientHealth } = require('./clientHealth');
-const { coerceHistory, mergeHistories } = require('./history');
+const { coerceHistory, localDayKey, mergeHistories } = require('./history');
 const { REASONIX_CLIENT } = require('./reasonixPaths');
 const { filterReasonixSyntheticSessions, isReasonixSyntheticSession } = require('./reasonixSessionGuard');
 const { canonicalProjectKey, deterministicProjectLabel } = require('./projectKey');
@@ -1102,18 +1102,93 @@ function carryDeviceHistory(previous, incoming) {
   return incoming;
 }
 
+// A real calendar day or nothing. This key arrives on the wire from anything that can
+// ingest, and it is consumed as a lexical maximum, so shape-only matching is not
+// enough twice over: an impossible day ('2026-99-99') outranks every real one forever,
+// and it makes dayKeyAddDays() build an invalid Date whose toISOString() throws —
+// taking down the stats read for every device on the hub. Match the whole string, then
+// confirm the day survives a UTC round trip, which is what rejects '2026-02-31'.
+function calendarDayKey(value) {
+  const key = String(value || '');
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(key)) return '';
+  const parsed = new Date(`${key}T00:00:00.000Z`);
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === key
+    ? key
+    : '';
+}
+
+// Could a correct clock somewhere on Earth be naming this day right now? The bound is
+// the real UTC-offset envelope, not a tolerance: every legal zone sits within
+// [-12h, +14h] of UTC, and both are under 24h, so at any instant a correct clock names
+// the UTC day, the one before it, or the one after. Anchored on UTC precisely because
+// the ends of that envelope are 26 hours apart — a UTC-12 reader and a UTC+14 producer
+// are both right and name days two apart, so the reader's own calendar day is not a
+// reference either end can be measured from. `key` is calendarDayKey() output, so the
+// parse cannot fail.
+function isPlausibleProducerDay(key, nowMs) {
+  const utcMidnight = Date.parse(`${utcDayKey(new Date(nowMs))}T00:00:00.000Z`);
+  return Math.abs(Date.parse(`${key}T00:00:00.000Z`) - utcMidnight) <= 86400000;
+}
+
 // History is durable device data, not live presence. Keep a stored device's
 // contributions in the aggregate while it is offline; explicit device deletion
 // is the boundary that removes them. Staleness still applies independently to
 // live limits and expired today/month period snapshots.
-function aggregateHistory(devices) {
+//
+// The aggregate's "today" is not the aggregating machine's today. Every day key in
+// a History is the *producer's* local calendar day, but this runs wherever the Hub
+// happens to be: a self-hosted Node hub can sit in another zone, and a Cloudflare
+// Worker isolate always reads UTC. Reading the wall clock there re-keys every
+// producer's day against a boundary they never used, which sorts a device's current
+// day past the rolling window (dropping it from the daily tier while the monthly
+// tier still counts it) or starts the streak walk on a day that holds no data.
+//
+// So the end key comes from the producers themselves: each one already stamps its
+// local day into periodWindows.today.key, and the aggregate takes the latest one it
+// was told about — the only end key that cannot cut off a device's own current day.
+// A caller that knows better (a widget aggregating its own record) may pass todayKey.
+//
+// Three conditions narrow which producers get that vote, and each is load-bearing.
+// Only a device that actually contributes a History may move the boundary: one that
+// merely reports a window would otherwise push the end past every contributing
+// device's day and zero their streak — the very failure this function exists to
+// prevent. Both spellings of "no History" are excluded, and they are different
+// records: an omitted field means this tick carried no History update, while an
+// explicit null is the sentinel for History disabled or unavailable. Hence the
+// `=== null` test rather than a truthiness check — the distinction is contractual.
+//
+// Only a window that has not closed yet counts, because a device offline since last
+// year still reports last year's day, and without that gate a dormant fleet pins the
+// rolling window and keeps serving a streak that ended with it.
+//
+// And only a day some correct clock could be naming right now, because one device
+// with a dead RTC reporting 2099 is a lexical maximum that drags the window there and
+// blanks every other device's daily tier. That bound never re-keys the day — the
+// whole point is that no clock here can — it only rejects what no zone explains.
+//
+// When no producer passes, nothing on the wire describes today and this machine's
+// clock is all there is. That is also all a pre-periodWindows agent ever offers, so a
+// fleet of those keeps the best-effort local-day behaviour it has always had.
+function aggregateHistory(devices, options = {}) {
+  const explicitToday = calendarDayKey(options.todayKey);
+  const clockToday = localDayKey();
+  const nowMs = Date.now();
   const histories = [];
+  let reportedToday = '';
   for (const record of devices) {
     const normalized = normalizeDeviceRecord(record);
-    if (!hasOwn(normalized, 'history')) continue;
+    if (!hasOwn(normalized, 'history') || normalized.history === null) continue;
     histories.push(normalized.history);
+    const reported = calendarDayKey(normalized.periodWindows?.today?.key);
+    if (reported > reportedToday
+      && isPlausibleProducerDay(reported, nowMs)
+      && !isPeriodExpired(normalized, 'today', nowMs)) {
+      reportedToday = reported;
+    }
   }
-  return mergeHistories(histories);
+  return mergeHistories(histories, {
+    todayKey: explicitToday || reportedToday || clockToday
+  });
 }
 
 // Adds every numeric field and nested map of `source` into `target` (an

--- a/tests/shared/history.test.js
+++ b/tests/shared/history.test.js
@@ -319,7 +319,11 @@ test('mergeHistories handles empty list', () => {
   assert.equal(m.summary.totalTokens, 0);
 });
 
-test('localDayKey renders the local calendar day, not the UTC one', () => {
+// A formatter smoke test: it derives `expected` the same way localDayKey() does, so it
+// pins the zero-padded shape and nothing about which calendar the key belongs to. The
+// local-vs-UTC behaviour is covered in historyDayBoundary.test.js, which fixes the
+// timezone and the instant so the two calendars actually disagree.
+test('localDayKey renders a zero-padded calendar day', () => {
   const at = new Date('2026-06-07T23:30:00.000Z');
   const expected = `${at.getFullYear()}-${String(at.getMonth() + 1).padStart(2, '0')}-${String(at.getDate()).padStart(2, '0')}`;
   assert.equal(localDayKey(at), expected);

--- a/tests/shared/history.test.js
+++ b/tests/shared/history.test.js
@@ -4,7 +4,7 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 
 const {
-  sumTokens, num, parseGraphResult, computeIntensities,
+  sumTokens, num, parseGraphResult, computeIntensities, localDayKey,
   computeStreaks, monthlyRollup, normalizeHistory, mergeHistories
 } = require('../../src/shared/history');
 
@@ -317,6 +317,35 @@ test('mergeHistories handles empty list', () => {
   assert.deepEqual(m.daily, []);
   assert.deepEqual(m.monthly, []);
   assert.equal(m.summary.totalTokens, 0);
+});
+
+test('localDayKey renders the local calendar day, not the UTC one', () => {
+  const at = new Date('2026-06-07T23:30:00.000Z');
+  const expected = `${at.getFullYear()}-${String(at.getMonth() + 1).padStart(2, '0')}-${String(at.getDate()).padStart(2, '0')}`;
+  assert.equal(localDayKey(at), expected);
+  assert.match(localDayKey(), /^\d{4}-\d{2}-\d{2}$/);
+});
+
+// aggregateHistory() calls mergeHistories() with no todayKey, so the default decides the
+// rolling window and the streak walk for every widget, hub and Worker read. Contributions
+// are keyed by local day, so a UTC default drops the current local day east of UTC and
+// starts the streak walk on an empty day west of it.
+test('mergeHistories defaults todayKey to the local day', () => {
+  const history = {
+    daily: [{ date: localDayKey(), tokens: 10, cost: 1, perClient: {}, perModel: {} }],
+    monthly: [],
+    summary: {}
+  };
+  const defaulted = mergeHistories([history]);
+  assert.deepEqual(defaulted.daily.map((d) => d.date), [localDayKey()]);
+  assert.equal(defaulted.summary.currentStreak, 1);
+  assert.deepEqual(defaulted, mergeHistories([history], { todayKey: localDayKey() }));
+});
+
+test('normalizeHistory defaults todayKey to the local day', () => {
+  const graph = parseGraphResult(graphFromDays([{ date: localDayKey(), tokens: 10, cost: 1, messages: 1 }]));
+  assert.deepEqual(normalizeHistory(graph).daily.map((d) => d.date), [localDayKey()]);
+  assert.deepEqual(normalizeHistory(graph), normalizeHistory(graph, { todayKey: localDayKey() }));
 });
 
 const {

--- a/tests/shared/historyDayBoundary.test.js
+++ b/tests/shared/historyDayBoundary.test.js
@@ -74,16 +74,27 @@ function graphOf(days) {
   };
 }
 
-// `history` mirrors the three wire states normalizeDeviceRecord distinguishes:
-// 'present' carries a payload, 'omitted' leaves the field off (no History update on
-// this tick), and 'disabled' sends the explicit null the collector emits when
-// historyEnabled is false. The last two are different records, not two spellings.
+// Every record shape that reaches the merge carrying no day. They are not spellings of
+// each other on the wire — an omitted field means this tick had no History update and
+// an explicit null is the disabled/unavailable sentinel — but coerceHistory() flattens
+// the rest to the same empty History, which is exactly why a `history` field being
+// present cannot stand in for a device having contributed anything.
+const NO_CONTRIBUTION = {
+  omitted: {},
+  disabled: { history: null },
+  string: { history: 'oops' },
+  array: { history: [] },
+  number: { history: 7 },
+  empty: { history: {} },
+  unavailable: { history: {}, historyAvailable: false }
+};
+
 function deviceOf({ deviceId, todayKey, endsAt, days, history = 'present' }) {
   return {
     deviceId,
     receivedAt: '2026-08-16T18:00:00.000Z',
     ...(todayKey ? { periodWindows: { today: { key: todayKey, endsAt } } } : {}),
-    ...(history === 'omitted' ? {} : { history: history === 'disabled' ? null : historyOf(days) })
+    ...(history === 'present' ? { history: historyOf(days) } : NO_CONTRIBUTION[history])
   };
 }
 
@@ -162,12 +173,13 @@ test('aggregateHistory takes the latest producer day across timezones', (t) => {
 // Only a device that puts contributions into the merge may move the end of it. A
 // device reporting a window without a History would otherwise push the boundary past
 // the day of every device that did contribute, and zero a streak nothing in the
-// aggregate disagrees with. Both no-History records are covered: 'disabled' is the
-// explicit null the collector sends for historyEnabled: false, which a hasOwn() gate
-// lets through, and it is the shape a real deployment actually produces.
+// aggregate disagrees with. Every no-day shape is covered because they reach this
+// function as one thing: 'disabled' is the explicit null a real deployment sends for
+// historyEnabled: false, which a hasOwn() gate lets through, and the rest are what
+// coerceHistory() returns for a payload that is not a History at all.
 test('aggregateHistory ignores the day of a device that contributes no history', (t) => {
   inZone(t, 'UTC', EAST_DIVERGES, () => {
-    for (const history of ['omitted', 'disabled']) {
+    for (const history of Object.keys(NO_CONTRIBUTION)) {
       const merged = aggregateHistory([
         deviceOf({ deviceId: 'tokyo', todayKey: '2026-08-17', endsAt: TOKYO_MIDNIGHT, history }),
         deviceOf({
@@ -293,6 +305,44 @@ test('aggregateHistory rejects a producer day no zone has reached yet', (t) => {
     const merged = aggregateHistory([onTime, fast]);
     assert.deepEqual(merged.daily.map((d) => d.date), ['2026-08-14', '2026-08-15', '2026-08-16']);
     assert.equal(merged.summary.currentStreak, 3);
+  });
+});
+
+// A closed window is not silence: it says the device has rolled over to at least the
+// day after the one it reported. Dropping the key instead of advancing it lets the
+// clock fallback re-select the day the window just declared finished — here a laptop
+// at UTC+14 asleep one minute past its own midnight, read by a UTC Worker that is
+// still on the 17th. The device's own widget would key on the 18th and show 0; before
+// this the Hub kept serving the 17th's live streak for the next fourteen hours.
+test('aggregateHistory advances past a producer day its window has closed', (t) => {
+  inZone(t, 'UTC', '2026-08-17T10:01:00.000Z', () => {
+    const merged = aggregateHistory([deviceOf({
+      deviceId: 'kiritimati',
+      todayKey: '2026-08-17',
+      endsAt: '2026-08-17T10:00:00.000Z', // 2026-08-18T00:00+14, one minute ago
+      days: [{ date: '2026-08-16', tokens: 5 }, { date: '2026-08-17', tokens: 10 }]
+    })]);
+    assert.equal(merged.daily[merged.daily.length - 1].date, '2026-08-17');
+    assert.equal(merged.summary.currentStreak, 0);
+    assert.equal(merged.summary.activeDays, 2);
+  });
+});
+
+// The reader's clock never re-enters the choice, not even as one term of a maximum.
+// A Hub east of a live producer is the case that first broke: taking the later of the
+// two would key the fleet on a day the only device with data has not reached, which is
+// the original bug wearing the producer-derived design as a disguise.
+test('aggregateHistory keeps a live producer day behind the reader clock', (t) => {
+  // 2026-08-17T13:00Z: 2026-08-18 03:00 at UTC+14, still 2026-08-17 01:00 at UTC-12.
+  inZone(t, 'Pacific/Kiritimati', '2026-08-17T13:00:00.000Z', () => {
+    assert.equal(localDayKey(), '2026-08-18'); // the reader really is a day ahead
+    const merged = aggregateHistory([deviceOf({
+      deviceId: 'baker',
+      todayKey: '2026-08-17',
+      endsAt: '2026-08-18T12:00:00.000Z', // 2026-08-18T00:00-12, still open
+      days: [{ date: '2026-08-16', tokens: 5 }, { date: '2026-08-17', tokens: 10 }]
+    })]);
+    assert.equal(merged.summary.currentStreak, 2);
   });
 });
 

--- a/tests/shared/historyDayBoundary.test.js
+++ b/tests/shared/historyDayBoundary.test.js
@@ -1,0 +1,355 @@
+'use strict';
+
+// Day-boundary regressions cannot be caught without pinning BOTH the zone and the
+// instant: the CI matrix runs UTC, where the local and the UTC calendar day agree,
+// and a non-UTC runner only diverges for part of the day. Every case below forces
+// the divergence window explicitly, so it fails against the old implementation on
+// every runner rather than depending on when it happens to run. The assertions are
+// literal day keys, never a key derived from the helper under test — deriving both
+// sides from the same function only proves f() === f().
+//
+// node --test gives this file its own process, and node:test's Date mock is
+// restored per test, so neither the zone nor the clock leaks anywhere else.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const { localDayKey, mergeHistories, normalizeHistory, parseGraphResult } = require('../../src/shared/history');
+const { aggregateHistory } = require('../../src/shared/usage');
+
+// 02:00 on the 17th at UTC+8, still the 16th in UTC: the local day sorts PAST a
+// UTC-keyed window end and drops out of the daily tier.
+const EAST_DIVERGES = '2026-08-16T18:00:00.000Z';
+// 18:00 on the 16th at UTC-7, already the 17th in UTC: a UTC-keyed streak walk
+// starts on a day that holds no data and reads zero.
+const WEST_DIVERGES = '2026-08-17T01:00:00.000Z';
+
+// Next local midnight for each producer, as the collector's computePeriodWindows
+// would stamp it. Spelled out rather than derived so the expiry gate is tested
+// against real UTC instants instead of whatever the helper would have produced.
+const TOKYO_MIDNIGHT = '2026-08-17T15:00:00.000Z'; // 2026-08-18T00:00+09
+const LA_MIDNIGHT = '2026-08-17T07:00:00.000Z'; // 2026-08-17T00:00-07
+
+function inZone(t, timeZone, instant, run) {
+  const previous = process.env.TZ;
+  process.env.TZ = timeZone;
+  t.mock.timers.enable({ apis: ['Date'], now: Date.parse(instant) });
+  try {
+    run();
+  } finally {
+    if (previous === undefined) delete process.env.TZ;
+    else process.env.TZ = previous;
+  }
+}
+
+function historyOf(days) {
+  return {
+    daily: days.map((d) => ({ date: d.date, tokens: d.tokens, cost: 1, perClient: {}, perModel: {} })),
+    monthly: [{
+      month: days[0].date.slice(0, 7),
+      tokens: days.reduce((sum, d) => sum + d.tokens, 0),
+      cost: days.length,
+      perClient: {},
+      perModel: {}
+    }],
+    summary: {}
+  };
+}
+
+function graphOf(days) {
+  return {
+    contributions: days.map((d) => ({
+      date: d.date,
+      clients: [{
+        client: 'claude',
+        modelId: 'opus',
+        providerId: 'p',
+        tokens: { input: d.tokens, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+        cost: 1,
+        messages: 1
+      }]
+    }))
+  };
+}
+
+// `history` mirrors the three wire states normalizeDeviceRecord distinguishes:
+// 'present' carries a payload, 'omitted' leaves the field off (no History update on
+// this tick), and 'disabled' sends the explicit null the collector emits when
+// historyEnabled is false. The last two are different records, not two spellings.
+function deviceOf({ deviceId, todayKey, endsAt, days, history = 'present' }) {
+  return {
+    deviceId,
+    receivedAt: '2026-08-16T18:00:00.000Z',
+    ...(todayKey ? { periodWindows: { today: { key: todayKey, endsAt } } } : {}),
+    ...(history === 'omitted' ? {} : { history: history === 'disabled' ? null : historyOf(days) })
+  };
+}
+
+test('mergeHistories keeps the producer current local day east of UTC', (t) => {
+  inZone(t, 'Asia/Shanghai', EAST_DIVERGES, () => {
+    const merged = mergeHistories([historyOf([
+      { date: '2026-08-16', tokens: 5 },
+      { date: '2026-08-17', tokens: 10 }
+    ])]);
+    assert.deepEqual(merged.daily.map((d) => d.date), ['2026-08-16', '2026-08-17']);
+    assert.equal(merged.summary.activeDays, 2);
+    assert.equal(merged.summary.currentStreak, 2);
+    assert.equal(merged.summary.peakDayTokens, 10);
+  });
+});
+
+test('mergeHistories does not zero the current streak west of UTC', (t) => {
+  inZone(t, 'America/Los_Angeles', WEST_DIVERGES, () => {
+    const merged = mergeHistories([historyOf([
+      { date: '2026-08-15', tokens: 5 },
+      { date: '2026-08-16', tokens: 10 }
+    ])]);
+    assert.equal(merged.summary.currentStreak, 2);
+    assert.equal(merged.daily[merged.daily.length - 1].date, '2026-08-16');
+  });
+});
+
+test('normalizeHistory caps the daily tier on the local day east of UTC', (t) => {
+  inZone(t, 'Asia/Shanghai', EAST_DIVERGES, () => {
+    const normalized = normalizeHistory(parseGraphResult(graphOf([
+      { date: '2026-08-16', tokens: 5 },
+      { date: '2026-08-17', tokens: 10 }
+    ])));
+    assert.deepEqual(normalized.daily.map((d) => d.date), ['2026-08-16', '2026-08-17']);
+    assert.equal(normalized.summary.currentStreak, 2);
+  });
+});
+
+test('normalizeHistory does not zero the current streak west of UTC', (t) => {
+  inZone(t, 'America/Los_Angeles', WEST_DIVERGES, () => {
+    const normalized = normalizeHistory(parseGraphResult(graphOf([
+      { date: '2026-08-15', tokens: 5 },
+      { date: '2026-08-16', tokens: 10 }
+    ])));
+    assert.equal(normalized.summary.currentStreak, 2);
+  });
+});
+
+// A Cloudflare Worker isolate always reads UTC, so the Hub's own clock can never
+// stand in for the producer's calendar day however it is formatted. These pin the
+// Hub side in UTC on purpose: that is the deployment the wall clock cannot fix.
+test('aggregateHistory keys the window on the producer day, not the Hub clock', (t) => {
+  inZone(t, 'UTC', EAST_DIVERGES, () => {
+    const merged = aggregateHistory([deviceOf({
+      deviceId: 'tokyo',
+      todayKey: '2026-08-17',
+      endsAt: TOKYO_MIDNIGHT,
+      days: [{ date: '2026-08-16', tokens: 5 }, { date: '2026-08-17', tokens: 10 }]
+    })]);
+    assert.deepEqual(merged.daily.map((d) => d.date), ['2026-08-16', '2026-08-17']);
+    assert.equal(merged.summary.activeDays, 2);
+    assert.equal(merged.summary.currentStreak, 2);
+  });
+});
+
+test('aggregateHistory takes the latest producer day across timezones', (t) => {
+  inZone(t, 'UTC', EAST_DIVERGES, () => {
+    const merged = aggregateHistory([
+      deviceOf({ deviceId: 'tokyo', todayKey: '2026-08-17', endsAt: TOKYO_MIDNIGHT, days: [{ date: '2026-08-17', tokens: 10 }] }),
+      deviceOf({ deviceId: 'losangeles', todayKey: '2026-08-16', endsAt: LA_MIDNIGHT, days: [{ date: '2026-08-16', tokens: 5 }] })
+    ]);
+    assert.deepEqual(merged.daily.map((d) => d.date), ['2026-08-16', '2026-08-17']);
+  });
+});
+
+// Only a device that puts contributions into the merge may move the end of it. A
+// device reporting a window without a History would otherwise push the boundary past
+// the day of every device that did contribute, and zero a streak nothing in the
+// aggregate disagrees with. Both no-History records are covered: 'disabled' is the
+// explicit null the collector sends for historyEnabled: false, which a hasOwn() gate
+// lets through, and it is the shape a real deployment actually produces.
+test('aggregateHistory ignores the day of a device that contributes no history', (t) => {
+  inZone(t, 'UTC', EAST_DIVERGES, () => {
+    for (const history of ['omitted', 'disabled']) {
+      const merged = aggregateHistory([
+        deviceOf({ deviceId: 'tokyo', todayKey: '2026-08-17', endsAt: TOKYO_MIDNIGHT, history }),
+        deviceOf({
+          deviceId: 'losangeles',
+          todayKey: '2026-08-16',
+          endsAt: LA_MIDNIGHT,
+          days: [{ date: '2026-08-15', tokens: 5 }, { date: '2026-08-16', tokens: 10 }]
+        })
+      ]);
+      assert.deepEqual(merged.daily.map((d) => d.date), ['2026-08-15', '2026-08-16'], `history: ${history}`);
+      assert.equal(merged.summary.currentStreak, 2, `history: ${history}`);
+    }
+  });
+});
+
+// The key is untrusted wire input consumed as a lexical maximum, so an impossible
+// day would outrank every real one forever — and '2026-99-99' additionally makes
+// the window arithmetic build an invalid Date and throw out of the stats read.
+test('aggregateHistory ignores an impossible or malformed producer day', (t) => {
+  inZone(t, 'UTC', EAST_DIVERGES, () => {
+    for (const todayKey of ['2026-99-99', '9999-99-99', '2026-02-31', '2026-08-17junk', '']) {
+      const merged = aggregateHistory([deviceOf({
+        deviceId: 'bad',
+        todayKey: todayKey || undefined,
+        endsAt: TOKYO_MIDNIGHT,
+        days: [{ date: '2026-08-15', tokens: 5 }, { date: '2026-08-16', tokens: 10 }]
+      })]);
+      assert.deepEqual(
+        merged.daily.map((d) => d.date),
+        ['2026-08-15', '2026-08-16'],
+        `key ${JSON.stringify(todayKey)} must not move the boundary`
+      );
+      assert.equal(merged.summary.currentStreak, 2, `key ${JSON.stringify(todayKey)}`);
+    }
+  });
+});
+
+// A device whose own clock is wrong reports a day nothing can reconcile, and one
+// lexical maximum is enough to drag the rolling window there — blanking the daily
+// tier of every OTHER device, which is a blast radius the aggregate never had while
+// it read its own clock. No zone puts a correct clock in 2099; that is skew.
+test('aggregateHistory ignores a producer day that no timezone could explain', (t) => {
+  inZone(t, 'Asia/Shanghai', EAST_DIVERGES, () => {
+    const healthy = deviceOf({
+      deviceId: 'healthy',
+      todayKey: '2026-08-17',
+      endsAt: TOKYO_MIDNIGHT,
+      days: [{ date: '2026-08-16', tokens: 5 }, { date: '2026-08-17', tokens: 10 }]
+    });
+    const skewed = deviceOf({
+      deviceId: 'skewed',
+      todayKey: '2099-01-01',
+      endsAt: '2099-01-02T00:00:00.000Z',
+      days: [{ date: '2099-01-01', tokens: 1 }]
+    });
+    const merged = aggregateHistory([healthy, skewed]);
+    assert.deepEqual(merged.daily.map((d) => d.date), ['2026-08-16', '2026-08-17']);
+    assert.equal(merged.summary.currentStreak, 2);
+  });
+});
+
+// The far end of the envelope against a UTC aggregator: one calendar day apart, and
+// a real deployment that must keep its vote.
+test('aggregateHistory still accepts the furthest real timezone ahead', (t) => {
+  inZone(t, 'UTC', EAST_DIVERGES, () => {
+    const merged = aggregateHistory([deviceOf({
+      deviceId: 'kiritimati',
+      todayKey: '2026-08-17',
+      endsAt: '2026-08-17T10:00:00.000Z', // 2026-08-18T00:00+14
+      days: [{ date: '2026-08-16', tokens: 5 }, { date: '2026-08-17', tokens: 10 }]
+    })]);
+    assert.deepEqual(merged.daily.map((d) => d.date), ['2026-08-16', '2026-08-17']);
+  });
+});
+
+// Both ends of the envelope at once, which is where measuring the producer against
+// the READER's calendar day breaks: UTC-12 and UTC+14 are 26 hours apart, so at this
+// instant two correct clocks name days two apart and the reader would score its own
+// end of the range as skew. Rejecting the only producer here does not merely lose a
+// day — the fallback window ends before every row it holds, so the daily tier empties
+// and the streak reads 0 while the monthly tier still counts the same tokens.
+test('aggregateHistory accepts a producer at the opposite end of the zone range', (t) => {
+  // 2026-01-01T10:30Z: 2025-12-31 22:30 at UTC-12, 2026-01-02 00:30 at UTC+14.
+  inZone(t, 'Etc/GMT+12', '2026-01-01T10:30:00.000Z', () => {
+    assert.equal(localDayKey(), '2025-12-31'); // the reader really is two days behind
+    const merged = aggregateHistory([deviceOf({
+      deviceId: 'kiritimati',
+      todayKey: '2026-01-02',
+      endsAt: '2026-01-02T10:00:00.000Z', // 2026-01-03T00:00+14
+      days: [{ date: '2026-01-01', tokens: 5 }, { date: '2026-01-02', tokens: 10 }]
+    })]);
+    assert.deepEqual(merged.daily.map((d) => d.date), ['2026-01-01', '2026-01-02']);
+    assert.equal(merged.summary.currentStreak, 2);
+  });
+});
+
+// A device offline since last year still reports last year's day. Honouring it
+// would pin the rolling window there and keep serving a streak that ended with it.
+test('aggregateHistory does not freeze the window on a closed producer day', (t) => {
+  inZone(t, 'Asia/Shanghai', EAST_DIVERGES, () => {
+    const merged = aggregateHistory([deviceOf({
+      deviceId: 'dormant',
+      todayKey: '2024-01-01',
+      endsAt: '2024-01-02T00:00:00.000Z',
+      days: [{ date: '2024-01-01', tokens: 10 }]
+    })]);
+    assert.deepEqual(merged.daily, []);
+    assert.equal(merged.summary.currentStreak, 0);
+    // The contributions themselves are durable: only the daily tier is a window.
+    assert.equal(merged.summary.totalTokens, 10);
+  });
+});
+
+// The explicit key is deliberately neither the producer's day nor the Hub clock's,
+// so this cannot pass by coinciding with whichever one the code actually read.
+test('aggregateHistory lets an explicit todayKey override the producers', (t) => {
+  inZone(t, 'UTC', EAST_DIVERGES, () => {
+    const merged = aggregateHistory([deviceOf({
+      deviceId: 'tokyo',
+      todayKey: '2026-08-17',
+      endsAt: TOKYO_MIDNIGHT,
+      days: [
+        { date: '2026-08-15', tokens: 3 },
+        { date: '2026-08-16', tokens: 5 },
+        { date: '2026-08-17', tokens: 10 }
+      ]
+    })], { todayKey: '2026-08-15' });
+    assert.deepEqual(merged.daily.map((d) => d.date), ['2026-08-15']);
+  });
+});
+
+test('aggregateHistory falls back to the local clock for records without a window', (t) => {
+  inZone(t, 'Asia/Shanghai', EAST_DIVERGES, () => {
+    const merged = aggregateHistory([deviceOf({
+      deviceId: 'legacy',
+      days: [{ date: '2026-08-16', tokens: 5 }, { date: '2026-08-17', tokens: 10 }]
+    })]);
+    assert.deepEqual(merged.daily.map((d) => d.date), ['2026-08-16', '2026-08-17']);
+  });
+});
+
+// The Worker serves the same reads from a vendored copy, and it is the deployment
+// whose runtime clock can never be right. Drift is already a CI failure; this pins
+// the behaviour itself rather than the bytes.
+test('the vendored Worker aggregate derives the same boundary', (t) => {
+  inZone(t, 'UTC', EAST_DIVERGES, () => {
+    const workerUsage = require('../../worker/src/shared/usage');
+    const devices = [deviceOf({
+      deviceId: 'tokyo',
+      todayKey: '2026-08-17',
+      endsAt: TOKYO_MIDNIGHT,
+      days: [{ date: '2026-08-16', tokens: 5 }, { date: '2026-08-17', tokens: 10 }]
+    })];
+    assert.deepEqual(workerUsage.aggregateHistory(devices), aggregateHistory(devices));
+    assert.deepEqual(
+      workerUsage.aggregateHistory(devices).daily.map((d) => d.date),
+      ['2026-08-16', '2026-08-17']
+    );
+  });
+});
+
+// The shared twin of the renderer guard in tests/electron/activityDateKey.test.js.
+// Key arithmetic on an already-correct key stays UTC-anchored on purpose (that is
+// what dayKeyAddDays does); what must never come back is reading the WALL CLOCK in
+// UTC and calling the result a calendar day.
+test('shared history modules derive today from the local day key, not toISOString', () => {
+  const sharedDir = path.join(__dirname, '../../src/shared');
+  for (const file of ['history.js', 'usage.js', 'collector.js']) {
+    const source = fs.readFileSync(path.join(sharedDir, file), 'utf8');
+    assert.ok(
+      !/new Date\(\)\.toISOString\(\)\.slice\(0, ?10\)/.test(source),
+      `${file} must derive today from localDayKey(), not new Date().toISOString()`
+    );
+  }
+});
+
+// Asserted on the day they name rather than on function identity, so wrapping either
+// side stays legal and only actually disagreeing about the calendar day fails.
+test('the collector stamp and the history boundary name the same day', (t) => {
+  inZone(t, 'Asia/Shanghai', EAST_DIVERGES, () => {
+    const { localTodayKey } = require('../../src/shared/collector');
+    assert.equal(localTodayKey(), '2026-08-17');
+    assert.equal(localTodayKey(), localDayKey());
+  });
+});

--- a/tests/shared/historyDayBoundary.test.js
+++ b/tests/shared/historyDayBoundary.test.js
@@ -264,6 +264,38 @@ test('aggregateHistory accepts a producer at the opposite end of the zone range'
   });
 });
 
+// The envelope is 26 hours wide, so how many calendar days it covers depends on where
+// in the UTC day it is read: at 00:30 UTC it reaches only 2026-08-15 (UTC-12) through
+// 2026-08-16 (UTC+14), and no correct clock anywhere is on the 17th yet. A device one
+// day fast is not exotic enough to look wrong — it is well formed, adjacent, and
+// passes the expiry gate because its endsAt is a day ahead too — so nothing else here
+// stops it from taking the boundary. When it happens to be idle on its own "today" it
+// contributes no row there either, and the streak of every device that is on time
+// reads 0. Anchoring ±1 day on the UTC date would admit exactly this producer.
+test('aggregateHistory rejects a producer day no zone has reached yet', (t) => {
+  inZone(t, 'UTC', '2026-08-16T00:30:00.000Z', () => {
+    const onTime = deviceOf({
+      deviceId: 'on-time',
+      todayKey: '2026-08-16',
+      endsAt: '2026-08-17T00:00:00.000Z',
+      days: [
+        { date: '2026-08-14', tokens: 5 },
+        { date: '2026-08-15', tokens: 5 },
+        { date: '2026-08-16', tokens: 10 }
+      ]
+    });
+    const fast = deviceOf({
+      deviceId: 'fast',
+      todayKey: '2026-08-17',
+      endsAt: '2026-08-18T00:00:00.000Z',
+      days: [{ date: '2026-08-16', tokens: 1 }]
+    });
+    const merged = aggregateHistory([onTime, fast]);
+    assert.deepEqual(merged.daily.map((d) => d.date), ['2026-08-14', '2026-08-15', '2026-08-16']);
+    assert.equal(merged.summary.currentStreak, 3);
+  });
+});
+
 // A device offline since last year still reports last year's day. Honouring it
 // would pin the rolling window there and keep serving a streak that ended with it.
 test('aggregateHistory does not freeze the window on a closed producer day', (t) => {

--- a/worker/src/shared/history.js
+++ b/worker/src/shared/history.js
@@ -525,7 +525,7 @@ function deviceHistoryRevision(devices) {
 }
 
 module.exports = {
-  num, sumTokens, parseGraphResult, computeIntensities, localDayKey,
+  num, sumTokens, parseGraphResult, computeIntensities, localDayKey, dayKeyAddDays,
   computeStreaks, monthlyRollup, normalizeHistory, mergeHistories,
   coerceHistory, historyPreview, historyRevision, deviceHistoryRevision
 };

--- a/worker/src/shared/history.js
+++ b/worker/src/shared/history.js
@@ -215,6 +215,18 @@ function dayKeyAddDays(key, delta) {
   return new Date(ms).toISOString().slice(0, 10);
 }
 
+// Every day key reaching this module is a local calendar day: the collector stamps
+// contributions with `localTodayKey()` and `computePeriodWindows` ends each window at
+// the next *local* midnight. Resolving "today" from `toISOString()` instead keys the
+// boundary in UTC, which east of UTC drops the current local day out of the rolling
+// window and west of UTC starts the streak walk on a day that holds no data.
+function localDayKey(date = new Date()) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
 // A day is "active" when tokens > 0. currentStreak = consecutive active days ending at
 // todayKey (0 if today is inactive). longestStreak = longest run anywhere.
 function computeStreaks(days, todayKey) {
@@ -331,7 +343,7 @@ function favoriteModelOf(contributions) {
 // never affects lifetime totals.
 function normalizeHistory(graphData, options = {}) {
   const capDays = Number.isFinite(options.capDays) ? options.capDays : DEFAULT_CAP_DAYS;
-  const todayKey = String(options.todayKey || new Date().toISOString().slice(0, 10)).slice(0, 10);
+  const todayKey = String(options.todayKey || localDayKey()).slice(0, 10);
   const full = (graphData && Array.isArray(graphData.contributions) ? graphData.contributions : [])
     .slice()
     .sort((a, b) => a.date.localeCompare(b.date));
@@ -405,7 +417,7 @@ function mergeMonthlyMaps(histories) {
 // stats (active days / peak / streaks) come from the merged daily window.
 function mergeHistories(histories, options = {}) {
   const list = Array.isArray(histories) ? histories : [];
-  const todayKey = String(options.todayKey || new Date().toISOString().slice(0, 10)).slice(0, 10);
+  const todayKey = String(options.todayKey || localDayKey()).slice(0, 10);
   const capDays = Number.isFinite(options.capDays) ? options.capDays : DEFAULT_CAP_DAYS;
 
   // Re-cap after merging: an offline device's persisted daily tier no longer
@@ -513,7 +525,7 @@ function deviceHistoryRevision(devices) {
 }
 
 module.exports = {
-  num, sumTokens, parseGraphResult, computeIntensities,
+  num, sumTokens, parseGraphResult, computeIntensities, localDayKey,
   computeStreaks, monthlyRollup, normalizeHistory, mergeHistories,
   coerceHistory, historyPreview, historyRevision, deviceHistoryRevision
 };

--- a/worker/src/shared/hubBuildRegistry.json
+++ b/worker/src/shared/hubBuildRegistry.json
@@ -28,7 +28,7 @@
       },
       {
         "revision": 7,
-        "buildId": "sha256:d9704d5dd1fbf8adbebf76a5395c8c1c4eceeadd69403278490f136df9665927"
+        "buildId": "sha256:c11547ddf7ae9ba6b950fbda7d539e0f092d4776c0e6183bc426a704e97c295e"
       }
     ],
     "node-hub": [

--- a/worker/src/shared/hubBuildRegistry.json
+++ b/worker/src/shared/hubBuildRegistry.json
@@ -28,7 +28,7 @@
       },
       {
         "revision": 7,
-        "buildId": "sha256:c11547ddf7ae9ba6b950fbda7d539e0f092d4776c0e6183bc426a704e97c295e"
+        "buildId": "sha256:56beeaa8bb294264ec399cf6a93b246a2dc7068a9b666c9b617d584b783648f1"
       }
     ],
     "node-hub": [

--- a/worker/src/shared/hubBuildRegistry.json
+++ b/worker/src/shared/hubBuildRegistry.json
@@ -28,7 +28,7 @@
       },
       {
         "revision": 7,
-        "buildId": "sha256:56beeaa8bb294264ec399cf6a93b246a2dc7068a9b666c9b617d584b783648f1"
+        "buildId": "sha256:b08b43274dd4a3086e99e37f6166cf40004885adf1b5733d5dbec245d1cbce85"
       }
     ],
     "node-hub": [

--- a/worker/src/shared/hubBuildRegistry.json
+++ b/worker/src/shared/hubBuildRegistry.json
@@ -25,6 +25,10 @@
       {
         "revision": 6,
         "buildId": "sha256:006ab65f658958e8f11ac8b5646e86531ce8d142321dccbe92db8edbc727ae94"
+      },
+      {
+        "revision": 7,
+        "buildId": "sha256:5419f897d8f6114c1ef38821ed0a6906fd92506cbcb838b6af4a90eafa56bab5"
       }
     ],
     "node-hub": [

--- a/worker/src/shared/hubBuildRegistry.json
+++ b/worker/src/shared/hubBuildRegistry.json
@@ -28,7 +28,7 @@
       },
       {
         "revision": 7,
-        "buildId": "sha256:5419f897d8f6114c1ef38821ed0a6906fd92506cbcb838b6af4a90eafa56bab5"
+        "buildId": "sha256:d9704d5dd1fbf8adbebf76a5395c8c1c4eceeadd69403278490f136df9665927"
       }
     ],
     "node-hub": [

--- a/worker/src/shared/usage.js
+++ b/worker/src/shared/usage.js
@@ -1184,8 +1184,12 @@ function isPlausibleProducerDay(key, nowMs) {
 // fleet of those keeps the best-effort local-day behaviour it has always had.
 function aggregateHistory(devices, options = {}) {
   const explicitToday = calendarDayKey(options.todayKey);
-  const clockToday = localDayKey();
-  const nowMs = Date.now();
+  // One instant for the whole pass. Reading the clock twice lets a local midnight fall
+  // between them, which would date the fallback a day behind the expiry and
+  // plausibility tests it is meant to back up.
+  const now = new Date();
+  const nowMs = now.getTime();
+  const clockToday = localDayKey(now);
   const histories = [];
   let reportedToday = '';
   for (const record of devices) {

--- a/worker/src/shared/usage.js
+++ b/worker/src/shared/usage.js
@@ -6,7 +6,7 @@
 const PERIODS = ['today', 'month', 'allTime'];
 const { aggregateLimits, normalizeLimitsSummary } = require('./limits');
 const { normalizeClientHealth } = require('./clientHealth');
-const { coerceHistory, mergeHistories } = require('./history');
+const { coerceHistory, localDayKey, mergeHistories } = require('./history');
 const { REASONIX_CLIENT } = require('./reasonixPaths');
 const { filterReasonixSyntheticSessions, isReasonixSyntheticSession } = require('./reasonixSessionGuard');
 const { canonicalProjectKey, deterministicProjectLabel } = require('./projectKey');
@@ -1105,18 +1105,93 @@ function carryDeviceHistory(previous, incoming) {
   return incoming;
 }
 
+// A real calendar day or nothing. This key arrives on the wire from anything that can
+// ingest, and it is consumed as a lexical maximum, so shape-only matching is not
+// enough twice over: an impossible day ('2026-99-99') outranks every real one forever,
+// and it makes dayKeyAddDays() build an invalid Date whose toISOString() throws —
+// taking down the stats read for every device on the hub. Match the whole string, then
+// confirm the day survives a UTC round trip, which is what rejects '2026-02-31'.
+function calendarDayKey(value) {
+  const key = String(value || '');
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(key)) return '';
+  const parsed = new Date(`${key}T00:00:00.000Z`);
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === key
+    ? key
+    : '';
+}
+
+// Could a correct clock somewhere on Earth be naming this day right now? The bound is
+// the real UTC-offset envelope, not a tolerance: every legal zone sits within
+// [-12h, +14h] of UTC, and both are under 24h, so at any instant a correct clock names
+// the UTC day, the one before it, or the one after. Anchored on UTC precisely because
+// the ends of that envelope are 26 hours apart — a UTC-12 reader and a UTC+14 producer
+// are both right and name days two apart, so the reader's own calendar day is not a
+// reference either end can be measured from. `key` is calendarDayKey() output, so the
+// parse cannot fail.
+function isPlausibleProducerDay(key, nowMs) {
+  const utcMidnight = Date.parse(`${utcDayKey(new Date(nowMs))}T00:00:00.000Z`);
+  return Math.abs(Date.parse(`${key}T00:00:00.000Z`) - utcMidnight) <= 86400000;
+}
+
 // History is durable device data, not live presence. Keep a stored device's
 // contributions in the aggregate while it is offline; explicit device deletion
 // is the boundary that removes them. Staleness still applies independently to
 // live limits and expired today/month period snapshots.
-function aggregateHistory(devices) {
+//
+// The aggregate's "today" is not the aggregating machine's today. Every day key in
+// a History is the *producer's* local calendar day, but this runs wherever the Hub
+// happens to be: a self-hosted Node hub can sit in another zone, and a Cloudflare
+// Worker isolate always reads UTC. Reading the wall clock there re-keys every
+// producer's day against a boundary they never used, which sorts a device's current
+// day past the rolling window (dropping it from the daily tier while the monthly
+// tier still counts it) or starts the streak walk on a day that holds no data.
+//
+// So the end key comes from the producers themselves: each one already stamps its
+// local day into periodWindows.today.key, and the aggregate takes the latest one it
+// was told about — the only end key that cannot cut off a device's own current day.
+// A caller that knows better (a widget aggregating its own record) may pass todayKey.
+//
+// Three conditions narrow which producers get that vote, and each is load-bearing.
+// Only a device that actually contributes a History may move the boundary: one that
+// merely reports a window would otherwise push the end past every contributing
+// device's day and zero their streak — the very failure this function exists to
+// prevent. Both spellings of "no History" are excluded, and they are different
+// records: an omitted field means this tick carried no History update, while an
+// explicit null is the sentinel for History disabled or unavailable. Hence the
+// `=== null` test rather than a truthiness check — the distinction is contractual.
+//
+// Only a window that has not closed yet counts, because a device offline since last
+// year still reports last year's day, and without that gate a dormant fleet pins the
+// rolling window and keeps serving a streak that ended with it.
+//
+// And only a day some correct clock could be naming right now, because one device
+// with a dead RTC reporting 2099 is a lexical maximum that drags the window there and
+// blanks every other device's daily tier. That bound never re-keys the day — the
+// whole point is that no clock here can — it only rejects what no zone explains.
+//
+// When no producer passes, nothing on the wire describes today and this machine's
+// clock is all there is. That is also all a pre-periodWindows agent ever offers, so a
+// fleet of those keeps the best-effort local-day behaviour it has always had.
+function aggregateHistory(devices, options = {}) {
+  const explicitToday = calendarDayKey(options.todayKey);
+  const clockToday = localDayKey();
+  const nowMs = Date.now();
   const histories = [];
+  let reportedToday = '';
   for (const record of devices) {
     const normalized = normalizeDeviceRecord(record);
-    if (!hasOwn(normalized, 'history')) continue;
+    if (!hasOwn(normalized, 'history') || normalized.history === null) continue;
     histories.push(normalized.history);
+    const reported = calendarDayKey(normalized.periodWindows?.today?.key);
+    if (reported > reportedToday
+      && isPlausibleProducerDay(reported, nowMs)
+      && !isPeriodExpired(normalized, 'today', nowMs)) {
+      reportedToday = reported;
+    }
   }
-  return mergeHistories(histories);
+  return mergeHistories(histories, {
+    todayKey: explicitToday || reportedToday || clockToday
+  });
 }
 
 // Adds every numeric field and nested map of `source` into `target` (an

--- a/worker/src/shared/usage.js
+++ b/worker/src/shared/usage.js
@@ -6,7 +6,7 @@
 const PERIODS = ['today', 'month', 'allTime'];
 const { aggregateLimits, normalizeLimitsSummary } = require('./limits');
 const { normalizeClientHealth } = require('./clientHealth');
-const { coerceHistory, localDayKey, mergeHistories } = require('./history');
+const { coerceHistory, dayKeyAddDays, localDayKey, mergeHistories } = require('./history');
 const { REASONIX_CLIENT } = require('./reasonixPaths');
 const { filterReasonixSyntheticSessions, isReasonixSyntheticSession } = require('./reasonixSessionGuard');
 const { canonicalProjectKey, deterministicProjectLabel } = require('./projectKey');
@@ -1152,23 +1152,32 @@ function isPlausibleProducerDay(key, nowMs) {
 // was told about — the only end key that cannot cut off a device's own current day.
 // A caller that knows better (a widget aggregating its own record) may pass todayKey.
 //
-// Three conditions narrow which producers get that vote, and each is load-bearing.
-// Only a device that actually contributes a History may move the boundary: one that
-// merely reports a window would otherwise push the end past every contributing
+// Two conditions narrow which producers get that vote, and each is load-bearing.
+//
+// Only a device that puts days into the merge may move the boundary. One that reports
+// a window but contributes nothing would otherwise push the end past every real
 // device's day and zero their streak — the very failure this function exists to
-// prevent. Both spellings of "no History" are excluded, and they are different
-// records: an omitted field means this tick carried no History update, while an
-// explicit null is the sentinel for History disabled or unavailable. Hence the
-// `=== null` test rather than a truthiness check — the distinction is contractual.
+// prevent — so the test is that its daily tier is non-empty, not that a `history`
+// field arrived. Those are far apart on the wire: coerceHistory() turns a string, an
+// array, a number and `{}` alike into an empty History, so a presence check hands a
+// vote to records that describe no day at all. The `=== null` test above is still
+// contractual and separate: an omitted field means this tick carried no History
+// update, while an explicit null is the disabled/unavailable sentinel.
 //
-// Only a window that has not closed yet counts, because a device offline since last
-// year still reports last year's day, and without that gate a dormant fleet pins the
-// rolling window and keeps serving a streak that ended with it.
+// And only a day some correct clock could be naming right now, because the key is a
+// lexical maximum and one device with a dead RTC reporting 2099 would drag the window
+// there and blank every other device's daily tier. That bound never re-keys the day —
+// the whole point is that no clock here can — it only rejects what no zone explains.
 //
-// And only a day some correct clock could be naming right now, because one device
-// with a dead RTC reporting 2099 is a lexical maximum that drags the window there and
-// blanks every other device's daily tier. That bound never re-keys the day — the
-// whole point is that no clock here can — it only rejects what no zone explains.
+// What each producer contributes is a lower bound on its own current day, which its
+// window states in one of two ways. While the window is open that day is exactly the
+// reported key. Once endsAt has passed the device has rolled over to at least the day
+// after, and dropping the key there rather than advancing it is not neutral: the
+// fallback would re-select the very day the window just declared finished, which is
+// how a UTC+14 laptop asleep across its own midnight kept feeding a live streak to a
+// UTC Worker for the next fourteen hours. Advancing it also retires a dormant fleet on
+// its own, since a window closed long enough ago has a successor no zone has been on
+// for years, and the plausibility bound drops it.
 //
 // When no producer passes, nothing on the wire describes today and this machine's
 // clock is all there is. That is also all a pre-periodWindows agent ever offers, so a
@@ -1183,12 +1192,13 @@ function aggregateHistory(devices, options = {}) {
     const normalized = normalizeDeviceRecord(record);
     if (!hasOwn(normalized, 'history') || normalized.history === null) continue;
     histories.push(normalized.history);
+    if (!normalized.history.daily.length) continue;
     const reported = calendarDayKey(normalized.periodWindows?.today?.key);
-    if (reported > reportedToday
-      && isPlausibleProducerDay(reported, nowMs)
-      && !isPeriodExpired(normalized, 'today', nowMs)) {
-      reportedToday = reported;
-    }
+    if (!reported) continue;
+    const floor = isPeriodExpired(normalized, 'today', nowMs)
+      ? dayKeyAddDays(reported, 1)
+      : reported;
+    if (floor > reportedToday && isPlausibleProducerDay(floor, nowMs)) reportedToday = floor;
   }
   return mergeHistories(histories, {
     todayKey: explicitToday || reportedToday || clockToday

--- a/worker/src/shared/usage.js
+++ b/worker/src/shared/usage.js
@@ -1120,17 +1120,18 @@ function calendarDayKey(value) {
     : '';
 }
 
-// Could a correct clock somewhere on Earth be naming this day right now? The bound is
-// the real UTC-offset envelope, not a tolerance: every legal zone sits within
-// [-12h, +14h] of UTC, and both are under 24h, so at any instant a correct clock names
-// the UTC day, the one before it, or the one after. Anchored on UTC precisely because
-// the ends of that envelope are 26 hours apart — a UTC-12 reader and a UTC+14 producer
-// are both right and name days two apart, so the reader's own calendar day is not a
-// reference either end can be measured from. `key` is calendarDayKey() output, so the
-// parse cannot fail.
+// Could a correct clock somewhere on Earth be naming this day right now? A zone at
+// offset o reads the UTC day of now+o, and every legal o sits within [-12h, +14h], so
+// the answer is exactly the UTC days this 26-hour interval touches — an envelope read
+// off the offset range itself, not a tolerance around a reference day. Which is why
+// neither end is a reference: the ends are 26 hours apart, so a UTC-12 reader and a
+// UTC+14 producer are both correct and name days two apart. Measuring ±1 day from
+// either would be both too loose and too tight — at 00:30 UTC the interval covers only
+// two days, and admitting the third lets a producer one day fast take the boundary and
+// zero the streak of every device that is on time.
 function isPlausibleProducerDay(key, nowMs) {
-  const utcMidnight = Date.parse(`${utcDayKey(new Date(nowMs))}T00:00:00.000Z`);
-  return Math.abs(Date.parse(`${key}T00:00:00.000Z`) - utcMidnight) <= 86400000;
+  return key >= utcDayKey(new Date(nowMs - 12 * 3600000))
+    && key <= utcDayKey(new Date(nowMs + 14 * 3600000));
 }
 
 // History is durable device data, not live presence. Keep a stored device's


### PR DESCRIPTION
## Problem

The first commit fixed the local-day default used by History normalization and streak calculations. The aggregate path had a separate boundary problem: `aggregateHistory()` runs in the Hub or Worker, while each History row and `periodWindows.today.key` are stamped from the producer's local calendar. Using the reader's wall clock could therefore re-key a fleet-wide daily window, and a future-dated producer key could become the lexical maximum and clear every device's daily tier while monthly totals still counted the same tokens.

## Fix

- Keep the original UTC-to-local correction for the collector stamp and local History defaults.
- Derive the aggregate boundary from the producers. Each device's `periodWindows.today` states a lower bound on its own current day: exactly `today.key` while the window is open, and at least the day after once `endsAt` has passed. The aggregate takes the latest such day. The reader's clock is a fallback for records that carry no window at all, never a term in that selection.
- Only devices that put days into the merge may move the boundary. The test is a non-empty daily tier rather than a `history` field being present, because `coerceHistory()` reduces a string, an array, a number and `{}` alike to an empty History.
- Validate the untrusted producer key as a real calendar day, and accept it only when some correct clock could be naming that day right now. A zone at offset `o` reads the UTC day of `now + o`, and every legal offset lies within `[-12h, +14h]`, so the admissible set is exactly the UTC days the 26-hour interval `[now - 12h, now + 14h]` touches — two calendar days for most of the UTC day, three only while the interval straddles two midnights. UTC is only a sanity bound here; it never chooses the aggregate day.
- Retain the local-clock fallback for pre-`periodWindows` agents as best effort, and read the clock once for the whole pass so a local midnight cannot fall between the fallback day and the instant the expiry and plausibility tests use.
- Keep the shared Node/Worker implementation and generated Worker registry in sync.

## Why these bounds and not the obvious ones

**Not `UTC day ± 1`.** It reads like the same rule and is not. A fixed `± 1` admits three calendar days at every instant, but the real envelope covers only two for 22 hours out of 24, and the extra day it admits is the future one for 10 of those hours. A device whose clock is one calendar day fast clears every other gate — its key is well formed, adjacent rather than absurd, and its `endsAt` is a day ahead too — so it wins the lexical maximum and takes the boundary. Read at 00:30 UTC with one such device idle on its own "today", the aggregate streak of every device that is on time went from 3 to 0.

**Not the reader's calendar day as the reference.** The ends of the offset range are 26 hours apart, so a UTC-12 reader and a UTC+14 producer are both correct and name days two apart. Measuring from the reader scores one real deployment as skew, and rejecting the only producer there does not merely lose a day: the fallback window ends before every row it holds, so the daily tier empties while the monthly tier still counts the same tokens.

**Not `max(readerClock, producerDay)`.** A hub east of a live producer would key the fleet on a day the only device with data has not reached — the original bug wearing the producer-derived design as a disguise.

**A closed window is not silence.** Dropping its key rather than advancing it let the clock fallback re-select the day the window had just declared finished. A UTC+14 laptop asleep one minute past its own midnight kept feeding a live streak to a UTC Worker for the next fourteen hours, while its own widget showed 0. Advancing it also retires a dormant fleet without a separate rule, since a long-closed window has a successor the plausibility bound already drops.

## Verification

- `node --test tests/shared/historyDayBoundary.test.js`: 20 passed
- `npm run verify`: 3313 tests, 3312 passed, 1 skipped
- `node --test tests/shared/hubBuild.test.js`: 13 passed
- Generated Worker shared-code parity: clean

The regression suite pins each of the cases above, plus malformed and impossible keys, every non-contributing record shape, history-less and explicitly disabled devices, dormant windows, the legacy local-clock fallback, and Worker behaviour parity. Every case fixes both the timezone and the instant, since the CI matrix runs UTC where the local and the UTC calendar day agree and these tests would otherwise pass against the bugs they exist to catch.
