### PR TITLE
fix(home): prevent heatmap edge clipping

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -6832,6 +6832,7 @@ function renderHomeTrendsModule() {
   activityCanvas.innerHTML = charts.heatmapSvg(activity, {
     monthLabel: (month) => compactMonthLabel(month.label),
     radius: activityLayout.radius,
+    edgePad: activityLayout.edgePad,
     glowFilterId: 'homeActivityHeatGlow',
     spotlightId: 'homeActivitySpotlight',
     spotlightRadius: 82

--- a/src/electron/renderer/homeOverview.js
+++ b/src/electron/renderer/homeOverview.js
@@ -269,7 +269,10 @@
   }
 
   function homeActivityHeatmapLayout() {
-    return { cell: 9, gap: 3, radius: 2 };
+    // Reserve room for the hover scale and glow on the first/last columns and
+    // first row. The chart renderer applies this in SVG coordinates so it also
+    // becomes real scrollable space rather than paint outside the viewport.
+    return { cell: 9, gap: 3, radius: 2, edgePad: 10 };
   }
 
   function historyHasDays(history) {

--- a/src/electron/renderer/usageCharts.js
+++ b/src/electron/renderer/usageCharts.js
@@ -520,8 +520,16 @@
   }
 
   function heatmapSvg(model, options) {
-    const o = Object.assign({ titleOf: () => '', monthLabel: (m) => m.label, radius: 3, glowFilterId: '', spotlightId: '', spotlightRadius: 86, initialHidden: false }, options || {});
+    const o = Object.assign({ titleOf: () => '', monthLabel: (m) => m.label, radius: 3, glowFilterId: '', spotlightId: '', spotlightRadius: 86, initialHidden: false, edgePad: 0 }, options || {});
     const botPad = 16;
+    // Interactive cells can scale and carry a glow filter beyond their source
+    // rect. Keep the padding in the SVG coordinate system so the scrollable
+    // width/height include the same safe area that the browser paints.
+    const edgePad = Math.max(0, Number(o.edgePad) || 0);
+    const modelWidth = Math.max(0, Number(model.width) || 0);
+    const modelHeight = Math.max(0, Number(model.height) || 0);
+    const svgWidth = modelWidth + edgePad * 2;
+    const svgHeight = modelHeight + botPad + edgePad;
     const pitch = (model.cell || 11) + (model.gap || 2);
     const glowFilterId = String(o.glowFilterId || '');
     const spotlightId = String(o.spotlightId || '');
@@ -533,17 +541,17 @@
       defsParts.push(`<filter id="${escapeXml(glowFilterId)}" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB"><feDropShadow dx="0" dy="0" stdDeviation="2.1" flood-color="rgb(120, 190, 255)" flood-opacity="0.95"></feDropShadow><feDropShadow dx="0" dy="0" stdDeviation="4.2" flood-color="rgb(120, 190, 255)" flood-opacity="0.42"></feDropShadow></filter>`);
     }
     if (spotlightId) {
-      defsParts.push(`<radialGradient id="${escapeXml(spotlightGradientId)}" gradientUnits="userSpaceOnUse" cx="-200" cy="-200" r="${radius}"><stop offset="0" stop-color="white" stop-opacity="1"></stop><stop offset="0.35" stop-color="white" stop-opacity="0.62"></stop><stop offset="0.75" stop-color="white" stop-opacity="0"></stop></radialGradient><mask id="${escapeXml(spotlightMaskId)}"><rect x="0" y="0" width="${svgRound(model.width)}" height="${svgRound(model.height)}" fill="url(#${escapeXml(spotlightGradientId)})"></rect></mask>`);
+      defsParts.push(`<radialGradient id="${escapeXml(spotlightGradientId)}" gradientUnits="userSpaceOnUse" cx="-200" cy="-200" r="${radius}"><stop offset="0" stop-color="white" stop-opacity="1"></stop><stop offset="0.35" stop-color="white" stop-opacity="0.62"></stop><stop offset="0.75" stop-color="white" stop-opacity="0"></stop></radialGradient><mask id="${escapeXml(spotlightMaskId)}"><rect x="0" y="0" width="${svgRound(svgWidth)}" height="${svgRound(svgHeight - botPad)}" fill="url(#${escapeXml(spotlightGradientId)})"></rect></mask>`);
     }
     const defs = defsParts.length ? `<defs>${defsParts.join('')}</defs>` : '';
     const initialVisibility = o.initialHidden ? ' data-motion-hidden="true" opacity="0"' : '';
-    const cellAttrs = (c) => `class="heat lvl-${c.intensity}" data-d="${escapeXml(c.date)}" data-t="${svgRound(c.tokens || 0)}" data-cost="${svgRound(c.cost || 0)}" x="${svgRound(c.x)}" y="${svgRound(c.y)}" width="${svgRound(c.size)}" height="${svgRound(c.size)}" rx="${svgRound(Math.max(0, Number(o.radius) || 0))}"${initialVisibility}`;
+    const cellAttrs = (c) => `class="heat lvl-${c.intensity}" data-d="${escapeXml(c.date)}" data-t="${svgRound(c.tokens || 0)}" data-cost="${svgRound(c.cost || 0)}" x="${svgRound(Number(c.x) + edgePad)}" y="${svgRound(Number(c.y) + edgePad)}" width="${svgRound(c.size)}" height="${svgRound(c.size)}" rx="${svgRound(Math.max(0, Number(o.radius) || 0))}"${initialVisibility}`;
     const cells = (model.cells || []).map((c) =>
       `<rect ${cellAttrs(c)}>${o.titleOf(c) ? `<title>${escapeXml(o.titleOf(c))}</title>` : ''}</rect>`
     ).join('');
     const brightCells = spotlightId
       ? (model.cells || []).map((c) =>
-        `<rect class="heat heat-bright lvl-${c.intensity}" x="${svgRound(c.x)}" y="${svgRound(c.y)}" width="${svgRound(c.size)}" height="${svgRound(c.size)}" rx="${svgRound(Math.max(0, Number(o.radius) || 0))}"></rect>`
+        `<rect class="heat heat-bright lvl-${c.intensity}" x="${svgRound(Number(c.x) + edgePad)}" y="${svgRound(Number(c.y) + edgePad)}" width="${svgRound(c.size)}" height="${svgRound(c.size)}" rx="${svgRound(Math.max(0, Number(o.radius) || 0))}"></rect>`
       ).join('')
       : '';
     const brightLayer = spotlightId
@@ -552,11 +560,11 @@
     // Month labels sit BELOW the grid, left-anchored at the column where each month
     // starts — so the current month naturally lands on whichever column its 1st falls in
     // (no special-casing), and the first month sits flush at the left edge.
-    const labelY = model.height + 12;
+    const labelY = edgePad + modelHeight + 12;
     const months = (model.monthLabels || []).map((m) =>
-      `<text class="heat-month" x="${svgRound(m.col * pitch)}" y="${svgRound(labelY)}" text-anchor="start">${escapeXml(o.monthLabel(m))}</text>`
+      `<text class="heat-month" x="${svgRound(edgePad + m.col * pitch)}" y="${svgRound(labelY)}" text-anchor="start">${escapeXml(o.monthLabel(m))}</text>`
     ).join('');
-    return `<svg class="dash-heatmap" viewBox="0 0 ${model.width} ${model.height + botPad}" width="${model.width}" height="${model.height + botPad}">${defs}<g class="heat-base-layer">${cells}</g>${brightLayer}${months}</svg>`;
+    return `<svg class="dash-heatmap" viewBox="0 0 ${svgRound(svgWidth)} ${svgRound(svgHeight)}" width="${svgRound(svgWidth)}" height="${svgRound(svgHeight)}">${defs}<g class="heat-base-layer">${cells}</g>${brightLayer}${months}</svg>`;
   }
 
   function statsCardsHtml(cards, options) {

--- a/tests/electron/homeOverview.test.js
+++ b/tests/electron/homeOverview.test.js
@@ -31,7 +31,7 @@ const historyWithDays = { daily: [{ date: '2026-06-01', tokens: 10, cost: 1 }], 
 const emptyHistory = { daily: [], monthly: [], summary: {} };
 
 test('Home activity heatmap is a scaled copy of the dashboard heatmap', () => {
-  assert.deepEqual(homeActivityHeatmapLayout(), { cell: 9, gap: 3, radius: 2 });
+  assert.deepEqual(homeActivityHeatmapLayout(), { cell: 9, gap: 3, radius: 2, edgePad: 10 });
 
   const rendererDir = path.join(__dirname, '../../src/electron/renderer');
   const css = fs.readFileSync(path.join(rendererDir, 'styles.css'), 'utf8');
@@ -61,6 +61,8 @@ test('Home activity heatmap is a scaled copy of the dashboard heatmap', () => {
   );
   assert.match(rule(css, '.home-activity-tooltip'), /position:\s*fixed/);
   assert.match(rule(css, '.home-activity-canvas .heat-month'), /fill:\s*rgba\(var\(--line-rgb\), 0\.5\)/);
+  const rendererSource = fs.readFileSync(path.join(rendererDir, 'app.js'), 'utf8');
+  assert.match(rendererSource, /heatmapSvg\(activity, \{[\s\S]*edgePad:\s*activityLayout\.edgePad/);
 });
 
 test('Home module selection is independent from main view preferences', () => {

--- a/tests/electron/usageCharts.test.js
+++ b/tests/electron/usageCharts.test.js
@@ -166,6 +166,21 @@ test('heatmapSvg scales its corner radius for compact variants', () => {
   assert.match(svg, /rx="2"/);
 });
 
+test('heatmapSvg reserves an SVG edge pad for interactive overflow', () => {
+  const svg = heatmapSvg({
+    width: 24,
+    height: 21,
+    cell: 9,
+    gap: 3,
+    cells: [{ date: '2026-06-22', intensity: 4, x: 0, y: 0, size: 9 }],
+    monthLabels: [{ col: 0, label: '2026-06' }]
+  }, { edgePad: 10 });
+
+  assert.match(svg, /viewBox="0 0 44 47"/);
+  assert.match(svg, /x="10" y="10" width="9" height="9"/);
+  assert.match(svg, /class="heat-month" x="10" y="43"/);
+});
+
 test('heatmapSvg embeds escaped per-cell titles when supplied', () => {
   const svg = heatmapSvg({
     width: 9,


### PR DESCRIPTION
## 变更

修复首页年度用量热力图在鼠标悬停或选中时，首列、末列和首行的放大与发光效果被 SVG/滚动容器裁切的问题。

## 根因

热力图单元格的原有悬停效果会在单元格原始矩形之外绘制，但首尾列和首行贴着 SVG 边界；父级滚动容器的裁切因此截断了这些视觉内容。底部原本已有月份标签的预留空间，所以底部没有表现出同样明显的裁切。

## 实现

- 为通用 `heatmapSvg` 增加可选的 `edgePad`，并将安全区纳入 SVG 的 `viewBox`、实际宽高和可滚动几何。
- 仅首页热力图启用 10px 安全区，同时同步偏移基础单元格、聚光灯发光层和月份标签。
- 保留原有悬停放大、描边、滤镜、阴影、透明度和过渡效果；其他图表未传入 `edgePad`，保持原有几何。
- 增加回归测试，覆盖安全区、单元格坐标和首页传参。

## 截图

| 验收场景 | 截图 |
| --- | --- |
| 最左侧真实边缘单元格悬停效果 | <img width="208" height="308" alt="Left" src="https://github.com/user-attachments/assets/564a4445-62cf-442b-b106-df3e8f901a52" /> |
| 最右侧真实边缘单元格悬停效果 | <img width="264" height="218" alt="Right" src="https://github.com/user-attachments/assets/8ceffb3e-db6a-4a52-8e3e-b4590433a1c8" /> |
| 最上方边缘单元格悬停效果 | <img width="252" height="196" alt="Up" src="https://github.com/user-attachments/assets/55658d58-4875-4531-8d54-c577277cdcaa" /> |

## 验证

- `npm run verify`：3379 项通过，0 失败，0 取消，1 项跳过。
- 人工视觉验收已确认首页热力图边缘裁切问题消失。
- 关联 issue：Fixes #450

<details>
<summary>English version</summary>

## Summary

Fix the Home yearly activity heatmap clipping its hover/selection effect at the true left edge, true right edge, and top edge.

## Root cause

The existing hover effect paints outside each cell's source rectangle, while the first/last columns and first row were flush with the SVG boundary. The parent scroller consequently clipped the scaled cell, stroke, and glow. The bottom already had room reserved for month labels, so it did not show the same obvious clipping.

## Implementation

- Add an optional `edgePad` to `heatmapSvg` and include the padding in the SVG `viewBox`, rendered dimensions, and scrollable geometry.
- Enable a 10px edge pad only for the Home heatmap, applying the same offset to base cells, the spotlight layer, and month labels.
- Preserve the existing hover scale, stroke, filter, shadows, opacity, and transitions. Other charts keep the original geometry because they use the default `edgePad: 0`.
- Add regression coverage for the SVG edge pad, cell coordinates, and Home wiring.

## Screenshots

| Acceptance scenario | Screenshot |
| --- | --- |
| Hover state at the true left edge | <img width="208" height="308" alt="Left" src="https://github.com/user-attachments/assets/564a4445-62cf-442b-b106-df3e8f901a52" /> |
| Hover state at the true right edge | <img width="264" height="218" alt="Right" src="https://github.com/user-attachments/assets/8ceffb3e-db6a-4a52-8e3e-b4590433a1c8" /> |
| Hover state at the top edge | <img width="252" height="196" alt="Up" src="https://github.com/user-attachments/assets/55658d58-4875-4531-8d54-c577277cdcaa" /> |

## Validation

- `npm run verify`: 3379 passed, 0 failed, 0 cancelled, 1 skipped.
- Manual visual acceptance confirmed that the Home heatmap edge clipping is gone.
- Fixes #450

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent edge clipping of hover/selection glow on the Home activity heatmap by padding the SVG edges. Adds a safe edge pad to the heatmap renderer so edge interactions render fully without changing other charts.

- Add optional `edgePad` to `heatmapSvg` and apply it to the viewBox, rendered size, cell/label coordinates, and spotlight mask.
- Enable `edgePad: 10` only for the Home heatmap; bottom spacing remains unchanged due to existing month-label padding.
- Keep default `edgePad: 0` so all other heatmaps retain their geometry and behavior.

| Area | Before | After |
| --- | --- | --- |
| Home heatmap hover on first/last columns and first row | Hover scale, stroke, and glow were clipped by SVG/scroller edges | Hover/selection renders fully; 10px safe area prevents clipping |
| Scrollable geometry | Width/height matched grid; overflow painted outside viewport | Width/height include edge pad; scroll area matches painted content |
| `heatmapSvg` API | No way to reserve edge padding | New optional `edgePad` (default 0) pads viewBox, size, and coordinates |
| Spotlight mask | Mask sized to grid only | Mask sized to padded area to match spotlight layer |

**Tests and risks**
- Add tests for SVG edge pad, coordinate offsets, and Home wiring; all tests pass. Manual visual check confirms edge clipping is gone.
- Backwards compatible API; no migration required. Only the Home heatmap opts in to padding. Fixes #450.

<sup>Written for commit ed20aa3a12ed0ce51f70a3e627c9db14afe13967. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

