### PR TITLE
fix(release): use platform-specific Electron runtimes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,8 @@ jobs:
           echo "TOKEN_MONITOR_ELECTRON_TARGET=linux" >> "$GITHUB_ENV"
           echo "TOKEN_MONITOR_LINUX_ELECTRON_VERSION=43.2.0" >> "$GITHUB_ENV"
       - name: Verify Electron packaging version
-        run: node -e "const config = require('./scripts/electron-builder.config.js'); const installed = require('electron/package.json').version; const effective = config.electronVersion || installed; const expected = process.env.TOKEN_MONITOR_LINUX_ELECTRON_VERSION || installed; console.log('Electron packaging version:', effective, '(installed:', installed + ')'); if (effective !== expected) throw new Error('Electron packaging version mismatch: expected ' + expected + ', got ' + effective);"
+        run: |
+          node -e "const config = require('./scripts/electron-builder.config.js'); const installed = require('electron/package.json').version; const effective = config.electronVersion || installed; const expected = process.env.TOKEN_MONITOR_LINUX_ELECTRON_VERSION || installed; console.log('Electron packaging version:', effective, '(installed:', installed + ')'); if (effective !== expected) throw new Error('Electron packaging version mismatch: expected ' + expected + ', got ' + effective);"
       # electron-builder needs the notarization key as a file, not the base64 secret directly.
       - name: Decode Apple API key
         if: matrix.target == 'mac'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,13 @@ jobs:
       - name: Platform evidence
         run: node -p "process.platform + '-' + process.arch"
       - run: npm ci
+      - name: Select Linux Electron runtime
+        if: matrix.target == 'linux'
+        run: |
+          echo "TOKEN_MONITOR_ELECTRON_TARGET=linux" >> "$GITHUB_ENV"
+          echo "TOKEN_MONITOR_LINUX_ELECTRON_VERSION=43.2.0" >> "$GITHUB_ENV"
+      - name: Verify Electron packaging version
+        run: node -e "const config = require('./scripts/electron-builder.config.js'); const installed = require('electron/package.json').version; const effective = config.electronVersion || installed; const expected = process.env.TOKEN_MONITOR_LINUX_ELECTRON_VERSION || installed; console.log('Electron packaging version:', effective, '(installed:', installed + ')'); if (effective !== expected) throw new Error('Electron packaging version mismatch: expected ' + expected + ', got ' + effective);"
       # electron-builder needs the notarization key as a file, not the base64 secret directly.
       - name: Decode Apple API key
         if: matrix.target == 'mac'

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@electron/osx-sign": "1.3.3",
         "@eslint/compat": "^2.1.0",
         "@eslint/js": "^10.0.1",
-        "electron": "43.3.0",
+        "electron": "43.4.0",
         "electron-builder": "26.15.3",
         "eslint": "^10.8.0",
         "globals": "^17.9.0"
@@ -2253,9 +2253,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "43.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-43.3.0.tgz",
-      "integrity": "sha512-nLlvu0WFjftWsSaTkV2B/c4NDuJBspTyXu8vKSQ6vLvFt8uG3NgN49LLKcXddwX0GqVvAQDhciWp+4xOdTdhew==",
+      "version": "43.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.4.0.tgz",
+      "integrity": "sha512-3qxGF0CeQbiox5oWV1JlbWGQ1VerbmDhTFqW4sJ8h7uqTHniFYPObXJcDna0DMh32et0fFyKzz0YY8lJv3t5jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dist:win": "electron-builder --win --x64 --publish never",
     "dist:win:dir": "electron-builder --win dir --x64 --publish never",
     "dist:win:prepackaged": "electron-builder --prepackaged dist/win-unpacked --win nsis portable --x64 --publish never",
-    "dist:linux": "electron-builder --linux --x64 --publish never",
+    "dist:linux": "electron-builder --config scripts/electron-builder.config.js --linux --x64 --publish never",
     "verify:release-artifact-names": "node scripts/verify-updater-artifact-names.js dist",
     "lint": "eslint .",
     "verify": "npm run lint && npm test"

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "@eslint/compat": "^2.1.0",
     "@electron/osx-sign": "1.3.3",
     "@eslint/js": "^10.0.1",
-    "electron": "43.3.0",
+    "electron": "43.4.0",
     "electron-builder": "26.15.3",
     "eslint": "^10.8.0",
     "globals": "^17.9.0"

