### PR TITLE
fix(limits): keep the fetch timeout armed while the body is read

### DIFF
--- a/src/shared/copilotDeviceFlow.js
+++ b/src/shared/copilotDeviceFlow.js
@@ -96,7 +96,7 @@ async function fetchForm(url, body, deps = {}) {
       ...(controller ? { signal: controller.signal } : {})
     });
     if (!response.ok) throw errorWithStatus('unavailable', `${url} returned ${response.status}`);
-    return response.json();
+    return await response.json();
   } catch (error) {
     if (externalSignal?.aborted) throw errorWithStatus('cancelled', 'Sign-in cancelled');
     if (error?.name === 'AbortError') throw errorWithStatus('timedOut', 'GitHub request timed out');

--- a/src/shared/copilotLimits.js
+++ b/src/shared/copilotLimits.js
@@ -253,7 +253,7 @@ async function fetchJson(url, headers, deps = {}) {
           : 'unavailable';
       throw errorWithStatus(status, `${url} returned ${response.status}`);
     }
-    return response.json();
+    return await response.json();
   } catch (error) {
     if (error?.name === 'AbortError') throw errorWithStatus('unavailable', `${url} timed out`);
     throw error;

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -652,7 +652,7 @@ async function fetchJson(url, headers, deps = {}, options = {}) {
       if (sourceChallenge) error.code = 'CLAUDE_WEB_SOURCE_CHALLENGE';
       throw error;
     }
-    return response.json();
+    return await response.json();
   } catch (error) {
     if (error?.name === 'AbortError') throw errorWithStatus('unavailable', `${url} timed out`);
     throw error;

--- a/src/shared/minimaxLimits.js
+++ b/src/shared/minimaxLimits.js
@@ -235,7 +235,7 @@ async function fetchMinimaxLimits(options = {}, deps = {}) {
         error.statusCode = response.status;
         throw error;
       }
-      return response.json();
+      return await response.json();
     } finally {
       if (timer) clearTimeout(timer);
     }

--- a/tests/shared/copilotDeviceFlow.test.js
+++ b/tests/shared/copilotDeviceFlow.test.js
@@ -253,3 +253,25 @@ test('main process Copilot sign-in owns controller cleanup per flow', () => {
   assert.match(cancelHandler, /const controller = copilotLoginController;/);
   assert.match(cancelHandler, /if \(copilotLoginController === controller\) \{/);
 });
+
+// Same bound applies once the head has arrived. Without it a stalled body leaves the
+// sign-in hanging with no way back to the timedOut/cancelled mapping below.
+test('requestDeviceCode bounds a body that stalls after the headers', { timeout: 5000 }, async () => {
+  await assert.rejects(
+    () => requestDeviceCode('', {
+      fetchTimeoutMs: 1,
+      fetch: async (_url, init) => ({
+        ok: true,
+        status: 200,
+        json: () => new Promise((_resolve, reject) => {
+          init.signal.addEventListener('abort', () => {
+            const error = new Error('aborted');
+            error.name = 'AbortError';
+            reject(error);
+          }, { once: true });
+        })
+      })
+    }),
+    (error) => error?.status === 'timedOut'
+  );
+});

--- a/tests/shared/copilotLimits.test.js
+++ b/tests/shared/copilotLimits.test.js
@@ -235,3 +235,28 @@ test('fetchCopilotLimits surfaces unauthorized responses', async () => {
   );
   assert.equal(provider.status, 'unauthorized');
 });
+
+// The fetch timeout has to stay armed while the body is read, otherwise a response whose
+// head arrives and whose body never does is unbounded by it.
+test('fetchCopilotLimits bounds a body that stalls after the headers', { timeout: 5000 }, async () => {
+  const provider = await fetchCopilotLimits(
+    { copilotApiToken: 'gho-token' },
+    {
+      env: {},
+      now: () => Date.parse('2026-06-25T00:00:00.000Z'),
+      fetchTimeoutMs: 10,
+      fetch: async (_url, init) => ({
+        ok: true,
+        status: 200,
+        json: () => new Promise((_resolve, reject) => {
+          init.signal.addEventListener('abort', () => {
+            const error = new Error('aborted');
+            error.name = 'AbortError';
+            reject(error);
+          }, { once: true });
+        })
+      })
+    }
+  );
+  assert.equal(provider.status, 'unavailable');
+});

