### PR TITLE
fix: handle child process stdin failures

### DIFF
--- a/src/shared/cursorAuth.js
+++ b/src/shared/cursorAuth.js
@@ -89,36 +89,55 @@ function readActiveAccount({ home = os.homedir() } = {}) {
   };
 }
 
-function runTokscaleSubcommand(args, { stdin = null, timeoutMs = 30000 } = {}) {
+function runTokscaleSubcommand(args, {
+  stdin = null,
+  timeoutMs = 30000,
+  spawn: spawnFn = spawn,
+  tokscaleCommand: resolveTokscaleCommand
+} = {}) {
   return new Promise((resolve, reject) => {
-    const { tokscaleCommand } = require('./collector');
+    const tokscaleCommand = resolveTokscaleCommand || require('./collector').tokscaleCommand;
     const { bin, prefixArgs, env } = tokscaleCommand();
-    const child = spawn(bin, [...prefixArgs, 'cursor', ...args], { env, windowsHide: true });
+    const child = spawnFn(bin, [...prefixArgs, 'cursor', ...args], { env, windowsHide: true });
     let stdout = '';
     let stderr = '';
-    const timer = setTimeout(() => {
+    let settled = false;
+    let timer;
+
+    function finish(error, value) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) reject(error);
+      else resolve(value);
+    }
+
+    timer = setTimeout(() => {
       child.kill('SIGTERM');
-      reject(annotateSyncError(new Error(`tokscale cursor ${args[0]} timed out after ${timeoutMs}ms`), 'timeout'));
+      finish(annotateSyncError(new Error(`tokscale cursor ${args[0]} timed out after ${timeoutMs}ms`), 'timeout'));
     }, timeoutMs);
     child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
     child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
-    child.on('error', (err) => { clearTimeout(timer); reject(annotateSyncError(err, 'spawn')); });
+    child.on('error', (error) => finish(annotateSyncError(error, 'spawn')));
+    child.stdin.on('error', (error) => {
+      try { child.kill('SIGTERM'); } catch (_) {}
+      finish(annotateSyncError(error, 'process-exit'));
+    });
     child.on('close', (code) => {
-      clearTimeout(timer);
       if (code !== 0) {
-        return reject(annotateSyncError(
+        return finish(annotateSyncError(
           new Error(`tokscale cursor ${args[0]} exited ${code}: ${(stderr || stdout).trim()}`),
           'process-exit',
           code
         ));
       }
-      resolve(stdout);
+      finish(null, stdout);
     });
-    if (stdin) {
-      child.stdin.write(stdin);
-      child.stdin.end();
-    } else {
-      child.stdin.end();
+    try {
+      child.stdin.end(stdin || undefined);
+    } catch (error) {
+      try { child.kill('SIGTERM'); } catch (_) {}
+      finish(annotateSyncError(error, 'process-exit'));
     }
   });
 }
@@ -203,12 +222,12 @@ async function runCursorLogout({ label = '', home = os.homedir() } = {}) {
   writeCredentialsStoreAtomic(file, store);
 }
 
-async function runCursorSync({ timeoutMs = 60000 } = {}) {
-  return runTokscaleSubcommand(['sync', '--json'], { timeoutMs });
+async function runCursorSync(options = {}) {
+  return runTokscaleSubcommand(['sync', '--json'], { ...options, timeoutMs: options.timeoutMs ?? 60000 });
 }
 
-function runCursorStatus({ timeoutMs = 15000 } = {}) {
-  return runTokscaleSubcommand(['status'], { timeoutMs });
+function runCursorStatus(options = {}) {
+  return runTokscaleSubcommand(['status'], { ...options, timeoutMs: options.timeoutMs ?? 15000 });
 }
 
 module.exports = {

--- a/src/shared/grokLimits.js
+++ b/src/shared/grokLimits.js
@@ -470,8 +470,15 @@ async function fetchGrokRpcBilling(options = {}, deps = {}) {
     }
 
     function writeJsonLine(value) {
+      if (settled) return;
       const raw = JSON.stringify(value).replace(/\\\//g, '/');
-      child.stdin.write(raw + '\n');
+      try {
+        child.stdin.write(raw + '\n', (error) => {
+          if (error) finish(error);
+        });
+      } catch (error) {
+        finish(error);
+      }
     }
 
     function handleMessage(message) {
@@ -518,6 +525,7 @@ async function fetchGrokRpcBilling(options = {}, deps = {}) {
       return;
     }
     child.on?.('error', finish);
+    child.stdin?.on?.('error', finish);
     child.on?.('exit', (code) => {
       if (!settled) finish(grokRpcError(`Grok RPC exited before billing response (${code ?? 'unknown'})`));
     });

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -2712,9 +2712,14 @@ function createJsonRpcClient(child, timeoutMs) {
     pending.clear();
   }
 
-  function abort(error) {
+  function failTransport(error) {
+    if (closed) return;
     closed = true;
     rejectAll(error);
+  }
+
+  function abort(error) {
+    failTransport(error);
   }
 
   function handleMessage(message) {
@@ -2736,14 +2741,20 @@ function createJsonRpcClient(child, timeoutMs) {
       try { handleMessage(JSON.parse(line)); } catch (_) {}
     }
   });
-  child.on('error', (error) => {
-    closed = true;
-    rejectAll(error);
-  });
-  child.on('close', (code) => {
-    closed = true;
-    rejectAll(new Error(`codex app-server exited ${code}`));
-  });
+  child.on('error', failTransport);
+  child.on('close', (code) => failTransport(new Error(`codex app-server exited ${code}`)));
+  child.stdin.on?.('error', failTransport);
+
+  function writeLine(line) {
+    if (closed) return;
+    try {
+      child.stdin.write(line, (error) => {
+        if (error) failTransport(error);
+      });
+    } catch (error) {
+      failTransport(error);
+    }
+  }
 
   function send(method, params) {
     if (closed) return Promise.reject(new Error('codex app-server is closed'));
@@ -2755,12 +2766,12 @@ function createJsonRpcClient(child, timeoutMs) {
         reject(new Error(`${method} timed out`));
       }, timeoutMs);
       pending.set(id, { resolve, reject, timer });
-      child.stdin.write(`${JSON.stringify(message)}\n`);
+      writeLine(`${JSON.stringify(message)}\n`);
     });
   }
 
   function notify(method, params) {
-    if (!closed) child.stdin.write(`${JSON.stringify(params === undefined ? { method } : { method, params })}\n`);
+    writeLine(`${JSON.stringify(params === undefined ? { method } : { method, params })}\n`);
   }
 
   return { abort, send, notify, rejectAll };

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -2702,6 +2702,7 @@ function createJsonRpcClient(child, timeoutMs) {
   let nextId = 1;
   let buffer = '';
   let closed = false;
+  let transportError = null;
   const pending = new Map();
 
   function rejectAll(error) {
@@ -2715,11 +2716,12 @@ function createJsonRpcClient(child, timeoutMs) {
   function failTransport(error) {
     if (closed) return;
     closed = true;
+    transportError = error;
     rejectAll(error);
   }
 
-  function failStdinTransport(error) {
-    const target = error instanceof Error ? error : new Error(String(error || 'codex app-server stdin failed'));
+  function failRetryableTransport(error) {
+    const target = error instanceof Error ? error : new Error(String(error || 'codex app-server transport failed'));
     target.codexTransportFailure = true;
     failTransport(target);
   }
@@ -2747,23 +2749,23 @@ function createJsonRpcClient(child, timeoutMs) {
       try { handleMessage(JSON.parse(line)); } catch (_) {}
     }
   });
-  child.on('error', failTransport);
-  child.on('close', (code) => failTransport(new Error(`codex app-server exited ${code}`)));
-  child.stdin.on?.('error', failStdinTransport);
+  child.on('error', failRetryableTransport);
+  child.on('close', (code) => failRetryableTransport(new Error(`codex app-server exited ${code}`)));
+  child.stdin.on?.('error', failRetryableTransport);
 
   function writeLine(line) {
     if (closed) return;
     try {
       child.stdin.write(line, (error) => {
-        if (error) failStdinTransport(error);
+        if (error) failRetryableTransport(error);
       });
     } catch (error) {
-      failStdinTransport(error);
+      failRetryableTransport(error);
     }
   }
 
   function send(method, params) {
-    if (closed) return Promise.reject(new Error('codex app-server is closed'));
+    if (closed) return Promise.reject(transportError || new Error('codex app-server is closed'));
     const id = nextId++;
     const message = params === undefined ? { method, id } : { method, id, params };
     return new Promise((resolve, reject) => {
@@ -2827,12 +2829,21 @@ async function readCodexRpcWithCommand(command, deps = {}) {
     });
     rpc.notify('initialized', {});
     let rateLimitResult = await rpc.send('account/rateLimits/read');
-    const accountResult = await rpc.send('account/read').catch(() => {
+    let accountReadError = null;
+    const accountResult = await rpc.send('account/read').catch((error) => {
       if (signal?.aborted) throw abortError(signal);
+      accountReadError = error;
       return null;
     });
     const account = accountResult?.account || null;
     let payload = codexRpcPayload(rateLimitResult, account, command, deps);
+    if (
+      accountReadError &&
+      !hasCodexRateLimitWindows(codexRateLimitSnapshot(payload)) &&
+      accountReadError.codexTransportFailure
+    ) {
+      throw accountReadError;
+    }
     if (deps.codexEmptyQuotaRetry !== false && shouldRetryCodexEmptyQuotaPayload(payload)) {
       await waitForCodexEmptyQuotaRetry(deps);
       try {
@@ -2844,8 +2855,9 @@ async function readCodexRpcWithCommand(command, deps = {}) {
             rateLimitResetCredits: retryPayload.rateLimitResetCredits || payload.rateLimitResetCredits
           };
         }
-      } catch (_) {
+      } catch (error) {
         if (signal?.aborted) throw abortError(signal);
+        if (error?.codexTransportFailure) throw error;
       }
     }
     if (!account && !hasCodexRateLimitWindows(codexRateLimitSnapshot(payload))) {

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -2718,6 +2718,12 @@ function createJsonRpcClient(child, timeoutMs) {
     rejectAll(error);
   }
 
+  function failStdinTransport(error) {
+    const target = error instanceof Error ? error : new Error(String(error || 'codex app-server stdin failed'));
+    target.codexTransportFailure = true;
+    failTransport(target);
+  }
+
   function abort(error) {
     failTransport(error);
   }
@@ -2743,16 +2749,16 @@ function createJsonRpcClient(child, timeoutMs) {
   });
   child.on('error', failTransport);
   child.on('close', (code) => failTransport(new Error(`codex app-server exited ${code}`)));
-  child.stdin.on?.('error', failTransport);
+  child.stdin.on?.('error', failStdinTransport);
 
   function writeLine(line) {
     if (closed) return;
     try {
       child.stdin.write(line, (error) => {
-        if (error) failTransport(error);
+        if (error) failStdinTransport(error);
       });
     } catch (error) {
-      failTransport(error);
+      failStdinTransport(error);
     }
   }
 
@@ -2778,6 +2784,7 @@ function createJsonRpcClient(child, timeoutMs) {
 }
 
 function shouldTryNextCodexCommand(error) {
+  if (error?.codexTransportFailure) return true;
   if (error?.code === 'ENOENT') return true;
   const message = String(error?.message || '').toLowerCase();
   return (

--- a/tests/shared/cursorAuth.test.js
+++ b/tests/shared/cursorAuth.test.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
 const test = require('node:test');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { readActiveAccount, runCursorLogin, runCursorLogout } = require('../../src/shared/cursorAuth');
+const { readActiveAccount, runCursorLogin, runCursorLogout, runCursorSync } = require('../../src/shared/cursorAuth');
 
 function withTempHome(payload) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cursorauth-'));
@@ -113,4 +114,29 @@ test('runCursorLogin throws on empty token', async () => {
   try {
     await assert.rejects(() => runCursorLogin('', { home }), /token/i);
   } finally { cleanup(); }
+});
+
+test('runCursorSync rejects when the tokscale stdin pipe breaks', async () => {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = new EventEmitter();
+  child.stdin.end = () => {};
+  let killed = false;
+  child.kill = () => { killed = true; };
+  const pending = runCursorSync({
+    spawn: () => child,
+    tokscaleCommand: () => ({ bin: 'tokscale', prefixArgs: [], env: {} }),
+    timeoutMs: 60_000
+  });
+  const error = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
+
+  child.stdin.emit('error', error);
+
+  await assert.rejects(pending, (caught) => {
+    assert.match(caught.message, /write EPIPE/);
+    assert.equal(caught.syncFailureStage, 'process-exit');
+    return true;
+  });
+  assert.equal(killed, true);
 });

--- a/tests/shared/grokLimits.test.js
+++ b/tests/shared/grokLimits.test.js
@@ -371,6 +371,26 @@ test('fetchGrokRpcBilling kills the CLI when the parent signal aborts', async ()
   assert.equal(killed, true);
 });
 
+test('fetchGrokRpcBilling rejects when the CLI stdin pipe breaks', async () => {
+  let killed = false;
+  const child = new EventEmitter();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.stdin = new Writable({ write(_chunk, _encoding, callback) { callback(); } });
+  child.kill = () => { killed = true; };
+  const pending = fetchGrokRpcBilling({}, {
+    env: {},
+    spawn: () => child,
+    rpcTimeoutMs: 60_000
+  });
+  const error = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
+
+  child.stdin.emit('error', error);
+
+  await assert.rejects(pending, /write EPIPE/);
+  assert.equal(killed, true);
+});
+
 test('fetchGrokLimits does not start web fallback after the RPC parent signal aborts', async () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-abort-'));
   writeAuthJson(home, { 'https://auth.x.ai::client': { key: 'eyJsecret.signature' } });

--- a/tests/shared/limitCollector.codex.test.js
+++ b/tests/shared/limitCollector.codex.test.js
@@ -994,6 +994,68 @@ test('fetchCodexLimits retries the next command after a Codex stdin transport fa
   assert.equal(providers.windows[0].remainingPercent, 96);
 });
 
+test('fetchCodexLimits retries another command when optional account read loses its stdin transport', async () => {
+  const { EventEmitter } = require('node:events');
+  const commands = [];
+  const providers = await fetchCodexLimits({}, {
+    now: () => Date.parse('2026-06-01T00:00:00Z'),
+    env: { PATH: '/usr/bin' },
+    platform: 'darwin',
+    existsSync: () => true,
+    codexEmptyQuotaRetryDelayMs: 0,
+    ...noLiveAuth,
+    spawn: (command) => {
+      commands.push(command);
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.stdin = new EventEmitter();
+      child.kill = () => {};
+      child.stdin.write = (line) => {
+        const message = JSON.parse(String(line));
+        const respond = (result) => {
+          queueMicrotask(() => child.stdout.emit('data', `${JSON.stringify({ id: message.id, result })}\n`));
+        };
+        if (commands.length === 1) {
+          if (message.method === 'initialize') respond({});
+          if (message.method === 'account/rateLimits/read') {
+            respond({ rateLimits: { planType: 'plus' }, rateLimitsByLimitId: {} });
+          }
+          if (message.method === 'account/read') {
+            const error = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
+            queueMicrotask(() => child.stdin.emit('error', error));
+          }
+          return;
+        }
+        if (message.method === 'initialize') respond({});
+        if (message.method === 'account/rateLimits/read') {
+          respond({
+            rateLimits: {
+              primary: {
+                usedPercent: 7,
+                resetsAt: '2026-06-01T05:00:00Z',
+                windowDurationMins: 300
+              }
+            }
+          });
+        }
+        if (message.method === 'account/read') {
+          respond({ account: { email: 'fallback@example.com', planType: 'plus' } });
+        }
+      };
+      return child;
+    }
+  });
+
+  assert.deepEqual(commands, [
+    '/Applications/Codex.app/Contents/Resources/codex',
+    '/Applications/ChatGPT.app/Contents/Resources/codex'
+  ]);
+  assert.equal(providers.status, 'ok');
+  assert.equal(providers.accountEmail, 'fallback@example.com');
+  assert.equal(providers.windows[0].remainingPercent, 93);
+});
+
 test('fetchCodexLimits retries empty Codex quota reads on the same RPC session', async () => {
   const { EventEmitter } = require('node:events');
   let spawns = 0;

--- a/tests/shared/limitCollector.codex.test.js
+++ b/tests/shared/limitCollector.codex.test.js
@@ -940,6 +940,60 @@ test('fetchCodexLimits fills the live account email from auth.json when the RPC 
   assert.match(live.accountKey, /^sha256:[0-9a-f]{64}$/);
 });
 
+test('fetchCodexLimits retries the next command after a Codex stdin transport failure', async () => {
+  const { EventEmitter } = require('node:events');
+  const commands = [];
+  const providers = await fetchCodexLimits({}, {
+    now: () => Date.parse('2026-06-01T00:00:00Z'),
+    env: { PATH: '/usr/bin' },
+    platform: 'darwin',
+    existsSync: () => true,
+    ...noLiveAuth,
+    spawn: (command) => {
+      commands.push(command);
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.stdin = new EventEmitter();
+      child.kill = () => {};
+      child.stdin.write = (line) => {
+        if (commands.length === 1) {
+          const error = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
+          queueMicrotask(() => child.stdin.emit('error', error));
+          return;
+        }
+        const message = JSON.parse(String(line));
+        const respond = (result) => {
+          queueMicrotask(() => child.stdout.emit('data', `${JSON.stringify({ id: message.id, result })}\n`));
+        };
+        if (message.method === 'initialize') respond({});
+        if (message.method === 'account/rateLimits/read') {
+          respond({
+            rateLimits: {
+              primary: {
+                usedPercent: 4,
+                resetsAt: '2026-06-01T05:00:00Z',
+                windowDurationMins: 300
+              }
+            }
+          });
+        }
+        if (message.method === 'account/read') {
+          respond({ account: { email: 'live@example.com', planType: 'plus' } });
+        }
+      };
+      return child;
+    }
+  });
+
+  assert.deepEqual(commands, [
+    '/Applications/Codex.app/Contents/Resources/codex',
+    '/Applications/ChatGPT.app/Contents/Resources/codex'
+  ]);
+  assert.equal(providers.status, 'ok');
+  assert.equal(providers.windows[0].remainingPercent, 96);
+});
+
 test('fetchCodexLimits retries empty Codex quota reads on the same RPC session', async () => {
   const { EventEmitter } = require('node:events');
   let spawns = 0;

--- a/tests/shared/providerProcessCancellation.test.js
+++ b/tests/shared/providerProcessCancellation.test.js
@@ -77,6 +77,20 @@ test('Codex RPC rejects a pending request when app-server stdin breaks', async (
   assert.equal(child.kills, 1);
 });
 
+test('Codex RPC rejects a pending request when the stdin write callback fails', async () => {
+  const child = fakeChild();
+  const error = Object.assign(new Error('stream destroyed'), { code: 'ERR_STREAM_DESTROYED' });
+  child.stdin.write = (_line, callback) => queueMicrotask(() => callback(error));
+  const pending = readCodexRpcWithCommand('codex', {
+    spawn: () => child,
+    platform: 'win32',
+    codexRpcTimeoutMs: 60_000
+  });
+
+  await assert.rejects(pending, /stream destroyed/);
+  assert.equal(child.kills, 1);
+});
+
 test('Codex RPC preserves cancellation from the optional account read', async () => {
   const controller = new AbortController();
   const child = fakeRpcChild((request, respond) => {

--- a/tests/shared/providerProcessCancellation.test.js
+++ b/tests/shared/providerProcessCancellation.test.js
@@ -13,7 +13,8 @@ function fakeChild() {
   const child = new EventEmitter();
   child.stdout = new EventEmitter();
   child.stderr = new EventEmitter();
-  child.stdin = { write() {} };
+  child.stdin = new EventEmitter();
+  child.stdin.write = () => {};
   child.kills = 0;
   child.kill = () => { child.kills += 1; };
   return child;
@@ -58,6 +59,21 @@ test('Codex RPC terminates its app-server child when its parent signal aborts', 
   await new Promise((resolve) => setImmediate(resolve));
   controller.abort(new Error('runtime stopped'));
   await assert.rejects(pending, /runtime stopped/);
+  assert.equal(child.kills, 1);
+});
+
+test('Codex RPC rejects a pending request when app-server stdin breaks', async () => {
+  const child = fakeChild();
+  const pending = readCodexRpcWithCommand('codex', {
+    spawn: () => child,
+    platform: 'win32',
+    codexRpcTimeoutMs: 60_000
+  });
+  const error = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
+
+  child.stdin.emit('error', error);
+
+  await assert.rejects(pending, /write EPIPE/);
   assert.equal(child.kills, 1);
 });
 


### PR DESCRIPTION
## Summary

- Route Codex app-server stdin errors and write callback failures through one idempotent transport failure path, rejecting pending RPC requests and clearing their timers.
- Handle broken stdin pipes in the Grok CLI RPC and Cursor tokscale subprocesses without surfacing an uncaught Electron main-process error.
- Add regression coverage for `EPIPE` from all three child stdin owners.

## Root cause

`child.on('error')` does not handle errors emitted by `child.stdin`. If a subprocess exits after a write begins but before its `close` event is observed, the writable stream can emit an asynchronous `EPIPE`. Without a stdin error listener, Electron surfaces it as a “JavaScript error occurred in the main process” dialog.

The existing safe stdio handler covers the main process’s own stdout and stderr only. It does not cover pipes used to write into child processes.

These failures now settle through each operation’s existing error path instead of being silently swallowed: pending work is rejected, timers are cleared, and the child is terminated where needed.

## Validation

- `node --test tests/shared/providerProcessCancellation.test.js tests/shared/limitCollector.codex.test.js tests/shared/grokLimits.test.js tests/shared/cursorAuth.test.js`
- `npm run verify` (3475 passed, 1 skipped)
- `git diff --check`

Closes #457
