### PR TITLE
fix(win): update Koffi for Windows startup regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "chokidar": "^4.0.3",
         "dotenv": "^17.4.2",
         "electron-updater": "6.8.9",
-        "koffi": "^3.1.4",
+        "koffi": "^3.1.5",
         "semver": "^7.8.5",
         "tar": "^7.5.22",
         "tokscale": "^4.13.0",
@@ -623,9 +623,9 @@
       }
     },
     "node_modules/@koromix/koffi-darwin-arm64": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.4.tgz",
-      "integrity": "sha512-/9o0uahf25sNXz7CczfMAsgdHrrrkDK3/d1W5ygJUC7QnpWo80103yTYpYahWP3vTABK5yjzKtURgssv1paskA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.5.tgz",
+      "integrity": "sha512-IpqITl2fJi3QN9bTtNnygWPdK7ScSjw3xtGu8e6feYGvimCysu+spgI5KyeslY2jTnqxGS9xr8pLAbLhGJ8edA==",
       "cpu": [
         "arm64"
       ],
@@ -639,9 +639,9 @@
       }
     },
     "node_modules/@koromix/koffi-darwin-x64": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.4.tgz",
-      "integrity": "sha512-6IOhfAHbrySr6lYRU720Hg+IMQvtMpN08k9Ppf9WF8NxYRdHLnW1FJm7zCbClfrwudtjhS/piwDYwgAkO5u8cg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.5.tgz",
+      "integrity": "sha512-4Tia4BS5EV/+vN9eIrdToanVe+U/2VqTZCBgOzoUbPKjgky51eqM+3J4qdRUvmYJohcJNPob5/hsxeItUZrl1g==",
       "cpu": [
         "x64"
       ],
@@ -655,9 +655,9 @@
       }
     },
     "node_modules/@koromix/koffi-freebsd-arm64": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.4.tgz",
-      "integrity": "sha512-JKCWC0awdVvq7Nd/etn4PXFTa7uvyHn7IzqtaOZ3r4dJRdwQVby7Ai/wsQo8UUrJfAYlALkLYgFgU8wgsnAE/A==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.5.tgz",
+      "integrity": "sha512-bP94uzseFO79NG3flpU3WxfyvltD+jzC/kN8FDZLi8J0VUZNW1Wmu8yq87KEzjX1qT9KyX4Y+elVbGqHXHTv2Q==",
       "cpu": [
         "arm64"
       ],
@@ -671,9 +671,9 @@
       }
     },
     "node_modules/@koromix/koffi-freebsd-ia32": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.4.tgz",
-      "integrity": "sha512-gU9pShDRLMZzftdGW+mTzyL8Cpa/7nzHPHe5vFakjGgtIzVFzdFBqwli4oB+tFsx44W1VqMMlvMMVlnz54ERiQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.5.tgz",
+      "integrity": "sha512-raFXXAPHzvCQWhaoMUF+Cc2ZWgg2UBU0RVoowHZhaw9nQYPC1pERcPRH+JA+SNIN6g4d2GFW6uPFc+QbUhsagA==",
       "cpu": [
         "ia32"
       ],
@@ -687,9 +687,9 @@
       }
     },
     "node_modules/@koromix/koffi-freebsd-x64": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.4.tgz",
-      "integrity": "sha512-2kppLX97xBM3WoQET6noN4W02zT2fkFRXHYluAwcCcmkEax8AVJ1CYs6hxcZ3kaNPc+5P7yMw3V/b1lg2v3aMw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.5.tgz",
+      "integrity": "sha512-h6RyBZmPMBIDWTABkJIhzDdYwSnYAJvTacHpEjbT55Arkmw1H15Rl7CFtXuEuBrqh+uivoCrRgA6vszl9CsJ9g==",
       "cpu": [
         "x64"
       ],
@@ -703,9 +703,9 @@
       }
     },
     "node_modules/@koromix/koffi-linux-arm64": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.4.tgz",
