### PR TITLE
feat(release): bridge DeepSeek Harness support with a pinned tokscale build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,15 @@ jobs:
       - name: Platform evidence
         run: node -p "process.platform + '-' + process.arch"
       - run: npm ci
+      # Bridges DeepSeek Harness (dsh) support merged upstream but not yet in
+      # a tagged tokscale npm release — see vendor/tokscale.json's "reason".
+      # Must run before any platform packaging step (dist:*, dist:win:dir):
+      # those bundle whatever bytes are on disk under node_modules/@tokscale
+      # at the time they run.
+      - name: Install vendored tokscale (DSH bridge)
+        run: node scripts/install-vendored-tokscale.js
+      - name: Verify vendored tokscale (DSH bridge)
+        run: node scripts/verify-vendored-tokscale.js
       - name: Select Linux Electron runtime
         if: matrix.target == 'linux'
         run: |

--- a/.github/workflows/vendor-tokscale.yml
+++ b/.github/workflows/vendor-tokscale.yml
@@ -17,6 +17,8 @@ on:
       - 'scripts/vendoredTokscale.js'
       - '.github/workflows/release.yml'
       - '.github/workflows/vendor-tokscale.yml'
+      - 'package.json'
+      - 'package-lock.json'
   pull_request:
     paths: *vendor_tokscale_paths
 

--- a/.github/workflows/vendor-tokscale.yml
+++ b/.github/workflows/vendor-tokscale.yml
@@ -1,0 +1,50 @@
+name: Vendored tokscale
+
+# release.yml only runs on `v*` tag push, so regular PR/push CI never
+# exercises install-vendored-tokscale.js / verify-vendored-tokscale.js on any
+# platform before a real release. This gate runs just those two steps (no
+# electron-builder, no signing) on the same 4 targets release.yml packages,
+# so a broken asset, checksum, or DSH regression fails fast on a PR instead
+# of at release time.
+
+on:
+  push:
+    branches: [main]
+    paths: &vendor_tokscale_paths
+      - 'vendor/tokscale.json'
+      - 'scripts/install-vendored-tokscale.js'
+      - 'scripts/verify-vendored-tokscale.js'
+      - 'scripts/vendoredTokscale.js'
+      - '.github/workflows/release.yml'
+      - '.github/workflows/vendor-tokscale.yml'
+  pull_request:
+    paths: *vendor_tokscale_paths
+
+jobs:
+  verify:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15
+            arch: arm64
+          - os: macos-15-intel
+            arch: x64
+          - os: windows-latest
+            arch: x64
+          - os: ubuntu-latest
+            arch: x64
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - name: Install vendored tokscale (DSH bridge)
+        run: node scripts/install-vendored-tokscale.js
+      - name: Verify vendored tokscale (DSH bridge)
+        run: node scripts/verify-vendored-tokscale.js

--- a/scripts/install-vendored-tokscale.js
+++ b/scripts/install-vendored-tokscale.js
@@ -14,7 +14,7 @@
 const crypto = require('node:crypto');
 const fs = require('node:fs');
 const { spawnSync } = require('node:child_process');
-const { loadManifest, resolveManifestEntry, resolveTargetBinPath } = require('./vendoredTokscale');
+const { loadManifest, resolveManifestEntry, resolveTargetBinPath, resolveInstalledPackageVersion } = require('./vendoredTokscale');
 
 const MAX_BYTES = 50 * 1024 * 1024;
 const DOWNLOAD_TIMEOUT_MS = 60 * 1000;