--- a/tests/shared/deepseekLimits.test.js
+++ b/tests/shared/deepseekLimits.test.js
@@ -196,3 +196,25 @@ test('fetchDeepSeekLimits exposes the balance as a credits window', async () => 
   assert.equal(provider.balance.amount, 4);
   assert.equal(provider.balance.currency, 'CNY');
 });
+
+// fetchJson's abort timer has to outlive the body read. A head-then-stall response is
+// otherwise bounded only by the outer probe deadline, two orders of magnitude later.
+test('fetchDeepSeekLimits bounds a body that stalls after the headers', { timeout: 5000 }, async () => {
+  const r = await fetchDeepSeekLimits({}, {
+    env: { DEEPSEEK_API_KEY: 'sk-test' },
+    now: () => Date.parse('2026-06-25T00:00:00.000Z'),
+    fetchTimeoutMs: 10,
+    fetch: async (_url, init) => ({
+      ok: true,
+      status: 200,
+      json: () => new Promise((_resolve, reject) => {
+        init.signal.addEventListener('abort', () => {
+          const error = new Error('aborted');
+          error.name = 'AbortError';
+          reject(error);
+        }, { once: true });
+      })
+    })
+  });
+  assert.equal(r.status, 'unavailable');
+});

--- a/tests/shared/minimaxLimits.test.js
+++ b/tests/shared/minimaxLimits.test.js
@@ -557,3 +557,27 @@ test('fetchMinimaxLimits reports cn region when pinned to the CN endpoint', asyn
   assert.equal(r.status, 'ok');
   assert.equal(r.region, 'cn');
 });
+
+// The abort timer must outlive the body read, not just the headers. Undici resolves the
+// fetch as soon as the head arrives, so a body that never arrives is only bounded if the
+// timer is still armed while `.json()` is pending.
+test('fetchMinimaxLimits aborts when the body stalls after the headers', { timeout: 5000 }, async () => {
+  const r = await fetchMinimaxLimits({ minimaxApiHost: 'cn' }, {
+    env: { MINIMAX_CODING_API_KEY: 'sk-cp-test' },
+    now: () => 1_716_350_000_000,
+    fetchTimeoutMs: 10,
+    fetch: async (_url, init) => ({
+      ok: true,
+      status: 200,
+      json: () => new Promise((_resolve, reject) => {
+        init.signal.addEventListener('abort', () => {
+          const error = new Error('aborted');
+          error.name = 'AbortError';
+          reject(error);
+        }, { once: true });
+      })
+    })
+  });
+  assert.equal(r.status, 'unavailable');
+  assert.deepEqual(r.windows, []);
+});


### PR DESCRIPTION
## Problem

`return response.json()` inside the `try` runs the `finally` at once, so `clearTimeout` fired before the body settled. The abort timer only bounded time to headers, and a response whose head arrives and whose body stalls fell through to the outer probe deadline instead.

## Fix

Await the body inside the `try` at the four sites that arm their own timer. Same shape `refreshClaudeAccessToken` and `grokLimits` already use. Providers wrapped in `runWithProbeDeadline` are unaffected, since that deadline already races the whole read.

## Verify

`npm run verify` green, failure set unchanged from main. Four regression tests stub a head then stall response, one per touched file. Each fails by timeout before the fix and passes after.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the per-request fetch timeout active while reading response bodies so head-then-stall responses abort promptly. Previously, clearing the timer in `finally` after `return response.json()` bounded only headers; now we `await response.json()` inside `try`, so stalled bodies hit the existing abort paths.

- Touches `src/shared/{copilotDeviceFlow,copilotLimits,limitCollector,minimaxLimits}.js`: change `return response.json()` to `return await response.json()` where a fetch timeout is armed. Providers wrapped by `runWithProbeDeadline` are unchanged.
- Behavior: Copilot sign-in now surfaces a `timedOut` error on a stalled body; limit fetchers report provider status `unavailable` in the same case. No API or interface changes.
- Tests: Add one regression per site that stubs a head-then-stall response; all fail before and pass after.

<sup>Written for commit 7ffa1b48ed4131af4919614b8fd8bf04777b0602. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