-      "integrity": "sha512-yYbypuGVGqrNchkAMY59kj+7TZ1c1u9lXRG1+74X9T8G4rOaushoVONNYLuu+ygpbwsKzz/NvEDtRioRU/dQlQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.5.tgz",
+      "integrity": "sha512-u0vCmKPu4yQDhl/ri1J6U3vDnvYtYjoZaIWb+oMbRXhVZeiqdE53MGPb+q2A7Dj2n9IbYloAfEICQbL6l0pmiQ==",
       "cpu": [
         "arm64"
       ],
@@ -719,9 +719,9 @@
       }
     },
     "node_modules/@koromix/koffi-linux-ia32": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.4.tgz",
-      "integrity": "sha512-IoA/8Qfc6ZEmwMw2Nf4aSp9RfJnxh0UHhdqD4FsVXm0vC797kLMuzj744vv5tll+waVfjrU10jREqjtnMVFoQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.5.tgz",
+      "integrity": "sha512-Xa5JbumWglwPVZgrJcLhqyC1wCWlfm7+C00p3FuOTNGp0qoYuf2/tOoAh0/q7+taVm30cMopu/6lRHwdmF6I/w==",
       "cpu": [
         "ia32"
       ],
@@ -735,9 +735,9 @@
       }
     },
     "node_modules/@koromix/koffi-linux-loong64": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.4.tgz",
-      "integrity": "sha512-ZUTdea+9dg6CV9J9CIGbhTh0FtSBgvcGKqDrlp9BVQF71jEDKOri1by/TrDe8yQUyC5kzWN8vWnkzES5wT0xDg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.5.tgz",
+      "integrity": "sha512-F3i2CeTcqVBUQiSRUBSEzX1VgtXmLLiZb/ouZtXHkWpTLhJNd9TH7s3CizTofci0VRqlKdexGUYhK5vzPDAAHA==",
       "cpu": [
         "loong64"
       ],
@@ -751,9 +751,9 @@
       }
     },
     "node_modules/@koromix/koffi-linux-riscv64": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.4.tgz",
-      "integrity": "sha512-CINyyhNYV/8MX52MGhYcik2G6PXH+KEU2JEO7dOONlsGol4lSGyW40RvYA4RQgNYk8q8imGSEScL08X8eOXnaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.5.tgz",
+      "integrity": "sha512-2TgQuzy+4PfDg+rw3kOmN6lywEWdzKT3eaLPbOp0b/9DaN7CLBJ/QIR5GhGsMNpeI30zU0YzFeYFxoVoJ/LqFw==",
       "cpu": [
         "riscv64"
       ],
@@ -767,9 +767,9 @@
       }
     },
     "node_modules/@koromix/koffi-linux-x64": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.4.tgz",
-      "integrity": "sha512-x3XnAy/tUTTCX/gMpV7VJNpOQIVQvzNhNYDrpyIeS9Q8/f1qLsE0vp0tj7A/YEDIfMVLqoJtyamfRJc04+vk4w==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.5.tgz",
+      "integrity": "sha512-2yaIg/1V0m4CiAUMzG4CIlWmq1WJ+QBMlFfaGr9su+OH5fuIqC7V3BbMiB03IwIl1VofIZO5JA4Db4lID8tpbw==",
       "cpu": [
         "x64"
       ],
@@ -783,9 +783,9 @@
       }
     },
     "node_modules/@koromix/koffi-openbsd-ia32": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.4.tgz",
-      "integrity": "sha512-r9p/fffvmBm7+iT5BZ+c17gZJ280jvmbinrPZqjG14rF9I4lk7xrlV79YfsexkeN4mcPjF2hSPtbMNFBoQU3Dw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.5.tgz",
+      "integrity": "sha512-8/OXd+u9omMooykhvdJPEP7u6FFzzrrFo9gOmSHc9/DPt3XkVYOtSsE97PDk6zYaAzwIYHSKjHvIXsfFwFc7sg==",
       "cpu": [
         "ia32"
       ],
@@ -799,9 +799,9 @@
       }
     },
     "node_modules/@koromix/koffi-openbsd-x64": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.4.tgz",
-      "integrity": "sha512-SNp5AxOzheC2YaWPu3Y86wxRHHWf6V9NMl5Ot5nu9OpnP61Yinzug7JwsCeXtcZZTbKLsfsWoT7y4n17UYpOVA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.5.tgz",
+      "integrity": "sha512-SpeqldKkuDk2aTj5PVWumy7eq6Tr2GtBPAOI1NiDHhg8xe433KraxrA9V9UjEd+1+kSGJQGR04nQByN3MPA9PQ==",
       "cpu": [
         "x64"
       ],
