### PR TITLE
fix(renderer): hide zero-value unclassified residual rows

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -2098,11 +2098,17 @@ function attributionComponent(period, field, key) {
   );
 }
 
-function toolRowsForPeriod(period) {
-  const clientRows = usageAttributionRowsApi.attributionRows(period?.clients, period?.clientCosts, {
+function periodAttributionRows(period, values, costs) {
+  const rows = usageAttributionRowsApi.attributionRows(values, costs, {
     totalValue: period?.totalTokens,
     totalCost: period?.costUsd
-  }).map(({ key: client, value, cost }) => ({ key: client, name: client === usageAttributionRowsApi.UNATTRIBUTED_KEY ? t('dashboard.tooltip.unclassified') : clientLabels[client] || client, value, cost, color: clientColors[client] || clientColors.default, stale: false, cacheReadTokens: attributionComponent(period, 'clientCacheReads', client), cacheWriteTokens: attributionComponent(period, 'clientCacheWrites', client), outputTokens: attributionComponent(period, 'clientOutputs', client), unclassifiedTokens: attributionComponent(period, 'clientUnclassifiedTokens', client) }));
+  });
+  return usageAttributionRowsApi.visibleAttributionRows(rows, formatCost);
+}
+
+function toolRowsForPeriod(period) {
+  const clientRows = periodAttributionRows(period, period?.clients, period?.clientCosts)
+    .map(({ key: client, value, cost }) => ({ key: client, name: client === usageAttributionRowsApi.UNATTRIBUTED_KEY ? t('dashboard.tooltip.unclassified') : clientLabels[client] || client, value, cost, color: clientColors[client] || clientColors.default, stale: false, cacheReadTokens: attributionComponent(period, 'clientCacheReads', client), cacheWriteTokens: attributionComponent(period, 'clientCacheWrites', client), outputTokens: attributionComponent(period, 'clientOutputs', client), unclassifiedTokens: attributionComponent(period, 'clientUnclassifiedTokens', client) }));
   if (clientRows.length > 0) {
     const usageSortedRows = clientRows.sort((a, b) => b.value - a.value);
     return clientDisplayPreferencesApi.applyClientDisplayPreferences(usageSortedRows, state.settings?.clientDisplayOrder, state.settings?.hiddenClients, KNOWN_CLIENTS, state.settings?.pinnedClients);
@@ -2112,10 +2118,7 @@ function toolRowsForPeriod(period) {
 }
 
 function modelRowsForPeriod(period) {
-  const modelRows = usageAttributionRowsApi.attributionRows(period?.models, period?.modelCosts, {
-    totalValue: period?.totalTokens,
-    totalCost: period?.costUsd
-  }).map(({ key: model, value, cost }) => ({
+  const modelRows = periodAttributionRows(period, period?.models, period?.modelCosts).map(({ key: model, value, cost }) => ({
     key: model,
     name: model === usageAttributionRowsApi.UNATTRIBUTED_KEY ? t('dashboard.tooltip.unclassified') : model,
     value,
@@ -6380,10 +6383,7 @@ function renderHomeModelModule(period) {
 }
 
 function homeToolSourceRows(period) {
-  return usageAttributionRowsApi.attributionRows(period?.clients, period?.clientCosts, {
-    totalValue: period?.totalTokens,
-    totalCost: period?.costUsd
-  }).map(({ key: client, value }) => ({
+  return periodAttributionRows(period, period?.clients, period?.clientCosts).map(({ key: client, value }) => ({
     key: client,
     name: client === usageAttributionRowsApi.UNATTRIBUTED_KEY ? t('dashboard.tooltip.unclassified') : clientLabels[client] || client,
     value: Number(value || 0),

--- a/src/electron/renderer/usageAttributionRows.js
+++ b/src/electron/renderer/usageAttributionRows.js
@@ -43,7 +43,7 @@
     if (typeof formatCost !== 'function') return sourceRows;
     const zeroCost = String(formatCost(0));
     return sourceRows.filter((row) => (
-      row?.key !== UNATTRIBUTED_KEY
+      row?.unattributed !== true
       || finiteNumber(row.value) > 0
       || String(formatCost(row.cost)) !== zeroCost
     ));

--- a/src/electron/renderer/usageAttributionRows.js
+++ b/src/electron/renderer/usageAttributionRows.js
@@ -38,6 +38,17 @@
     return rows;
   }
 
+  function visibleAttributionRows(rows, formatCost) {
+    const sourceRows = Array.isArray(rows) ? rows : [];
+    if (typeof formatCost !== 'function') return sourceRows;
+    const zeroCost = String(formatCost(0));
+    return sourceRows.filter((row) => (
+      row?.key !== UNATTRIBUTED_KEY
+      || finiteNumber(row.value) > 0
+      || String(formatCost(row.cost)) !== zeroCost
+    ));
+  }
+
   function attributionValue(values, total, key) {
     if (key !== UNATTRIBUTED_KEY) return finiteNumber(values?.[key]);
     const attributed = Object.values(values || {}).reduce(
@@ -47,5 +58,5 @@
     return Math.max(0, finiteNumber(total) - attributed);
   }
 
-  return { attributionRows, attributionValue, UNATTRIBUTED_KEY };
+  return { attributionRows, visibleAttributionRows, attributionValue, UNATTRIBUTED_KEY };
 });

--- a/tests/electron/usageAttributionRows.test.js
+++ b/tests/electron/usageAttributionRows.test.js
@@ -63,6 +63,19 @@ test('display rows hide a zero-token synthetic residual that formats as zero', (
   );
 });
 
+test('display rows hide zero-token synthetic residuals with a custom key', () => {
+  const rows = attributionRows(
+    { codex: 100 },
+    { codex: 1 },
+    { totalValue: 100, totalCost: 1.000001, unattributedKey: 'custom-unclassified' }
+  );
+
+  assert.deepEqual(
+    visibleAttributionRows(rows, (value) => `$${Number(value || 0).toFixed(4)}`),
+    [{ key: 'codex', value: 100, cost: 1 }]
+  );
+});
+
 test('display rows retain meaningful synthetic and known cost-only rows', () => {
   const synthetic = attributionRows(
     { codex: 100 },

--- a/tests/electron/usageAttributionRows.test.js
+++ b/tests/electron/usageAttributionRows.test.js
@@ -7,6 +7,7 @@ const test = require('node:test');
 
 const {
   attributionRows,
+  visibleAttributionRows,
   attributionValue,
   UNATTRIBUTED_KEY
 } = require('../../src/electron/renderer/usageAttributionRows');
@@ -49,11 +50,40 @@ test('attribution rows expose totals without a tool or model identity as Unclass
   assert.equal(attributionValue({ codex: 60 }, 90, 'codex'), 60);
 });
 
+test('display rows hide a zero-token synthetic residual that formats as zero', () => {
+  const rows = attributionRows(
+    { codex: 100 },
+    { codex: 1 },
+    { totalValue: 100, totalCost: 1.000001 }
+  );
+
+  assert.deepEqual(
+    visibleAttributionRows(rows, (value) => `$${Number(value || 0).toFixed(4)}`),
+    [{ key: 'codex', value: 100, cost: 1 }]
+  );
+});
+
+test('display rows retain meaningful synthetic and known cost-only rows', () => {
+  const synthetic = attributionRows(
+    { codex: 100 },
+    { codex: 1 },
+    { totalValue: 100, totalCost: 1.01 }
+  );
+  const knownCostOnly = attributionRows({ codex: 0 }, { codex: 2.5 });
+  const formatCost = (value) => `$${Number(value || 0).toFixed(4)}`;
+
+  assert.equal(visibleAttributionRows(synthetic, formatCost).at(-1).key, UNATTRIBUTED_KEY);
+  assert.deepEqual(visibleAttributionRows(knownCostOnly, formatCost), [
+    { key: 'codex', value: 0, cost: 2.5 }
+  ]);
+});
+
 test('Tool and Model breakdowns consume the shared token-or-cost rows', () => {
   const index = fs.readFileSync(path.join(rendererDir, 'index.html'), 'utf8');
   const app = fs.readFileSync(path.join(rendererDir, 'app.js'), 'utf8');
   assert.ok(index.indexOf('usageAttributionRows.js') < index.indexOf('app.js'));
-  assert.match(app, /attributionRows\(period\?\.clients, period\?\.clientCosts,/);
-  assert.match(app, /attributionRows\(period\?\.models, period\?\.modelCosts,/);
+  assert.match(app, /periodAttributionRows\(period, period\?\.clients, period\?\.clientCosts\)/);
+  assert.match(app, /periodAttributionRows\(period, period\?\.models, period\?\.modelCosts\)/);
+  assert.match(app, /visibleAttributionRows\(rows, formatCost\)/);
   assert.match(app, /attributionValue\(/);
 });


### PR DESCRIPTION
## Summary

Tool and Model breakdowns could show an `Unclassified` row with 0 tokens and a cost formatted as `HK$0.0000` when a period contained only a tiny positive cost residual.

This affected both local and Hub mode because both use the same renderer attribution path.

The fix filters synthetic `__unattributed` rows at display time only when:

- the token value is zero; and
- the cost formats to the same value as zero under the active currency and exchange rate.

Meaningful unclassified token rows and visible cost-only rows remain unchanged. Raw period totals, attribution maps, Hub payloads, and Worker behavior are not modified.

## Behavior

| Case | Before | After |
| --- | --- | --- |
| Tiny cost residual, 0 tokens | Shows `Unclassified 0 / HK$0.0000` | Hidden |
| Real unclassified tokens | Shown | Still shown |
| Meaningful cost-only attribution | Shown | Still shown |

## Validation

- `node --test tests/electron/usageAttributionRows.test.js`
- `npm run verify`
- Result: 3353 passed, 1 skipped, 0 failed

Follow-up to the attribution changes in #398.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides zero-value Unclassified residual rows in Tool and Model breakdowns to remove noise from tiny cost residuals. Previously we showed an “Unclassified” row with 0 tokens and a cost that formatted to zero; now we filter only synthetic unattributed rows at render time.

- Applies to both local and Hub modes (shared renderer attribution path).
- Display-only change: totals, attribution maps, and Hub payloads are unchanged.

| Area | Before | After |
| --- | --- | --- |
| Tool/Model breakdown: tiny residual with 0 tokens | Shows “Unclassified 0 / [formatted zero cost]” | Hidden |
| Tool/Model breakdown: real unclassified tokens | Shown | Still shown |
| Tool/Model breakdown: meaningful cost-only rows | Shown | Still shown |

**Notes for reviewers**
- Implementation: `visibleAttributionRows` filters rows only when `row.unattributed === true`, token value is 0, and `formatCost(row.cost)` equals `formatCost(0)`; integrated via `periodAttributionRows` for consistent display-only filtering.
- Tests: added unit tests for `visibleAttributionRows` and renderer integration; suite passes (3353 passed, 1 skipped).
- Risks: depends on currency/exchange-rate formatting via `formatCost`; no migrations or API changes.

<sup>Written for commit 2415702711f530a57ab8fe4a3f352ca4e8b54cf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

