### PR TITLE
fix(antigravity): detect quoted Windows language-server paths

### DIFF
--- a/src/shared/antigravityProbe.js
+++ b/src/shared/antigravityProbe.js
@@ -103,9 +103,7 @@ function isAntigravityCommand(lowerCommand) {
 // (e.g. `/opt/imagytool/...`, `legacy-agent`) do not match.
 function isAntigravityCliCommand(lowerCommand) {
   if (/(^|[/\\])(antigravity-cli|antigravity_cli)([\s/\\]|$)/.test(lowerCommand)) return true;
-  // Win32_Process.CommandLine preserves the closing quote around a quoted
-  // executable path, so `agy.exe"` is also a complete command token.
-  if (/(^|[/\\])agy(\.exe)?(["\s]|$)/.test(lowerCommand)) return true;
+  if (/(^|[/\\])agy(\.exe)?(\s|$)/.test(lowerCommand)) return true;
   return false;
 }
 
@@ -155,6 +153,15 @@ function extractPortFlag(flag, command) {
   return Number.isFinite(n) && n > 0 && n < 65536 ? n : null;
 }
 
+// `Win32_Process.CommandLine` reports the command line a process was created
+// with, which quotes the executable path whenever it contains spaces (and
+// PowerShell quotes it even when it does not). Unwrap that one leading pair so
+// the matchers above keep anchoring on path separators and whitespace alone;
+// quoted flag values further along the line are left untouched.
+function commandForMatching(command) {
+  return command.replace(/^"([^"]+)"(?=\s|$)/, '$1').toLowerCase();
+}
+
 function parseProcessLine(line) {
   const trimmed = String(line || '').trim();
   if (!trimmed) return null;
@@ -164,7 +171,7 @@ function parseProcessLine(line) {
   if (!Number.isFinite(pid) || pid <= 0) return null;
   const command = trimmed.slice(split + 1).trim();
   if (!command) return null;
-  const lower = command.toLowerCase();
+  const lower = commandForMatching(command);
   const kind = antigravityProcessKind(lower);
   if (!kind) return null;
   const csrfToken = extractFlag('--csrf_token', command);
@@ -231,7 +238,7 @@ function processInfosFromText(stdout) {
       continue;
     }
     const split = trimmed.indexOf(' ');
-    const lower = split === -1 ? '' : trimmed.slice(split + 1).trim().toLowerCase();
+    const lower = split === -1 ? '' : commandForMatching(trimmed.slice(split + 1).trim());
     const kind = antigravityProcessKind(lower);
     if ((kind === 'app' || kind === 'ide') && !extractFlag('--csrf_token', trimmed)) {
       sawDesktopWithoutCsrf = true;

--- a/src/shared/antigravityProbe.js
+++ b/src/shared/antigravityProbe.js
@@ -154,8 +154,9 @@ function extractPortFlag(flag, command) {
 }
 
 // `Win32_Process.CommandLine` reports the command line a process was created
-// with, which quotes the executable path whenever it contains spaces (and
-// PowerShell quotes it even when it does not). Unwrap that one leading pair so
+// with, verbatim: whoever launched it quotes the executable path when it
+// contains spaces, and PowerShell quotes it even when it does not, so the
+// closing quote reaches us as part of the line. Unwrap that one leading pair so
 // the matchers above keep anchoring on path separators and whitespace alone;
 // quoted flag values further along the line are left untouched.
 function commandForMatching(command) {

--- a/tests/shared/antigravityProbe.test.js
+++ b/tests/shared/antigravityProbe.test.js
@@ -112,6 +112,11 @@ test('parseProcessLine matches a quoted language_server.exe on win32 cmdlines', 
   assert.equal(info.csrfToken, 'win-token');
 });
 
+test('parseProcessLine does not match a quoted agy.exe inside a flag value', () => {
+  const line = '703 C:\\tools\\watcher.exe --exec "C:\\Users\\j\\.antigravity\\agy.exe"';
+  assert.equal(probe._parseProcessLine(line), null);
+});
+
 test('parseProcessLine does not match agy embedded in an unrelated path', () => {
   assert.equal(probe._parseProcessLine('700 /opt/imagytool/bin/run --serve'), null);
   assert.equal(probe._parseProcessLine('701 /usr/local/bin/legacy-agent start'), null);
@@ -212,6 +217,13 @@ test('detectProcessInfo (win32) finds the agy.exe CLI when no IDE LS is running'
   assert.equal(info.pid, 9001);
   assert.equal(info.kind, 'cli');
   assert.equal(info.csrfToken, '');
+});
+
+test('detectProcessInfo (win32) reports unavailable for a quoted desktop LS without csrf', async () => {
+  const stdout = '7777 "C:\\Program Files\\Antigravity\\language_server.exe" --app_data_dir antigravity\n';
+  const err = await probe.detectProcessInfo({ platform: 'win32', spawn: fakeSpawn(stdout) })
+    .catch((e) => e);
+  assert.equal(err.status, 'unavailable');
 });
 
 test('listeningPorts (posix) extracts ports from lsof output', async () => {

--- a/tests/shared/antigravityProbe.test.js
+++ b/tests/shared/antigravityProbe.test.js
@@ -95,6 +95,23 @@ test('parseProcessLine matches agy.exe on win32 cmdlines', () => {
   assert.equal(info.kind, 'cli');
 });
 
+test('parseProcessLine matches a quoted agy.exe on win32 cmdlines', () => {
+  const info = probe._parseProcessLine('9001 "C:\\Users\\j\\.antigravity\\agy.exe" language-server');
+  assert.equal(info.pid, 9001);
+  assert.equal(info.kind, 'cli');
+});
+
+test('parseProcessLine matches a quoted agy.exe with no directory component', () => {
+  assert.equal(probe._parseProcessLine('9002 "agy.exe" language-server').kind, 'cli');
+});
+
+test('parseProcessLine matches a quoted language_server.exe on win32 cmdlines', () => {
+  const line = '7777 "C:\\Program Files\\Antigravity\\language_server.exe" --app_data_dir antigravity --csrf_token win-token';
+  const info = probe._parseProcessLine(line);
+  assert.equal(info.kind, 'app');
+  assert.equal(info.csrfToken, 'win-token');
+});
+
 test('parseProcessLine does not match agy embedded in an unrelated path', () => {
   assert.equal(probe._parseProcessLine('700 /opt/imagytool/bin/run --serve'), null);
   assert.equal(probe._parseProcessLine('701 /usr/local/bin/legacy-agent start'), null);


### PR DESCRIPTION
## Summary

- unwrap a quoted executable path once where the process line is parsed, instead of inside individual matchers
- detect the desktop/IDE language server when its path is quoted, which was still dropped after #440

## Root cause

`Win32_Process.CommandLine` reports the command line a process was created with, and the executable path is quoted whenever it contains spaces. PowerShell quotes it even when it does not. Every path matcher in the probe ends the executable token on `(\s|$)`, so the closing quote made the match fail and the process was discarded before listener-port and RPC discovery.

The fix in #440 handled this for `agy.exe` by accepting a trailing quote inside that one regex. The same shape affects `isLanguageServerCommand`, so a desktop install under a path with spaces (`"C:\Program Files\Antigravity\language_server.exe" ...`) was still dropped.

## What changed

`commandForMatching()` unwraps the leading quoted token and lowercases the command line, and both classification call sites (`parseProcessLine`, `processInfosFromText`) go through it. The matchers keep their original `(\s|$)` boundaries, which makes the regex change from #440 redundant, so it is reverted: accepting a trailing quote anywhere also let a quoted path inside a flag value match as the CLI (`... --exec "C:\Users\j\.antigravity\agy.exe"`), which the restored boundary rejects. Quoted flag values are otherwise left untouched and `--csrf_token` parsing is unchanged.

## Validation

- `npm run verify`
- regression cases for a quoted `agy.exe` (with and without a directory component), a quoted `language_server.exe` under a path with spaces, and a quoted desktop language server missing `--csrf_token`, which now reports `unavailable` instead of `notConfigured`
- a negative case pinning that a quoted path inside a flag value does not match
- checked against live Windows `Win32_Process.CommandLine`: PowerShell quotes the executable path even when the path has no spaces, and a libuv spawn quotes it when the path has spaces