@@ -58,6 +58,23 @@ async function main() {
   const targetBinPath = resolveTargetBinPath(entry);
   if (!fs.existsSync(targetBinPath)) {
     throw new Error(`Expected npm-installed binary not found at ${targetBinPath} — did npm ci run first?`);
+  }
+
+  // Refuse to overwrite a binary from a different npm-installed version than
+  // this override was built against. collector.js's locateBundledBinary()
+  // and tokscaleUpdater.js's update check both trust the platform package's
+  // package.json version as truth — silently overwriting its binary while
+  // that version has moved would ship stale vendor bytes under a newer
+  // version label, and the in-app updater would never notice the mismatch.
+  // A version drift here means the tokscale dependency was already bumped
+  // and this override needs to be updated or removed, not applied blindly.
+  const installedVersion = resolveInstalledPackageVersion(entry);
+  if (installedVersion !== manifest.baseVersion) {
+    throw new Error(
+      `Installed ${entry.package} is ${installedVersion}, but this vendor override was built against ` +
+        `${manifest.baseVersion}. The tokscale dependency has moved — update vendor/tokscale.json to a new ` +
+        `pinned build, or remove the vendor install step if the installed version already includes DSH support.`
+    );
   }
 
   const buffer = await downloadAsset(manifest, entry);

--- a/scripts/install-vendored-tokscale.js
+++ b/scripts/install-vendored-tokscale.js
@@ -1,0 +1,78 @@
+'use strict';
+
+// Overwrites the npm-installed tokscale platform binary with the pinned
+// downstream build recorded in vendor/tokscale.json. Bridges DSH support
+// merged upstream (junhoyeo/tokscale@<commit>) but not yet in a tagged
+// tokscale npm release — see vendor/tokscale.json's "reason" field.
+//
+// Must run after `npm ci` and before any platform packaging step, since
+// electron-builder/dist:* bundle whatever bytes are on disk under
+// node_modules/@tokscale/**/bin/ at the time they run. Follow with
+// verify-vendored-tokscale.js, which is the release gate that actually
+// proves the swapped binary parses DSH correctly.
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const { spawnSync } = require('node:child_process');
+const { loadManifest, resolveManifestEntry, resolveTargetBinPath } = require('./vendoredTokscale');
+
+const MAX_BYTES = 50 * 1024 * 1024;
+const DOWNLOAD_TIMEOUT_MS = 60 * 1000;
+
+async function downloadAsset(manifest, entry) {
+  const url = `https://github.com/${manifest.releaseRepo}/releases/download/${manifest.releaseTag}/${entry.asset}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, { signal: controller.signal, redirect: 'follow' });
+    if (!response.ok) throw new Error(`Download failed: ${response.status} ${url}`);
+    const contentLength = Number(response.headers.get('content-length') || 0);
+    if (contentLength > MAX_BYTES) throw new Error(`Asset too large: ${contentLength} bytes`);
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.length > MAX_BYTES) throw new Error(`Asset too large: ${buffer.length} bytes`);
+    return buffer;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function verifySha256(buffer, expected) {
+  const actual = crypto.createHash('sha256').update(buffer).digest('hex');
+  if (actual !== expected) {
+    throw new Error(`sha256 mismatch: expected ${expected}, got ${actual}`);
+  }
+}
+
+function smokeTest(binPath) {
+  const result = spawnSync(binPath, ['--version'], { encoding: 'utf8', timeout: 10_000 });
+  if (result.error) throw new Error(`Binary failed to execute: ${result.error.message}`);
+  if (result.status !== 0) throw new Error(`Binary exited ${result.status}: ${result.stderr || result.stdout}`);
+  return result.stdout.trim();
+}
+
+async function main() {
+  const manifest = loadManifest();
+  const { key, entry } = resolveManifestEntry(manifest);
+  console.log(`Installing vendored tokscale (${manifest.releaseTag}, source ${manifest.commit.slice(0, 12)}) for ${key}...`);
+
+  const targetBinPath = resolveTargetBinPath(entry);
+  if (!fs.existsSync(targetBinPath)) {
+    throw new Error(`Expected npm-installed binary not found at ${targetBinPath} — did npm ci run first?`);
+  }
+
+  const buffer = await downloadAsset(manifest, entry);
+  verifySha256(buffer, entry.sha256);
+
+  const tempPath = `${targetBinPath}.vendor-tmp`;
+  fs.writeFileSync(tempPath, buffer);
+  if (process.platform !== 'win32') fs.chmodSync(tempPath, 0o755);
+  fs.renameSync(tempPath, targetBinPath);
+
+  const version = smokeTest(targetBinPath);
+  console.log(`Vendored tokscale installed at ${targetBinPath} (${version})`);
+}
+
+main().catch((error) => {
+  console.error(`install-vendored-tokscale failed: ${error.message}`);
+  process.exit(1);
+});

--- a/scripts/vendoredTokscale.js
+++ b/scripts/vendoredTokscale.js
@@ -38,4 +38,26 @@ function resolveTargetBinPath(entry) {
   return path.join(binDir, 'bin', binaryName());
 }
 
-module.exports = { loadManifest, platformKey, binaryName, resolvePackageBinDir, resolveManifestEntry, resolveTargetBinPath };
+// The npm-installed platform package's own package.json version — the same
+// field collector.js's locateBundledBinary() reports as the "bundled"
+// version, and tokscaleUpdater.js's semver comparison uses as its baseline.
+// The vendor override must only ever apply on top of the exact version it
+// was built against: if package.json disagrees, some other change already
+// bumped the tokscale dependency, and overwriting its binary anyway would
+// silently ship stale vendor bytes under a newer version label — which also
+// blinds the in-app updater, since it trusts this same field.
+function resolveInstalledPackageVersion(entry) {
+  const binDir = resolvePackageBinDir(entry.package);
+  const pkgJson = JSON.parse(fs.readFileSync(path.join(binDir, 'package.json'), 'utf8'));
+  return pkgJson.version;
+}
+
+module.exports = {
+  loadManifest,
+  platformKey,
+  binaryName,
+  resolvePackageBinDir,
+  resolveManifestEntry,
+  resolveTargetBinPath,
+  resolveInstalledPackageVersion
+};

--- a/scripts/vendoredTokscale.js
+++ b/scripts/vendoredTokscale.js
@@ -1,0 +1,41 @@
+'use strict';
+
+// Shared by install-vendored-tokscale.js and verify-vendored-tokscale.js so
+// the two scripts can never resolve a different binary path than each other.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function loadManifest() {
+  const manifestPath = path.join(__dirname, '..', 'vendor', 'tokscale.json');
+  return JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+}
+
+function platformKey() {
+  return `${process.platform}-${process.arch}`;
+}
+
+function binaryName() {
+  return process.platform === 'win32' ? 'tokscale.exe' : 'tokscale';
+}
+
+function resolvePackageBinDir(packageName) {
+  const pkgJsonPath = require.resolve(`${packageName}/package.json`, { paths: [process.cwd()] });
+  return path.dirname(pkgJsonPath);
+}
+
+function resolveManifestEntry(manifest) {
+  const key = platformKey();
+  const entry = manifest.platforms[key];
+  if (!entry) {
+    throw new Error(`No vendored tokscale binary recorded for platform ${key} in vendor/tokscale.json`);
+  }
+  return { key, entry };
+}
+
+function resolveTargetBinPath(entry) {
+  const binDir = resolvePackageBinDir(entry.package);
+  return path.join(binDir, 'bin', binaryName());
+}
+
+module.exports = { loadManifest, platformKey, binaryName, resolvePackageBinDir, resolveManifestEntry, resolveTargetBinPath };

--- a/scripts/verify-vendored-tokscale.js
+++ b/scripts/verify-vendored-tokscale.js
@@ -12,7 +12,16 @@
 // (reasoning_tokens_do_not_inflate_the_additive_output_bucket): raw
 // outputTokens 25 with reasoningTokens 23 must report output 2 (25 - 23), not
 // 25 — otherwise reasoning tokens get billed twice, once inside "output" and
-// once as "reasoning".
+// once as "reasoning". Same fixture as tokscale's own
+// test_dsh_zstd_transcript_counts_identically_cold_and_warm_cache.
+//
+// The child process must be hermetic: without pinning HOME/XDG_*/config dirs
+// and clearing scan-path env vars, a run on a machine (or CI runner) that
+// happens to have its own tokscale config, DSH_HOME, or TOKSCALE_EXTRA_DIRS
+// set could read real data instead of the fixture and pass or fail for the
+// wrong reason, or hit the network for pricing and flake on a slow/blocked
+// runner. This mirrors tokscale's own cmd_with_home()/prime_pricing_cache()
+// in crates/tokscale-cli/tests/cli_tests.rs — same guarantees, ported to JS.
 
 const fs = require('node:fs');
 const os = require('node:os');
@@ -28,6 +37,12 @@ const FIXTURE_LINES = [
 ];
 const EXPECTED = { client: 'dsh', model: 'deepseek-reasoner', input: 2885, output: 2, reasoning: 23, cacheRead: 0 };
 
+// Guaranteed-unreachable loopback port (nothing listens on 9/discard), used
+// as an offline guarantee for pricing lookups even if TOKSCALE_PRICING_CACHE_ONLY
+// is ever bypassed by a future code path — same technique tokscale's own
+// harness uses.
+const BLACKHOLE_PROXY = 'http://127.0.0.1:9';
+
 function writeFixtureHome() {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-dsh-fixture-'));
   const sessionDir = path.join(home, '.dsh', 'sessions', FIXTURE_WORKSPACE_DIR, FIXTURE_SESSION_ID);
@@ -40,10 +55,55 @@ function writeFixtureHome() {
   return home;
 }
 
+// Empty-but-fresh pricing cache: TOKSCALE_PRICING_CACHE_ONLY=1 stops the
+// pricing service from fetching, but it still needs *some* non-stale cache
+// file to read instead of treating the cache as missing. Content is
+// deliberately empty — this fixture doesn't assert on cost, only on the
+// token buckets — matching tokscale's own prime_pricing_cache() fixture.
+function primePricingCache(configDir) {
+  const cacheDir = path.join(configDir, 'cache');
+  fs.mkdirSync(cacheDir, { recursive: true });
+  const now = Math.floor(Date.now() / 1000);
+  const empty = JSON.stringify({ timestamp: now, data: {} });
+  fs.writeFileSync(path.join(cacheDir, 'pricing-litellm.json'), empty);
+  fs.writeFileSync(path.join(cacheDir, 'pricing-openrouter.json'), empty);
+  fs.writeFileSync(path.join(cacheDir, 'pricing-models-dev.json'), empty);
+}
+
+function hermeticEnv(home) {
+  const configDir = path.join(home, '.config', 'tokscale');
+  primePricingCache(configDir);
+
+  const env = {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home, // Windows equivalent of HOME for path resolution
+    XDG_CONFIG_HOME: path.join(home, '.config'),
+    XDG_DATA_HOME: path.join(home, '.local', 'share'),
+    XDG_CACHE_HOME: path.join(home, '.cache'),
+    TOKSCALE_CONFIG_DIR: configDir,
+    TOKSCALE_PRICING_CACHE_ONLY: '1',
+    HTTP_PROXY: BLACKHOLE_PROXY,
+    HTTPS_PROXY: BLACKHOLE_PROXY,
+    ALL_PROXY: BLACKHOLE_PROXY,
+    http_proxy: BLACKHOLE_PROXY,
+    https_proxy: BLACKHOLE_PROXY,
+    all_proxy: BLACKHOLE_PROXY
+  };
+  // Scan-path overrides that must not leak in from the runner/dev shell —
+  // DSH_HOME in particular would otherwise redirect the scan away from the
+  // fixture entirely, since DSH resolves it ahead of `~/.dsh`.
+  for (const key of ['NO_PROXY', 'no_proxy', 'TOKSCALE_EXTRA_DIRS', 'DSH_HOME']) {
+    delete env[key];
+  }
+  return env;
+}
+
 function runAgainstFixture(binPath, home) {
-  const result = spawnSync(binPath, ['--home', home, '--json', '--client', 'dsh', '--group-by', 'client,model'], {
+  const result = spawnSync(binPath, ['--json', '--client', 'dsh', '--group-by', 'client,model', '--no-spinner'], {
     encoding: 'utf8',
-    timeout: 15_000
+    timeout: 15_000,
+    env: hermeticEnv(home)
   });
   if (result.error) throw new Error(`Fixture run failed to execute: ${result.error.message}`);
   if (result.status !== 0) throw new Error(`Fixture run exited ${result.status}: ${result.stderr || result.stdout}`);

--- a/scripts/verify-vendored-tokscale.js
+++ b/scripts/verify-vendored-tokscale.js
@@ -1,0 +1,95 @@
+'use strict';
+
+// Release gate for install-vendored-tokscale.js. Checking `--version` is not
+// enough to prove the swap worked: tokscale's Cargo.toml version stays at the
+// last tagged release (4.13.0) even on commits far past it, since DSH landed
+// without a version bump upstream. So this runs the swapped binary against a
+// minimal DSH session fixture and asserts the parsed token buckets match the
+// upstream-documented reasoning-accounting fix — proof the binary in place is
+// actually the pinned DSH build, not just an executable that runs.
+//
+// Fixture values are the vendor pair upstream's own dsh.rs test module cites
+// (reasoning_tokens_do_not_inflate_the_additive_output_bucket): raw
+// outputTokens 25 with reasoningTokens 23 must report output 2 (25 - 23), not
+// 25 — otherwise reasoning tokens get billed twice, once inside "output" and
+// once as "reasoning".
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { loadManifest, resolveManifestEntry, resolveTargetBinPath } = require('./vendoredTokscale');
+
+const FIXTURE_SESSION_ID = '96cf59c9-b347-48b9-b234-a5200913ad05';
+const FIXTURE_WORKSPACE_DIR = '-tmp-dsh-workspace';
+const FIXTURE_LINES = [
+  '{"type":"session","version":0,"id":"96cf59c9-b347-48b9-b234-a5200913ad05","createdAt":1783352134832,"cwd":"/tmp/dsh-workspace","delegationDepth":0}',
+  '{"type":"assistant/message","seq":39,"time":1785730448979,"data":{"turn":1,"message":{"id":"7ac2e3d7-d558-4b24-b71e-40fc2f42216d","source":{"kind":"model","provider":"deepseek","model":"deepseek-reasoner"}},"usage":{"inputTokens":2885,"outputTokens":25,"cacheReadTokens":0,"reasoningTokens":23}}}'
+];
+const EXPECTED = { client: 'dsh', model: 'deepseek-reasoner', input: 2885, output: 2, reasoning: 23, cacheRead: 0 };
+
+function writeFixtureHome() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-dsh-fixture-'));
+  const sessionDir = path.join(home, '.dsh', 'sessions', FIXTURE_WORKSPACE_DIR, FIXTURE_SESSION_ID);
+  fs.mkdirSync(sessionDir, { recursive: true });
+  // Plain-text session.jsonl (no zstd framing needed): DSH's `compression:
+  // none` backend writes this exact spelling, and the scanner/parser both
+  // sniff the frame magic rather than assume compression, so this and a
+  // zstd-compressed session.jsonl.zstd are equivalent inputs.
+  fs.writeFileSync(path.join(sessionDir, 'session.jsonl'), `${FIXTURE_LINES.join('\n')}\n`);
+  return home;
+}
+
+function runAgainstFixture(binPath, home) {
+  const result = spawnSync(binPath, ['--home', home, '--json', '--client', 'dsh', '--group-by', 'client,model'], {
+    encoding: 'utf8',
+    timeout: 15_000
+  });
+  if (result.error) throw new Error(`Fixture run failed to execute: ${result.error.message}`);
+  if (result.status !== 0) throw new Error(`Fixture run exited ${result.status}: ${result.stderr || result.stdout}`);
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (error) {
+    throw new Error(`Fixture run did not produce valid JSON:\n${result.stdout}`, { cause: error });
+  }
+  return parsed;
+}
+
+function assertExpected(parsed) {
+  const entry = Array.isArray(parsed.entries) ? parsed.entries[0] : null;
+  if (!entry) throw new Error(`Fixture run produced no entries: ${JSON.stringify(parsed)}`);
+  const mismatches = Object.entries(EXPECTED).filter(([key, value]) => entry[key] !== value);
+  if (mismatches.length > 0) {
+    throw new Error(
+      `DSH fixture mismatch — expected ${JSON.stringify(EXPECTED)}, got ${JSON.stringify(entry)}. ` +
+        'If this is a legitimate upstream behavior change, update EXPECTED and vendor/tokscale.json together, do not just silence this check.'
+    );
+  }
+}
+
+function main() {
+  const manifest = loadManifest();
+  const { key, entry } = resolveManifestEntry(manifest);
+  const binPath = resolveTargetBinPath(entry);
+  if (!fs.existsSync(binPath)) {
+    throw new Error(`No binary at ${binPath} for ${key} — run install-vendored-tokscale.js first`);
+  }
+
+  const home = writeFixtureHome();
+  try {
+    const parsed = runAgainstFixture(binPath, home);
+    assertExpected(parsed);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+
+  console.log(`Verified vendored tokscale (${key}): DSH fixture parses with correct reasoning-corrected token buckets.`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`verify-vendored-tokscale failed: ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/verify-vendored-tokscale.js
+++ b/scripts/verify-vendored-tokscale.js
@@ -117,8 +117,11 @@ function runAgainstFixture(binPath, home) {
 }
 
 function assertExpected(parsed) {
-  const entry = Array.isArray(parsed.entries) ? parsed.entries[0] : null;
-  if (!entry) throw new Error(`Fixture run produced no entries: ${JSON.stringify(parsed)}`);
+  const entries = Array.isArray(parsed.entries) ? parsed.entries : [];
+  if (entries.length !== 1) {
+    throw new Error(`Expected exactly 1 fixture entry, got ${entries.length}: ${JSON.stringify(parsed)}`);
+  }
+  const entry = entries[0];
   const mismatches = Object.entries(EXPECTED).filter(([key, value]) => entry[key] !== value);
   if (mismatches.length > 0) {
     throw new Error(

--- a/vendor/tokscale.json
+++ b/vendor/tokscale.json
@@ -5,7 +5,7 @@
   "commitTitle": "feat(clients): add DeepSeek Harness support (#1126)",
   "releaseRepo": "Javis603/tokscale",
   "releaseTag": "token-monitor-59712ada",
-  "reason": "Bridges DeepSeek Harness (dsh) client support merged upstream but not yet in a tagged tokscale npm release. Remove this override once an official tokscale release includes commit 59712ada or later — the bundled npm binary then wins again automatically.",
+  "reason": "Bridges DeepSeek Harness (dsh) client support merged upstream but not yet in a tagged tokscale npm release. Once Token Monitor updates its npm lockfile to an official tokscale release containing commit 59712ada or later, remove this override so the official bundled binary becomes authoritative again — the bundled version is never faked, so tokscaleUpdater.js's existing semver comparison keeps working, but packaged builds themselves need that explicit lockfile bump and step removal, not just an upstream release existing.",
   "platforms": {
     "darwin-arm64": {
       "package": "@tokscale/cli-darwin-arm64",

--- a/vendor/tokscale.json
+++ b/vendor/tokscale.json
@@ -3,6 +3,8 @@
   "fork": "Javis603/tokscale",
   "commit": "59712ada85640b7aaa00d7da92ed1a15367e961b",
   "commitTitle": "feat(clients): add DeepSeek Harness support (#1126)",
+  "baseVersion": "4.13.0",
+  "baseVersionNote": "The npm-installed @tokscale/cli-<platform> package.json version this override was built against. install-vendored-tokscale.js refuses to run if the installed package reports a different version — that means the tokscale dependency already moved and this override needs to be updated or removed, not silently kept.",
   "releaseRepo": "Javis603/tokscale",
   "releaseTag": "token-monitor-59712ada",
   "reason": "Bridges DeepSeek Harness (dsh) client support merged upstream but not yet in a tagged tokscale npm release. Once Token Monitor updates its npm lockfile to an official tokscale release containing commit 59712ada or later, remove this override so the official bundled binary becomes authoritative again — the bundled version is never faked, so tokscaleUpdater.js's existing semver comparison keeps working, but packaged builds themselves need that explicit lockfile bump and step removal, not just an upstream release existing.",

--- a/vendor/tokscale.json
+++ b/vendor/tokscale.json
@@ -1,0 +1,31 @@
+{
+  "upstream": "junhoyeo/tokscale",
+  "fork": "Javis603/tokscale",
+  "commit": "59712ada85640b7aaa00d7da92ed1a15367e961b",
+  "commitTitle": "feat(clients): add DeepSeek Harness support (#1126)",
+  "releaseRepo": "Javis603/tokscale",
+  "releaseTag": "token-monitor-59712ada",
+  "reason": "Bridges DeepSeek Harness (dsh) client support merged upstream but not yet in a tagged tokscale npm release. Remove this override once an official tokscale release includes commit 59712ada or later — the bundled npm binary then wins again automatically.",
+  "platforms": {
+    "darwin-arm64": {
+      "package": "@tokscale/cli-darwin-arm64",
+      "asset": "tokscale-darwin-arm64",
+      "sha256": "3cab6986cd23f6fd9c4173ccf61213f1d123f4490a5ce56945e7a7d78c575771"
+    },
+    "darwin-x64": {
+      "package": "@tokscale/cli-darwin-x64",
+      "asset": "tokscale-darwin-x64",
+      "sha256": "ce1e3388a3e77599813597afdd0a339e3ce72e5d639400c5dc6658d77ed4dc5f"
+    },
+    "linux-x64": {
+      "package": "@tokscale/cli-linux-x64-gnu",
+      "asset": "tokscale-linux-x64",
+      "sha256": "8ac6ed43aadb9d2861f95ca7d3de42d179155a3fd276c5eaefdbe439c2640560"
+    },
+    "win32-x64": {
+      "package": "@tokscale/cli-win32-x64-msvc",
+      "asset": "tokscale-win32-x64.exe",
+      "sha256": "bbecf68d88abf2b0b7a50de018dcc54e4a6cf95260a71acde633da1a8bd3fe98"
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds a vendoring mechanism so packaged Token Monitor releases ship a tokscale binary that includes DeepSeek Harness (dsh) client support, without waiting for an official tokscale npm release.

## Why

tokscale merged DSH support upstream at `junhoyeo/tokscale@59712ada` ("feat(clients): add DeepSeek Harness support"), but the currently published npm package (4.13.0) does not include it. Multiple users have asked for DSH tracking (#424, #422, #407). Several community PRs (#419, #412, #410) attempt to bridge the gap with a local session parser, duplicating logic tokscale's upstream DSH parser already implements. #408 already takes the preferred tokscale-backed route and can serve as the follow-up client-plumbing change once this release bridge lands.

## How

- A maintained fork ([Javis603/tokscale](https://github.com/Javis603/tokscale)) carries a downstream-only `token-monitor-binaries.yml` workflow (kept out of the upstream-tracked `build-native.yml` so syncing with upstream never conflicts). It builds tokscale-cli from an explicit pinned commit SHA for the 4 platforms Token Monitor ships and uploads them as Actions artifacts. Those artifacts were then promoted to a [GitHub Release](https://github.com/Javis603/tokscale/releases/tag/token-monitor-59712ada) with SHA256SUMS as a separate manual step — durable storage, unlike the workflow's own 7-day Actions-artifact retention, though that promotion isn't automated yet inside the same workflow run.
- `vendor/tokscale.json` records the pinned commit, the fork release tag, and each platform's asset name + sha256.
- `scripts/install-vendored-tokscale.js` runs after `npm ci` and before any packaging step in `release.yml`: downloads the matching release asset, verifies its checksum, and overwrites the npm-installed `@tokscale/cli-<platform>/bin/tokscale[.exe]` in place. `package.json`'s `tokscale` dependency and the installed package metadata (including its reported version) are untouched — only the binary bytes change. It also refuses to run if the installed platform package's version doesn't exactly match `vendor/tokscale.json`'s `baseVersion` (4.13.0): both `collector.js`'s `locateBundledBinary()` and `tokscaleUpdater.js`'s update check trust that version field, so silently overwriting a binary that came from a different npm-installed version would ship stale vendor bytes under a newer, misleading version label — and blind the in-app updater from ever correcting it.
- `scripts/verify-vendored-tokscale.js` is the release gate: `--version` can't prove the swap worked (tokscale's Cargo.toml version stays at 4.13.0 even on commits far past the tag, since DSH landed without a version bump), so this runs the swapped binary against a minimal DSH session fixture and asserts the parsed token buckets match tokscale's own documented reasoning-accounting fix. The fixture run is hermetic — HOME/XDG_*/TOKSCALE_CONFIG_DIR pinned to the fixture dir, pricing forced cache-only against an empty primed cache, a blackhole proxy, and DSH_HOME/TOKSCALE_EXTRA_DIRS/NO_PROXY cleared — mirroring tokscale's own `cmd_with_home()`/`prime_pricing_cache()` test harness, so a CI runner or dev machine with its own tokscale config, real DSH data, or network restrictions can't change the result.
- `.github/workflows/vendor-tokscale.yml` runs the install + verify scripts (no packaging, no signing) on all 4 release platforms on every PR that touches this bridge, since `release.yml` itself only runs on `v*` tag push and would otherwise never be exercised by normal CI before an actual release.

## Exit path

The installed package version is never faked, so `tokscaleUpdater.js` keeps its existing semver behavior: on platforms it supports (macOS and Windows — `tokscalePackageNameForPlatform()` returns null on Linux, so the in-app updater is a no-op there today, independent of this PR), a future official npm release with a higher version can replace the bundled 4.13.0 vendor build on existing installations.

For packaged releases, the vendored override remains explicit and pinned until Token Monitor updates its npm lockfile to an official tokscale release that contains DSH support and removes the vendor install step. That cleanup is small and deliberate rather than encoded as a fake downstream version.

## Scope

This PR only adds the ability to ship a patched tokscale binary. It does not register `dsh` as a tracked client in Token Monitor itself (`DEFAULT_CLIENTS`, source roots, renderer labels, icons, etc.) — that's a separate, normal "Adding a tracked client" change once this bridge is in place.

## Test plan

- `npm run verify` (3377 passing, 0 failing)
- Manually ran `install-vendored-tokscale.js` + the hermetic `verify-vendored-tokscale.js` against the real published fork release, in an isolated sandbox (not the working tree's own `node_modules`): downloads and checksum-verifies correctly, the swapped binary passes the DSH fixture check (reasoning tokens correctly excluded from the additive output bucket), and the unswapped/stock binary correctly *fails* the same fixture check, so the gate isn't a tautology.
- Confirmed the install step in `release.yml` runs before every packaging step in all 4 matrix legs, including Windows `dist:win:dir`.
- `.github/workflows/vendor-tokscale.yml` will run install + verify on all 4 platforms in CI on this PR itself, since it touches paths the new workflow is filtered on.
