### PR TITLE
fix(claude): honor CLAUDE_CONFIG_DIR across session paths

### DIFF
--- a/src/shared/claudePaths.js
+++ b/src/shared/claudePaths.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const path = require('node:path');
+
+function nonBlank(value) {
+  const text = String(value ?? '').trim();
+  return text || '';
+}
+
+// Claude Code resolves both projects and transcript sessions from
+// CLAUDE_CONFIG_DIR, falling back to ~/.claude. `useEnvRoots: false` is used
+// for an explicit secondary home such as a WSL distro, where the scoped home
+// must win over the host process environment.
+function resolveClaudeConfigDir({ env, homeDir = '', useEnvRoots = true } = {}) {
+  const configured = useEnvRoots ? nonBlank((env || process.env).CLAUDE_CONFIG_DIR) : '';
+  return configured || path.join(homeDir, '.claude');
+}
+
+function claudeSessionRoots(options = {}) {
+  const configDir = resolveClaudeConfigDir(options);
+  return {
+    projects: path.join(configDir, 'projects'),
+    transcripts: path.join(configDir, 'transcripts')
+  };
+}
+
+module.exports = { claudeSessionRoots, resolveClaudeConfigDir };

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -832,8 +832,12 @@ function sessionTimestampMap(periods, home = os.homedir(), deps = {}) {
     env: deps.env,
     useEnvRoots: !deps.scopedHome
   });
-  const claudeFiles = findSessionFiles(claudeRoots.projects, byClient.get('claude') || []);
-  for (const [sessionId, filePath] of claudeFiles) applyFile('claude', sessionId, filePath);
+  const claudeIds = byClient.get('claude') || new Set();
+  const projectFiles = findSessionFiles(claudeRoots.projects, claudeIds);
+  for (const [sessionId, filePath] of projectFiles) applyFile('claude', sessionId, filePath);
+  const missingClaudeIds = new Set([...claudeIds].filter((sessionId) => !projectFiles.has(sessionId)));
+  const transcriptFiles = findSessionFiles(claudeRoots.transcripts, missingClaudeIds);
+  for (const [sessionId, filePath] of transcriptFiles) applyFile('claude', sessionId, filePath);
 
   const codexIds = byClient.get('codex') || new Set();
   const missingCodexIds = new Set();

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -33,6 +33,7 @@ const { hermesProfileWatchDirs, resolveHermesHome } = require('./hermesProfiles'
 const { localDayKey, mergeHistories, parseGraphResult, normalizeHistory } = require('./history');
 const { retainDailyHistory, retainLiveDailyHistory } = require('./dailyHistoryArchive');
 const cursorAuth = require('./cursorAuth');
+const { claudeSessionRoots } = require('./claudePaths');
 const { findSessionFiles, codexSessionFile } = require('./sessionFiles');
 const opencodeSession = require('./opencodeSession');
 const { buildPromaHistoryGraph, buildPromaPeriods, collectPromaRows } = require('./promaUsage');
@@ -826,7 +827,12 @@ function sessionTimestampMap(periods, home = os.homedir(), deps = {}) {
     }
   }
 
-  const claudeFiles = findSessionFiles(path.join(home, '.claude', 'projects'), byClient.get('claude') || []);
+  const claudeRoots = claudeSessionRoots({
+    homeDir: home,
+    env: deps.env,
+    useEnvRoots: !deps.scopedHome
+  });
+  const claudeFiles = findSessionFiles(claudeRoots.projects, byClient.get('claude') || []);
   for (const [sessionId, filePath] of claudeFiles) applyFile('claude', sessionId, filePath);
 
   const codexIds = byClient.get('codex') || new Set();
@@ -1731,7 +1737,8 @@ function clientSourceRoots(clientsCsv) {
       }));
     }
   };
