### PR TITLE
fix(settings): stop the raw patch overwriting its own normalization

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -279,7 +279,7 @@ const {
   runManualDeviceRefresh,
   settingsLimitInvalidationPlan
 } = require('./deviceRuntimeCoordinator');
-const { describeWindowBehavior, normalizeWindowBehaviorSettings } = require('./windowBehavior');
+const { describeWindowBehavior, normalizeWindowBehaviorSettings, windowBehaviorSelection } = require('./windowBehavior');
 const {
   normalizeWindowToggleShortcut,
   windowToggleShortcutAction,
@@ -6119,7 +6119,7 @@ app.whenReady().then(() => {
       customModelPricing: patch.customModelPricing !== undefined
         ? normalizeCustomPricingSetting(patch.customModelPricing)
         : normalizeCustomPricingSetting(settings.customModelPricing)
-    }, normalizedPatch);
+    }, windowBehaviorSelection(normalizedPatch));
     settings.archivedClientUsage = normalizeArchivedClientUsage(settings.archivedClientUsage);
     if (settings.clients !== previousClients) updateArchivedClientUsage(previousClients, settings.clients);
     delete settings.edgeDrawerEnabled;

--- a/src/electron/windowBehavior.js
+++ b/src/electron/windowBehavior.js
@@ -63,6 +63,17 @@ function describeWindowBehavior(settings = {}) {
   return { ...WINDOW_BEHAVIOR_PROFILES[modeFromSettings(settings)] };
 }
 
+// The only two keys that select a mode. A caller which has already merged and
+// normalized its patch must narrow it through this before handing it over, since
+// normalizeWindowBehaviorSettings spreads whatever patch it is given over the
+// settings and would otherwise reinstate the raw values it just normalized away.
+function windowBehaviorSelection(patch = {}) {
+  const selection = {};
+  if (hasOwn(patch, 'windowBehavior')) selection.windowBehavior = patch.windowBehavior;
+  if (hasOwn(patch, 'alwaysOnTop')) selection.alwaysOnTop = patch.alwaysOnTop;
+  return selection;
+}
+
 function normalizeWindowBehaviorSettings(settings = {}, patch = {}) {
   const merged = { ...settings, ...patch };
   const previousMode = modeFromSettings(settings);
@@ -85,5 +96,6 @@ function normalizeWindowBehaviorSettings(settings = {}, patch = {}) {
 module.exports = {
   describeWindowBehavior,
   normalizeWindowBehavior,
-  normalizeWindowBehaviorSettings
+  normalizeWindowBehaviorSettings,
+  windowBehaviorSelection
 };

--- a/tests/electron/windowBehavior.test.js
+++ b/tests/electron/windowBehavior.test.js
@@ -1,12 +1,15 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const test = require('node:test');
 
 const {
   describeWindowBehavior,
   normalizeWindowBehavior,
-  normalizeWindowBehaviorSettings
+  normalizeWindowBehaviorSettings,
+  windowBehaviorSelection
 } = require('../../src/electron/windowBehavior');
 
 test('normalizes supported window behavior modes', () => {
@@ -70,4 +73,37 @@ test('keeps alwaysOnTop synchronized with behavior updates', () => {
     normalizeWindowBehaviorSettings({ windowBehavior: 'floating', alwaysOnTop: true }, { alwaysOnTop: false }),
     { windowBehavior: 'normal', alwaysOnTop: false }
   );
+});
+
+test('windowBehaviorSelection keeps only the keys that select a mode', () => {
+  assert.deepEqual(windowBehaviorSelection({ windowBehavior: 'desktop' }), { windowBehavior: 'desktop' });
+  assert.deepEqual(windowBehaviorSelection({ alwaysOnTop: true }), { alwaysOnTop: true });
+  assert.deepEqual(windowBehaviorSelection({}), {});
+  assert.deepEqual(windowBehaviorSelection(), {});
+  assert.deepEqual(
+    windowBehaviorSelection({ windowBehavior: 'normal', alwaysOnTop: false, glassOpacity: '9999', deviceId: '   ' }),
+    { windowBehavior: 'normal', alwaysOnTop: false }
+  );
+});
+
+// settings:update normalizes ~50 keys into an object and then hands it here. Passing the
+// raw patch a second time reinstated every value the clamps and fallbacks had just
+// removed, so the narrowed selection has to leave the merged object alone.
+test('a narrowed selection leaves already-normalized values intact', () => {
+  const normalized = { deviceId: 'my-box', glassOpacity: 68, refreshMs: 15000, hubHostPort: 17321 };
+  const rawPatch = { deviceId: '   ', glassOpacity: '9999', refreshMs: 1, hubHostPort: 70000, windowBehavior: 'desktop' };
+
+  const narrowed = normalizeWindowBehaviorSettings(normalized, windowBehaviorSelection(rawPatch));
+  assert.equal(narrowed.deviceId, 'my-box');
+  assert.equal(narrowed.glassOpacity, 68);
+  assert.equal(narrowed.refreshMs, 15000);
+  assert.equal(narrowed.hubHostPort, 17321);
+  assert.equal(narrowed.windowBehavior, 'desktop');
+  assert.equal(narrowed.alwaysOnTop, false);
+});
+
+test('settings:update hands the mode selection over, not the whole patch', () => {
+  const main = fs.readFileSync(path.join(__dirname, '..', '..', 'src/electron/main.js'), 'utf8');
+  assert.match(main, /\}, windowBehaviorSelection\(normalizedPatch\)\);/);
+  assert.doesNotMatch(main, /\}, normalizedPatch\);/);
 });


