### PR TITLE
fix(limits): slow unconfigured provider probes

### DIFF
--- a/src/shared/limitsRuntime.js
+++ b/src/shared/limitsRuntime.js
@@ -33,6 +33,7 @@ const {
 } = require('./limitsRetryPolicy');
 
 const DEFAULT_LIMITS_MAX_CONCURRENCY = 3;
+const DEFAULT_UNCONFIGURED_RECHECK_MS = 60 * 60 * 1000;
 
 const TRANSIENT_STATUSES = new Set([
   'timeout',
@@ -185,6 +186,9 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
   let refreshMs = refreshMode === 'adaptive'
     ? LIMITS_ADAPTIVE_BASE_MS
     : normalizeLimitsRefreshMs(config.limitsRefreshMs ?? config.refreshMs);
+  const unconfiguredRecheckMs = Number.isFinite(Number(deps.unconfiguredRecheckMs))
+    ? Math.max(refreshMs, Number(deps.unconfiguredRecheckMs))
+    : DEFAULT_UNCONFIGURED_RECHECK_MS;
   let configuredProviders = new Set(parseLimitProviders(config.limitProviders ?? config.providers));
   let runtimeEpoch = 1;
   let stopped = false;
@@ -477,7 +481,19 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
   function runScheduledFullRefresh() {
     if (!started || stopped || !enabled) return;
     lastScheduledFullAt = now();
-    void refresh({}, 'interval');
+    const currentMs = now();
+    const dueProviders = [...configuredProviders].filter((provider) => {
+      const rows = providerRows(provider);
+      if (rows.length === 0 || rows.some((row) => row.status !== 'notConfigured' && row.status !== 'disabled')) {
+        return true;
+      }
+      const lane = lanes.get(provider);
+      const lastAttemptMs = Math.max(0, ...[...(lane?.identities.values() || [])]
+        .map((state) => Date.parse(state.lastAttempt?.at || ''))
+        .filter(Number.isFinite));
+      return currentMs - lastAttemptMs >= unconfiguredRecheckMs;
+    });
+    void Promise.all(dueProviders.map((provider) => queueScope({ provider }, 'interval')));
     scheduleInterval(refreshMs);
   }
 
@@ -945,6 +961,7 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
 
 module.exports = {
   DEFAULT_LIMITS_MAX_CONCURRENCY,
+  DEFAULT_UNCONFIGURED_RECHECK_MS,
   TRANSIENT_STATUSES,
   accountIdentityPart,
   createLimitsRuntime,

--- a/tests/shared/limitsRuntime.test.js
+++ b/tests/shared/limitsRuntime.test.js
@@ -595,6 +595,39 @@ test('limitsRefreshMs reconfigures only one runtime timer using elapsed cadence'
   runtime.stop();
 });
 
+test('scheduled refresh slows providers that remain unconfigured', async () => {
+  const clock = fakeClock(1_000);
+  const calls = [];
+  const runtime = createLimitsRuntime({
+    limitProviders: ['claude', 'codex'],
+    limitsRefreshMs: 300_000
+  }, runtimeDeps({
+    autoStart: true,
+    now: clock.now,
+    setTimeout: clock.setTimeout,
+    clearTimeout: clock.clearTimeout,
+    unconfiguredRecheckMs: 600_000,
+    probeProvider: async (provider, _config, context) => {
+      calls.push({ provider, reason: context.reason });
+      return [providerRow(provider, provider, provider, {
+        status: provider === 'claude' ? 'notConfigured' : 'ok',
+        updatedAt: new Date(clock.now()).toISOString(),
+        windows: provider === 'claude' ? [] : undefined
+      })];
+    }
+  }));
+
+  await waitFor(() => calls.length === 2, 'startup refresh');
+  clock.advance(300_000);
+  await waitFor(() => calls.length === 3, 'first interval refresh');
+  assert.deepEqual(calls.slice(2), [{ provider: 'codex', reason: 'interval' }]);
+
+  clock.advance(300_000);
+  await waitFor(() => calls.length === 5, 'unconfigured recheck');
+  assert.deepEqual(calls.slice(3).map((call) => call.provider).sort(), ['claude', 'codex']);
+  runtime.stop();
+});
+
 function burnRateRuntime(clock, usedPercent, overrides = {}, config = {}) {
   const calls = [];
   const runtime = createLimitsRuntime(


### PR DESCRIPTION
## Summary

Reduce scheduled AI limits probing for providers that remain unconfigured or disabled from the normal limits cadence to once per hour.

Configured providers continue to refresh at the normal cadence. Startup, manual refreshes, and credential or settings changes still probe immediately.

## Root cause

The limits runtime previously launched every configured provider probe on every five-minute refresh, including providers that had already reported `notConfigured` or `disabled`. Some discovery adapters invoke external processes and can briefly disturb latency-sensitive fullscreen applications on Windows even though the provider has no usable account.

## User impact

- Active provider quota refresh behavior is unchanged.
- Unconfigured or disabled providers are rechecked hourly during scheduled refreshes.
- Manual refresh and account/configuration changes remain immediate.
- Repeated process discovery and associated background work are reduced on machines with many unconfigured providers.

## Validation

- `node --test tests/shared/limitsRuntime.test.js` (38 passed)
- `npm run lint` passed.
- Full `npm test` completed with one unrelated Windows `EPERM` failure in the existing macOS Widget symlink test; the remaining suite, including the new scheduling test, passed.
- Reproduced the periodic game interruption on the unmodified v0.45.0 build, correlated it with the five-minute limits refresh, and confirmed through an extended Windows game test that the patched build no longer interrupted gameplay.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slows scheduled limits probes for providers that remain unconfigured or disabled to reduce background process churn and Windows interference. Previously we probed all providers every refresh; now unconfigured/disabled providers are rechecked less often while active providers keep the normal cadence.

- Filters scheduled refresh to only include providers due for probing; unconfigured/disabled providers are skipped until their recheck window elapses.
- Keeps immediate probes on startup, manual refresh, and credential/config changes.
- Adds `DEFAULT_UNCONFIGURED_RECHECK_MS` (1h) and a test-only `unconfiguredRecheckMs` override in runtime deps; the override is clamped to be no shorter than the refresh cadence.

| Area | Before | After |
| --- | --- | --- |
| Scheduled refresh for unconfigured/disabled providers | Probed every refresh interval (typically 5 min) | Skipped during scheduled refresh until ≥1h since last attempt; still probed immediately on startup, manual refresh, or config/credential changes |
| Background process discovery on Windows | Frequent discovery even without accounts; could interrupt fullscreen apps | Discovery for unconfigured providers runs at most hourly, reducing interruptions |

**Notes for reviewers**
- Implementation: new dueProvider filter uses provider rows to detect all-`notConfigured`/`disabled` states and checks per-lane identity `lastAttempt` timestamps.
- Configurability: `unconfiguredRecheckMs` is injectable via runtime deps for tests and is clamped to ≥ refresh interval; default is 1h.
- Tests/validation: added a scheduling test; lint and tests pass; manual Windows validation confirms no periodic game interruptions with this change. Risks are low; worst case is slower background detection if relying only on scheduled refresh without a config-change trigger.

<sup>Written for commit 0cddec69eb6912fdd7a2e1012362e377e618f3d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