-  add('claude', ['claude-projects', path.join(home, '.claude', 'projects')], ['claude-transcripts', path.join(home, '.claude', 'transcripts')]);
+  const claudeRoots = claudeSessionRoots({ homeDir: home });
+  add('claude', ['claude-projects', claudeRoots.projects], ['claude-transcripts', claudeRoots.transcripts]);
   const codexHome = nonBlankEnvPath('CODEX_HOME', path.join(home, '.codex'));
   add(
     'codex',

--- a/src/shared/sessionDetail.js
+++ b/src/shared/sessionDetail.js
@@ -338,10 +338,10 @@ function readReasonixSessionDetail({ sessionId, period = 'total', home, deps = {
   };
 }
 
-function readSessionDetail({ client, sessionId, period = 'total', sessionCost = 0, home, deps = {} }) {
+function readSessionDetail({ client, sessionId, period = 'total', sessionCost = 0, home, env, useEnvRoots, deps = {} }) {
   if (client === 'opencode') return readOpenCodeSessionDetail({ sessionId, period, deps });
   if (client === 'reasonix') return readReasonixSessionDetail({ sessionId, period, home, deps });
-  const filePath = resolveSessionFile(client, sessionId, home);
+  const filePath = resolveSessionFile(client, sessionId, home, { env, useEnvRoots });
   if (!filePath) return { found: false, client, sessionId, period, exchanges: [], totals: totalsOf([], sessionCost) };
   let text;
   try { text = fs.readFileSync(filePath, 'utf8'); } catch (_) {

--- a/src/shared/sessionDetailResolver.js
+++ b/src/shared/sessionDetailResolver.js
@@ -26,7 +26,12 @@ function resolveSessionDetailForPlatform(args = {}, deps = {}) {
   // real env; every WSL attempt gets none, forcing `home` to be authoritative.
   const readDetail = args.client === 'dsh'
     ? (detailArgs, scoped) => (deps.readDshSessionDetail || readDshSessionDetail)({ ...detailArgs, platform, env: scoped ? {} : deps.env, cwdDir: deps.cwdDir })
-    : (detailArgs) => (deps.readSessionDetail || readSessionDetail)(detailArgs);
+    : (detailArgs, scoped) => (deps.readSessionDetail || readSessionDetail)({
+      ...detailArgs,
+      ...(scoped
+        ? { env: {}, useEnvRoots: false }
+        : (deps.env === undefined ? {} : { env: deps.env }))
+    });
   const nativeDetail = readDetail({ ...args, home: nativeHome }, false);
 
   if (nativeDetail.found || platform !== 'win32' || !WSL_FALLBACK_CLIENTS.has(args.client)) {

--- a/src/shared/sessionFiles.js
+++ b/src/shared/sessionFiles.js
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { claudeSessionRoots } = require('./claudePaths');
 
 function findSessionFiles(root, sessionIds) {
   const wanted = new Set(Array.from(sessionIds).map((id) => `${id}.jsonl`));
@@ -34,13 +35,18 @@ function codexSessionFile(home, sessionId) {
   try { return fs.statSync(filePath).isFile() ? filePath : ''; } catch (_) { return ''; }
 }
 
-function resolveSessionFile(client, sessionId, home) {
+function resolveSessionFile(client, sessionId, home, options = {}) {
   const id = String(sessionId || '');
   if (!id) return '';
   if (client === 'claude') {
-    const projectFile = findSessionFiles(path.join(home, '.claude', 'projects'), [id]).get(id);
+    const { projects, transcripts } = claudeSessionRoots({
+      homeDir: home,
+      env: options.env,
+      useEnvRoots: options.useEnvRoots
+    });
+    const projectFile = findSessionFiles(projects, [id]).get(id);
     if (projectFile) return projectFile;
-    return findSessionFiles(path.join(home, '.claude', 'transcripts'), [id]).get(id) || '';
+    return findSessionFiles(transcripts, [id]).get(id) || '';
   }
   if (client === 'codex') {
     const direct = codexSessionFile(home, id);

--- a/tests/shared/clientHealth.test.js
+++ b/tests/shared/clientHealth.test.js
@@ -332,6 +332,23 @@ test('every source-root id the collector emits is in the allowlist', () => {
   }
 });
 
+test('Claude source roots follow CLAUDE_CONFIG_DIR like tokscale', () => {
+  const previousConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  const originalHomedir = os.homedir;
+  os.homedir = () => path.join(path.sep, 'home', 'alice');
+  process.env.CLAUDE_CONFIG_DIR = path.join(path.sep, 'srv', 'claude-config');
+  try {
+    assert.deepEqual(clientSourceRoots('claude').claude, [
+      { id: 'claude-projects', dir: path.join(path.sep, 'srv', 'claude-config', 'projects') },
+      { id: 'claude-transcripts', dir: path.join(path.sep, 'srv', 'claude-config', 'transcripts') }
+    ]);
+  } finally {
+    os.homedir = originalHomedir;
+    if (previousConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = previousConfigDir;
+  }
+});
+
 test('labelling roots keeps diagnostics separate from watcher roots', () => {
   const roots = clientSourceRoots(KNOWN_CLIENTS);
   const candidates = clientWatchCandidates(KNOWN_CLIENTS);

--- a/tests/shared/collectorSessionTimestamps.test.js
+++ b/tests/shared/collectorSessionTimestamps.test.js
@@ -82,6 +82,33 @@ test('applySessionTimestamps resolves Claude metadata from CLAUDE_CONFIG_DIR', (
   }
 });
 
+test('applySessionTimestamps resolves Claude metadata from configured transcripts', () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-claude-transcripts-'));
+  const configDir = path.join(home, 'relocated-claude');
+  try {
+    const dir = path.join(configDir, 'transcripts', '-transcript-app');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'transcript-session.jsonl');
+    fs.writeFileSync(file, `${JSON.stringify({ cwd: '/work/transcript-app', timestamp: '2026-07-13T10:00:00.000Z' })}\n`);
+
+    const periods = { today: { sessions: {
+      'claude:transcript-session': { client: 'claude', sessionId: 'transcript-session' }
+    } } };
+    applySessionTimestamps(periods, home, {
+      env: { CLAUDE_CONFIG_DIR: configDir },
+      metadataCache: new Map(),
+      resolvedSessionKeys: new Set(),
+      attemptedSessionKeys: new Set()
+    });
+
+    const session = periods.today.sessions['claude:transcript-session'];
+    assert.equal(session.projectLabel, 'transcript-app');
+    assert.equal(session.lastUsedAt, '2026-07-13T10:00:00.000Z');
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
 test('scopedHome Claude metadata ignores a host CLAUDE_CONFIG_DIR override', () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-claude-scoped-'));
   const hostConfigDir = path.join(home, 'host-claude');

--- a/tests/shared/collectorSessionTimestamps.test.js
+++ b/tests/shared/collectorSessionTimestamps.test.js
@@ -55,6 +55,61 @@ test('applySessionTimestamps leaves non-opencode sessions to the file path (no D
   assert.strictEqual(called, false, 'opencode reader must not run when there are no opencode sessions');
 });
 
+test('applySessionTimestamps resolves Claude metadata from CLAUDE_CONFIG_DIR', () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-claude-config-'));
+  const configDir = path.join(home, 'relocated-claude');
+  try {
+    const dir = path.join(configDir, 'projects', '-work-app');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'configured-session.jsonl');
+    fs.writeFileSync(file, `${JSON.stringify({ cwd: '/work/app', timestamp: '2026-07-13T10:00:00.000Z' })}\n`);
+
+    const periods = { today: { sessions: {
+      'claude:configured-session': { client: 'claude', sessionId: 'configured-session' }
+    } } };
+    applySessionTimestamps(periods, home, {
+      env: { CLAUDE_CONFIG_DIR: configDir },
+      metadataCache: new Map(),
+      resolvedSessionKeys: new Set(),
+      attemptedSessionKeys: new Set()
+    });
+
+    const session = periods.today.sessions['claude:configured-session'];
+    assert.equal(session.projectLabel, 'app');
+    assert.equal(session.lastUsedAt, '2026-07-13T10:00:00.000Z');
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('scopedHome Claude metadata ignores a host CLAUDE_CONFIG_DIR override', () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-claude-scoped-'));
+  const hostConfigDir = path.join(home, 'host-claude');
+  try {
+    const dir = path.join(home, '.claude', 'projects', '-scoped-home');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'scoped-session.jsonl');
+    fs.writeFileSync(file, `${JSON.stringify({ cwd: '/work/scoped', timestamp: '2026-07-13T10:00:00.000Z' })}\n`);
+
+    const periods = { today: { sessions: {
+      'claude:scoped-session': { client: 'claude', sessionId: 'scoped-session' }
+    } } };
+    applySessionTimestamps(periods, home, {
+      scopedHome: true,
+      env: { CLAUDE_CONFIG_DIR: hostConfigDir },
+      metadataCache: new Map(),
+      resolvedSessionKeys: new Set(),
+      attemptedSessionKeys: new Set()
+    });
+
+    const session = periods.today.sessions['claude:scoped-session'];
+    assert.equal(session.projectLabel, 'scoped');
+    assert.equal(session.lastUsedAt, '2026-07-13T10:00:00.000Z');
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
 test('applySessionTimestamps reuses resolved metadata across progressive periods', () => {
   const cache = { metadataCache: new Map(), resolvedSessionKeys: new Set(), attemptedSessionKeys: new Set() };
   const calls = [];

--- a/tests/shared/sessionDetail.test.js
+++ b/tests/shared/sessionDetail.test.js
@@ -226,6 +226,32 @@ test('readSessionDetail resolves, parses, groups, and distributes cost', () => {
   assert.ok(Math.abs(detail.exchanges[0].costEstimate - 0.5) < 1e-9);
 });
 
+test('readSessionDetail resolves Claude transcripts from CLAUDE_CONFIG_DIR', () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-detail-config-'));
+  const configDir = path.join(home, 'relocated-claude');
+  const id = 'configured-detail';
+  const dir = path.join(configDir, 'projects', '-proj');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${id}.jsonl`), [
+    JSON.stringify({ type: 'user', timestamp: new Date().toISOString(), message: { role: 'user', content: 'configured' } }),
+    JSON.stringify({ type: 'assistant', timestamp: new Date().toISOString(), message: { role: 'assistant', usage: { input_tokens: 3, output_tokens: 2 }, content: [] } })
+  ].join('\n'));
+
+  try {
+    const detail = readSessionDetail({
+      client: 'claude',
+      sessionId: id,
+      period: 'total',
+      home,
+      env: { CLAUDE_CONFIG_DIR: configDir }
+    });
+    assert.equal(detail.found, true);
+    assert.equal(detail.totals.totalTokens, 5);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
 test('readSessionDetail reports not found instead of throwing', () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-detail-'));
   const detail = readSessionDetail({ client: 'claude', sessionId: 'nope', period: 'total', sessionCost: 0, home });

--- a/tests/shared/sessionDetail.test.js
+++ b/tests/shared/sessionDetail.test.js
@@ -230,7 +230,7 @@ test('readSessionDetail resolves Claude transcripts from CLAUDE_CONFIG_DIR', () 
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-detail-config-'));
   const configDir = path.join(home, 'relocated-claude');
   const id = 'configured-detail';
-  const dir = path.join(configDir, 'projects', '-proj');
+  const dir = path.join(configDir, 'transcripts', '-proj');
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, `${id}.jsonl`), [
     JSON.stringify({ type: 'user', timestamp: new Date().toISOString(), message: { role: 'user', content: 'configured' } }),

--- a/tests/shared/sessionDetailResolver.test.js
+++ b/tests/shared/sessionDetailResolver.test.js
@@ -52,6 +52,36 @@ test('reads a Claude transcript from a discovered WSL home', (t) => {
   assert.equal(detail.totals.costUsd, 0.25);
 });
 
+test('WSL Claude detail ignores the host CLAUDE_CONFIG_DIR override', (t) => {
+  const nativeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-native-detail-'));
+  const wslHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-wsl-detail-'));
+  const hostConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-host-claude-'));
+  t.after(() => fs.rmSync(nativeHome, { recursive: true, force: true }));
+  t.after(() => fs.rmSync(wslHome, { recursive: true, force: true }));
+  t.after(() => fs.rmSync(hostConfigDir, { recursive: true, force: true }));
+  const sessionId = 'wsl-scoped-config';
+  const transcriptDir = path.join(wslHome, '.claude', 'projects', '-workspace');
+  fs.mkdirSync(transcriptDir, { recursive: true });
+  fs.writeFileSync(path.join(transcriptDir, `${sessionId}.jsonl`), [
+    JSON.stringify({ type: 'user', timestamp: '2026-07-31T00:00:00.000Z', message: { content: 'from scoped WSL' } }),
+    JSON.stringify({ type: 'assistant', timestamp: '2026-07-31T00:00:01.000Z', message: { usage: { input_tokens: 2, output_tokens: 1 }, content: [] } })
+  ].join('\n'));
+
+  const detail = resolveSessionDetailForPlatform(
+    { client: 'claude', sessionId, period: 'total' },
+    {
+      platform: 'win32',
+      homedir: () => nativeHome,
+      env: { CLAUDE_CONFIG_DIR: hostConfigDir },
+      wslUsageHomes: () => [wslHome]
+    }
+  );
+
+  assert.equal(detail.found, true);
+  assert.equal(detail.exchanges[0].promptPreview, 'from scoped WSL');
+  assert.equal(detail.totals.totalTokens, 3);
+});
+
 test('reads a Claude transcript from the alternate root in a discovered WSL home', (t) => {
   const nativeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-native-detail-'));
   const wslHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-wsl-detail-'));

--- a/tests/shared/sessionFiles.test.js
+++ b/tests/shared/sessionFiles.test.js
@@ -38,6 +38,35 @@ test('resolves a claude session file from the alternate transcripts root', () =>
   } finally { cleanup(home); }
 });
 
+test('resolves Claude sessions from CLAUDE_CONFIG_DIR', () => {
+  const home = tmpHome();
+  const configDir = path.join(home, 'relocated-claude');
+  try {
+    const dir = path.join(configDir, 'projects', '-some-project');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'configured-123.jsonl');
+    fs.writeFileSync(file, '{}\n');
+    assert.equal(resolveSessionFile('claude', 'configured-123', home, {
+      env: { CLAUDE_CONFIG_DIR: configDir }
+    }), file);
+  } finally { cleanup(home); }
+});
+
+test('an explicit scoped home ignores the host CLAUDE_CONFIG_DIR', () => {
+  const home = tmpHome();
+  const hostConfigDir = path.join(home, 'host-claude');
+  try {
+    const dir = path.join(home, '.claude', 'projects', '-scoped-home');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'scoped-123.jsonl');
+    fs.writeFileSync(file, '{}\n');
+    assert.equal(resolveSessionFile('claude', 'scoped-123', home, {
+      env: { CLAUDE_CONFIG_DIR: hostConfigDir },
+      useEnvRoots: false
+    }), file);
+  } finally { cleanup(home); }
+});
+
 test('resolves a codex rollout via the dated path', () => {
   const home = tmpHome();
   try {


### PR DESCRIPTION
## Summary

Tokscale commit `59712ada` already includes the upstream `CLAUDE_CONFIG_DIR` discovery fix from [Tokscale PR #1102](https://github.com/junhoyeo/tokscale/pull/1102). This PR keeps Token Monitor's own auxiliary Claude paths aligned with that behavior.

- Centralize `CLAUDE_CONFIG_DIR` with the `~/.claude` fallback.
- Use the same roots for source health/watch diagnostics, session timestamp and project metadata, and session detail lookup across both `projects` and `transcripts`.
- Preserve `projects` precedence when metadata enrichment falls back to `transcripts`.
- Keep explicit scoped homes, including running WSL distros, authoritative by ignoring the host `CLAUDE_CONFIG_DIR` during those lookups.
- Leave `package.json`, `package-lock.json`, and the existing Tokscale vendor pin unchanged.

## Scope

This is the Token Monitor-side follow-up for [#375](https://github.com/Javis603/token-monitor/issues/375). The pinned upstream Tokscale commit covers aggregate discovery. Claude Desktop's separate `Claude-3p/local-agent-mode-sessions` root remains a separate upstream follow-up, so this PR references rather than closes the issue.

## Verification

- `npm run verify`: 3465 passed, 1 skipped.