--- a/scripts/electron-builder-version.js
+++ b/scripts/electron-builder-version.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const semver = require('semver');
+
+function resolveElectronVersionOverride(env = process.env) {
+  const value = String(env.TOKEN_MONITOR_LINUX_ELECTRON_VERSION || '').trim();
+  if (!value) return undefined;
+  const target = String(env.TOKEN_MONITOR_ELECTRON_TARGET || '').trim();
+  if (target !== 'linux') {
+    throw new Error('TOKEN_MONITOR_LINUX_ELECTRON_VERSION is only valid for a Linux build');
+  }
+  if (!semver.valid(value)) {
+    throw new Error(`TOKEN_MONITOR_LINUX_ELECTRON_VERSION must be an exact semver version: ${value}`);
+  }
+  return value;
+}
+
+module.exports = {
+  resolveElectronVersionOverride
+};

--- a/scripts/electron-builder.config.js
+++ b/scripts/electron-builder.config.js
@@ -2,5 +2,16 @@
 
 const packageJson = require('../package.json');
 const { createBuilderConfig } = require('./macos-packaging');
+const { resolveElectronVersionOverride } = require('./electron-builder-version');
 
-module.exports = createBuilderConfig({ baseConfig: packageJson.build });
+// electron-builder downloads the framework selected by this top-level option.
+// The release workflow sets the override only for the Linux artifact, so macOS
+// and Windows continue to use the package.json Electron version.
+const electronVersion = resolveElectronVersionOverride();
+
+module.exports = createBuilderConfig({
+  baseConfig: {
+    ...packageJson.build,
+    ...(electronVersion ? { electronVersion } : {})
+  }
+});

--- a/tests/shared/releaseArtifactNames.test.js
+++ b/tests/shared/releaseArtifactNames.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -13,6 +14,7 @@ const {
   verifyUpdaterArtifactNames
 } = require('../../scripts/verify-updater-artifact-names');
 const { mergeMacUpdaterMetadata } = require('../../scripts/merge-mac-updater-metadata');
+const { resolveElectronVersionOverride } = require('../../scripts/electron-builder-version');
 const { extractReleaseNotes } = require('../../src/shared/appUpdater');
 const { MAC_APP_MIN_DARWIN_VERSION } = require('../../src/shared/macSystemRequirements');
 
@@ -96,6 +98,61 @@ test('mac release scripts build native Apple Silicon and Intel artifacts', () =>
     releaseTemplate,
     /---\s*<details>\s*<summary><strong>Full Changelog:<\/strong> <a href="[^"]+">v\d+\.\d+\.\d+\.\.\.v\d+\.\d+\.\d+<\/a><\/summary>\s*<!-- github-generated-release-notes -->\s*<\/details>\s*<details>\s*<summary>繁體中文 · 한국어 · 日本語<\/summary>/
   );