@@ -815,9 +815,9 @@
       }
     },
     "node_modules/@koromix/koffi-win32-arm64": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.4.tgz",
-      "integrity": "sha512-oS8ETU35AelOD6DY7xmmz9qq26Xl38upXWiZbsdxbtH9UEIY0QpenQOuCK/0+q4CtfiLorRUlglGkO9YgPAIeA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.5.tgz",
+      "integrity": "sha512-uej3YAEKAhlfVPoIo5sOwtxhTLRVJ01LgtWrKGpnnAQU3C+Ilmaxdh+Oc2xc1G3NK30N5eCVJpyO9r3pjKC6Vw==",
       "cpu": [
         "arm64"
       ],
@@ -831,9 +831,9 @@
       }
     },
     "node_modules/@koromix/koffi-win32-ia32": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.4.tgz",
-      "integrity": "sha512-zd7Qh8s4fzblD9zzuDf44XCbujYg3QrffhgcNJg79/YC6ABT2m0CUtX4yFic9EWm2ps8NPAM25kCTCXPpt3eaw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.5.tgz",
+      "integrity": "sha512-d42jv2f4PwtJGNJS19Xfn/BRtGsBNNVkw0O0K5tkIGI+yNq4MnPTSUsaGbDIkCLNsCgk/LFqAaE8BExyCdrujA==",
       "cpu": [
         "ia32"
       ],
@@ -847,9 +847,9 @@
       }
     },
     "node_modules/@koromix/koffi-win32-x64": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.4.tgz",
-      "integrity": "sha512-BPeQXc1bRd0QBOklvsP+AjoRnUzKbPNE6rfx7VNxrebhh09MKld2ibstgKWn6ejQLEcfKEoUJ+WAWIhX4AOsIg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.5.tgz",
+      "integrity": "sha512-Pyo1WEHEP6Ek2NEn2pquwJzSPLOdY4vymoPSz0an1DgvFWSkOyBYYkGVoxL1ajfj5I1pPdXysYqixtVTzAtOfQ==",
       "cpu": [
         "x64"
       ],
@@ -3485,30 +3485,30 @@
       }
     },
     "node_modules/koffi": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.1.4.tgz",
