### PR TITLE
fix(collector): fall back on unsafe targeted scans

### DIFF
--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1323,33 +1323,20 @@ async function collectUsageOnce(options) {
         freshPartitions = bundle.byClient;
         const unattributed = freshPartitions[UNATTRIBUTED_USAGE_CLIENT];
         const attributedClients = Object.keys(freshPartitions).filter((client) => client !== UNATTRIBUTED_USAGE_CLIENT);
-        let hasUnsafeTargetedResult = (
+        const hasMissingTargetPartition = (
+          targetTokscaleClientList.length > 1
+          && targetTokscaleClientList.some((client) => !Object.prototype.hasOwnProperty.call(freshPartitions, client))
+        );
+        const hasUnsafeTargetedResult = (
           periodHasUsage(unattributed)
           || attributedClients.some((client) => !targetTokscaleClientSet.has(client))
+          || hasMissingTargetPartition
         );
 
         // A unioned watch scan can hide cross-attribution inside its own target
-        // set (for example Hermes missing while its rows land under WorkBuddy).
-        // Confirm only whether each missing member is genuinely empty. Any usage
-        // proves the union result was incomplete, but cannot prove that its
-        // existing partitions are unpolluted, so rebuild the full snapshot.
-        if (targetTokscaleClientList.length > 1 && attributedClients.length > 0 && !hasUnsafeTargetedResult) {
-          const missingClients = targetTokscaleClientList.filter((client) => !Object.prototype.hasOwnProperty.call(freshPartitions, client));
-          for (const client of missingClients) {
-            const confirmationJson = await runTokscaleFn({ clients: client, flags: ['--today'], commandTimeoutMs });
-            const confirmationPartitions = extractUsageBundleFromTokscale(confirmationJson).byClient;
-            const confirmationUnattributed = confirmationPartitions[UNATTRIBUTED_USAGE_CLIENT];
-            const confirmationClients = Object.keys(confirmationPartitions).filter((key) => key !== UNATTRIBUTED_USAGE_CLIENT);
-            if (
-              periodHasUsage(confirmationUnattributed)
-              || confirmationClients.length > 0
-            ) {
-              hasUnsafeTargetedResult = true;
-              break;
-            }
-          }
-        }
-
+        // set, and a missing partition cannot distinguish deletion from an
+        // incomplete or polluted union. Rebuild one authoritative full snapshot
+        // rather than trying to repair a partial result client by client.
         if (targetRequested && hasUnsafeTargetedResult) {
           // Every attributed row from a targeted scan must normalize back into
           // the requested set. An unattributed row or an unexpected client would

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1323,13 +1323,16 @@ async function collectUsageOnce(options) {
         freshPartitions = bundle.byClient;
         const unattributed = freshPartitions[UNATTRIBUTED_USAGE_CLIENT];
         const attributedClients = Object.keys(freshPartitions).filter((client) => client !== UNATTRIBUTED_USAGE_CLIENT);
-        let hasUnsafeTargetedResult = attributedClients.some((client) => !targetTokscaleClientSet.has(client));
+        let hasUnsafeTargetedResult = (
+          periodHasUsage(unattributed)
+          || attributedClients.some((client) => !targetTokscaleClientSet.has(client))
+        );
 
         // A unioned watch scan can hide cross-attribution inside its own target
         // set (for example Hermes missing while its rows land under WorkBuddy).
-        // Confirm only the missing members individually; an empty confirmation
-        // remains a valid deletion, while a differently attributed row proves
-        // that the union result cannot safely replace the anchor partitions.
+        // Confirm only whether each missing member is genuinely empty. Any usage
+        // proves the union result was incomplete, but cannot prove that its
+        // existing partitions are unpolluted, so rebuild the full snapshot.
         if (targetTokscaleClientList.length > 1 && attributedClients.length > 0 && !hasUnsafeTargetedResult) {
           const missingClients = targetTokscaleClientList.filter((client) => !Object.prototype.hasOwnProperty.call(freshPartitions, client));
           for (const client of missingClients) {
@@ -1339,18 +1342,15 @@ async function collectUsageOnce(options) {
             const confirmationClients = Object.keys(confirmationPartitions).filter((key) => key !== UNATTRIBUTED_USAGE_CLIENT);
             if (
               periodHasUsage(confirmationUnattributed)
-              || confirmationClients.some((key) => key !== client)
+              || confirmationClients.length > 0
             ) {
               hasUnsafeTargetedResult = true;
               break;
             }
-            if (Object.prototype.hasOwnProperty.call(confirmationPartitions, client)) {
-              freshPartitions[client] = confirmationPartitions[client];
-            }
           }
         }
 
-        if (targetRequested && (periodHasUsage(unattributed) || hasUnsafeTargetedResult)) {
+        if (targetRequested && hasUnsafeTargetedResult) {
           // Every attributed row from a targeted scan must normalize back into
           // the requested set. An unattributed row or an unexpected client would
           // otherwise clear the target while partially overwriting an unrelated

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1222,6 +1222,7 @@ async function collectUsageOnce(options) {
   const trackedClientSet = new Set(normalizedClients.split(',').filter(Boolean));
   const targetClients = [...new Set(normalizeClientsCsv(options.targetClients).split(',').filter((client) => trackedClientSet.has(client)))];
   const targetRequested = targetClients.length > 0;
+  const targetClientSet = new Set(targetClients);
   const targetTokscaleClients = targetClients.filter((client) => !localClients.has(client)).join(',');
   const qoderCnReadState = options.qoderCnReadState;
   if (qoderCnReadState) {
@@ -1319,9 +1320,14 @@ async function collectUsageOnce(options) {
         const bundle = extractUsageBundleFromTokscale(todayJson);
         freshPartitions = bundle.byClient;
         const unattributed = freshPartitions[UNATTRIBUTED_USAGE_CLIENT];
-        if (targetRequested && periodHasUsage(unattributed)) {
-          // A row without a client cannot be replaced safely inside one client
-          // partition. Fall back to one all-client today scan for correctness.
+        const hasUnexpectedClientPartition = Object.keys(freshPartitions).some((client) => (
+          client !== UNATTRIBUTED_USAGE_CLIENT && !targetClientSet.has(client)
+        ));
+        if (targetRequested && (periodHasUsage(unattributed) || hasUnexpectedClientPartition)) {
+          // Every attributed row from a targeted scan must normalize back into
+          // the requested set. An unattributed row or an unexpected client would
+          // otherwise clear the target while partially overwriting an unrelated
+          // anchor partition. Rebuild the complete today snapshot instead.
           const fullTodayJson = await runTokscaleFn({ clients: tokscaleClients, flags: ['--today'], commandTimeoutMs });
           freshPartitions = extractUsageBundleFromTokscale(fullTodayJson).byClient;
           useTargetedPartitions = false;

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1223,7 +1223,9 @@ async function collectUsageOnce(options) {
   const targetClients = [...new Set(normalizeClientsCsv(options.targetClients).split(',').filter((client) => trackedClientSet.has(client)))];
   const targetRequested = targetClients.length > 0;
   const targetClientSet = new Set(targetClients);
-  const targetTokscaleClients = targetClients.filter((client) => !localClients.has(client)).join(',');
+  const targetTokscaleClientList = targetClients.filter((client) => !localClients.has(client));
+  const targetTokscaleClientSet = new Set(targetTokscaleClientList);
+  const targetTokscaleClients = targetTokscaleClientList.join(',');
   const qoderCnReadState = options.qoderCnReadState;
   if (qoderCnReadState) {
     qoderCnReadState.periodFailed = false;
@@ -1320,10 +1322,35 @@ async function collectUsageOnce(options) {
         const bundle = extractUsageBundleFromTokscale(todayJson);
         freshPartitions = bundle.byClient;
         const unattributed = freshPartitions[UNATTRIBUTED_USAGE_CLIENT];
-        const hasUnexpectedClientPartition = Object.keys(freshPartitions).some((client) => (
-          client !== UNATTRIBUTED_USAGE_CLIENT && !targetClientSet.has(client)
-        ));
-        if (targetRequested && (periodHasUsage(unattributed) || hasUnexpectedClientPartition)) {
+        const attributedClients = Object.keys(freshPartitions).filter((client) => client !== UNATTRIBUTED_USAGE_CLIENT);
+        let hasUnsafeTargetedResult = attributedClients.some((client) => !targetTokscaleClientSet.has(client));
+
+        // A unioned watch scan can hide cross-attribution inside its own target
+        // set (for example Hermes missing while its rows land under WorkBuddy).
+        // Confirm only the missing members individually; an empty confirmation
+        // remains a valid deletion, while a differently attributed row proves
+        // that the union result cannot safely replace the anchor partitions.
+        if (targetTokscaleClientList.length > 1 && attributedClients.length > 0 && !hasUnsafeTargetedResult) {
+          const missingClients = targetTokscaleClientList.filter((client) => !Object.prototype.hasOwnProperty.call(freshPartitions, client));
+          for (const client of missingClients) {
+            const confirmationJson = await runTokscaleFn({ clients: client, flags: ['--today'], commandTimeoutMs });
+            const confirmationPartitions = extractUsageBundleFromTokscale(confirmationJson).byClient;
+            const confirmationUnattributed = confirmationPartitions[UNATTRIBUTED_USAGE_CLIENT];
+            const confirmationClients = Object.keys(confirmationPartitions).filter((key) => key !== UNATTRIBUTED_USAGE_CLIENT);
+            if (
+              periodHasUsage(confirmationUnattributed)
+              || confirmationClients.some((key) => key !== client)
+            ) {
+              hasUnsafeTargetedResult = true;
+              break;
+            }
+            if (Object.prototype.hasOwnProperty.call(confirmationPartitions, client)) {
+              freshPartitions[client] = confirmationPartitions[client];
+            }
+          }
+        }
+
+        if (targetRequested && (periodHasUsage(unattributed) || hasUnsafeTargetedResult)) {
           // Every attributed row from a targeted scan must normalize back into
           // the requested set. An unattributed row or an unexpected client would
           // otherwise clear the target while partially overwriting an unrelated
@@ -1343,6 +1370,20 @@ async function collectUsageOnce(options) {
         // A transient local.db read failure must not turn the existing Qoder CN
         // partition into an empty one or subtract it from month/allTime.
         freshPartitions.qodercn = anchor.todayPartitions.qodercn;
+      }
+      if (!useTargetedPartitions) {
+        // The fallback rebuilds every Tokscale partition, but parse-local
+        // adapters do not participate in that scan. Preserve any adapter that
+        // this tick did not refresh instead of treating its absence as empty.
+        for (const client of localClients) {
+          if (
+            !targetClientSet.has(client)
+            && !Object.prototype.hasOwnProperty.call(freshPartitions, client)
+            && anchor.todayPartitions?.[client]
+          ) {
+            freshPartitions[client] = anchor.todayPartitions[client];
+          }
+        }
       }
       todayPartitions = useTargetedPartitions
         ? replaceTodayPartitions(anchor.todayPartitions, freshPartitions, targetClients)

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -2359,6 +2359,7 @@ test('live watch events scan only changed clients and preserve the other client 
   const calls = [];
   let codexDeleted = false;
   let codexUnattributed = false;
+  let codexUnexpectedClient = false;
   childProcess.spawn = (_bin, args) => {
     calls.push(args);
     const selected = String(args[args.indexOf('--client') + 1] || '').split(',').filter(Boolean);
@@ -2370,6 +2371,8 @@ test('live watch events scan only changed clients and preserve the other client 
     setImmediate(() => {
       const entries = codexUnattributed && selected.length === 1 && selected[0] === 'codex'
         ? [{ model: 'unknown', totalTokens: 99 }]
+        : codexUnexpectedClient && selected.length === 1 && selected[0] === 'codex'
+          ? [{ client: 'claude', model: 'unexpected-model', totalTokens: 99 }]
         : selected.filter((client) => !(codexDeleted && client === 'codex')).map((client) => {
             const tokens = client === 'codex' && selected.length === 1 ? 30 : (client === 'codex' ? 20 : 10);
             return {
@@ -2451,19 +2454,32 @@ test('live watch events scan only changed clients and preserve the other client 
     assert.equal(calls[7][calls[7].indexOf('--client') + 1], 'claude,codex');
     assert.equal(updates[4].summary.today.totalTokens, 30);
 
+    // An attributed row outside the requested client set is just as unsafe as
+    // an unattributed row: applying it would clear codex and replace claude with
+    // a partial targeted result. Rebuild today from an all-client scan instead.
+    codexUnattributed = false;
+    codexUnexpectedClient = true;
+    watchHandler('change', path.join(tmp, '.codex', 'sessions', 'unexpected.jsonl'));
+    await waitForCondition(() => updates.length === 6);
+    assert.equal(calls[8][calls[8].indexOf('--client') + 1], 'codex');
+    assert.equal(calls[9][calls[9].indexOf('--client') + 1], 'claude,codex');
+    assert.equal(updates[5].summary.today.totalTokens, 30);
+    assert.equal(updates[5].summary.today.clients.claude, 10);
+    assert.equal(updates[5].summary.today.clients.codex, 20);
+
     // A targeted scan that returns no rows replaces that client's partition
     // with empty usage, so deletes do not leave stale totals behind.
-    codexUnattributed = false;
+    codexUnexpectedClient = false;
     codexDeleted = true;
     watchHandler('unlink', path.join(tmp, '.codex', 'sessions', 'active.jsonl'));
-    await waitForCondition(() => updates.length === 6);
-    const deletion = calls[8];
+    await waitForCondition(() => updates.length === 7);
+    const deletion = calls[10];
     assert.equal(deletion[deletion.indexOf('--client') + 1], 'codex');
-    assert.equal(updates[5].summary.today.totalTokens, 10);
-    assert.equal(updates[5].summary.today.clients.claude, 10);
-    assert.equal(updates[5].summary.today.clients.codex, undefined);
-    assert.equal(updates[5].summary.month.totalTokens, 10);
-    assert.equal(updates[5].summary.allTime.totalTokens, 10);
+    assert.equal(updates[6].summary.today.totalTokens, 10);
+    assert.equal(updates[6].summary.today.clients.claude, 10);
+    assert.equal(updates[6].summary.today.clients.codex, undefined);
+    assert.equal(updates[6].summary.month.totalTokens, 10);
+    assert.equal(updates[6].summary.allTime.totalTokens, 10);
   } finally {
     if (handle) handle.stop();
     childProcess.spawn = originalSpawn;

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -2834,7 +2834,7 @@ test('collector publishes live periods when only Qoder CN history read fails', a
   }
 });
 
-test('smart collection coalesces watch events into one targeted interval scan', async () => {
+test('smart collection coalesces watch events into one targeted interval tick', async () => {
   const tmp = withTmpHome([
     path.join('.claude', 'projects'),
     path.join('.codex', 'sessions')
@@ -2885,10 +2885,11 @@ test('smart collection coalesces watch events into one targeted interval scan', 
     assert.equal(calls.length, 3, 'watch events never scan immediately in smart mode');
 
     await waitForCondition(() => updates.length === 2);
-    assert.equal(calls.length, 4, 'one today-only scan acknowledges the event batch');
+    assert.equal(calls.length, 5, 'one targeted tick acknowledges the event batch');
     assert.equal(calls[3][calls[3].indexOf('--client') + 1], 'claude,cursor');
+    assert.equal(calls[4][calls[4].indexOf('--client') + 1], 'claude,codex,cursor');
     await new Promise((resolve) => setTimeout(resolve, 100));
-    assert.equal(calls.length, 4, 'the acknowledged batch does not repeat');
+    assert.equal(calls.length, 5, 'the acknowledged batch does not repeat');
   } finally {
     if (handle) handle.stop();
     childProcess.spawn = originalSpawn;

--- a/tests/shared/collectorTodayDelta.test.js
+++ b/tests/shared/collectorTodayDelta.test.js
@@ -230,7 +230,7 @@ test('an all-client fallback preserves parse-local partitions that were not refr
   assert.equal(summary.allTime.clients.proma, 5);
 });
 
-test('a non-empty multi-target confirmation falls back from a polluted union result', async () => {
+test('a partial multi-target union falls back instead of trusting a polluted partition', async () => {
   const { collectUsageOnce, localTodayKey } = freshCollector();
   const calls = [];
   const anchorClients = { claude: 10, codex: 20 };
@@ -246,7 +246,6 @@ test('a non-empty multi-target confirmation falls back from a polluted union res
   };
   const runTokscale = async ({ clients }) => {
     calls.push(clients);
-    if (clients === 'claude') return tokscaleRows({ claude: 10 });
     if (calls.length === 1) return tokscaleRows({ codex: 30 });
     return tokscaleRows({ claude: 10, codex: 20 });
   };
@@ -261,14 +260,85 @@ test('a non-empty multi-target confirmation falls back from a polluted union res
     projectsEnabled: false
   });
 
-  assert.deepEqual(calls, ['claude,codex', 'claude', 'claude,codex']);
+  assert.deepEqual(calls, ['claude,codex', 'claude,codex']);
   assert.equal(summary.today.totalTokens, 30);
   assert.deepEqual(summary.today.clients, anchorClients);
   assert.deepEqual(summary.month.clients, anchorClients);
   assert.deepEqual(summary.allTime.clients, anchorClients);
 });
 
-test('an unsafe unattributed union skips missing-client confirmations', async () => {
+test('an empty multi-target union falls back before clearing live partitions', async () => {
+  const { collectUsageOnce, localTodayKey } = freshCollector();
+  const calls = [];
+  const anchorClients = { claude: 10, codex: 20 };
+  const anchor = {
+    dateKey: localTodayKey(),
+    today: combinedPeriod(anchorClients),
+    month: combinedPeriod(anchorClients),
+    allTime: combinedPeriod(anchorClients),
+    todayPartitions: {
+      claude: clientPeriod('claude', 10),
+      codex: clientPeriod('codex', 20)
+    }
+  };
+  const runTokscale = async ({ clients }) => {
+    calls.push(clients);
+    return calls.length === 1 ? tokscaleRows({}) : tokscaleRows(anchorClients);
+  };
+
+  const summary = await collectUsageOnce({
+    ...baseOptions,
+    clients: 'claude,codex',
+    targetClients: ['claude', 'codex'],
+    todayOnlyAnchor: anchor,
+    runTokscale,
+    historyEnabled: false,
+    projectsEnabled: false
+  });
+
+  assert.deepEqual(calls, ['claude,codex', 'claude,codex']);
+  assert.equal(summary.today.totalTokens, 30);
+  assert.deepEqual(summary.today.clients, anchorClients);
+  assert.deepEqual(summary.month.clients, anchorClients);
+  assert.deepEqual(summary.allTime.clients, anchorClients);
+});
+
+test('an empty multi-target union and full snapshot clear genuinely deleted usage', async () => {
+  const { collectUsageOnce, localTodayKey } = freshCollector();
+  const calls = [];
+  const anchorClients = { claude: 10, codex: 20 };
+  const anchor = {
+    dateKey: localTodayKey(),
+    today: combinedPeriod(anchorClients),
+    month: combinedPeriod(anchorClients),
+    allTime: combinedPeriod(anchorClients),
+    todayPartitions: {
+      claude: clientPeriod('claude', 10),
+      codex: clientPeriod('codex', 20)
+    }
+  };
+  const runTokscale = async ({ clients }) => {
+    calls.push(clients);
+    return tokscaleRows({});
+  };
+
+  const summary = await collectUsageOnce({
+    ...baseOptions,
+    clients: 'claude,codex',
+    targetClients: ['claude', 'codex'],
+    todayOnlyAnchor: anchor,
+    runTokscale,
+    historyEnabled: false,
+    projectsEnabled: false
+  });
+
+  assert.deepEqual(calls, ['claude,codex', 'claude,codex']);
+  assert.equal(summary.today.totalTokens, 0);
+  assert.equal(summary.month.totalTokens, 0);
+  assert.equal(summary.allTime.totalTokens, 0);
+});
+
+test('an unsafe unattributed union falls back without intermediate scans', async () => {
   const { collectUsageOnce, localTodayKey } = freshCollector();
   const calls = [];
   const anchorClients = { claude: 10, codex: 20 };
@@ -305,7 +375,7 @@ test('an unsafe unattributed union skips missing-client confirmations', async ()
   assert.deepEqual(summary.today.clients, anchorClients);
 });
 
-test('an empty multi-target confirmation still clears genuinely deleted usage', async () => {
+test('a multi-target full fallback still clears genuinely deleted usage', async () => {
   const { collectUsageOnce, localTodayKey } = freshCollector();
   const calls = [];
   const anchorClients = { claude: 10, codex: 20 };
@@ -321,7 +391,6 @@ test('an empty multi-target confirmation still clears genuinely deleted usage', 
   };
   const runTokscale = async ({ clients }) => {
     calls.push(clients);
-    if (clients === 'claude') return tokscaleRows({});
     return tokscaleRows({ codex: 20 });
   };
 
@@ -335,7 +404,7 @@ test('an empty multi-target confirmation still clears genuinely deleted usage', 
     projectsEnabled: false
   });
 
-  assert.deepEqual(calls, ['claude,codex', 'claude']);
+  assert.deepEqual(calls, ['claude,codex', 'claude,codex']);
   assert.equal(summary.today.totalTokens, 20);
   assert.equal(summary.today.clients.claude || 0, 0);
   assert.equal(summary.month.clients.claude || 0, 0);

--- a/tests/shared/collectorTodayDelta.test.js
+++ b/tests/shared/collectorTodayDelta.test.js
@@ -230,7 +230,7 @@ test('an all-client fallback preserves parse-local partitions that were not refr
   assert.equal(summary.allTime.clients.proma, 5);
 });
 
-test('a partial multi-target result confirms missing clients before replacing partitions', async () => {
+test('a non-empty multi-target confirmation falls back from a polluted union result', async () => {
   const { collectUsageOnce, localTodayKey } = freshCollector();
   const calls = [];
   const anchorClients = { claude: 10, codex: 20 };
@@ -246,8 +246,8 @@ test('a partial multi-target result confirms missing clients before replacing pa
   };
   const runTokscale = async ({ clients }) => {
     calls.push(clients);
-    if (clients === 'claude') return tokscaleRows({ codex: 99 });
-    if (calls.length === 1) return tokscaleRows({ codex: 20 });
+    if (clients === 'claude') return tokscaleRows({ claude: 10 });
+    if (calls.length === 1) return tokscaleRows({ codex: 30 });
     return tokscaleRows({ claude: 10, codex: 20 });
   };
 
@@ -266,6 +266,43 @@ test('a partial multi-target result confirms missing clients before replacing pa
   assert.deepEqual(summary.today.clients, anchorClients);
   assert.deepEqual(summary.month.clients, anchorClients);
   assert.deepEqual(summary.allTime.clients, anchorClients);
+});
+
+test('an unsafe unattributed union skips missing-client confirmations', async () => {
+  const { collectUsageOnce, localTodayKey } = freshCollector();
+  const calls = [];
+  const anchorClients = { claude: 10, codex: 20 };
+  const anchor = {
+    dateKey: localTodayKey(),
+    today: combinedPeriod(anchorClients),
+    month: combinedPeriod(anchorClients),
+    allTime: combinedPeriod(anchorClients),
+    todayPartitions: {
+      claude: clientPeriod('claude', 10),
+      codex: clientPeriod('codex', 20)
+    }
+  };
+  const runTokscale = async ({ clients }) => {
+    calls.push(clients);
+    if (calls.length > 1) return tokscaleRows({ claude: 10, codex: 20 });
+    const partial = tokscaleRows({ codex: 20 });
+    partial.entries.push({ model: 'unknown-model', input: 99, output: 0, cost: 0 });
+    return partial;
+  };
+
+  const summary = await collectUsageOnce({
+    ...baseOptions,
+    clients: 'claude,codex',
+    targetClients: ['claude', 'codex'],
+    todayOnlyAnchor: anchor,
+    runTokscale,
+    historyEnabled: false,
+    projectsEnabled: false
+  });
+
+  assert.deepEqual(calls, ['claude,codex', 'claude,codex']);
+  assert.equal(summary.today.totalTokens, 30);
+  assert.deepEqual(summary.today.clients, anchorClients);
 });
 
 test('an empty multi-target confirmation still clears genuinely deleted usage', async () => {

--- a/tests/shared/collectorTodayDelta.test.js
+++ b/tests/shared/collectorTodayDelta.test.js
@@ -65,6 +65,37 @@ const baseOptions = {
   limitsEnabled: false
 };
 
+function clientPeriod(client, totalTokens) {
+  const { emptyPeriod } = require('../../src/shared/usage');
+  return {
+    ...emptyPeriod(),
+    totalTokens,
+    clients: { [client]: totalTokens }
+  };
+}
+
+function combinedPeriod(clientTokens) {
+  const { emptyPeriod } = require('../../src/shared/usage');
+  return {
+    ...emptyPeriod(),
+    totalTokens: Object.values(clientTokens).reduce((sum, value) => sum + value, 0),
+    clients: { ...clientTokens }
+  };
+}
+
+function tokscaleRows(clientTokens) {
+  return {
+    entries: Object.entries(clientTokens).map(([client, input]) => ({
+      client,
+      sessionId: `${client}-session`,
+      model: `${client}-model`,
+      input,
+      output: 0,
+      cost: 0
+    }))
+  };
+}
+
 test('collectUsageOnce with a valid anchor runs a single --today scan and derives the broader periods', async () => {
   const childProcess = require('node:child_process');
   const originalSpawn = childProcess.spawn;
@@ -159,6 +190,119 @@ test('an anchored watch tick does not re-read session files that only appear in 
     fs.rmSync(home, { recursive: true, force: true });
     delete require.cache[collectorPath];
   }
+});
+
+test('an all-client fallback preserves parse-local partitions that were not refreshed', async () => {
+  const { collectUsageOnce, localTodayKey } = freshCollector();
+  const calls = [];
+  const anchorClients = { claude: 10, codex: 20, proma: 5 };
+  const anchor = {
+    dateKey: localTodayKey(),
+    today: combinedPeriod(anchorClients),
+    month: combinedPeriod(anchorClients),
+    allTime: combinedPeriod(anchorClients),
+    todayPartitions: {
+      claude: clientPeriod('claude', 10),
+      codex: clientPeriod('codex', 20),
+      proma: clientPeriod('proma', 5)
+    }
+  };
+  const runTokscale = async ({ clients }) => {
+    calls.push(clients);
+    if (clients === 'codex') return tokscaleRows({ claude: 99 });
+    return tokscaleRows({ claude: 10, codex: 20 });
+  };
+
+  const summary = await collectUsageOnce({
+    ...baseOptions,
+    clients: 'claude,codex,proma',
+    targetClients: ['codex'],
+    todayOnlyAnchor: anchor,
+    runTokscale,
+    historyEnabled: false,
+    projectsEnabled: false
+  });
+
+  assert.deepEqual(calls, ['codex', 'claude,codex']);
+  assert.equal(summary.today.totalTokens, 35);
+  assert.equal(summary.today.clients.proma, 5);
+  assert.equal(summary.month.clients.proma, 5);
+  assert.equal(summary.allTime.clients.proma, 5);
+});
+
+test('a partial multi-target result confirms missing clients before replacing partitions', async () => {
+  const { collectUsageOnce, localTodayKey } = freshCollector();
+  const calls = [];
+  const anchorClients = { claude: 10, codex: 20 };
+  const anchor = {
+    dateKey: localTodayKey(),
+    today: combinedPeriod(anchorClients),
+    month: combinedPeriod(anchorClients),
+    allTime: combinedPeriod(anchorClients),
+    todayPartitions: {
+      claude: clientPeriod('claude', 10),
+      codex: clientPeriod('codex', 20)
+    }
+  };
+  const runTokscale = async ({ clients }) => {
+    calls.push(clients);
+    if (clients === 'claude') return tokscaleRows({ codex: 99 });
+    if (calls.length === 1) return tokscaleRows({ codex: 20 });
+    return tokscaleRows({ claude: 10, codex: 20 });
+  };
+
+  const summary = await collectUsageOnce({
+    ...baseOptions,
+    clients: 'claude,codex',
+    targetClients: ['claude', 'codex'],
+    todayOnlyAnchor: anchor,
+    runTokscale,
+    historyEnabled: false,
+    projectsEnabled: false
+  });
+
+  assert.deepEqual(calls, ['claude,codex', 'claude', 'claude,codex']);
+  assert.equal(summary.today.totalTokens, 30);
+  assert.deepEqual(summary.today.clients, anchorClients);
+  assert.deepEqual(summary.month.clients, anchorClients);
+  assert.deepEqual(summary.allTime.clients, anchorClients);
+});
+
+test('an empty multi-target confirmation still clears genuinely deleted usage', async () => {
+  const { collectUsageOnce, localTodayKey } = freshCollector();
+  const calls = [];
+  const anchorClients = { claude: 10, codex: 20 };
+  const anchor = {
+    dateKey: localTodayKey(),
+    today: combinedPeriod(anchorClients),
+    month: combinedPeriod(anchorClients),
+    allTime: combinedPeriod(anchorClients),
+    todayPartitions: {
+      claude: clientPeriod('claude', 10),
+      codex: clientPeriod('codex', 20)
+    }
+  };
+  const runTokscale = async ({ clients }) => {
+    calls.push(clients);
+    if (clients === 'claude') return tokscaleRows({});
+    return tokscaleRows({ codex: 20 });
+  };
+
+  const summary = await collectUsageOnce({
+    ...baseOptions,
+    clients: 'claude,codex',
+    targetClients: ['claude', 'codex'],
+    todayOnlyAnchor: anchor,
+    runTokscale,
+    historyEnabled: false,
+    projectsEnabled: false
+  });
+
+  assert.deepEqual(calls, ['claude,codex', 'claude']);
+  assert.equal(summary.today.totalTokens, 20);
+  assert.equal(summary.today.clients.claude || 0, 0);
+  assert.equal(summary.month.clients.claude || 0, 0);
+  assert.equal(summary.allTime.clients.claude || 0, 0);
 });
 
 test('collectUsageOnce ignores a stale anchor from a previous day and runs the full scan', async () => {

--- a/tests/shared/usageRuntime.test.js
+++ b/tests/shared/usageRuntime.test.js
@@ -346,7 +346,10 @@ test('coalesced targeted refreshes preserve the union of their clients', async (
     const results = await Promise.all([held, cursor, claude]);
 
     assert.deepEqual(results, [true, true, true]);
-    assert.deepEqual(scans.at(-1), { clients: 'cursor,claude', flags: ['--today'] });
+    assert.deepEqual(scans.slice(-2), [
+      { clients: 'cursor,claude', flags: ['--today'] },
+      { clients: 'claude,cursor', flags: ['--today'] }
+    ]);
     assert.equal(updates.at(-1).reason, 'coalesced');
   } finally {
     runtime.stop();


### PR DESCRIPTION
## Summary

- Treat a targeted `--today` result as unsafe when it contains an attributed client partition outside the requested target set.
- Treat a multi-client targeted result as unsafe when it omits any requested Tokscale partition, rebuilding today with one all-client scan instead of repairing a partial union client by client.
- Preserve unrefreshed parse-local partitions such as Proma and Qoder CN when rebuilding Tokscale partitions after a fallback.
- Preserve empty-result semantics so genuinely deleted client data can still clear stale usage.

## Verification

- `npm run verify` (3532 passed, 1 skipped)

Refs #456
