### PR TITLE
fix(antigravity): detect quoted Windows CLI paths

### DIFF
--- a/src/shared/antigravityProbe.js
+++ b/src/shared/antigravityProbe.js
@@ -103,7 +103,9 @@ function isAntigravityCommand(lowerCommand) {
 // (e.g. `/opt/imagytool/...`, `legacy-agent`) do not match.
 function isAntigravityCliCommand(lowerCommand) {
   if (/(^|[/\\])(antigravity-cli|antigravity_cli)([\s/\\]|$)/.test(lowerCommand)) return true;
-  if (/(^|[/\\])agy(\.exe)?(\s|$)/.test(lowerCommand)) return true;
+  // Win32_Process.CommandLine preserves the closing quote around a quoted
+  // executable path, so `agy.exe"` is also a complete command token.
+  if (/(^|[/\\])agy(\.exe)?(["\s]|$)/.test(lowerCommand)) return true;
   return false;
 }
 

--- a/tests/shared/antigravityProbe.test.js
+++ b/tests/shared/antigravityProbe.test.js
@@ -190,7 +190,7 @@ test('detectProcessInfo (win32) includes hyphenated language-server names in the
 });
 
 test('detectProcessInfo (win32) finds the agy.exe CLI when no IDE LS is running', async () => {
-  const stdout = '9001 C:\\Users\\j\\.antigravity\\agy.exe language-server\n';
+  const stdout = '9001 "C:\\Users\\j\\.antigravity\\agy.exe" language-server\n';
   const info = await probe.detectProcessInfo({ platform: 'win32', spawn: fakeSpawn(stdout) });
   assert.equal(info.pid, 9001);
   assert.equal(info.kind, 'cli');


### PR DESCRIPTION
## Summary

- accept quoted `agy.exe` command paths reported by `Win32_Process.CommandLine`
- cover the quoted Windows command line through the production process-discovery seam

## Root cause

PowerShell can launch `agy.exe` with a quoted executable path even when the path contains no spaces. The probe previously treated only whitespace or the end of the command line as a valid boundary after `agy.exe`, so the closing quote caused the running CLI process to be discarded before listener-port and RPC discovery.

## Impact

Antigravity CLI quota detection now works with both quoted and unquoted Windows command lines without relaxing the existing path anchors that prevent unrelated processes from matching.

## Validation

- `node --test tests/shared/antigravityProbe.test.js`
- `npm run verify`
- live Windows probe against a running `agy.exe`: detected the CLI listener and retrieved four quota windows


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects quoted Windows `agy.exe` paths so the Antigravity CLI is found and quotas are collected when PowerShell launches the CLI with quotes.

| Area | Before | After |
| --- | --- | --- |
| Windows CLI detection | Matched `agy(.exe)` only when followed by whitespace or EOL; `"C:\...\agy.exe"` was missed. | Also matches when followed by a closing quote; quoted and unquoted command lines are detected. |
| Quota discovery | CLI listener and RPC quota retrieval could be skipped on Windows. | Listener is detected and quotas are retrieved as expected. |

**Implementation & validation**
- Relaxed the CLI match to accept a trailing quote after `agy(.exe)` without changing path anchors.
- Updated win32 test to use a quoted `agy.exe` path.
- Ran unit tests and `npm run verify`; validated against a live Windows probe.

<sup>Written for commit c59d65a46014c5495608a78c893f6619f9a54ed7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

