### PR TITLE
fix(settings): disable Hub Save for unchanged drafts

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -8337,10 +8337,8 @@ function hubDraftFieldIsActive(field) {
 }
 
 function syncHubDraftDirty(field) {
-  if (!hubDraftFieldIsActive(field)) {
-    hubDraftDirty[field] = false;
-    return;
-  }
+  // Inactive fields stop affecting Save, but their drafts must survive mode switches.
+  if (!hubDraftFieldIsActive(field)) return;
   const submittedRevision = hubSaveInFlightRevisions?.[field];
   if (submittedRevision !== undefined && hubDraftRevisions[field] > submittedRevision) {
     hubDraftDirty[field] = true;

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -8348,8 +8348,9 @@ function syncHubDraftDirty(field) {
   }
   const inputId = HUB_DRAFT_FIELDS.find(([name]) => name === field)?.[1];
   const input = inputId ? els[inputId] : null;
+  const savedValue = state.settings?.[field];
   hubDraftDirty[field] = Boolean(input) && (
-    normalizeHubDraftValue(field, input.value) !== normalizeHubDraftValue(field, state.settings?.[field])
+    normalizeHubDraftValue(field, input.value, savedValue) !== normalizeHubDraftValue(field, savedValue)
   );
 }
 
@@ -8380,8 +8381,19 @@ function syncHubDraftFields() {
   syncHubSaveButton();
 }
 
-function normalizeHubDraftValue(field, value) {
-  if (field === 'hubHostPort') return String(Number(value) || 17321);
+// Keep this aligned with main's normalizeHubPort: dirty state must describe
+// the value settings:update will actually persist, including its fallback.
+function normalizeHubDraftPort(value, fallback = 17321) {
+  const fallbackNumber = Math.floor(Number(fallback));
+  const normalizedFallback = Number.isFinite(fallbackNumber) && fallbackNumber >= 1 && fallbackNumber <= 65535
+    ? fallbackNumber
+    : 17321;
+  const number = Math.floor(Number(value));
+  return String(Number.isFinite(number) && number >= 1 && number <= 65535 ? number : normalizedFallback);
+}
+
+function normalizeHubDraftValue(field, value, fallback) {
+  if (field === 'hubHostPort') return normalizeHubDraftPort(value, fallback);
   if (field === 'secret') return String(value ?? '');
   return String(value ?? '').trim();
 }
@@ -8392,7 +8404,7 @@ function hubDraftValuesFromInputs() {
     if (field === 'hubHostPort' && state.settings?.hubMode !== 'host') continue;
     const input = els[inputId];
     if (!input) continue;
-    values[field] = normalizeHubDraftValue(field, input.value);
+    values[field] = normalizeHubDraftValue(field, input.value, state.settings?.[field]);
   }
   return values;
 }
@@ -8425,7 +8437,7 @@ function reconcileHubDraftsAfterSave(submitted, submittedRevisions) {
     const input = els[inputId];
     if (!input) continue;
     if (!Object.prototype.hasOwnProperty.call(submitted, field)) continue;
-    const current = normalizeHubDraftValue(field, input.value);
+    const current = normalizeHubDraftValue(field, input.value, submitted[field]);
     if (
       hubDraftRevisions[field] === submittedRevisions[field]
       && current === submitted[field]

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -8330,17 +8330,46 @@ const HUB_DRAFT_FIELDS = [
 const hubDraftDirty = Object.fromEntries(HUB_DRAFT_FIELDS.map(([field]) => [field, false]));
 const hubDraftRevisions = Object.fromEntries(HUB_DRAFT_FIELDS.map(([field]) => [field, 0]));
 let hubSaveBusy = false;
+let hubSaveInFlightRevisions = null;
+
+function hubDraftFieldIsActive(field) {
+  return field !== 'hubHostPort' || state.settings?.hubMode === 'host';
+}
+
+function syncHubDraftDirty(field) {
+  if (!hubDraftFieldIsActive(field)) {
+    hubDraftDirty[field] = false;
+    return;
+  }
+  const submittedRevision = hubSaveInFlightRevisions?.[field];
+  if (submittedRevision !== undefined && hubDraftRevisions[field] > submittedRevision) {
+    hubDraftDirty[field] = true;
+    return;
+  }
+  const inputId = HUB_DRAFT_FIELDS.find(([name]) => name === field)?.[1];
+  const input = inputId ? els[inputId] : null;
+  hubDraftDirty[field] = Boolean(input) && (
+    normalizeHubDraftValue(field, input.value) !== normalizeHubDraftValue(field, state.settings?.[field])
+  );
+}
+
+function reconcileHubDraftDirtyState() {
+  for (const [field] of HUB_DRAFT_FIELDS) {
+    if (hubDraftDirty[field]) syncHubDraftDirty(field);
+  }
+}
 
 function markHubDraftDirty(field) {
   const inputId = HUB_DRAFT_FIELDS.find(([name]) => name === field)?.[1];
   const input = inputId ? els[inputId] : null;
   if (!input) return;
   hubDraftRevisions[field] += 1;
-  hubDraftDirty[field] = true;
+  syncHubDraftDirty(field);
   syncHubSaveButton();
 }
 
 function syncHubDraftFields() {
+  reconcileHubDraftDirtyState();
   for (const [field, inputId] of HUB_DRAFT_FIELDS) {
     const input = els[inputId];
     if (!input || hubDraftDirty[field]) continue;
@@ -11052,12 +11081,15 @@ els.saveSettingsButton.addEventListener('click', async () => {
     const submittedHubRevisions = Object.fromEntries(
       Object.keys(submittedHubFields).map((field) => [field, hubDraftRevisions[field]])
     );
+    hubSaveInFlightRevisions = submittedHubRevisions;
     await saveSettings(patch);
     reconcileHubDraftsAfterSave(submittedHubFields, submittedHubRevisions);
     await refreshHubInfo();
     void refreshHubBuildStatus();
     await refreshStats();
   } finally {
+    hubSaveInFlightRevisions = null;
+    syncHubDraftFields();
     hubSaveBusy = false;
     syncHubSaveButton();
   }

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -8125,6 +8125,7 @@ function syncHubModeUi() {
   }
   renderSyncClientStatus();
   renderHubBuildStatus();
+  syncHubSaveButton();
 }
 
 function renderHubStatus() {
@@ -8328,6 +8329,7 @@ const HUB_DRAFT_FIELDS = [
 ];
 const hubDraftDirty = Object.fromEntries(HUB_DRAFT_FIELDS.map(([field]) => [field, false]));
 const hubDraftRevisions = Object.fromEntries(HUB_DRAFT_FIELDS.map(([field]) => [field, 0]));
+let hubSaveBusy = false;
 
 function markHubDraftDirty(field) {
   const inputId = HUB_DRAFT_FIELDS.find(([name]) => name === field)?.[1];
@@ -8335,6 +8337,7 @@ function markHubDraftDirty(field) {
   if (!input) return;
   hubDraftRevisions[field] += 1;
   hubDraftDirty[field] = true;
+  syncHubSaveButton();
 }
 
 function syncHubDraftFields() {
@@ -8345,12 +8348,47 @@ function syncHubDraftFields() {
       ? String(state.settings?.hubHostPort || 17321)
       : state.settings?.[field] || '';
   }
+  syncHubSaveButton();
 }
 
 function normalizeHubDraftValue(field, value) {
   if (field === 'hubHostPort') return String(Number(value) || 17321);
   if (field === 'secret') return String(value ?? '');
   return String(value ?? '').trim();
+}
+
+function hubDraftValuesFromInputs() {
+  const values = {};
+  for (const [field, inputId] of HUB_DRAFT_FIELDS) {
+    if (field === 'hubHostPort' && state.settings?.hubMode !== 'host') continue;
+    const input = els[inputId];
+    if (!input) continue;
+    values[field] = normalizeHubDraftValue(field, input.value);
+  }
+  return values;
+}
+
+function hubDraftValuesFromSettings() {
+  const values = {};
+  for (const [field] of HUB_DRAFT_FIELDS) {
+    if (field === 'hubHostPort' && state.settings?.hubMode !== 'host') continue;
+    values[field] = normalizeHubDraftValue(field, state.settings?.[field]);
+  }
+  return values;
+}
+
+function hubDraftHasChanges() {
+  const draft = hubDraftValuesFromInputs();
+  const saved = hubDraftValuesFromSettings();
+  return Object.keys(draft).some((field) => draft[field] !== saved[field]);
+}
+
+function syncHubSaveButton() {
+  if (!els.saveSettingsButton) return;
+  const busy = hubSaveBusy;
+  els.saveSettingsButton.disabled = busy || !hubDraftHasChanges();
+  if (busy) els.saveSettingsButton.setAttribute('aria-busy', 'true');
+  else els.saveSettingsButton.removeAttribute('aria-busy');
 }
 
 function reconcileHubDraftsAfterSave(submitted, submittedRevisions) {
@@ -11002,25 +11040,27 @@ els.settingsButton.addEventListener('click', (event) => {
   requestAnimationFrame(() => { els.shell.style.transform = ''; });
 });
 els.saveSettingsButton.addEventListener('click', async () => {
-  const submittedHubFields = {
-    hubUrl: els.hubUrlInput.value.trim(),
-    secret: els.secretInput.value,
-    deviceId: els.deviceIdInput.value.trim()
-  };
-  const patch = { ...submittedHubFields };
-  if (state.settings.hubMode === 'host') {
-    const hubHostPort = Number(els.hubPortInput.value) || 17321;
-    submittedHubFields.hubHostPort = String(hubHostPort);
-    patch.hubHostPort = hubHostPort;
+  if (hubSaveBusy || !hubDraftHasChanges()) return;
+  hubSaveBusy = true;
+  syncHubSaveButton();
+  try {
+    const submittedHubFields = hubDraftValuesFromInputs();
+    const patch = { ...submittedHubFields };
+    if (Object.prototype.hasOwnProperty.call(submittedHubFields, 'hubHostPort')) {
+      patch.hubHostPort = Number(submittedHubFields.hubHostPort) || 17321;
+    }
+    const submittedHubRevisions = Object.fromEntries(
+      Object.keys(submittedHubFields).map((field) => [field, hubDraftRevisions[field]])
+    );
+    await saveSettings(patch);
+    reconcileHubDraftsAfterSave(submittedHubFields, submittedHubRevisions);
+    await refreshHubInfo();
+    void refreshHubBuildStatus();
+    await refreshStats();
+  } finally {
+    hubSaveBusy = false;
+    syncHubSaveButton();
   }
-  const submittedHubRevisions = Object.fromEntries(
-    Object.keys(submittedHubFields).map((field) => [field, hubDraftRevisions[field]])
-  );
-  await saveSettings(patch);
-  reconcileHubDraftsAfterSave(submittedHubFields, submittedHubRevisions);
-  await refreshHubInfo();
-  void refreshHubBuildStatus();
-  await refreshStats();
 });
 
 els.hubModeOptions.addEventListener('change', async (event) => {

--- a/tests/electron/cursorSettingsLayout.test.js
+++ b/tests/electron/cursorSettingsLayout.test.js
@@ -1922,6 +1922,77 @@ test('Host Hub port draft survives settings rehydration and saves with Hub field
   assert.equal(els.hubPortInput.value, '18000');
 });
 
+test('Host Hub port draft survives leaving and returning to Host mode', async () => {
+  const classList = { toggle() {} };
+  const els = {
+    saveSettingsButton: fakeHubControl(),
+    hubModeOptions: { querySelectorAll: () => [] },
+    hubClientFields: { classList },
+    hubHostFields: { classList },
+    hubPortInput: fakeHubControl(),
+    hubSecretInput: fakeHubControl(),
+    hubUrlInput: fakeHubControl(),
+    secretInput: fakeHubControl(),
+    deviceIdInput: fakeHubControl(),
+    syncUploadIntervalInput: fakeHubControl('0'),
+    showLimitUsedInputs: []
+  };
+  const state = {
+    settings: {
+      hubMode: 'host',
+      hubHostPort: 17321,
+      hubHostSecret: 'host-secret',
+      hubUrl: '',
+      secret: '',
+      deviceId: 'saved-device',
+      syncUploadIntervalMs: 0
+    }
+  };
+  const patches = [];
+  let vmContext;
+  vmContext = loadHubSettingsWiring(els, {
+    state,
+    saveSettings: async (patch) => {
+      patches.push({ ...patch });
+      Object.assign(state.settings, patch);
+      vmContext.syncHubModeUi();
+      vmContext.syncHubDraftFields();
+    },
+    refreshHubInfo: async () => {},
+    refreshHubBuildStatus: async () => {},
+    refreshStats: async () => {}
+  });
+  vmContext.syncHubModeUi();
+  vmContext.syncHubDraftFields();
+
+  els.hubPortInput.value = '18000';
+  await els.hubPortInput.dispatch('input');
+  assert.equal(els.saveSettingsButton.disabled, false);
+
+  // Model the settings pushes emitted by switching away from Host and back.
+  state.settings.hubMode = 'client';
+  vmContext.syncHubModeUi();
+  vmContext.syncHubDraftFields();
+  assert.equal(els.hubPortInput.value, '18000');
+  assert.equal(els.saveSettingsButton.disabled, true);
+
+  state.settings.hubMode = 'host';
+  vmContext.syncHubModeUi();
+  vmContext.syncHubDraftFields();
+  assert.equal(els.hubPortInput.value, '18000');
+  assert.equal(els.saveSettingsButton.disabled, false);
+
+  await els.saveSettingsButton.dispatch('click');
+  assert.deepEqual(patches, [{
+    hubUrl: '',
+    secret: '',
+    deviceId: 'saved-device',
+    hubHostPort: 18000
+  }]);
+  assert.equal(els.hubPortInput.value, '18000');
+  assert.equal(els.saveSettingsButton.disabled, true);
+});
+
 test('remote Hub build status is wired as a separate localized sync hint', () => {
   const html = readRendererFile('index.html');
   const app = readRendererFile('app.js');

--- a/tests/electron/cursorSettingsLayout.test.js
+++ b/tests/electron/cursorSettingsLayout.test.js
@@ -1561,7 +1561,7 @@ test('Hub Save re-enables a failed draft after clearing busy state', async () =>
   assert.equal(els.hubUrlInput.value, 'https://draft.example');
 });
 
-test('Hub Save compares Host Hub ports after canonicalizing numeric input', async () => {
+test('Hub Save compares Host Hub ports with main-process normalization', async () => {
   const classList = { toggle() {} };
   const els = {
     saveSettingsButton: fakeHubControl(),
@@ -1602,9 +1602,86 @@ test('Hub Save compares Host Hub ports after canonicalizing numeric input', asyn
   await els.hubPortInput.dispatch('input');
   assert.equal(els.saveSettingsButton.disabled, true);
 
-  els.hubPortInput.value = '18000';
+  els.hubPortInput.value = '17321.9';
+  await els.hubPortInput.dispatch('input');
+  assert.equal(els.saveSettingsButton.disabled, true);
+
+  state.settings.hubHostPort = 18000;
+  vmContext.syncHubDraftFields();
+  assert.equal(els.hubPortInput.value, '18000');
+
+  els.hubPortInput.value = '70000';
+  await els.hubPortInput.dispatch('input');
+  assert.equal(els.saveSettingsButton.disabled, true);
+
+  els.hubPortInput.value = '17321.9';
   await els.hubPortInput.dispatch('input');
   assert.equal(els.saveSettingsButton.disabled, false);
+});
+
+test('Host Hub invalid ports preserve the persisted port when another field saves', async () => {
+  const classList = { toggle() {} };
+  const els = {
+    saveSettingsButton: fakeHubControl(),
+    hubModeOptions: { querySelectorAll: () => [] },
+    hubClientFields: { classList },
+    hubHostFields: { classList },
+    hubPortInput: fakeHubControl(),
+    hubSecretInput: fakeHubControl(),
+    hubUrlInput: fakeHubControl(),
+    secretInput: fakeHubControl(),
+    deviceIdInput: fakeHubControl(),
+    syncUploadIntervalInput: fakeHubControl('0'),
+    showLimitUsedInputs: []
+  };
+  const state = {
+    settings: {
+      hubMode: 'host',
+      hubHostPort: 18000,
+      hubHostSecret: 'host-secret',
+      hubUrl: '',
+      secret: '',
+      deviceId: 'saved-device',
+      syncUploadIntervalMs: 0
+    }
+  };
+  const patches = [];
+  let vmContext;
+  vmContext = loadHubSettingsWiring(els, {
+    state,
+    saveSettings: async (patch) => {
+      patches.push({ ...patch });
+      Object.assign(state.settings, patch);
+    },
+    refreshHubInfo: async () => {},
+    refreshHubBuildStatus: async () => {},
+    refreshStats: async () => {}
+  });
+  vmContext.syncHubDraftFields();
+
+  els.hubPortInput.value = '70000';
+  await els.hubPortInput.dispatch('input');
+  assert.equal(els.saveSettingsButton.disabled, true);
+
+  els.deviceIdInput.value = 'draft-device';
+  await els.deviceIdInput.dispatch('input');
+  assert.equal(els.saveSettingsButton.disabled, false);
+  await els.saveSettingsButton.dispatch('click');
+
+  assert.deepEqual(patches, [{
+    hubUrl: '',
+    secret: '',
+    deviceId: 'draft-device',
+    hubHostPort: 18000
+  }]);
+  assert.equal(els.hubPortInput.value, '18000');
+
+  els.hubPortInput.value = '17321.9';
+  await els.hubPortInput.dispatch('input');
+  assert.equal(els.saveSettingsButton.disabled, false);
+  await els.saveSettingsButton.dispatch('click');
+  assert.equal(patches[1].hubHostPort, 17321);
+  assert.equal(els.hubPortInput.value, '17321');
 });
 
 test('changing sync upload frequency auto-saves without replacing Hub drafts', async () => {

--- a/tests/electron/cursorSettingsLayout.test.js
+++ b/tests/electron/cursorSettingsLayout.test.js
@@ -1460,6 +1460,105 @@ test('Hub Save disables for clean and reverted drafts', async () => {
   assert.equal(els.saveSettingsButton.disabled, true);
   await els.saveSettingsButton.dispatch('click');
   assert.deepEqual(patches, []);
+
+  state.settings.hubUrl = 'https://pushed.example';
+  vmContext.syncHubDraftFields();
+  assert.equal(els.hubUrlInput.value, 'https://pushed.example');
+});
+
+test('Hub Save exposes busy state and ignores repeated clicks', async () => {
+  const els = {
+    saveSettingsButton: fakeHubControl(),
+    hubUrlInput: fakeHubControl(),
+    secretInput: fakeHubControl(),
+    deviceIdInput: fakeHubControl(),
+    syncUploadIntervalInput: fakeHubControl('0'),
+    showLimitUsedInputs: []
+  };
+  const state = {
+    settings: {
+      hubMode: 'client',
+      hubUrl: 'https://saved.example',
+      secret: 'saved-secret',
+      deviceId: 'saved-device',
+      syncUploadIntervalMs: 0
+    }
+  };
+  const patches = [];
+  let releaseSave;
+  let resolveSaveStarted;
+  const saveGate = new Promise((resolve) => { releaseSave = resolve; });
+  const saveStarted = new Promise((resolve) => { resolveSaveStarted = resolve; });
+  let vmContext;
+  vmContext = loadHubSettingsWiring(els, {
+    state,
+    saveSettings: async (patch) => {
+      patches.push({ ...patch });
+      resolveSaveStarted();
+      await saveGate;
+      Object.assign(state.settings, patch);
+    },
+    refreshHubInfo: async () => {},
+    refreshHubBuildStatus: async () => {},
+    refreshStats: async () => {}
+  });
+  vmContext.syncHubDraftFields();
+
+  els.hubUrlInput.value = 'https://draft.example';
+  await els.hubUrlInput.dispatch('input');
+  const savePromise = els.saveSettingsButton.dispatch('click');
+  await saveStarted;
+
+  assert.equal(els.saveSettingsButton.disabled, true);
+  assert.equal(els.saveSettingsButton.getAttribute('aria-busy'), 'true');
+  await els.saveSettingsButton.dispatch('click');
+  assert.deepEqual(patches, [{
+    hubUrl: 'https://draft.example',
+    secret: 'saved-secret',
+    deviceId: 'saved-device'
+  }]);
+
+  releaseSave();
+  await savePromise;
+  assert.equal(els.saveSettingsButton.disabled, true);
+  assert.equal(els.saveSettingsButton.getAttribute('aria-busy'), null);
+});
+
+test('Hub Save re-enables a failed draft after clearing busy state', async () => {
+  const els = {
+    saveSettingsButton: fakeHubControl(),
+    hubUrlInput: fakeHubControl(),
+    secretInput: fakeHubControl(),
+    deviceIdInput: fakeHubControl(),
+    syncUploadIntervalInput: fakeHubControl('0'),
+    showLimitUsedInputs: []
+  };
+  const state = {
+    settings: {
+      hubMode: 'client',
+      hubUrl: 'https://saved.example',
+      secret: 'saved-secret',
+      deviceId: 'saved-device',
+      syncUploadIntervalMs: 0
+    }
+  };
+  let vmContext;
+  vmContext = loadHubSettingsWiring(els, {
+    state,
+    saveSettings: async () => { throw new Error('save failed'); },
+    refreshHubInfo: async () => {},
+    refreshHubBuildStatus: async () => {},
+    refreshStats: async () => {}
+  });
+  vmContext.syncHubDraftFields();
+
+  els.hubUrlInput.value = 'https://draft.example';
+  await els.hubUrlInput.dispatch('input');
+  await assert.rejects(els.saveSettingsButton.dispatch('click'), /save failed/);
+
+  assert.equal(els.saveSettingsButton.disabled, false);
+  assert.equal(els.saveSettingsButton.getAttribute('aria-busy'), null);
+  assert.equal(els.hubUrlInput.value, 'https://draft.example');
 });
 
 test('Hub Save compares Host Hub ports after canonicalizing numeric input', async () => {

--- a/tests/electron/cursorSettingsLayout.test.js
+++ b/tests/electron/cursorSettingsLayout.test.js
@@ -1358,12 +1358,23 @@ test('sync upload interval setting is exposed in the Multi-device Sync panel', (
 // their local drafts until the explicit Hub Save commits them.
 function fakeHubControl(value = '') {
   const listeners = new Map();
+  const attributes = new Map();
   return {
     value,
+    disabled: false,
     addEventListener(type, listener) {
       const current = listeners.get(type) || [];
       current.push(listener);
       listeners.set(type, current);
+    },
+    setAttribute(name, value) {
+      attributes.set(name, String(value));
+    },
+    removeAttribute(name) {
+      attributes.delete(name);
+    },
+    getAttribute(name) {
+      return attributes.get(name) ?? null;
     },
     async dispatch(type) {
       for (const listener of listeners.get(type) || []) await listener({ target: this });
@@ -1402,6 +1413,100 @@ function loadHubSettingsWiring(els, context) {
   );
   return vmContext;
 }
+
+test('Hub Save disables for clean and reverted drafts', async () => {
+  const els = {
+    saveSettingsButton: fakeHubControl(),
+    hubUrlInput: fakeHubControl(),
+    secretInput: fakeHubControl(),
+    deviceIdInput: fakeHubControl(),
+    syncUploadIntervalInput: fakeHubControl('0'),
+    showLimitUsedInputs: []
+  };
+  const state = {
+    settings: {
+      hubMode: 'client',
+      hubUrl: 'https://saved.example',
+      secret: 'saved-secret',
+      deviceId: 'saved-device',
+      syncUploadIntervalMs: 0
+    }
+  };
+  const patches = [];
+  let vmContext;
+  vmContext = loadHubSettingsWiring(els, {
+    state,
+    saveSettings: async (patch) => {
+      patches.push({ ...patch });
+      Object.assign(state.settings, patch);
+    },
+    refreshHubInfo: async () => {},
+    refreshHubBuildStatus: async () => {},
+    refreshStats: async () => {}
+  });
+  vmContext.syncHubDraftFields();
+
+  assert.equal(els.saveSettingsButton.disabled, true);
+  els.hubUrlInput.value = '  https://saved.example  ';
+  await els.hubUrlInput.dispatch('input');
+  assert.equal(els.saveSettingsButton.disabled, true);
+
+  els.hubUrlInput.value = 'https://draft.example';
+  await els.hubUrlInput.dispatch('input');
+  assert.equal(els.saveSettingsButton.disabled, false);
+
+  els.hubUrlInput.value = 'https://saved.example';
+  await els.hubUrlInput.dispatch('input');
+  assert.equal(els.saveSettingsButton.disabled, true);
+  await els.saveSettingsButton.dispatch('click');
+  assert.deepEqual(patches, []);
+});
+
+test('Hub Save compares Host Hub ports after canonicalizing numeric input', async () => {
+  const classList = { toggle() {} };
+  const els = {
+    saveSettingsButton: fakeHubControl(),
+    hubModeOptions: { querySelectorAll: () => [] },
+    hubClientFields: { classList },
+    hubHostFields: { classList },
+    hubPortInput: fakeHubControl(),
+    hubSecretInput: fakeHubControl(),
+    hubUrlInput: fakeHubControl(),
+    secretInput: fakeHubControl(),
+    deviceIdInput: fakeHubControl('saved-device'),
+    syncUploadIntervalInput: fakeHubControl('0'),
+    showLimitUsedInputs: []
+  };
+  const state = {
+    settings: {
+      hubMode: 'host',
+      hubHostPort: 17321,
+      hubHostSecret: 'host-secret',
+      hubUrl: '',
+      secret: '',
+      deviceId: 'saved-device',
+      syncUploadIntervalMs: 0
+    }
+  };
+  let vmContext;
+  vmContext = loadHubSettingsWiring(els, {
+    state,
+    saveSettings: async () => {},
+    refreshHubInfo: async () => {},
+    refreshHubBuildStatus: async () => {},
+    refreshStats: async () => {}
+  });
+  vmContext.syncHubDraftFields();
+
+  assert.equal(els.saveSettingsButton.disabled, true);
+  els.hubPortInput.value = '017321';
+  await els.hubPortInput.dispatch('input');
+  assert.equal(els.saveSettingsButton.disabled, true);
+
+  els.hubPortInput.value = '18000';
+  await els.hubPortInput.dispatch('input');
+  assert.equal(els.saveSettingsButton.disabled, false);
+});
 
 test('changing sync upload frequency auto-saves without replacing Hub drafts', async () => {
   const els = {


### PR DESCRIPTION
## Summary

The Multi-device Sync `Save` button now stays disabled until a manually edited Hub field differs from the persisted settings.

- Compare normalized Hub URL, secret, device ID, and Host Hub port values.
- Re-disable the button when a draft is changed back to its saved value.
- Disable the button while persistence is in flight to prevent duplicate submissions.
- Restore the button after a failed save.
- Preserve the existing draft protection for settings pushes and edits made during persistence.
- Reuse the existing disabled button styling. No layout changes.

## Validation

- `node --test tests/electron/cursorSettingsLayout.test.js`
  - 60 passed
- `npm run verify`
  - 3,379 passed
  - 1 skipped
  - 0 failed
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the Multi-device Sync Hub Save button until a draft differs from persisted settings and while a save is in flight, preventing no-op and duplicate saves. Reconcile dirty state on settings refresh and Hub mode changes so the button reflects actual changes, and keep Host port drafts intact when leaving and returning to Host mode.

- Compare normalized `hubUrl`, `secret`, `deviceId`, and (Host mode) `hubHostPort` after canonicalizing numeric input.
- Track in-flight draft revisions and recompute dirty state; re-disable when a draft matches saved settings.
- Disable Hub Save during persistence and set `aria-busy`; clear busy and restore drafts on failure.
- Preserve existing draft protection during persistence. No layout changes.

| Area | Before | After |
| --- | --- | --- |
| Unchanged drafts | Hub Save enabled, allowed no-op saves | Hub Save disabled until any draft differs from saved settings |
| Reverting drafts | Hub Save could stay enabled | Hub Save re-disables when a draft matches saved settings |
| During save | Button clickable; possible double submit | Button disabled with `aria-busy`, preventing duplicates |
| External updates / mode change | Button state could be stale; Host port drafts lost on mode switch | Dirty state reconciled on settings refresh and Hub mode changes; Host port drafts survive mode switches |
| Host Hub port | Invalid input could overwrite the saved custom port | Invalid input is treated as unchanged and the saved port is preserved; omitted outside Host mode |
| Failed save | Button might stay disabled | Button re-enabled after errors; draft remains editable |

**Tests and risks**
- Added tests for clean/reverted drafts, busy state and duplicate-click ignore, failed save re-enable, Host port canonicalization, invalid-port preservation, and port-draft survival across mode switches; existing Electron layout tests pass.
- Low risk: UI-only; no API or data model changes. Host port logic applies only in Host mode.

<sup>Written for commit dfe7bf7063ff836c2f502658d875d886015a9d83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