+});
+
+test('release workflow pins Electron only for the Linux artifact', () => {
+  assert.equal(rootPackage.devDependencies.electron, '43.4.0');
+  assert.equal(resolveElectronVersionOverride({}), undefined);
+  assert.equal(
+    resolveElectronVersionOverride({
+      TOKEN_MONITOR_ELECTRON_TARGET: 'linux',
+      TOKEN_MONITOR_LINUX_ELECTRON_VERSION: '43.2.0'
+    }),
+    '43.2.0'
+  );
+  assert.throws(
+    () => resolveElectronVersionOverride({ TOKEN_MONITOR_LINUX_ELECTRON_VERSION: '43.2.0' }),
+    /only valid for a Linux build/
+  );
+  const defaultConfig = execFileSync(
+    process.execPath,
+    ['-e', "process.stdout.write(String(require('./scripts/electron-builder.config.js').electronVersion || ''))"],
+    {
+      cwd: path.join(__dirname, '..', '..'),
+      env: {
+        ...process.env,
+        TOKEN_MONITOR_ELECTRON_TARGET: '',
+        TOKEN_MONITOR_LINUX_ELECTRON_VERSION: ''
+      }
+    }
+  ).toString();
+  assert.equal(defaultConfig, '');
+  const configWithLinuxOverride = execFileSync(
+    process.execPath,
+    ['-e', "process.stdout.write(String(require('./scripts/electron-builder.config.js').electronVersion || ''))"],
+    {
+      cwd: path.join(__dirname, '..', '..'),
+      env: {
+        ...process.env,
+        TOKEN_MONITOR_ELECTRON_TARGET: 'linux',
+        TOKEN_MONITOR_LINUX_ELECTRON_VERSION: '43.2.0'
+      }
+    }
+  ).toString();
+  assert.equal(configWithLinuxOverride, '43.2.0');
+  assert.throws(
+    () => resolveElectronVersionOverride({
+      TOKEN_MONITOR_ELECTRON_TARGET: 'linux',
+      TOKEN_MONITOR_LINUX_ELECTRON_VERSION: '43.2'
+    }),
+    /must be an exact semver version/
+  );
+
+  const workflow = fs.readFileSync(path.join(__dirname, '..', '..', '.github', 'workflows', 'release.yml'), 'utf8');
+  assert.match(workflow, /if: matrix\.target == 'linux'\s+run: \|\s+echo "TOKEN_MONITOR_ELECTRON_TARGET=linux" >> "\$GITHUB_ENV"/);
+  assert.match(workflow, /echo "TOKEN_MONITOR_LINUX_ELECTRON_VERSION=43\.2\.0" >> "\$GITHUB_ENV"/);
+  assert.match(workflow, /require\('\.\/scripts\/electron-builder\.config\.js'\)/);
+  assert.match(workflow, /npm run \$\{\{ matrix\.dist_script \}\}/);
 });
 
 test('release icons use source assets without the legacy generator', () => {

--- a/tests/shared/releaseArtifactNames.test.js
+++ b/tests/shared/releaseArtifactNames.test.js
@@ -102,6 +102,10 @@ test('mac release scripts build native Apple Silicon and Intel artifacts', () =>
 
 test('release workflow pins Electron only for the Linux artifact', () => {
   assert.equal(rootPackage.devDependencies.electron, '43.4.0');
+  assert.match(
+    rootPackage.scripts['dist:linux'],
+    /^electron-builder --config scripts\/electron-builder\.config\.js --linux --x64 --publish never$/
+  );
   assert.equal(resolveElectronVersionOverride({}), undefined);
   assert.equal(
     resolveElectronVersionOverride({
@@ -151,6 +155,7 @@ test('release workflow pins Electron only for the Linux artifact', () => {
   const workflow = fs.readFileSync(path.join(__dirname, '..', '..', '.github', 'workflows', 'release.yml'), 'utf8');
   assert.match(workflow, /if: matrix\.target == 'linux'\s+run: \|\s+echo "TOKEN_MONITOR_ELECTRON_TARGET=linux" >> "\$GITHUB_ENV"/);
   assert.match(workflow, /echo "TOKEN_MONITOR_LINUX_ELECTRON_VERSION=43\.2\.0" >> "\$GITHUB_ENV"/);
+  assert.match(workflow, /- name: Verify Electron packaging version\s+run: \|\s+node -e /);
   assert.match(workflow, /require\('\.\/scripts\/electron-builder\.config\.js'\)/);
   assert.match(workflow, /npm run \$\{\{ matrix\.dist_script \}\}/);
 });


### PR DESCRIPTION
## Summary

- Update the default Electron runtime from 43.3.0 to 43.4.0 for macOS and Windows release artifacts.
- Keep the Linux release artifact on Electron 43.2.0 to avoid the upstream AppIndicator/StatusNotifierItem regression introduced in Electron 43.3.
- Add packaging-version checks and regression tests to ensure the Linux override is target-scoped.

## Context

Electron 43.4.0 updates Chromium to 150.0.7871.224 and includes upstream ANGLE, Chromium, and V8 backports, but its [release notes](https://github.com/electron/electron/releases/tag/v43.4.0) do not include a fix for the Linux tray regression tracked in [electron/electron#52674](https://github.com/electron/electron/issues/52674).

Token Monitor [#417](https://github.com/Javis603/token-monitor/issues/417) combines the upstream tray regression with two application-side issues. The application-side fixes were merged in [#413](https://github.com/Javis603/token-monitor/pull/413). This PR completes the product-side workaround by pinning only the Linux release artifact to Electron 43.2.0, while macOS and Windows move to Electron 43.4.0.

This closes the Token Monitor issue; it does not imply that the upstream Electron issue has been fixed.

## Verification

- `npm ci --no-audit --no-fund`
- `npm run verify` (3314 passed, 1 skipped)
- `TOKEN_MONITOR_ELECTRON_TARGET=linux TOKEN_MONITOR_LINUX_ELECTRON_VERSION=43.2.0 npm run pack -- --linux --x64`
- Confirmed the Linux packaging log uses Electron 43.2.0.
- Confirmed the default package version remains Electron 43.4.0.

Closes #417

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uses platform-specific `electron` runtimes to avoid the Linux tray regression while upgrading macOS and Windows. Previously all platforms used 43.3.0; now macOS/Windows use 43.4.0 and Linux uses 43.2.0.

- Bumps `electron` in `package.json`/lockfile to 43.4.0; Linux packaging can override via environment.
- Adds `scripts/electron-builder-version.js` to validate `TOKEN_MONITOR_ELECTRON_TARGET` and `TOKEN_MONITOR_LINUX_ELECTRON_VERSION` and require an exact semver.
- Applies `electronVersion` in `scripts/electron-builder.config.js` only when the override is set; otherwise uses the package version.
- Updates `dist:linux` to use `scripts/electron-builder.config.js`; the release workflow sets the Linux override and verifies the packaging version.
- Extends tests to assert the override is Linux-only and to keep release artifact naming stable.
- No migration required; CI pins Linux automatically.

<sup>Written for commit 6a13df0c802ff3826d82f696307e3e683b9d3b96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