### PR DESCRIPTION
## Problem

`settings:update` applies about fifty clamps, enum guards and fallbacks over the spread patch, then hands the raw patch to `normalizeWindowBehaviorSettings`, which does `{ ...settings, ...patch }` internally. The raw values win a second time.

```js
normalizeWindowBehaviorSettings(
  { deviceId: 'my-box', glassOpacity: 68, refreshMs: 15000, hubHostPort: 17321 },
  { deviceId: '   ',    glassOpacity: '9999', refreshMs: 1,  hubHostPort: 70000 })

// -> { deviceId: '   ', glassOpacity: '9999', refreshMs: 1, hubHostPort: 70000 }
```

Clearing the Device ID field is the reachable case. Its placeholder offers `auto (hostname)` and the fallback implementing that is one of the discarded lines, so an empty `deviceId` is persisted and the widget stops recognising its own device in client and host mode.

## Fix

Narrow the patch to the two keys that select a window mode. The first spread has already applied every patch key, so nothing else needs the second pass. The helper sits next to the code that reads those keys so the list has one owner.

## Verify

`npm run verify` green, failure set unchanged from main. Reverting just the call site fails the new source assertion.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops settings:update from reapplying raw, unnormalized values by narrowing the second merge to only window mode selectors. Previously, normalizeWindowBehaviorSettings spread the raw patch again and reinstated invalid values (e.g., empty deviceId persisted); now, only windowBehavior and alwaysOnTop are considered, so prior normalization stands.

| Area | Before | After |
| --- | --- | --- |
| Patch merge in window behavior normalization | Raw patch was spread over settings again, reintroducing unnormalized values | Only `windowBehavior` and `alwaysOnTop` are merged; other normalized values remain intact |
| Device ID fallback | Empty `deviceId` was persisted, breaking device recognition | Fallback to hostname applies; device remains recognized |
| Clamps/guards (e.g., `refreshMs`, port) | Floors/guards were overridden by raw inputs | Floors/guards are preserved after update |

**Implementation and tests**
- Introduces windowBehaviorSelection(patch) to keep only `windowBehavior` and `alwaysOnTop`, and uses it when calling normalizeWindowBehaviorSettings.
- Adds tests to verify selection behavior, preservation of normalized values, and the call site change in main.js.
- No migrations; risk limited to settings update path.

<sup>Written for commit 19ce3fbacb018d1a7ee52be220d0cb0618493183. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