-      "integrity": "sha512-KHX39XIg7afe8ds+0MHPoLiKR9dCzsVK4oAmBUSaeJlcX0xur22f15C2DILbZ6GJ9eyqC+e6Sb1cTG7M17z+Tg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.1.5.tgz",
+      "integrity": "sha512-XVwwrxg0Ca6IEUQF4YtGIU4XN0LSselFYpYvgfhh8wafCunhEEx5hPr7LZhp5QyeFA/LcRsKHTqncCdjWjWAlg==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
         "url": "https://liberapay.com/Koromix"
       },
       "optionalDependencies": {
-        "@koromix/koffi-darwin-arm64": "3.1.4",
-        "@koromix/koffi-darwin-x64": "3.1.4",
-        "@koromix/koffi-freebsd-arm64": "3.1.4",
-        "@koromix/koffi-freebsd-ia32": "3.1.4",
-        "@koromix/koffi-freebsd-x64": "3.1.4",
-        "@koromix/koffi-linux-arm64": "3.1.4",
-        "@koromix/koffi-linux-ia32": "3.1.4",
-        "@koromix/koffi-linux-loong64": "3.1.4",
-        "@koromix/koffi-linux-riscv64": "3.1.4",
-        "@koromix/koffi-linux-x64": "3.1.4",
-        "@koromix/koffi-openbsd-ia32": "3.1.4",
-        "@koromix/koffi-openbsd-x64": "3.1.4",
-        "@koromix/koffi-win32-arm64": "3.1.4",
-        "@koromix/koffi-win32-ia32": "3.1.4",
-        "@koromix/koffi-win32-x64": "3.1.4"
+        "@koromix/koffi-darwin-arm64": "3.1.5",
+        "@koromix/koffi-darwin-x64": "3.1.5",
+        "@koromix/koffi-freebsd-arm64": "3.1.5",
+        "@koromix/koffi-freebsd-ia32": "3.1.5",
+        "@koromix/koffi-freebsd-x64": "3.1.5",
+        "@koromix/koffi-linux-arm64": "3.1.5",
+        "@koromix/koffi-linux-ia32": "3.1.5",
+        "@koromix/koffi-linux-loong64": "3.1.5",
+        "@koromix/koffi-linux-riscv64": "3.1.5",
+        "@koromix/koffi-linux-x64": "3.1.5",
+        "@koromix/koffi-openbsd-ia32": "3.1.5",
+        "@koromix/koffi-openbsd-x64": "3.1.5",
+        "@koromix/koffi-win32-arm64": "3.1.5",
+        "@koromix/koffi-win32-ia32": "3.1.5",
+        "@koromix/koffi-win32-x64": "3.1.5"
       }
     },
     "node_modules/lazy-val": {

--- a/package.json
+++ b/package.json
@@ -154,15 +154,15 @@
     "chokidar": "^4.0.3",
     "dotenv": "^17.4.2",
     "electron-updater": "6.8.9",
-    "koffi": "^3.1.4",
+    "koffi": "^3.1.5",
     "semver": "^7.8.5",
     "tar": "^7.5.22",
     "tokscale": "^4.13.0",
     "undici": "^7.29.0"
   },
   "devDependencies": {
-    "@eslint/compat": "^2.1.0",
     "@electron/osx-sign": "1.3.3",
+    "@eslint/compat": "^2.1.0",
     "@eslint/js": "^10.0.1",
     "electron": "43.4.0",
     "electron-builder": "26.15.3",


### PR DESCRIPTION
## Summary

- Update Koffi from `^3.1.4` to `^3.1.5`.
- Refresh the locked platform-specific Koffi packages.

## Why

Issue #359 reports a Windows x64 startup failure with the current Electron 43.4.0 and Koffi 3.1.4 combination.

The reporter verified that the affected Windows environment starts and remains running with both Electron 43.4.0 + Koffi 3.1.5 and Electron 43.4.0 + Koffi 3.1.2. The current v0.45.0 build, which uses Electron 43.4.0 + Koffi 3.1.4, still reproduces the failure.

Koffi upstream also documents a related Windows prebuilt-binary regression in 3.1.3 and 3.1.4, with 3.1.5 restoring native Windows compilation: https://github.com/Koromix/koffi/issues/275

Electron is already pinned to 43.4.0 on `main`, so this PR applies the Koffi fix-forward update without changing the Electron runtime.

## Validation

- `npm run verify`
- 3377 tests passed
- 1 test skipped
- Signed Windows diagnostic builds were verified by the reporter on the affected machine

Fixes #359


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows x64 startup failures by updating `koffi` to 3.1.5 and refreshing platform-specific lock entries.

- Bumps `koffi` from `^3.1.4` to `^3.1.5`; updates all `@koromix/koffi-*` optional packages to 3.1.5.
- Leaves Electron pinned at 43.4.0; no app code changes.
- Addresses upstream Windows prebuilt-binary regression in `koffi` 3.1.3–3.1.4.

| Area | Before | After |
| --- | --- | --- |
| Windows x64 startup (Electron 43.4.0 + `koffi` 3.1.x) | App exited on startup due to `koffi` regression (3.1.4) | App starts and remains running with `koffi` 3.1.5 |
| `koffi` Windows builds | Prebuilt-binary regression affected load on Windows | Native Windows compilation restored in 3.1.5 |
| Dependency config | `koffi` `^3.1.4`; lockfile pinned to 3.1.4 platform packages | `koffi` `^3.1.5`; lockfile refreshed to 3.1.5 platform packages |

**Validation and risks**
- 3377 tests passed; 1 skipped. Reporter verified signed Windows builds on the affected machine.
- Low risk across other OSes; perform a quick `koffi` smoke test on macOS/Linux.
- No migrations. After merge, run `npm ci` to pick up updated optional binaries and rebuild Windows artifacts.

Fixes #359

<sup>Written for commit 111ae647fa86b2a5761755aac56526664ae57593. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

