### PR TITLE
fix(tray): fill the Windows notification-area cell

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
       "src/shared/**/*",
       "src/hub/**/*",
       "assets/icon.png",
+      "assets/icon-win.png",
       "assets/icons/**/*",
       "package.json"
     ],

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
       "src/shared/**/*",
       "src/hub/**/*",
       "assets/icon.png",
-      "assets/icon-win.png",
       "assets/icons/**/*",
       "package.json"
     ],
@@ -81,6 +80,9 @@
         }
       ],
       "icon": "assets/icon-win.png",
+      "files": [
+        "assets/icon-win.png"
+      ],
       "verifyUpdateCodeSignature": true,
       "signtoolOptions": {
         "publisherName": "SignPath Foundation"

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -248,7 +248,8 @@ const {
   watchSystemDarkUi,
   sortCodexAccountsForDisplay,
   shouldUseTemplateTrayIcon,
-  trayShowsTitle
+  trayShowsTitle,
+  trimTrayIconPadding
 } = require('./tray');
 const {
   macActivationPolicyMode,
@@ -314,7 +315,11 @@ const { applyWindowsAccentBlur } = require('./windowsBackdrop');
 if (!app.isPackaged) loadDotEnv();
 
 const APP_NAME = 'Token Monitor';
-const APP_ICON_PATH = path.join(__dirname, '..', '..', 'assets', 'icon.png');
+// Same split as the tray (see WINDOWS_ICON_PATH in tray.js): the macOS artwork
+// carries the Dock's inset margin, so passing it as the BrowserWindow `icon`
+// would override the exe's own full-bleed icon with a visibly smaller taskbar
+// and Alt-Tab entry. app.dock.setIcon is darwin-only and keeps icon.png.
+const APP_ICON_PATH = path.join(__dirname, '..', '..', 'assets', process.platform === 'win32' ? 'icon-win.png' : 'icon.png');
 
 const DEFAULT_WINDOW = { width: 340, height: 650 };
 const WINDOW_LIMITS = { minWidth: 240, minHeight: 140, maxWidth: 1200, maxHeight: 1400 };
@@ -6319,13 +6324,17 @@ app.whenReady().then(() => {
       if (typeof dataUrl !== 'string' || !dataUrl.startsWith('data:image/png')) continue;
       const img = nativeImage.createFromDataURL(dataUrl);
       if (img.isEmpty()) continue;
+      // Windows fits the bitmap into one square cell, so the renderer's macOS
+      // breathing room is cell space the icon never gets back (see
+      // trimTrayIconPadding). Everywhere else the padding is load-bearing.
+      const source = process.platform === 'win32' ? trimTrayIconPadding(img) : img;
       // Resize by height only; aspect ratio is preserved, so wide bar-style
       // icons keep their width while square provider icons stay square.
       // Windows targets its own small-icon metric (16px x the display scale
       // factor) rather than the macOS menubar height, so a single high-quality
       // downscale of the 44px-tall renderer source stays crisp in the
       // notification area instead of the old fixed 20px-for-all blur.
-      const sized = resizeTrayIconForPlatform(img, {
+      const sized = resizeTrayIconForPlatform(source, {
         platform: process.platform,
         scaleFactor: screen.getPrimaryDisplay().scaleFactor
       });

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -242,14 +242,13 @@ const {
   pickUsageTrayIconId,
   parseWindowsSystemUsesLightTheme,
   popoverBounds,
+  prepareTrayIconForPlatform,
   reconcileCodexAccountSelection,
-  resizeTrayIconForPlatform,
   runTrayMenuAction,
   watchSystemDarkUi,
   sortCodexAccountsForDisplay,
   shouldUseTemplateTrayIcon,
-  trayShowsTitle,
-  trimTrayIconPadding
+  trayShowsTitle
 } = require('./tray');
 const {
   macActivationPolicyMode,
@@ -315,11 +314,22 @@ const { applyWindowsAccentBlur } = require('./windowsBackdrop');
 if (!app.isPackaged) loadDotEnv();
 
 const APP_NAME = 'Token Monitor';
-// Same split as the tray (see WINDOWS_ICON_PATH in tray.js): the macOS artwork
-// carries the Dock's inset margin, so passing it as the BrowserWindow `icon`
-// would override the exe's own full-bleed icon with a visibly smaller taskbar
-// and Alt-Tab entry. app.dock.setIcon is darwin-only and keeps icon.png.
-const APP_ICON_PATH = path.join(__dirname, '..', '..', 'assets', process.platform === 'win32' ? 'icon-win.png' : 'icon.png');
+const APP_ICON_PATH = path.join(__dirname, '..', '..', 'assets', 'icon.png');
+const WINDOWS_APP_ICON_PATH = path.join(__dirname, '..', '..', 'assets', 'icon-win.png');
+
+// Electron falls back to the executable's own icon when a window is given none,
+// and on Windows that executable carries the multi-resolution ICO
+// electron-builder generates from `win.icon` — a better source at 16-32px than
+// a 1024px PNG downscaled at runtime. So a packaged window deliberately sets
+// nothing here: whatever it set could only override that, which is exactly what
+// naming the macOS artwork was doing to the taskbar button and Alt-Tab entry
+// (it carries the Dock's inset margin — see WINDOWS_ICON_PATH in tray.js). An
+// unpackaged run has no icon of ours inside electron.exe to inherit, so it names
+// the same full-bleed artwork the installer is built from.
+function appWindowIcon() {
+  if (process.platform !== 'win32') return { icon: APP_ICON_PATH };
+  return app.isPackaged ? {} : { icon: WINDOWS_APP_ICON_PATH };
+}
 
 const DEFAULT_WINDOW = { width: 340, height: 650 };
 const WINDOW_LIMITS = { minWidth: 240, minHeight: 140, maxWidth: 1200, maxHeight: 1400 };
@@ -5590,7 +5600,7 @@ function createWindow(boundsOverride, options = {}) {
     resizable: !collapsedFloatingBubble,
     show: false,
     backgroundColor: '#00000000',
-    icon: APP_ICON_PATH,
+    ...appWindowIcon(),
     skipTaskbar: collapsedFloatingBubble || Boolean(settings?.trayMode),
     ...(collapsedFloatingBubble ? { fullscreenable: false, maximizable: false, minimizable: false } : {}),
     // Keeps a popover unmaximizable across rebuilds, which never re-run enterTrayMode().
@@ -5745,7 +5755,7 @@ function createDashboardWindow() {
     transparent: !(process.platform === 'win32' && glass),
     show: false,
     backgroundColor: '#00000000',
-    icon: APP_ICON_PATH,
+    ...appWindowIcon(),
     skipTaskbar: false,
     ...(process.platform === 'darwin' && glass ? { vibrancy: 'hud', visualEffectState: 'active' } : {}),
     ...(process.platform === 'win32' && glass ? { backgroundMaterial: 'acrylic' } : {}),
@@ -6324,17 +6334,14 @@ app.whenReady().then(() => {
       if (typeof dataUrl !== 'string' || !dataUrl.startsWith('data:image/png')) continue;
       const img = nativeImage.createFromDataURL(dataUrl);
       if (img.isEmpty()) continue;
-      // Windows fits the bitmap into one square cell, so the renderer's macOS
-      // breathing room is cell space the icon never gets back (see
-      // trimTrayIconPadding). Everywhere else the padding is load-bearing.
-      const source = process.platform === 'win32' ? trimTrayIconPadding(img) : img;
       // Resize by height only; aspect ratio is preserved, so wide bar-style
       // icons keep their width while square provider icons stay square.
       // Windows targets its own small-icon metric (16px x the display scale
       // factor) rather than the macOS menubar height, so a single high-quality
       // downscale of the 44px-tall renderer source stays crisp in the
-      // notification area instead of the old fixed 20px-for-all blur.
-      const sized = resizeTrayIconForPlatform(source, {
+      // notification area instead of the old fixed 20px-for-all blur, and its
+      // square cell gets the bitmap trimmed to the pixels the renderer drew.
+      const sized = prepareTrayIconForPlatform(img, {
         platform: process.platform,
         scaleFactor: screen.getPrimaryDisplay().scaleFactor
       });

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -317,10 +317,11 @@ const APP_NAME = 'Token Monitor';
 const APP_ICON_PATH = path.join(__dirname, '..', '..', 'assets', 'icon.png');
 const WINDOWS_APP_ICON_PATH = path.join(__dirname, '..', '..', 'assets', 'icon-win.png');
 
-// Electron falls back to the executable's own icon when a window is given none,
-// and on Windows that executable carries the multi-resolution ICO
-// electron-builder generates from `win.icon` — a better source at 16-32px than
-// a 1024px PNG downscaled at runtime. So a packaged window deliberately sets
+// Electron's own documentation says a window given no icon falls back to the
+// executable's, and recommends ICO on Windows; electron-builder already
+// converts `win.icon` into the ICO embedded in that executable, which is the
+// icon built for this platform rather than one PNG scaled at runtime. So a
+// packaged window deliberately sets
 // nothing here: whatever it set could only override that, which is exactly what
 // naming the macOS artwork was doing to the taskbar button and Alt-Tab entry
 // (it carries the Dock's inset margin — see WINDOWS_ICON_PATH in tray.js). An

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -11685,13 +11685,13 @@ function providerImageOpticalSample(image) {
   return sample;
 }
 
-function paintProviderImage(ctx, image, x, y, size, templateColor = '') {
+function paintProviderImage(ctx, image, x, y, size, templateColor = '', optical = {}) {
   const {
     trayProviderOpticalLayout,
     trayProviderOpticalRatio
   } = window.TokenMonitorTrayProviderIcons;
   const sample = providerImageOpticalSample(image);
-  const opticalRatio = trayProviderOpticalRatio(trayProviderImageIds.get(image));
+  const opticalRatio = trayProviderOpticalRatio(trayProviderImageIds.get(image), optical);
   const layout = trayProviderOpticalLayout(sample.bounds, size, opticalRatio);
   const maskSize = Math.max(1, Math.round(size));
   const mask = document.createElement('canvas');
@@ -11732,16 +11732,16 @@ function trayGlyphInk(options, image) {
   );
 }
 
-function drawProviderImage(ctx, image, x, y, size, contrastHalo = false, templateColor = '') {
+function drawProviderImage(ctx, image, x, y, size, contrastHalo = false, templateColor = '', optical = {}) {
   if (contrastHalo) {
     const lightSurface = themePresetsApi.isLightHex(resolvedThemeColor('bg'));
     ctx.save();
     ctx.shadowColor = lightSurface ? 'rgba(0, 0, 0, 0.58)' : 'rgba(255, 255, 255, 0.82)';
     ctx.shadowBlur = Math.max(2, Math.round(size * 0.1));
-    paintProviderImage(ctx, image, x, y, size, templateColor);
+    paintProviderImage(ctx, image, x, y, size, templateColor, optical);
     ctx.restore();
   }
-  paintProviderImage(ctx, image, x, y, size, templateColor);
+  paintProviderImage(ctx, image, x, y, size, templateColor, optical);
 }
 
 function renderBarsIcon(stats, height = 44, picker = pickWorstProvider, colors = {}, options = {}) {
@@ -12687,11 +12687,15 @@ function providerImageToPngDataUrl(img, size, showBadge = false, options = {}) {
   const ctx = canvas.getContext('2d');
   const imageInset = showBadge ? Math.max(1, Math.round(layout.iconSize * 0.07)) : 0;
   const imageSize = layout.iconSize - imageInset * 2;
+  // Only the tray delivery marks itself standalone: there the mark is the whole
+  // icon and Windows expects it to fill its cell. The composer's provider picker
+  // renders previews through here too and keeps the composed optical inset.
+  const optical = { standalone: options.standalone === true, platform: state.appInfo?.platform };
   if (showBadge) {
     ctx.save();
     ctx.shadowColor = 'rgba(255, 255, 255, 0.95)';
     ctx.shadowBlur = Math.max(2, Math.round(layout.iconSize * 0.1));
-    paintProviderImage(ctx, img, imageInset, imageInset, imageSize);
+    paintProviderImage(ctx, img, imageInset, imageInset, imageSize, '', optical);
     ctx.restore();
   }
   drawProviderImage(
@@ -12701,7 +12705,8 @@ function providerImageToPngDataUrl(img, size, showBadge = false, options = {}) {
     imageInset,
     imageSize,
     false,
-    trayGlyphInk({ templateIconColor: options.templateColor, trayInk: options.trayInk }, img)
+    trayGlyphInk({ templateIconColor: options.templateColor, trayInk: options.trayInk }, img),
+    optical
   );
 
   if (!showBadge) return canvas.toDataURL('image/png');
@@ -12745,7 +12750,7 @@ async function deliverTrayProviderIcons(showBadge = state.settings?.showTrayProv
       const img = await loadImage(path);
       trayProviderImages[id] = img;
       trayProviderImageIds.set(img, id);
-      icons[id] = providerImageToPngDataUrl(img, 44, showBadge, { trayInk: true });
+      icons[id] = providerImageToPngDataUrl(img, 44, showBadge, { trayInk: true, standalone: true });
     } catch (_) { /* skip missing */ }
   }
   if (!trayProviderIconDeliveryGuard.isCurrent(deliveryId)) return;

--- a/src/electron/renderer/trayProviderIcons.js
+++ b/src/electron/renderer/trayProviderIcons.js
@@ -85,11 +85,24 @@
     };
   }
 
-  function trayProviderOpticalRatio(providerId) {
+  // How much of its box a provider mark fills. The inset is optical balance for
+  // a mark sharing a canvas with bars or text — the macOS menubar case, where
+  // the composed icon is one wide image and the glyph must not crowd its
+  // neighbours.
+  const TRAY_PROVIDER_OPTICAL_RATIO = 0.78;
+
+  function trayProviderOpticalRatio(providerId, options = {}) {
+    // A mark that IS the whole tray icon is a different problem. Windows hands
+    // each notification-area icon one square cell of the small-icon metric and
+    // spaces the cells itself, so anything short of filling that cell reads
+    // smaller than every neighbouring app — 18px of mark in a 24px cell at 150%
+    // (#314). macOS keeps the inset: its menubar has no cell to fill, and the
+    // icon sits inline with text that the breathing room is measured against.
+    if (options.standalone === true && options.platform === 'win32') return 1;
     // Claude Code's intentionally wide mark already uses the full horizontal
     // viewBox with balanced vertical breathing room. Cropping it into the
     // shared square optical box makes it noticeably smaller than its peers.
-    return providerId === 'claude' ? 1 : 0.78;
+    return providerId === 'claude' ? 1 : TRAY_PROVIDER_OPTICAL_RATIO;
   }
 
   function createTrayProviderIconDeliveryGuard() {

--- a/src/electron/renderer/trayProviderIcons.js
+++ b/src/electron/renderer/trayProviderIcons.js
@@ -95,9 +95,10 @@
     // A mark that IS the whole tray icon is a different problem. Windows hands
     // each notification-area icon one square cell of the small-icon metric and
     // spaces the cells itself, so anything short of filling that cell reads
-    // smaller than every neighbouring app — 18px of mark in a 24px cell at 150%
-    // (#314). macOS keeps the inset: its menubar has no cell to fill, and the
-    // icon sits inline with text that the breathing room is measured against.
+    // smaller than every neighbouring app at every scale (#314): 0.78 leaves
+    // 12px of mark in the 16px cell at 100% and 18px in the 24px cell at 150%.
+    // macOS keeps the inset: its menubar has no cell to fill, and the icon sits
+    // inline with text that the breathing room is measured against.
     if (options.standalone === true && options.platform === 'win32') return 1;
     // Claude Code's intentionally wide mark already uses the full horizontal
     // viewBox with balanced vertical breathing room. Cropping it into the

--- a/src/electron/tray.js
+++ b/src/electron/tray.js
@@ -17,9 +17,10 @@ const ICON_PATH = path.join(__dirname, '..', '..', 'assets', 'icon.png');
 // its canvas — the artwork covers ~75% of the 1024px square and the Dock reads
 // the margin as spacing. The Windows notification area spaces the cells itself
 // and expects full-bleed artwork, so downscaling that padded canvas into the
-// small-icon metric leaves ~18px of visible mark in a 24px cell, a quarter
-// smaller than every neighbouring app (#314). icon-win.png is the full-bleed
-// variant electron-builder already ships to the Windows installer.
+// small-icon metric spends a quarter of the cell on nothing at every scale,
+// which is why #314 reads as undersized at 100% (12px of mark in a 16px cell)
+// as much as at 150% (18px in 24px). icon-win.png is the full-bleed variant
+// electron-builder already ships to the Windows installer.
 const WINDOWS_ICON_PATH = path.join(__dirname, '..', '..', 'assets', 'icon-win.png');
 const TRAY_ICON_PATH = path.join(__dirname, '..', '..', 'assets', 'icons', 'tray-token-monitor.png');
 

--- a/src/electron/tray.js
+++ b/src/electron/tray.js
@@ -13,6 +13,14 @@ const { codexAccountDisplayLabel } = require('./renderer/accountIdentity');
 const { translate: translateMessage } = require('./renderer/i18n');
 
 const ICON_PATH = path.join(__dirname, '..', '..', 'assets', 'icon.png');
+// icon.png is authored to the macOS icon grid, where the squircle is inset from
+// its canvas — the artwork covers ~75% of the 1024px square and the Dock reads
+// the margin as spacing. The Windows notification area spaces the cells itself
+// and expects full-bleed artwork, so downscaling that padded canvas into the
+// small-icon metric leaves ~18px of visible mark in a 24px cell, a quarter
+// smaller than every neighbouring app (#314). icon-win.png is the full-bleed
+// variant electron-builder already ships to the Windows installer.
+const WINDOWS_ICON_PATH = path.join(__dirname, '..', '..', 'assets', 'icon-win.png');
 const TRAY_ICON_PATH = path.join(__dirname, '..', '..', 'assets', 'icons', 'tray-token-monitor.png');
 
 // Windows keeps the taskbar's theme in SystemUsesLightTheme, separate from the
@@ -134,6 +142,49 @@ function resizeTrayIconForPlatform(img, { platform = process.platform, scaleFact
     : img.resize({ height: 20, quality: 'best' });
 }
 
+// The tightest rectangle covering every drawn pixel, or null when nothing is
+// drawn. `bitmap` is Electron's raw 4-bytes-per-pixel buffer; only the alpha
+// byte matters, and its offset is the same whether the transport is RGBA or
+// BGRA. The threshold ignores the near-invisible tail of an antialiased edge,
+// which would otherwise pin the bounds to a pixel nobody can see.
+function trayIconOpaqueBounds(bitmap, width, height, alphaThreshold = 12) {
+  if (!bitmap || !(width > 0) || !(height > 0)) return null;
+  if (bitmap.length < width * height * 4) return null;
+  let minX = width;
+  let minY = height;
+  let maxX = -1;
+  let maxY = -1;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      if (bitmap[(y * width + x) * 4 + 3] <= alphaThreshold) continue;
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+    }
+  }
+  if (maxX < minX || maxY < minY) return null;
+  return { x: minX, y: minY, width: maxX - minX + 1, height: maxY - minY + 1 };
+}
+
+// Windows fits the whole bitmap into one square cell of the small-icon metric,
+// so every transparent row and column the renderer left around the artwork is
+// cell space the icon does not get. The renderer composes at 44px with the macOS
+// menubar's breathing room built in — a provider mark sits at 78% of its box, a
+// text segment's ink at about half its canvas height — which on a 24px cell is a
+// quarter of the icon spent on nothing, while every neighbouring app draws edge
+// to edge. Trimming to the drawn pixels is a no-op for a bitmap that already
+// reaches its edges, and is deliberately not applied on macOS: the menubar has
+// no cell to fill and that breathing room is what keeps the icon off the text
+// beside it.
+function trimTrayIconPadding(img) {
+  const { width, height } = img.getSize();
+  const bounds = trayIconOpaqueBounds(img.toBitmap(), width, height);
+  if (!bounds) return img;
+  if (bounds.width === width && bounds.height === height) return img;
+  return img.crop(bounds);
+}
+
 function buildTrayIcon(options = {}) {
   const platform = options.platform || process.platform;
   const nativeImage = options.nativeImage || require('electron').nativeImage;
@@ -143,11 +194,12 @@ function buildTrayIcon(options = {}) {
     sized.setTemplateImage(true);
     return sized;
   }
-  // Windows / Linux: the bundled icon.png is already high-resolution, so a
+  // Windows / Linux: the bundled app icon is already high-resolution, so a
   // single best-quality downscale to the platform metric keeps the small
-  // notification-area icon crisp on HiDPI instead of the old fixed 20x20. The
-  // default app icon is square, so it keeps the force-square 20x20 tile.
-  const image = nativeImage.createFromPath(ICON_PATH);
+  // notification-area icon crisp on HiDPI instead of the old fixed 20x20.
+  // Windows takes the full-bleed variant so the mark fills its cell; both
+  // canvases are square, so the force-square 20x20 tile still applies.
+  const image = nativeImage.createFromPath(platform === 'win32' ? WINDOWS_ICON_PATH : ICON_PATH);
   return resizeTrayIconForPlatform(image, { platform, scaleFactor: options.scaleFactor, square: true });
 }
 
@@ -419,6 +471,8 @@ module.exports = {
   runTrayMenuAction,
   shouldUseTemplateTrayIcon,
   sortCodexAccountsForDisplay,
+  trayIconOpaqueBounds,
   trayShowsTitle,
+  trimTrayIconPadding,
   windowsTrayIconHeight
 };

--- a/src/electron/tray.js
+++ b/src/electron/tray.js
@@ -185,6 +185,14 @@ function trimTrayIconPadding(img) {
   return img.crop(bounds);
 }
 
+// The whole path from a renderer-composed bitmap to the one the shell draws, so
+// the Windows-only trim travels with the resize it belongs to instead of living
+// at the IPC boundary.
+function prepareTrayIconForPlatform(img, { platform = process.platform, scaleFactor, square = false } = {}) {
+  const source = platform === 'win32' ? trimTrayIconPadding(img) : img;
+  return resizeTrayIconForPlatform(source, { platform, scaleFactor, square });
+}
+
 function buildTrayIcon(options = {}) {
   const platform = options.platform || process.platform;
   const nativeImage = options.nativeImage || require('electron').nativeImage;
@@ -465,6 +473,7 @@ module.exports = {
   pickUsageTrayIconId,
   pickWorstLimit,
   popoverBounds,
+  prepareTrayIconForPlatform,
   primaryDisplayScaleFactor,
   reconcileCodexAccountSelection,
   resizeTrayIconForPlatform,

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -725,8 +725,10 @@ test('provider tray badges are opt-in and keep monochrome assets visible', () =>
   assert.match(app, /showTrayProviderBadgeInput: document\.getElementById\('showTrayProviderBadgeInput'\)/);
   assert.match(app, /saveSettings\(\{ showTrayProviderBadge: els\.showTrayProviderBadgeInput\.checked \}\)/);
   assert.match(app, /deliverTrayProviderIcons\(patch\.showTrayProviderBadge === true\)/);
-  // `trayInk` is what lets a flat-ink mark be re-inked for the taskbar it will sit on.
-  assert.match(app, /providerImageToPngDataUrl\(img, 44, showBadge, \{ trayInk: true \}\)/);
+  // `trayInk` is what lets a flat-ink mark be re-inked for the taskbar it will sit
+  // on; `standalone` is what lets it fill the Windows cell instead of carrying the
+  // optical inset a composed icon needs (#314).
+  assert.match(app, /providerImageToPngDataUrl\(img, 44, showBadge, \{ trayInk: true, standalone: true \}\)/);
   // A system-theme flip invalidates BOTH tray bitmap caches. Repainting only the
   // generated one leaves the usage modes showing the provider icon main cached
   // under the old ink, which is the whole bug on a taskbar that just went dark.

--- a/tests/electron/trayIconSizing.test.js
+++ b/tests/electron/trayIconSizing.test.js
@@ -12,6 +12,7 @@ const test = require('node:test');
 
 const {
   buildTrayIcon,
+  prepareTrayIconForPlatform,
   primaryDisplayScaleFactor,
   resizeTrayIconForPlatform,
   trayIconOpaqueBounds,
@@ -32,12 +33,21 @@ function bitmapWithOpaqueRect(width, height, rect, alpha = 255) {
 }
 
 function fakeTrayImage(width, height, bitmap) {
-  const calls = [];
+  const crops = [];
+  const resizes = [];
   return {
-    calls,
+    crops,
+    resizes,
     getSize() { return { width, height }; },
     toBitmap() { return bitmap; },
-    crop(bounds) { calls.push(bounds); return { cropped: bounds }; }
+    crop(bounds) {
+      crops.push(bounds);
+      return {
+        cropped: bounds,
+        resize(opts) { resizes.push(opts); return { resized: opts, source: 'cropped' }; }
+      };
+    },
+    resize(opts) { resizes.push(opts); return { resized: opts, source: 'whole' }; }
   };
 }
 
@@ -111,8 +121,8 @@ test('tray:setIcons does not force-square the generated tray icons', () => {
   const main = fs.readFileSync(path.join(__dirname, '../../src/electron/main.js'), 'utf8');
   const handlerStart = main.indexOf("ipcMain.handle('tray:setIcons'");
   assert.notEqual(handlerStart, -1, 'tray:setIcons handler exists');
-  const callStart = main.indexOf('resizeTrayIconForPlatform(', handlerStart);
-  assert.notEqual(callStart, -1, 'handler calls resizeTrayIconForPlatform');
+  const callStart = main.indexOf('prepareTrayIconForPlatform(', handlerStart);
+  assert.notEqual(callStart, -1, 'handler calls prepareTrayIconForPlatform');
   const callEnd = main.indexOf('});', callStart);
   assert.notEqual(callEnd, -1, 'resizeTrayIconForPlatform call terminates with });');
   const callText = main.slice(callStart, callEnd + '});'.length);
@@ -182,41 +192,72 @@ test('trimTrayIconPadding crops a padded tray bitmap and leaves a full-bleed one
   // Windows fits the whole bitmap into one square cell, so that padding is cell
   // space the icon never gets back (#314).
   const padded = fakeTrayImage(44, 44, bitmapWithOpaqueRect(44, 44, { x: 5, y: 5, width: 34, height: 34 }));
-  assert.deepEqual(trimTrayIconPadding(padded), { cropped: { x: 5, y: 5, width: 34, height: 34 } });
-  assert.deepEqual(padded.calls, [{ x: 5, y: 5, width: 34, height: 34 }]);
+  assert.deepEqual(trimTrayIconPadding(padded).cropped, { x: 5, y: 5, width: 34, height: 34 });
+  assert.deepEqual(padded.crops, [{ x: 5, y: 5, width: 34, height: 34 }]);
 
   const fullBleed = fakeTrayImage(44, 44, bitmapWithOpaqueRect(44, 44, { x: 0, y: 0, width: 44, height: 44 }));
   assert.equal(trimTrayIconPadding(fullBleed), fullBleed, 'already edge to edge: no crop');
-  assert.deepEqual(fullBleed.calls, []);
+  assert.deepEqual(fullBleed.crops, []);
 
   // A wide composed icon is width-bound in the square cell, so the horizontal
   // trim is the part that buys anything — but the crop must keep both axes tight.
   const wide = fakeTrayImage(91, 44, bitmapWithOpaqueRect(91, 44, { x: 2, y: 11, width: 87, height: 22 }));
-  assert.deepEqual(trimTrayIconPadding(wide), { cropped: { x: 2, y: 11, width: 87, height: 22 } });
+  assert.deepEqual(trimTrayIconPadding(wide).cropped, { x: 2, y: 11, width: 87, height: 22 });
 
   // An icon whose canvas is entirely transparent has no bounds to crop to;
   // cropping it to nothing would hand the tray an empty image.
   const blank = fakeTrayImage(44, 44, Buffer.alloc(44 * 44 * 4));
   assert.equal(trimTrayIconPadding(blank), blank);
-  assert.deepEqual(blank.calls, []);
+  assert.deepEqual(blank.crops, []);
 });
 
-test('only Windows trims the tray bitmap before resizing it', () => {
+test('prepareTrayIconForPlatform trims before resizing on Windows only', () => {
+  const padded = () => fakeTrayImage(44, 44, bitmapWithOpaqueRect(44, 44, { x: 5, y: 5, width: 34, height: 34 }));
+
+  const windows = padded();
+  const sized = prepareTrayIconForPlatform(windows, { platform: 'win32', scaleFactor: 1.5 });
+  assert.deepEqual(windows.crops, [{ x: 5, y: 5, width: 34, height: 34 }]);
+  assert.deepEqual(windows.resizes, [{ height: 24, quality: 'best' }]);
+  assert.equal(sized.source, 'cropped', 'the resize consumes the trimmed image, not the original');
+
   // macOS must keep the padding: its menubar has no cell to fill and the icon
   // sits inline with the title text that the breathing room is measured against.
-  const main = fs.readFileSync(path.join(__dirname, '../../src/electron/main.js'), 'utf8');
-  const handlerStart = main.indexOf("ipcMain.handle('tray:setIcons'");
-  assert.notEqual(handlerStart, -1, 'tray:setIcons handler exists');
-  const handler = main.slice(handlerStart, main.indexOf("ipcMain.handle('stats:get'", handlerStart));
-  assert.match(handler, /const source = process\.platform === 'win32' \? trimTrayIconPadding\(img\) : img;/);
-  assert.match(handler, /resizeTrayIconForPlatform\(source, \{/, 'the resize consumes the trimmed source');
+  for (const platform of ['darwin', 'linux']) {
+    const other = padded();
+    const result = prepareTrayIconForPlatform(other, { platform, scaleFactor: 1.5 });
+    assert.deepEqual(other.crops, [], `${platform} never trims`);
+    assert.deepEqual(other.resizes, [{ height: 20, quality: 'best' }]);
+    assert.equal(result.source, 'whole');
+  }
+
+  // The bundled square app icon opts into the force-square tile, and that has to
+  // survive the extra hop rather than being dropped by the wrapper.
+  const linuxSquare = padded();
+  prepareTrayIconForPlatform(linuxSquare, { platform: 'linux', square: true });
+  assert.deepEqual(linuxSquare.resizes, [{ width: 20, height: 20 }]);
 });
 
-test('the full-bleed Windows icon ships in the packaged app', () => {
+test('the full-bleed Windows icon ships in the Windows package and nowhere else', () => {
   // The tray reads this at runtime, but electron-builder only treats `win.icon`
   // as a build input — left out of `files` it would be missing from the asar and
   // the Windows tray would come up blank, which no CI job here would catch.
+  // Platform `files` are appended to the shared list rather than replacing it,
+  // so scoping it to `win` keeps a 1MB Windows-only asset out of the macOS and
+  // Linux artifacts without narrowing what they package.
   const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf8'));
   assert.ok(fs.existsSync(path.join(__dirname, '../../assets/icon-win.png')), 'assets/icon-win.png exists');
-  assert.ok(pkg.build.files.includes('assets/icon-win.png'), 'assets/icon-win.png is in build.files');
+  assert.ok(pkg.build.win.files.includes('assets/icon-win.png'), 'assets/icon-win.png is in build.win.files');
+  assert.ok(!pkg.build.files.includes('assets/icon-win.png'), 'and not in the shared list');
+});
+
+test('Windows leaves the window icon to the executable that already carries an ICO', () => {
+  // Electron falls back to the exe icon when a window names none, and
+  // electron-builder generates a multi-resolution ICO from win.icon. Naming a
+  // PNG here overrides that with a worse source at 16-32px, which is what the
+  // taskbar and Alt-Tab regression was (#314).
+  const main = fs.readFileSync(path.join(__dirname, '../../src/electron/main.js'), 'utf8');
+  assert.doesNotMatch(main, /\n\s*icon: APP_ICON_PATH,/, 'no window names the icon directly');
+  assert.match(main, /function appWindowIcon\(\) \{[\s\S]*?return app\.isPackaged \? \{\} : \{ icon: WINDOWS_APP_ICON_PATH \};[\s\S]*?\}/);
+  // app.dock.setIcon is darwin-only and keeps the macOS-grid artwork.
+  assert.match(main, /process\.platform === 'darwin' && app\.dock\) app\.dock\.setIcon\(APP_ICON_PATH\)/);
 });

--- a/tests/electron/trayIconSizing.test.js
+++ b/tests/electron/trayIconSizing.test.js
@@ -252,9 +252,9 @@ test('the full-bleed Windows icon ships in the Windows package and nowhere else'
 
 test('Windows leaves the window icon to the executable that already carries an ICO', () => {
   // Electron falls back to the exe icon when a window names none, and
-  // electron-builder generates a multi-resolution ICO from win.icon. Naming a
-  // PNG here overrides that with a worse source at 16-32px, which is what the
-  // taskbar and Alt-Tab regression was (#314).
+  // electron-builder converts win.icon into the ICO embedded there. Naming a
+  // PNG here overrides the icon built for the platform, which is what reached
+  // the taskbar and Alt-Tab entry (#314).
   const main = fs.readFileSync(path.join(__dirname, '../../src/electron/main.js'), 'utf8');
   assert.doesNotMatch(main, /\n\s*icon: APP_ICON_PATH,/, 'no window names the icon directly');
   assert.match(main, /function appWindowIcon\(\) \{[\s\S]*?return app\.isPackaged \? \{\} : \{ icon: WINDOWS_APP_ICON_PATH \};[\s\S]*?\}/);

--- a/tests/electron/trayIconSizing.test.js
+++ b/tests/electron/trayIconSizing.test.js
@@ -14,8 +14,32 @@ const {
   buildTrayIcon,
   primaryDisplayScaleFactor,
   resizeTrayIconForPlatform,
+  trayIconOpaqueBounds,
+  trimTrayIconPadding,
   windowsTrayIconHeight
 } = require('../../src/electron/tray');
+
+// A 4-bytes-per-pixel buffer with one opaque rectangle, i.e. what
+// nativeImage.toBitmap() hands back for a renderer-composed tray icon.
+function bitmapWithOpaqueRect(width, height, rect, alpha = 255) {
+  const bitmap = Buffer.alloc(width * height * 4);
+  for (let y = rect.y; y < rect.y + rect.height; y += 1) {
+    for (let x = rect.x; x < rect.x + rect.width; x += 1) {
+      bitmap[(y * width + x) * 4 + 3] = alpha;
+    }
+  }
+  return bitmap;
+}
+
+function fakeTrayImage(width, height, bitmap) {
+  const calls = [];
+  return {
+    calls,
+    getSize() { return { width, height }; },
+    toBitmap() { return bitmap; },
+    crop(bounds) { calls.push(bounds); return { cropped: bounds }; }
+  };
+}
 
 test('windowsTrayIconHeight tracks the Windows small-icon metric across DPI without capping', () => {
   assert.equal(windowsTrayIconHeight(1), 16, 'SM_CXSMICON at 100%');
@@ -95,7 +119,7 @@ test('tray:setIcons does not force-square the generated tray icons', () => {
   assert.doesNotMatch(callText, /square/, 'tray:setIcons must keep generated icons aspect-preserving (no square:true)');
 });
 
-test('buildTrayIcon resizes the Windows default icon to the small-icon metric from the high-res app asset', () => {
+function recordBuildTrayIcon(options) {
   const calls = [];
   const image = {
     resize(opts) {
@@ -104,8 +128,7 @@ test('buildTrayIcon resizes the Windows default icon to the small-icon metric fr
     }
   };
   const result = buildTrayIcon({
-    platform: 'win32',
-    scaleFactor: 1,
+    ...options,
     nativeImage: {
       createFromPath(iconPath) {
         calls.push(['path', iconPath]);
@@ -113,8 +136,87 @@ test('buildTrayIcon resizes the Windows default icon to the small-icon metric fr
       }
     }
   });
+  return { calls, result };
+}
 
-  assert.match(calls[0][1], /assets[\\/]icon\.png$/);
+test('buildTrayIcon resizes the Windows default icon to the small-icon metric from the full-bleed app asset', () => {
+  const { calls, result } = recordBuildTrayIcon({ platform: 'win32', scaleFactor: 1 });
+
+  // icon.png carries the macOS icon grid's inset margin (~75% artwork), which
+  // the notification area has no reason to reserve — it would draw a quarter
+  // smaller than the neighbouring icons even at the right pixel height (#314).
+  assert.match(calls[0][1], /assets[\\/]icon-win\.png$/, 'Windows takes the full-bleed variant');
   assert.deepEqual(calls[1], ['resize', { height: 16, quality: 'best' }]);
   assert.deepEqual(result, { resized: true });
+});
+
+test('buildTrayIcon keeps the macOS-grid app icon everywhere except Windows', () => {
+  const { calls } = recordBuildTrayIcon({ platform: 'linux' });
+  assert.match(calls[0][1], /assets[\\/]icon\.png$/);
+  assert.deepEqual(calls[1], ['resize', { width: 20, height: 20 }]);
+});
+
+test('trayIconOpaqueBounds finds the drawn pixels and ignores an antialiased tail', () => {
+  const bounds = trayIconOpaqueBounds(bitmapWithOpaqueRect(44, 44, { x: 5, y: 9, width: 34, height: 26 }), 44, 44);
+  assert.deepEqual(bounds, { x: 5, y: 9, width: 34, height: 26 });
+
+  // Alpha at or below the threshold is the invisible tail of a soft edge; pinning
+  // the bounds to it would make the trim a no-op for every antialiased icon.
+  assert.equal(trayIconOpaqueBounds(bitmapWithOpaqueRect(8, 8, { x: 0, y: 0, width: 8, height: 8 }, 12), 8, 8), null);
+  assert.deepEqual(
+    trayIconOpaqueBounds(bitmapWithOpaqueRect(8, 8, { x: 0, y: 0, width: 8, height: 8 }, 13), 8, 8),
+    { x: 0, y: 0, width: 8, height: 8 }
+  );
+
+  // Nothing drawn, and a buffer too short to be the bitmap it claims: both have
+  // no answer, and must not be reported as an empty crop.
+  assert.equal(trayIconOpaqueBounds(Buffer.alloc(44 * 44 * 4), 44, 44), null);
+  assert.equal(trayIconOpaqueBounds(Buffer.alloc(16), 44, 44), null);
+  assert.equal(trayIconOpaqueBounds(null, 44, 44), null);
+  assert.equal(trayIconOpaqueBounds(Buffer.alloc(0), 0, 0), null);
+});
+
+test('trimTrayIconPadding crops a padded tray bitmap and leaves a full-bleed one untouched', () => {
+  // The renderer composes provider marks at 78% of their box and text segments
+  // at roughly half their canvas height, which is macOS menubar breathing room.
+  // Windows fits the whole bitmap into one square cell, so that padding is cell
+  // space the icon never gets back (#314).
+  const padded = fakeTrayImage(44, 44, bitmapWithOpaqueRect(44, 44, { x: 5, y: 5, width: 34, height: 34 }));
+  assert.deepEqual(trimTrayIconPadding(padded), { cropped: { x: 5, y: 5, width: 34, height: 34 } });
+  assert.deepEqual(padded.calls, [{ x: 5, y: 5, width: 34, height: 34 }]);
+
+  const fullBleed = fakeTrayImage(44, 44, bitmapWithOpaqueRect(44, 44, { x: 0, y: 0, width: 44, height: 44 }));
+  assert.equal(trimTrayIconPadding(fullBleed), fullBleed, 'already edge to edge: no crop');
+  assert.deepEqual(fullBleed.calls, []);
+
+  // A wide composed icon is width-bound in the square cell, so the horizontal
+  // trim is the part that buys anything — but the crop must keep both axes tight.
+  const wide = fakeTrayImage(91, 44, bitmapWithOpaqueRect(91, 44, { x: 2, y: 11, width: 87, height: 22 }));
+  assert.deepEqual(trimTrayIconPadding(wide), { cropped: { x: 2, y: 11, width: 87, height: 22 } });
+
+  // An icon whose canvas is entirely transparent has no bounds to crop to;
+  // cropping it to nothing would hand the tray an empty image.
+  const blank = fakeTrayImage(44, 44, Buffer.alloc(44 * 44 * 4));
+  assert.equal(trimTrayIconPadding(blank), blank);
+  assert.deepEqual(blank.calls, []);
+});
+
+test('only Windows trims the tray bitmap before resizing it', () => {
+  // macOS must keep the padding: its menubar has no cell to fill and the icon
+  // sits inline with the title text that the breathing room is measured against.
+  const main = fs.readFileSync(path.join(__dirname, '../../src/electron/main.js'), 'utf8');
+  const handlerStart = main.indexOf("ipcMain.handle('tray:setIcons'");
+  assert.notEqual(handlerStart, -1, 'tray:setIcons handler exists');
+  const handler = main.slice(handlerStart, main.indexOf("ipcMain.handle('stats:get'", handlerStart));
+  assert.match(handler, /const source = process\.platform === 'win32' \? trimTrayIconPadding\(img\) : img;/);
+  assert.match(handler, /resizeTrayIconForPlatform\(source, \{/, 'the resize consumes the trimmed source');
+});
+
+test('the full-bleed Windows icon ships in the packaged app', () => {
+  // The tray reads this at runtime, but electron-builder only treats `win.icon`
+  // as a build input — left out of `files` it would be missing from the asar and
+  // the Windows tray would come up blank, which no CI job here would catch.
+  const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf8'));
+  assert.ok(fs.existsSync(path.join(__dirname, '../../assets/icon-win.png')), 'assets/icon-win.png exists');
+  assert.ok(pkg.build.files.includes('assets/icon-win.png'), 'assets/icon-win.png is in build.files');
 });

--- a/tests/electron/trayProviderIcons.test.js
+++ b/tests/electron/trayProviderIcons.test.js
@@ -90,8 +90,9 @@ test('Claude Code keeps its intentional wide mark while other providers use the 
 });
 
 test('a standalone mark fills the Windows notification-area cell, everywhere else keeps the inset', () => {
-  // Windows gives each tray icon one square cell and spaces the cells itself,
-  // so the 0.78 optical inset drew 18px of mark in a 24px cell at 150% (#314).
+  // Windows gives each tray icon one square cell and spaces the cells itself, so
+  // the 0.78 optical inset left a quarter of that cell empty at every scale
+  // (#314): 12px of mark in the 16px cell at 100%, 18px in the 24px cell at 150%.
   assert.equal(trayProviderOpticalRatio('codex', { standalone: true, platform: 'win32' }), 1);
   assert.equal(trayProviderOpticalRatio('codex', { standalone: true, platform: 'darwin' }), 0.78);
   assert.equal(trayProviderOpticalRatio('codex', { standalone: true, platform: 'linux' }), 0.78);

--- a/tests/electron/trayProviderIcons.test.js
+++ b/tests/electron/trayProviderIcons.test.js
@@ -89,6 +89,28 @@ test('Claude Code keeps its intentional wide mark while other providers use the 
   assert.equal(trayProviderOpticalRatio('codex'), 0.78);
 });
 
+test('a standalone mark fills the Windows notification-area cell, everywhere else keeps the inset', () => {
+  // Windows gives each tray icon one square cell and spaces the cells itself,
+  // so the 0.78 optical inset drew 18px of mark in a 24px cell at 150% (#314).
+  assert.equal(trayProviderOpticalRatio('codex', { standalone: true, platform: 'win32' }), 1);
+  assert.equal(trayProviderOpticalRatio('codex', { standalone: true, platform: 'darwin' }), 0.78);
+  assert.equal(trayProviderOpticalRatio('codex', { standalone: true, platform: 'linux' }), 0.78);
+  // Composed icons (bars / sessions / the custom layout) share their canvas with
+  // bars or text on every platform, so the mark keeps its breathing room there.
+  assert.equal(trayProviderOpticalRatio('codex', { platform: 'win32' }), 0.78);
+  assert.equal(trayProviderOpticalRatio('codex', { standalone: false, platform: 'win32' }), 0.78);
+});
+
+test('a standalone Windows mark is scaled to fill its box edge to edge', () => {
+  const ratio = trayProviderOpticalRatio('codex', { standalone: true, platform: 'win32' });
+  assert.deepEqual(trayProviderOpticalLayout({ width: 128, height: 128 }, 44, ratio), {
+    x: 0,
+    y: 0,
+    width: 44,
+    height: 44
+  });
+});
+
 test('tray provider icon delivery guard invalidates older async work', () => {
   const guard = createTrayProviderIconDeliveryGuard();
   const olderDelivery = guard.begin();


### PR DESCRIPTION
The Windows tray icon still drew smaller than every neighbouring app after #345 sized its bitmap to the small-icon metric. #314 reports it at 100% scale, where the cell is 16px, and says explicitly that it is not a HiDPI problem; measuring here on Windows 11 at 150% (SM_CXSMICON = 24) put the neighbouring apps' icons at 24x24 and ours at 19x19 in icon mode and 18x18 in the usage modes. The shortfall is the same fraction of the cell at either scale, because it is padding baked into the artwork rather than resolution, which is why sizing the bitmap correctly could not reach it. There are three sources of it, and they are independent.

**The default icon came from the macOS artwork.** `assets/icon.png` is authored to the macOS icon grid, where the squircle is inset from its canvas — the artwork covers 771x773 of the 1024px square and the Dock reads the surrounding margin as spacing. Windows spaces the notification area itself and expects full-bleed artwork, so downscaling that padded canvas into the cell spends a quarter of it on nothing. `assets/icon-win.png` is the full-bleed variant (99.9% of its canvas) that electron-builder already ships to the Windows installer, so the tray takes it on win32 and it joins `build.win.files` — it was only a build input before, so reading it at runtime would have found nothing in the packaged app.

The same margin was reaching the taskbar button and Alt-Tab entry through `BrowserWindow`'s `icon`, but the fix there is the opposite one. Electron falls back to the executable's own icon when a window names none, and that executable already carries the multi-resolution ICO electron-builder generates from `win.icon` — a better source at 16-32px than any single PNG downscaled at runtime. Naming the full-bleed artwork would have fixed the size while still overriding a better icon with a worse one, so a packaged window now names nothing at all on Windows. An unpackaged run has no icon of ours inside `electron.exe` to inherit, so it keeps naming the artwork.

**Provider marks carried a second inset.** `trayProviderOpticalRatio` draws a mark at 0.78 of its box. That is optical balance for a mark sharing a canvas with bars or text, so it stays wherever the mark is composed; a mark that is the whole tray icon now fills its box on win32.

**The composed icons carried a third one, spread across every item type rather than any single constant.** The renderer draws at 44px with the macOS menubar's breathing room built in, so a text segment's ink covers about half its canvas height (`fontSize` is 0.68 of it) and a bars segment's 61%. Windows fits the whole bitmap into one square cell, so all of that is space the icon never gets back. `trimTrayIconPadding` crops to the drawn pixels before the resize — one place, covering provider icons, bars, sessions and custom layouts alike, and a no-op for a bitmap that already reaches its edges.

### Scope

macOS and Linux are untouched by design, not by accident:

- `buildTrayIcon`'s darwin branch is unchanged, and its other branch resolves to `icon.png` for everything that is not win32.
- `appWindowIcon()` returns `{ icon: APP_ICON_PATH }` off win32, the same value both windows named before; `app.dock.setIcon` is darwin-only either way.
- `trayProviderOpticalRatio` needs both `standalone` and win32 to drop the inset, so darwin and Linux always fall through to the existing `claude ? 1 : 0.78`.
- `paintProviderImage` / `drawProviderImage` gained a trailing options argument defaulting to `{}`, so every existing call site resolves the same ratio it did before.
- `prepareTrayIconForPlatform` trims only on win32 and otherwise hands `resizeTrayIconForPlatform` exactly what it was given. macOS keeps the padding on purpose: its menubar has no cell to fill and the icon sits inline with the title text the breathing room is measured against.
- `assets/icon-win.png` sits in `build.win.files`, so the macOS and Linux artifacts do not carry a 1 MB asset they never read. Platform file patterns are appended to the shared list rather than replacing it, so nothing those artifacts already packaged is narrowed.

### Known limit

A wide composed layout is still bound by its aspect ratio against a square cell, and no amount of trimming changes that. The trim buys an icon-only custom layout 28% (it becomes the full 24px, matching the built-in modes), a text-heavy one under 10% and a bars layout 6%, because the fit is width-bound either way. Making a wide custom layout genuinely larger on Windows means fewer items in it, which the composer preview does not currently show — a follow-up rather than part of this change.

### Testing

`npm run verify` (lint + 3373 tests). New coverage pins the alpha threshold and the empty-canvas guard in `trayIconOpaqueBounds`, that a full-bleed bitmap is not cropped, that `prepareTrayIconForPlatform` trims on win32 and on no other platform while still carrying the square-tile option through, that win32 builds its default icon from the full-bleed asset while every other platform keeps `icon.png`, that no window names an icon directly, and that the asset is scoped to the Windows package — that last one is the failure no CI job here would otherwise catch, since a missing runtime asset only shows up in a Windows installer build.

Verified on Windows 11 at 150%: icon mode now measures 24x24, matching the neighbouring apps.

Closes #314
