### PR TITLE
fix(sync): preserve Hub drafts when changing upload frequency

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -10940,7 +10940,8 @@ els.saveSettingsButton.addEventListener('click', async () => {
   const patch = {
     hubUrl: els.hubUrlInput.value.trim(),
     secret: els.secretInput.value,
-    deviceId: els.deviceIdInput.value.trim()
+    deviceId: els.deviceIdInput.value.trim(),
+    syncUploadIntervalMs: Number(els.syncUploadIntervalInput.value)
   };
   if (state.settings.hubMode === 'host') {
     patch.hubHostPort = Number(els.hubPortInput.value) || 17321;
@@ -11110,9 +11111,6 @@ for (const input of els.showLimitUsedInputs || []) {
     if (input.checked) await saveSettings({ showLimitUsed: input.value === 'used' });
   });
 }
-els.syncUploadIntervalInput?.addEventListener('change', async () => {
-  await saveSettings({ syncUploadIntervalMs: Number(els.syncUploadIntervalInput.value) });
-});
 els.collectionCadenceInput?.addEventListener('change', async () => {
   const value = els.collectionCadenceInput.value;
   await saveSettings({

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -8120,7 +8120,6 @@ function syncHubModeUi() {
   els.hubClientFields.classList.toggle('hidden', mode !== 'client');
   els.hubHostFields.classList.toggle('hidden', mode !== 'host');
   if (mode === 'host') {
-    els.hubPortInput.value = String(state.settings.hubHostPort || 17321);
     els.hubSecretInput.value = state.settings.hubHostSecret || '';
     renderHubStatus();
   }
@@ -8324,31 +8323,48 @@ function renderSessionUsageArchiveStatus() {
 const HUB_DRAFT_FIELDS = [
   ['hubUrl', 'hubUrlInput'],
   ['secret', 'secretInput'],
-  ['deviceId', 'deviceIdInput']
+  ['deviceId', 'deviceIdInput'],
+  ['hubHostPort', 'hubPortInput']
 ];
 const hubDraftDirty = Object.fromEntries(HUB_DRAFT_FIELDS.map(([field]) => [field, false]));
+const hubDraftRevisions = Object.fromEntries(HUB_DRAFT_FIELDS.map(([field]) => [field, 0]));
 
 function markHubDraftDirty(field) {
   const inputId = HUB_DRAFT_FIELDS.find(([name]) => name === field)?.[1];
   const input = inputId ? els[inputId] : null;
   if (!input) return;
-  hubDraftDirty[field] = input.value !== String(state.settings?.[field] || '');
+  hubDraftRevisions[field] += 1;
+  hubDraftDirty[field] = true;
 }
 
 function syncHubDraftFields() {
   for (const [field, inputId] of HUB_DRAFT_FIELDS) {
     const input = els[inputId];
     if (!input || hubDraftDirty[field]) continue;
-    input.value = state.settings?.[field] || '';
+    input.value = field === 'hubHostPort'
+      ? String(state.settings?.hubHostPort || 17321)
+      : state.settings?.[field] || '';
   }
 }
 
-function reconcileHubDraftsAfterSave(submitted) {
+function normalizeHubDraftValue(field, value) {
+  if (field === 'hubHostPort') return String(Number(value) || 17321);
+  if (field === 'secret') return String(value ?? '');
+  return String(value ?? '').trim();
+}
+
+function reconcileHubDraftsAfterSave(submitted, submittedRevisions) {
   for (const [field, inputId] of HUB_DRAFT_FIELDS) {
     const input = els[inputId];
     if (!input) continue;
-    const current = field === 'secret' ? input.value : input.value.trim();
-    if (current === submitted[field]) hubDraftDirty[field] = false;
+    if (!Object.prototype.hasOwnProperty.call(submitted, field)) continue;
+    const current = normalizeHubDraftValue(field, input.value);
+    if (
+      hubDraftRevisions[field] === submittedRevisions[field]
+      && current === submitted[field]
+    ) {
+      hubDraftDirty[field] = false;
+    }
   }
   syncHubDraftFields();
 }
@@ -10974,10 +10990,15 @@ els.saveSettingsButton.addEventListener('click', async () => {
   };
   const patch = { ...submittedHubFields };
   if (state.settings.hubMode === 'host') {
-    patch.hubHostPort = Number(els.hubPortInput.value) || 17321;
+    const hubHostPort = Number(els.hubPortInput.value) || 17321;
+    submittedHubFields.hubHostPort = String(hubHostPort);
+    patch.hubHostPort = hubHostPort;
   }
+  const submittedHubRevisions = Object.fromEntries(
+    Object.keys(submittedHubFields).map((field) => [field, hubDraftRevisions[field]])
+  );
   await saveSettings(patch);
-  reconcileHubDraftsAfterSave(submittedHubFields);
+  reconcileHubDraftsAfterSave(submittedHubFields, submittedHubRevisions);
   await refreshHubInfo();
   void refreshHubBuildStatus();
   await refreshStats();

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -8321,6 +8321,38 @@ function renderSessionUsageArchiveStatus() {
     : t('settings.collection.sessionArchiveEmpty');
 }
 
+const HUB_DRAFT_FIELDS = [
+  ['hubUrl', 'hubUrlInput'],
+  ['secret', 'secretInput'],
+  ['deviceId', 'deviceIdInput']
+];
+const hubDraftDirty = Object.fromEntries(HUB_DRAFT_FIELDS.map(([field]) => [field, false]));
+
+function markHubDraftDirty(field) {
+  const inputId = HUB_DRAFT_FIELDS.find(([name]) => name === field)?.[1];
+  const input = inputId ? els[inputId] : null;
+  if (!input) return;
+  hubDraftDirty[field] = input.value !== String(state.settings?.[field] || '');
+}
+
+function syncHubDraftFields() {
+  for (const [field, inputId] of HUB_DRAFT_FIELDS) {
+    const input = els[inputId];
+    if (!input || hubDraftDirty[field]) continue;
+    input.value = state.settings?.[field] || '';
+  }
+}
+
+function reconcileHubDraftsAfterSave(submitted) {
+  for (const [field, inputId] of HUB_DRAFT_FIELDS) {
+    const input = els[inputId];
+    if (!input) continue;
+    const current = field === 'secret' ? input.value : input.value.trim();
+    if (current === submitted[field]) hubDraftDirty[field] = false;
+  }
+  syncHubDraftFields();
+}
+
 function syncSettingsForm() {
   applySettingsTranslations();
   applyInitialBreakdownPreference();
@@ -8332,9 +8364,7 @@ function syncSettingsForm() {
   }
   if (els.currencyInput) els.currencyInput.value = currentCurrency();
   syncCurrencyRateControls();
-  els.hubUrlInput.value = state.settings.hubUrl || '';
-  els.secretInput.value = state.settings.secret || '';
-  els.deviceIdInput.value = state.settings.deviceId || '';
+  syncHubDraftFields();
   els.limitsRefreshInput.value = state.settings.limitsRefreshMode === 'adaptive'
     ? 'adaptive'
     : String(LIMIT_REFRESH_OPTIONS.includes(Number(state.settings.limitsRefreshMs)) ? state.settings.limitsRefreshMs : 300000);
@@ -10937,16 +10967,17 @@ els.settingsButton.addEventListener('click', (event) => {
   requestAnimationFrame(() => { els.shell.style.transform = ''; });
 });
 els.saveSettingsButton.addEventListener('click', async () => {
-  const patch = {
+  const submittedHubFields = {
     hubUrl: els.hubUrlInput.value.trim(),
     secret: els.secretInput.value,
-    deviceId: els.deviceIdInput.value.trim(),
-    syncUploadIntervalMs: Number(els.syncUploadIntervalInput.value)
+    deviceId: els.deviceIdInput.value.trim()
   };
+  const patch = { ...submittedHubFields };
   if (state.settings.hubMode === 'host') {
     patch.hubHostPort = Number(els.hubPortInput.value) || 17321;
   }
   await saveSettings(patch);
+  reconcileHubDraftsAfterSave(submittedHubFields);
   await refreshHubInfo();
   void refreshHubBuildStatus();
   await refreshStats();
@@ -11035,6 +11066,7 @@ els.secretPasteButton?.addEventListener('click', async () => {
     const text = await navigator.clipboard.readText();
     if (text) {
       els.secretInput.value = text.trim();
+      markHubDraftDirty('secret');
     }
   } catch (_) {}
 });
@@ -11111,6 +11143,12 @@ for (const input of els.showLimitUsedInputs || []) {
     if (input.checked) await saveSettings({ showLimitUsed: input.value === 'used' });
   });
 }
+for (const [field, inputId] of HUB_DRAFT_FIELDS) {
+  els[inputId]?.addEventListener('input', () => markHubDraftDirty(field));
+}
+els.syncUploadIntervalInput?.addEventListener('change', async () => {
+  await saveSettings({ syncUploadIntervalMs: Number(els.syncUploadIntervalInput.value) });
+});
 els.collectionCadenceInput?.addEventListener('change', async () => {
   const value = els.collectionCadenceInput.value;
   await saveSettings({

--- a/tests/electron/cursorSettingsLayout.test.js
+++ b/tests/electron/cursorSettingsLayout.test.js
@@ -1349,21 +1349,31 @@ function fakeHubControl(value = '') {
 
 function loadHubSettingsWiring(els, context) {
   const app = readRendererFile('app.js');
+  const modeStart = app.indexOf('function syncHubModeUi()');
+  const modeEnd = app.indexOf('function renderHubStatus()', modeStart);
   const draftStart = app.indexOf('const HUB_DRAFT_FIELDS = [');
   const draftEnd = app.indexOf('function syncSettingsForm()', draftStart);
   const saveStart = app.indexOf("els.saveSettingsButton.addEventListener('click'");
   const saveEnd = app.indexOf("els.hubModeOptions.addEventListener('change'", saveStart);
   const intervalStart = app.indexOf('for (const input of els.showLimitUsedInputs || [])', saveEnd);
   const intervalEnd = app.indexOf("els.collectionCadenceInput?.addEventListener('change'", intervalStart);
+  assert.notEqual(modeStart, -1, 'Hub mode UI sync should exist');
+  assert.notEqual(modeEnd, -1, 'Hub mode UI sync should precede Hub status rendering');
   assert.notEqual(draftStart, -1, 'Hub draft tracking should exist');
   assert.notEqual(draftEnd, -1, 'Hub draft tracking should precede settings sync');
   assert.notEqual(saveStart, -1, 'Hub Save handler should exist');
   assert.notEqual(saveEnd, -1, 'Hub mode handler should follow Hub Save');
   assert.notEqual(intervalStart, -1, 'limits display wiring should precede sync upload wiring');
   assert.notEqual(intervalEnd, -1, 'collection cadence wiring should follow sync upload wiring');
-  const vmContext = { els, ...context };
+  const vmContext = {
+    els,
+    ...context,
+    renderHubStatus: () => {},
+    renderSyncClientStatus: () => {},
+    renderHubBuildStatus: () => {}
+  };
   vm.runInNewContext(
-    `${app.slice(draftStart, draftEnd)}\n${app.slice(saveStart, saveEnd)}\n${app.slice(intervalStart, intervalEnd)}`,
+    `${app.slice(modeStart, modeEnd)}\n${app.slice(draftStart, draftEnd)}\n${app.slice(saveStart, saveEnd)}\n${app.slice(intervalStart, intervalEnd)}`,
     vmContext
   );
   return vmContext;
@@ -1493,6 +1503,118 @@ test('Hub Save keeps edits made while persistence is in flight', async () => {
   assert.equal(els.deviceIdInput.value, 'draft-device');
   vmContext.syncHubDraftFields();
   assert.equal(els.hubUrlInput.value, 'https://draft-b.example');
+});
+
+test('Hub Save keeps an in-flight edit even when it returns to the persisted value', async () => {
+  const els = {
+    saveSettingsButton: fakeHubControl(),
+    hubUrlInput: fakeHubControl(),
+    secretInput: fakeHubControl(),
+    deviceIdInput: fakeHubControl(),
+    syncUploadIntervalInput: fakeHubControl('0'),
+    showLimitUsedInputs: []
+  };
+  const state = {
+    settings: {
+      hubMode: 'client',
+      hubUrl: 'https://saved.example',
+      secret: 'saved-secret',
+      deviceId: 'saved-device',
+      syncUploadIntervalMs: 0
+    }
+  };
+  let releaseSave;
+  let resolveSaveStarted;
+  const saveGate = new Promise((resolve) => { releaseSave = resolve; });
+  const saveStarted = new Promise((resolve) => { resolveSaveStarted = resolve; });
+  let vmContext;
+  vmContext = loadHubSettingsWiring(els, {
+    state,
+    saveSettings: async (patch) => {
+      resolveSaveStarted();
+      await saveGate;
+      Object.assign(state.settings, patch);
+      vmContext.syncHubDraftFields();
+    },
+    refreshHubInfo: async () => {},
+    refreshHubBuildStatus: async () => {},
+    refreshStats: async () => {}
+  });
+  vmContext.syncHubDraftFields();
+
+  els.hubUrlInput.value = 'https://draft.example';
+  await els.hubUrlInput.dispatch('input');
+
+  const savePromise = els.saveSettingsButton.dispatch('click');
+  await saveStarted;
+  els.hubUrlInput.value = 'https://saved.example';
+  await els.hubUrlInput.dispatch('input');
+  releaseSave();
+  await savePromise;
+
+  assert.equal(els.hubUrlInput.value, 'https://saved.example');
+  vmContext.syncHubDraftFields();
+  assert.equal(els.hubUrlInput.value, 'https://saved.example');
+});
+
+test('Host Hub port draft survives settings rehydration and saves with Hub fields', async () => {
+  const classList = { toggle() {} };
+  const els = {
+    saveSettingsButton: fakeHubControl(),
+    hubModeOptions: { querySelectorAll: () => [] },
+    hubClientFields: { classList },
+    hubHostFields: { classList },
+    hubPortInput: fakeHubControl(),
+    hubSecretInput: fakeHubControl(),
+    hubUrlInput: fakeHubControl(),
+    secretInput: fakeHubControl(),
+    deviceIdInput: fakeHubControl(),
+    syncUploadIntervalInput: fakeHubControl('0'),
+    showLimitUsedInputs: []
+  };
+  const state = {
+    settings: {
+      hubMode: 'host',
+      hubHostPort: 17321,
+      hubHostSecret: 'host-secret',
+      hubUrl: '',
+      secret: '',
+      deviceId: 'saved-device',
+      syncUploadIntervalMs: 0
+    }
+  };
+  const patches = [];
+  let vmContext;
+  vmContext = loadHubSettingsWiring(els, {
+    state,
+    saveSettings: async (patch) => {
+      patches.push({ ...patch });
+      Object.assign(state.settings, patch);
+      vmContext.syncHubModeUi();
+      vmContext.syncHubDraftFields();
+    },
+    refreshHubInfo: async () => {},
+    refreshHubBuildStatus: async () => {},
+    refreshStats: async () => {}
+  });
+  vmContext.syncHubModeUi();
+  vmContext.syncHubDraftFields();
+
+  els.hubPortInput.value = '18000';
+  await els.hubPortInput.dispatch('input');
+  // Model the same renderer rehydration that follows any settings push.
+  vmContext.syncHubModeUi();
+  vmContext.syncHubDraftFields();
+  assert.equal(els.hubPortInput.value, '18000');
+
+  await els.saveSettingsButton.dispatch('click');
+  assert.deepEqual(patches, [{
+    hubUrl: '',
+    secret: '',
+    deviceId: 'saved-device',
+    hubHostPort: 18000
+  }]);
+  assert.equal(els.hubPortInput.value, '18000');
 });
 
 test('remote Hub build status is wired as a separate localized sync hint', () => {

--- a/tests/electron/cursorSettingsLayout.test.js
+++ b/tests/electron/cursorSettingsLayout.test.js
@@ -1305,7 +1305,7 @@ test('collection cadence setting is exposed in the Collection panel', () => {
   assert.match(listenerSlice, /600000/);
 });
 
-test('sync upload interval setting is exposed in the Multi-device Sync panel', () => {
+test('sync upload interval setting is exposed and saved with the Hub connection', () => {
   const html = readRendererFile('index.html');
   const controls = html.match(/<label class="sync-upload-interval-row[^"]*"[\s\S]*?<select id="syncUploadIntervalInput"[\s\S]*?<\/select>[\s\S]*?<\/label>/)?.[0] || '';
   const clientFields = html.slice(html.indexOf('<div id="hubClientFields"'), html.indexOf('<div id="hubHostFields"'));
@@ -1323,11 +1323,12 @@ test('sync upload interval setting is exposed in the Multi-device Sync panel', (
   assert.match(syncBody, /Array\.from\(els\.syncUploadIntervalInput\.options/);
   assert.doesNotMatch(syncBody, /const allowed = \[0, 600000, 1200000, 1800000\]/);
 
-  const listenerSlice = app.slice(
-    app.indexOf("els.syncUploadIntervalInput?.addEventListener('change'"),
-    app.indexOf("els.collectionCadenceInput?.addEventListener('change'")
+  const saveHandler = app.slice(
+    app.indexOf("els.saveSettingsButton.addEventListener('click'"),
+    app.indexOf("els.hubModeOptions.addEventListener('change'")
   );
-  assert.match(listenerSlice, /saveSettings\(\{ syncUploadIntervalMs: Number\(els\.syncUploadIntervalInput\.value\) \}\)/);
+  assert.match(saveHandler, /syncUploadIntervalMs: Number\(els\.syncUploadIntervalInput\.value\)/);
+  assert.doesNotMatch(app, /els\.syncUploadIntervalInput\?\.addEventListener\('change'/);
 });
 
 test('remote Hub build status is wired as a separate localized sync hint', () => {

--- a/tests/electron/cursorSettingsLayout.test.js
+++ b/tests/electron/cursorSettingsLayout.test.js
@@ -1305,7 +1305,7 @@ test('collection cadence setting is exposed in the Collection panel', () => {
   assert.match(listenerSlice, /600000/);
 });
 
-test('sync upload interval setting is exposed and saved with the Hub connection', () => {
+test('sync upload interval setting is exposed in the Multi-device Sync panel', () => {
   const html = readRendererFile('index.html');
   const controls = html.match(/<label class="sync-upload-interval-row[^"]*"[\s\S]*?<select id="syncUploadIntervalInput"[\s\S]*?<\/select>[\s\S]*?<\/label>/)?.[0] || '';
   const clientFields = html.slice(html.indexOf('<div id="hubClientFields"'), html.indexOf('<div id="hubHostFields"'));
@@ -1322,13 +1322,94 @@ test('sync upload interval setting is exposed and saved with the Hub connection'
   assert.match(syncBody, /state\.settings\.syncUploadIntervalMs/);
   assert.match(syncBody, /Array\.from\(els\.syncUploadIntervalInput\.options/);
   assert.doesNotMatch(syncBody, /const allowed = \[0, 600000, 1200000, 1800000\]/);
+  assert.doesNotMatch(app, /saveSettings\(\{\s*syncUploadIntervalMs:/);
+});
 
-  const saveHandler = app.slice(
-    app.indexOf("els.saveSettingsButton.addEventListener('click'"),
-    app.indexOf("els.hubModeOptions.addEventListener('change'")
-  );
-  assert.match(saveHandler, /syncUploadIntervalMs: Number\(els\.syncUploadIntervalInput\.value\)/);
-  assert.doesNotMatch(app, /els\.syncUploadIntervalInput\?\.addEventListener\('change'/);
+// Run the shipped event wiring against controls that model the settings push:
+// every save rehydrates the form from persisted state, which is the path that
+// used to replace an unsaved URL and secret when the interval changed.
+function fakeHubControl(value = '') {
+  const listeners = new Map();
+  return {
+    value,
+    addEventListener(type, listener) {
+      const current = listeners.get(type) || [];
+      current.push(listener);
+      listeners.set(type, current);
+    },
+    async dispatch(type) {
+      for (const listener of listeners.get(type) || []) await listener({ target: this });
+    }
+  };
+}
+
+function loadHubSettingsWiring(els, context) {
+  const app = readRendererFile('app.js');
+  const saveStart = app.indexOf("els.saveSettingsButton.addEventListener('click'");
+  const saveEnd = app.indexOf("els.hubModeOptions.addEventListener('change'", saveStart);
+  const intervalStart = app.indexOf('for (const input of els.showLimitUsedInputs || [])', saveEnd);
+  const intervalEnd = app.indexOf("els.collectionCadenceInput?.addEventListener('change'", intervalStart);
+  assert.notEqual(saveStart, -1, 'Hub Save handler should exist');
+  assert.notEqual(saveEnd, -1, 'Hub mode handler should follow Hub Save');
+  assert.notEqual(intervalStart, -1, 'limits display wiring should precede sync upload wiring');
+  assert.notEqual(intervalEnd, -1, 'collection cadence wiring should follow sync upload wiring');
+  vm.runInNewContext(`${app.slice(saveStart, saveEnd)}\n${app.slice(intervalStart, intervalEnd)}`, { els, ...context });
+}
+
+test('changing sync upload frequency preserves Hub drafts until one complete Save', async () => {
+  const els = {
+    saveSettingsButton: fakeHubControl(),
+    hubUrlInput: fakeHubControl(),
+    secretInput: fakeHubControl(),
+    deviceIdInput: fakeHubControl(),
+    syncUploadIntervalInput: fakeHubControl('0'),
+    showLimitUsedInputs: []
+  };
+  const state = {
+    settings: {
+      hubMode: 'client',
+      hubUrl: 'https://saved.example',
+      secret: 'saved-secret',
+      deviceId: 'saved-device',
+      syncUploadIntervalMs: 0
+    }
+  };
+  const patches = [];
+  const syncSettingsForm = () => {
+    els.hubUrlInput.value = state.settings.hubUrl;
+    els.secretInput.value = state.settings.secret;
+    els.deviceIdInput.value = state.settings.deviceId;
+    els.syncUploadIntervalInput.value = String(state.settings.syncUploadIntervalMs);
+  };
+  loadHubSettingsWiring(els, {
+    state,
+    saveSettings: async (patch) => {
+      patches.push({ ...patch });
+      Object.assign(state.settings, patch);
+      syncSettingsForm();
+    },
+    refreshHubInfo: async () => {},
+    refreshHubBuildStatus: async () => {},
+    refreshStats: async () => {}
+  });
+
+  els.hubUrlInput.value = 'https://draft.example';
+  els.secretInput.value = 'draft-secret';
+  els.deviceIdInput.value = 'draft-device';
+  els.syncUploadIntervalInput.value = '1200000';
+
+  await els.syncUploadIntervalInput.dispatch('change');
+  assert.equal(els.hubUrlInput.value, 'https://draft.example');
+  assert.equal(els.secretInput.value, 'draft-secret');
+  assert.deepEqual(patches, []);
+
+  await els.saveSettingsButton.dispatch('click');
+  assert.deepEqual(patches, [{
+    hubUrl: 'https://draft.example',
+    secret: 'draft-secret',
+    deviceId: 'draft-device',
+    syncUploadIntervalMs: 1200000
+  }]);
 });
 
 test('remote Hub build status is wired as a separate localized sync hint', () => {

--- a/tests/electron/cursorSettingsLayout.test.js
+++ b/tests/electron/cursorSettingsLayout.test.js
@@ -155,7 +155,7 @@ test('Hub secret input stays masked and exposes an accessible paste button', () 
   const pasteBody = app.slice(start, end);
   assert.match(pasteBody, /const text = await navigator\.clipboard\.readText\(\);/);
   assert.match(pasteBody, /els\.secretInput\.value = text\.trim\(\);/);
-  assert.doesNotMatch(pasteBody, /dispatchEvent\(new Event\('input'/);
+  assert.match(pasteBody, /markHubDraftDirty\('secret'\);/);
 });
 
 test('Cursor account header omits plan and reset details', () => {
@@ -1322,12 +1322,16 @@ test('sync upload interval setting is exposed in the Multi-device Sync panel', (
   assert.match(syncBody, /state\.settings\.syncUploadIntervalMs/);
   assert.match(syncBody, /Array\.from\(els\.syncUploadIntervalInput\.options/);
   assert.doesNotMatch(syncBody, /const allowed = \[0, 600000, 1200000, 1800000\]/);
-  assert.doesNotMatch(app, /saveSettings\(\{\s*syncUploadIntervalMs:/);
+  const listenerStart = app.indexOf("els.syncUploadIntervalInput?.addEventListener('change'");
+  const listenerEnd = app.indexOf("els.collectionCadenceInput?.addEventListener('change'", listenerStart);
+  assert.notEqual(listenerStart, -1, 'sync upload interval listener should exist');
+  assert.notEqual(listenerEnd, -1, 'collection cadence listener should follow sync upload listener');
+  assert.match(app.slice(listenerStart, listenerEnd), /saveSettings\(\{\s*syncUploadIntervalMs:/);
 });
 
-// Run the shipped event wiring against controls that model the settings push:
-// every save rehydrates the form from persisted state, which is the path that
-// used to replace an unsaved URL and secret when the interval changed.
+// Run the shipped event wiring against controls that model a settings push:
+// an auto-saved interval updates persisted state while the Hub fields keep
+// their local drafts until the explicit Hub Save commits them.
 function fakeHubControl(value = '') {
   const listeners = new Map();
   return {
@@ -1345,18 +1349,27 @@ function fakeHubControl(value = '') {
 
 function loadHubSettingsWiring(els, context) {
   const app = readRendererFile('app.js');
+  const draftStart = app.indexOf('const HUB_DRAFT_FIELDS = [');
+  const draftEnd = app.indexOf('function syncSettingsForm()', draftStart);
   const saveStart = app.indexOf("els.saveSettingsButton.addEventListener('click'");
   const saveEnd = app.indexOf("els.hubModeOptions.addEventListener('change'", saveStart);
   const intervalStart = app.indexOf('for (const input of els.showLimitUsedInputs || [])', saveEnd);
   const intervalEnd = app.indexOf("els.collectionCadenceInput?.addEventListener('change'", intervalStart);
+  assert.notEqual(draftStart, -1, 'Hub draft tracking should exist');
+  assert.notEqual(draftEnd, -1, 'Hub draft tracking should precede settings sync');
   assert.notEqual(saveStart, -1, 'Hub Save handler should exist');
   assert.notEqual(saveEnd, -1, 'Hub mode handler should follow Hub Save');
   assert.notEqual(intervalStart, -1, 'limits display wiring should precede sync upload wiring');
   assert.notEqual(intervalEnd, -1, 'collection cadence wiring should follow sync upload wiring');
-  vm.runInNewContext(`${app.slice(saveStart, saveEnd)}\n${app.slice(intervalStart, intervalEnd)}`, { els, ...context });
+  const vmContext = { els, ...context };
+  vm.runInNewContext(
+    `${app.slice(draftStart, draftEnd)}\n${app.slice(saveStart, saveEnd)}\n${app.slice(intervalStart, intervalEnd)}`,
+    vmContext
+  );
+  return vmContext;
 }
 
-test('changing sync upload frequency preserves Hub drafts until one complete Save', async () => {
+test('changing sync upload frequency auto-saves without replacing Hub drafts', async () => {
   const els = {
     saveSettingsButton: fakeHubControl(),
     hubUrlInput: fakeHubControl(),
@@ -1375,41 +1388,111 @@ test('changing sync upload frequency preserves Hub drafts until one complete Sav
     }
   };
   const patches = [];
-  const syncSettingsForm = () => {
-    els.hubUrlInput.value = state.settings.hubUrl;
-    els.secretInput.value = state.settings.secret;
-    els.deviceIdInput.value = state.settings.deviceId;
-    els.syncUploadIntervalInput.value = String(state.settings.syncUploadIntervalMs);
-  };
-  loadHubSettingsWiring(els, {
+  let vmContext;
+  vmContext = loadHubSettingsWiring(els, {
     state,
     saveSettings: async (patch) => {
       patches.push({ ...patch });
       Object.assign(state.settings, patch);
-      syncSettingsForm();
+      vmContext.syncHubDraftFields();
+      els.syncUploadIntervalInput.value = String(state.settings.syncUploadIntervalMs);
     },
     refreshHubInfo: async () => {},
     refreshHubBuildStatus: async () => {},
     refreshStats: async () => {}
   });
+  vmContext.syncHubDraftFields();
 
   els.hubUrlInput.value = 'https://draft.example';
   els.secretInput.value = 'draft-secret';
   els.deviceIdInput.value = 'draft-device';
+  await els.hubUrlInput.dispatch('input');
+  await els.secretInput.dispatch('input');
+  await els.deviceIdInput.dispatch('input');
   els.syncUploadIntervalInput.value = '1200000';
 
   await els.syncUploadIntervalInput.dispatch('change');
   assert.equal(els.hubUrlInput.value, 'https://draft.example');
   assert.equal(els.secretInput.value, 'draft-secret');
-  assert.deepEqual(patches, []);
+  assert.equal(els.deviceIdInput.value, 'draft-device');
+  assert.deepEqual(patches, [{ syncUploadIntervalMs: 1200000 }]);
 
   await els.saveSettingsButton.dispatch('click');
   assert.deepEqual(patches, [{
+    syncUploadIntervalMs: 1200000
+  }, {
     hubUrl: 'https://draft.example',
     secret: 'draft-secret',
-    deviceId: 'draft-device',
-    syncUploadIntervalMs: 1200000
+    deviceId: 'draft-device'
   }]);
+  assert.equal(els.hubUrlInput.value, 'https://draft.example');
+  assert.equal(els.secretInput.value, 'draft-secret');
+  assert.equal(els.deviceIdInput.value, 'draft-device');
+});
+
+test('Hub Save keeps edits made while persistence is in flight', async () => {
+  const els = {
+    saveSettingsButton: fakeHubControl(),
+    hubUrlInput: fakeHubControl(),
+    secretInput: fakeHubControl(),
+    deviceIdInput: fakeHubControl(),
+    syncUploadIntervalInput: fakeHubControl('0'),
+    showLimitUsedInputs: []
+  };
+  const state = {
+    settings: {
+      hubMode: 'client',
+      hubUrl: 'https://saved.example',
+      secret: 'saved-secret',
+      deviceId: 'saved-device',
+      syncUploadIntervalMs: 0
+    }
+  };
+  const patches = [];
+  let releaseSave;
+  let resolveSaveStarted;
+  const saveGate = new Promise((resolve) => { releaseSave = resolve; });
+  const saveStarted = new Promise((resolve) => { resolveSaveStarted = resolve; });
+  let vmContext;
+  vmContext = loadHubSettingsWiring(els, {
+    state,
+    saveSettings: async (patch) => {
+      patches.push({ ...patch });
+      resolveSaveStarted();
+      await saveGate;
+      Object.assign(state.settings, patch);
+      vmContext.syncHubDraftFields();
+    },
+    refreshHubInfo: async () => {},
+    refreshHubBuildStatus: async () => {},
+    refreshStats: async () => {}
+  });
+  vmContext.syncHubDraftFields();
+
+  els.hubUrlInput.value = 'https://draft-a.example';
+  els.secretInput.value = 'draft-secret';
+  els.deviceIdInput.value = 'draft-device';
+  await els.hubUrlInput.dispatch('input');
+  await els.secretInput.dispatch('input');
+  await els.deviceIdInput.dispatch('input');
+
+  const savePromise = els.saveSettingsButton.dispatch('click');
+  await saveStarted;
+  els.hubUrlInput.value = 'https://draft-b.example';
+  await els.hubUrlInput.dispatch('input');
+  releaseSave();
+  await savePromise;
+
+  assert.deepEqual(patches, [{
+    hubUrl: 'https://draft-a.example',
+    secret: 'draft-secret',
+    deviceId: 'draft-device'
+  }]);
+  assert.equal(els.hubUrlInput.value, 'https://draft-b.example');
+  assert.equal(els.secretInput.value, 'draft-secret');
+  assert.equal(els.deviceIdInput.value, 'draft-device');
+  vmContext.syncHubDraftFields();
+  assert.equal(els.hubUrlInput.value, 'https://draft-b.example');
 });
 
 test('remote Hub build status is wired as a separate localized sync hint', () => {


### PR DESCRIPTION
## Summary

- Keep sync upload frequency auto-saving when changed.
- Preserve unsaved Hub URL, secret, device ID, and host port drafts across settings pushes.
- Use per-field edit revisions so in-flight saves cannot overwrite newer user edits.
- Add regression coverage for interval auto-save, rehydration, save races, and Host port drafts.

## Root cause

Changing the sync upload frequency saves only `syncUploadIntervalMs`, but the resulting settings push rehydrates the renderer form. The old form sync unconditionally restored persisted Hub values and overwrote unsaved drafts.

## User impact

Changing the sync upload frequency now takes effect immediately without discarding unsaved Hub fields. Hub fields remain local drafts until the user clicks Save.

If a field is edited while a Save is in flight, its newer value is preserved even when it temporarily matches the previously persisted value.

## Validation

- `npm run verify`
  - 3,322 passed
  - 1 skipped
  - 0 failed
- Focused renderer settings tests
  - 58 passed
- `git diff --check`

## Related issue

None — this regression was not previously reported.
