### PR TITLE
feat(antigravity): probe quotas through CLI first

### DIFF
--- a/src/shared/antigravityProbe.js
+++ b/src/shared/antigravityProbe.js
@@ -3,12 +3,17 @@
 const { abortError } = require('./probeDeadline');
 
 const { spawn } = require('node:child_process');
+const fs = require('node:fs');
 const https = require('node:https');
 const http = require('node:http');
+const path = require('node:path');
+const semver = require('semver');
 const { appVersion } = require('./appVersion');
 
 const DEFAULT_PROBE_TIMEOUT_MS = 8000;
 const DEFAULT_RPC_TIMEOUT_MS = 12000;
+const DEFAULT_CLI_VERSION_TIMEOUT_MS = 5000;
+const CLI_VERSION_CACHE_STATE_KEY = 'antigravity.cli-version-cache';
 
 function errorWithStatus(status, message) {
   const error = new Error(message || status);
@@ -417,6 +422,107 @@ function parseResetTime(value) {
   return Number.isNaN(d.getTime()) ? null : d.toISOString();
 }
 
+function parseCliUsage(stdout) {
+  let payload;
+  try {
+    payload = JSON.parse(String(stdout || ''));
+  } catch (error) {
+    throw errorWithStatus('unavailable', `Antigravity CLI returned invalid JSON: ${error.message}`);
+  }
+  if (payload?.status !== 'SUCCESS' || String(payload?.command?.name || '').toLowerCase() !== 'usage') {
+    throw errorWithStatus('unavailable', 'Antigravity CLI did not return usage data');
+  }
+
+  const windows = [];
+  const groups = Array.isArray(payload?.command?.data?.groups) ? payload.command.data.groups : [];
+  for (const group of groups) {
+    const groupName = quotaGroupName(group?.name);
+    for (const bucket of Array.isArray(group?.buckets) ? group.buckets : []) {
+      const cadence = String(bucket?.window || '').trim().toLowerCase();
+      const kind = cadence === 'weekly' || cadence === 'week'
+        ? 'weekly'
+        : cadence === '5h' || cadence === '5-hour' ? 'session' : null;
+      const remainingFraction = bucket?.remaining_fraction;
+      if (!kind || typeof remainingFraction !== 'number' || !Number.isFinite(remainingFraction)) continue;
+      windows.push({
+        name: `${groupName} ${kind === 'session' ? '5-hour' : 'weekly'}`,
+        kind,
+        remainingFraction: Math.max(0, Math.min(1, remainingFraction)),
+        resetTime: parseResetTime(bucket?.reset_time)
+      });
+    }
+  }
+  if (windows.length === 0) {
+    throw errorWithStatus('unavailable', 'Antigravity CLI returned no quota windows');
+  }
+  return { accountPlan: null, accountEmail: null, windows, source: 'cli' };
+}
+
+function resolveAgyCommand(deps = {}) {
+  if (deps.agyCommand) return deps.agyCommand;
+  const platform = deps.platform || process.platform;
+  if (platform !== 'win32') return 'agy';
+  const localAppData = String((deps.env || process.env).LOCALAPPDATA || '').trim();
+  const candidate = localAppData ? path.win32.join(localAppData, 'agy', 'bin', 'agy.exe') : '';
+  if (candidate && (deps.existsSync || fs.existsSync)(candidate)) return candidate;
+  return 'agy.exe';
+}
+
+async function runAgyText(command, args, timeoutMs, deps) {
+  try {
+    return await runProcessText(command, args, { timeoutMs, deps });
+  } catch (error) {
+    if (!error?.status) {
+      error.status = error?.code === 'ENOENT' ? 'notConfigured' : 'unavailable';
+    }
+    throw error;
+  }
+}
+
+function cliVersionCache(deps) {
+  if (!(deps.providerRuntimeState instanceof Map)) return null;
+  let cache = deps.providerRuntimeState.get(CLI_VERSION_CACHE_STATE_KEY);
+  if (!(cache instanceof Map)) {
+    cache = new Map();
+    deps.providerRuntimeState.set(CLI_VERSION_CACHE_STATE_KEY, cache);
+  }
+  return cache;
+}
+
+async function agyVersion(command, deps) {
+  const cache = cliVersionCache(deps);
+  const cached = cache?.get(command);
+  if (cached && deps.refreshReason !== 'manual') return cached;
+
+  const versionText = await runAgyText(
+    command,
+    ['--version'],
+    DEFAULT_CLI_VERSION_TIMEOUT_MS,
+    deps
+  );
+  const version = semver.coerce(String(versionText));
+  if (!version) {
+    throw errorWithStatus('notConfigured', 'Unable to determine Antigravity CLI version');
+  }
+  cache?.set(command, version.version);
+  return version.version;
+}
+
+async function probeCliUsage(deps = {}) {
+  const command = resolveAgyCommand(deps);
+  const version = await agyVersion(command, deps);
+  if (semver.lt(version, '1.1.11')) {
+    throw errorWithStatus('notConfigured', 'Antigravity CLI /usage requires agy 1.1.11 or newer');
+  }
+  const stdout = await runAgyText(
+    command,
+    ['-p', '/usage', '--output-format', 'json'],
+    30_000,
+    deps
+  );
+  return parseCliUsage(stdout);
+}
+
 function quotaRemainingFraction(bucket) {
   const direct = bucket?.remainingFraction;
   if (typeof direct === 'number' && Number.isFinite(direct)) return direct;
@@ -705,10 +811,73 @@ async function detectedProcessInfos(deps) {
   return normalizeProcessInfos(await detectProcessInfos(deps));
 }
 
+function preferredProbeError(rpcError, cliError) {
+  if (rpcError?.status === 'notConfigured' && cliError?.status && cliError.status !== 'notConfigured') {
+    return cliError;
+  }
+  return rpcError;
+}
+
+async function supplementCliAccountPlan(snapshot, deps) {
+  const deadlineMs = Date.now() + DEFAULT_PROBE_TIMEOUT_MS;
+  const listPorts = deps.listeningPorts || listeningPorts;
+  const call = deps.callLs || callLs;
+  try {
+    const infos = await promiseBeforeDeadline(
+      (remainingTimeoutMs) => detectedProcessInfos({ ...deps, timeoutMs: remainingTimeoutMs }),
+      deadlineMs,
+      DEFAULT_PROBE_TIMEOUT_MS,
+      deps.signal
+    );
+    for (const info of infos) {
+      let ports;
+      try {
+        ports = await promiseBeforeDeadline(
+          (remainingTimeoutMs) => listPorts(info.pid, { ...deps, timeoutMs: remainingTimeoutMs }),
+          deadlineMs,
+          DEFAULT_PROBE_TIMEOUT_MS,
+          deps.signal
+        );
+      } catch (_) {
+        throwIfAborted(deps.signal);
+        if (remainingMs(deadlineMs) <= 0) return snapshot;
+        continue;
+      }
+      for (const candidate of endpointCandidates(info, ports)) {
+        try {
+          const data = await callBeforeDeadline(call, {
+            ...candidate,
+            method: 'GetUserStatus',
+            body: { metadata: PROBE_METADATA },
+            signal: deps.signal
+          }, deadlineMs, 1000);
+          const accountPlan = firstTrimmedString(data?.userStatus?.userTier?.name)
+            || preferredPlanInfoName(data?.userStatus?.planStatus?.planInfo);
+          if (accountPlan) return { ...snapshot, accountPlan };
+        } catch (_) {
+          throwIfAborted(deps.signal);
+          if (remainingMs(deadlineMs) <= 0) return snapshot;
+        }
+      }
+    }
+  } catch (_) {
+    throwIfAborted(deps.signal);
+  }
+  return snapshot;
+}
+
 async function probe(deps = {}) {
+  throwIfAborted(deps.signal);
+  let cliError;
+  try {
+    const snapshot = await probeCliUsage(deps);
+    return await supplementCliAccountPlan(snapshot, deps);
+  } catch (error) {
+    throwIfAborted(deps.signal);
+    cliError = error;
+  }
   const probeTimeoutMs = Math.max(1, Number(deps.probeTimeoutMs) || DEFAULT_PROBE_TIMEOUT_MS);
   const probeDeadlineMs = Date.now() + probeTimeoutMs;
-  throwIfAborted(deps.signal);
   const abortController = new AbortController();
   const abortTimer = setTimeout(() => abortController.abort(probeTimeoutError()), probeTimeoutMs);
   const signal = deps.signal
@@ -720,12 +889,17 @@ async function probe(deps = {}) {
   let lastError = errorWithStatus('notConfigured', 'Antigravity language server not running');
 
   try {
-    const infos = await promiseBeforeDeadline(
-      (timeoutMs) => detectedProcessInfos({ ...runtimeDeps, timeoutMs }),
-      probeDeadlineMs,
-      DEFAULT_RPC_TIMEOUT_MS,
-      signal
-    );
+    let infos;
+    try {
+      infos = await promiseBeforeDeadline(
+        (timeoutMs) => detectedProcessInfos({ ...runtimeDeps, timeoutMs }),
+        probeDeadlineMs,
+        DEFAULT_RPC_TIMEOUT_MS,
+        signal
+      );
+    } catch (error) {
+      throw preferredProbeError(error, cliError);
+    }
 
     // Source priority is deliberate and independent of ps/PID order. Processes
     // within one source are probed concurrently under the same provider-wide
@@ -783,7 +957,7 @@ async function probe(deps = {}) {
       if (legacy?.snapshot) return { ...legacy.snapshot, sourceDetail: kind };
       for (const result of legacyResults) lastError = result.lastError || lastError;
     }
-    throw lastError;
+    throw preferredProbeError(lastError, cliError);
   } finally {
     clearTimeout(abortTimer);
     abortController.abort();

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -3092,8 +3092,9 @@ async function fetchAntigravityLimits(_options = {}, deps = {}) {
   const probeFn = deps.antigravityProbe || antigravityProbe.probe;
   try {
     const snapshot = await probeFn(deps);
-    const accountLabel = snapshot.accountPlan ? antigravityPlanLabelFromParts(snapshot.accountPlan) : '';
-    const accountKeySeed = snapshot.accountEmail || snapshot.accountPlan || 'default';
+    const planLabel = snapshot.accountPlan ? antigravityPlanLabelFromParts(snapshot.accountPlan) : '';
+    const accountKeySeed = snapshot.accountEmail
+      || (snapshot.source === 'cli' ? '' : snapshot.accountPlan || 'default');
     const windows = Array.isArray(snapshot.windows)
       ? snapshot.windows.map((window) => ({
           kind: window.kind,
@@ -3115,10 +3116,11 @@ async function fetchAntigravityLimits(_options = {}, deps = {}) {
         }));
     return normalizeLimitProvider({
       provider: 'antigravity',
-      accountKey: hashKey('antigravity', accountKeySeed),
-      accountLabel,
+      accountKey: accountKeySeed ? hashKey('antigravity', accountKeySeed) : '',
+      accountLabel: snapshot.source === 'cli' ? '' : planLabel,
+      planLabel: snapshot.source === 'cli' ? planLabel : '',
       accountEmail: snapshot.accountEmail || '',
-      source: 'rpc',
+      source: snapshot.source || 'rpc',
       sourceDetail: snapshot.sourceDetail || '',
       status: 'ok',
       updatedAt,
@@ -3777,6 +3779,7 @@ async function probeLimitProvider(provider, options = {}, context = {}, deps = {
     const result = await fetcher(options, {
       ...deps,
       fetch: createProbeFetch(resolveProviderFetch(provider, deps), { ...context, signal }, deps),
+      refreshReason: context.reason ?? deps.refreshReason,
       signal
     });
     return (Array.isArray(result) ? result : [result]).filter(Boolean);

--- a/tests/shared/antigravityLimits.test.js
+++ b/tests/shared/antigravityLimits.test.js
@@ -3,7 +3,21 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 
-const { fetchAntigravityLimits } = require('../../src/shared/limitCollector');
+const { fetchAntigravityLimits, probeLimitProvider } = require('../../src/shared/limitCollector');
+
+test('probeLimitProvider forwards the manual refresh reason to Antigravity', async () => {
+  let refreshReason = null;
+  await probeLimitProvider('antigravity', {}, { reason: 'manual' }, {
+    providerFetchers: {
+      antigravity: async (_options, deps) => {
+        refreshReason = deps.refreshReason;
+        return { provider: 'antigravity', status: 'ok', windows: [] };
+      }
+    }
+  });
+
+  assert.equal(refreshReason, 'manual');
+});
 
 test('fetchAntigravityLimits returns notConfigured when probe says LS not running', async () => {
   const result = await fetchAntigravityLimits({}, {
@@ -62,6 +76,29 @@ test('fetchAntigravityLimits preserves Antigravity IDE source detail', async () 
 
   assert.equal(result.status, 'ok');
   assert.equal(result.sourceDetail, 'ide');
+});
+
+test('fetchAntigravityLimits keeps CLI identity stable when plan enrichment is unavailable', async () => {
+  const fetchWithPlan = (accountPlan) => fetchAntigravityLimits({}, {
+    antigravityProbe: async () => ({
+      accountPlan,
+      accountEmail: null,
+      source: 'cli',
+      windows: [
+        { name: 'Gemini weekly', kind: 'weekly', remainingFraction: 0.8 }
+      ]
+    })
+  });
+
+  const withPlan = await fetchWithPlan('Google AI Pro');
+  const withoutPlan = await fetchWithPlan(null);
+
+  assert.equal(withPlan.accountKey, withoutPlan.accountKey);
+  assert.equal(withPlan.accountKey, '');
+  assert.equal(withPlan.accountLabel, '');
+  assert.equal(withPlan.planLabel, 'Pro');
+  assert.equal(withoutPlan.accountLabel, '');
+  assert.equal(withoutPlan.planLabel, '');
 });
 
 test('fetchAntigravityLimits does not invent session windows for Starter accounts', async () => {

--- a/tests/shared/antigravityProbe.test.js
+++ b/tests/shared/antigravityProbe.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
 const test = require('node:test');
 
 const probe = require('../../src/shared/antigravityProbe');
@@ -8,7 +9,7 @@ const rootPackage = require('../../package.json');
 
 test('probe stops waiting for process discovery when the parent signal aborts', async () => {
   const controller = new AbortController();
-  const pending = probe.probe({
+  const pending = runProbe({
     signal: controller.signal,
     probeTimeoutMs: 60_000,
     detectProcessInfos: () => new Promise(() => {})
@@ -26,7 +27,7 @@ test('an already-aborted parent does not create the provider timeout timer', asy
   const controller = new AbortController();
   controller.abort(new Error('already stopped'));
 
-  await assert.rejects(probe.probe({
+  await assert.rejects(runProbe({
     signal: controller.signal,
     probeTimeoutMs: 60_000
   }), /already stopped/);
@@ -122,8 +123,7 @@ test('parseProcessLine does not match agy embedded in an unrelated path', () => 
   assert.equal(probe._parseProcessLine('701 /usr/local/bin/legacy-agent start'), null);
 });
 
-function fakeSpawn(stdout, { exitCode = 0, stderr = '' } = {}) {
-  const { EventEmitter } = require('node:events');
+function fakeSpawn(stdout, { exitCode = 0, stderr = '', errorCode = '' } = {}) {
   return () => {
     const child = new EventEmitter();
     child.stdout = new EventEmitter();
@@ -131,6 +131,12 @@ function fakeSpawn(stdout, { exitCode = 0, stderr = '' } = {}) {
     child.stdin = { end: () => {} };
     child.kill = () => {};
     setImmediate(() => {
+      if (errorCode) {
+        const error = new Error(`spawn failed: ${errorCode}`);
+        error.code = errorCode;
+        child.emit('error', error);
+        return;
+      }
       child.stdout.emit('data', Buffer.from(stdout));
       if (stderr) child.stderr.emit('data', Buffer.from(stderr));
       child.emit('close', exitCode);
@@ -138,6 +144,201 @@ function fakeSpawn(stdout, { exitCode = 0, stderr = '' } = {}) {
     return child;
   };
 }
+
+function cliUsagePayload() {
+  return {
+    status: 'SUCCESS',
+    command: {
+      name: 'usage',
+      data: {
+        groups: [{
+          name: 'Gemini',
+          buckets: [{
+            id: 'gemini-weekly',
+            window: 'weekly',
+            remaining_fraction: 0.75,
+            reset_time: '2026-08-28T00:00:00Z'
+          }]
+        }]
+      }
+    }
+  };
+}
+
+function isAgyCommand(command) {
+  return /(?:^|[\\/])agy(?:\.exe)?$/i.test(String(command));
+}
+
+function fakeProbeSpawn({
+  payload = cliUsagePayload(),
+  version = '1.1.17',
+  processOutput = '',
+  usageExitCode = 0,
+  usageStderr = '',
+  agyErrorCode = ''
+} = {}) {
+  return (cmd, args) => {
+    if (!isAgyCommand(cmd)) return fakeSpawn(processOutput)();
+    if (agyErrorCode) return fakeSpawn('', { errorCode: agyErrorCode })();
+    if (args[0] === '--version') return fakeSpawn(`${version}\n`)();
+    return fakeSpawn(usageExitCode === 0 ? JSON.stringify(payload) : '', {
+      exitCode: usageExitCode,
+      stderr: usageStderr
+    })();
+  };
+}
+
+function runProbe(deps = {}) {
+  return probe.probe({
+    agyCommand: 'agy',
+    spawn: fakeProbeSpawn({ version: '1.1.10' }),
+    ...deps
+  });
+}
+
+test('probe starts agy to read quota when no Antigravity process is running', async () => {
+  const calls = [];
+  let processDiscoveryCalls = 0;
+  const probeSpawn = fakeProbeSpawn();
+  const spawn = (cmd, args) => {
+    if (isAgyCommand(cmd)) calls.push([cmd, args]);
+    else processDiscoveryCalls += 1;
+    return probeSpawn(cmd, args);
+  };
+
+  const result = await runProbe({
+    platform: 'win32',
+    agyCommand: 'agy.exe',
+    spawn
+  });
+
+  assert.deepEqual(calls, [
+    ['agy.exe', ['--version']],
+    ['agy.exe', ['-p', '/usage', '--output-format', 'json']]
+  ]);
+  assert.equal(processDiscoveryCalls, 1);
+  assert.equal(result.source, 'cli');
+  assert.deepEqual(result.windows, [{
+    name: 'Gemini weekly',
+    kind: 'weekly',
+    remainingFraction: 0.75,
+    resetTime: '2026-08-28T00:00:00.000Z'
+  }]);
+});
+
+test('probe caches the agy version for automatic refreshes and rechecks it manually', async () => {
+  const calls = [];
+  const providerRuntimeState = new Map();
+  const probeSpawn = fakeProbeSpawn();
+  const spawn = (cmd, args) => {
+    if (isAgyCommand(cmd)) calls.push(args);
+    return probeSpawn(cmd, args);
+  };
+
+  const deps = {
+    platform: 'win32',
+    agyCommand: 'agy',
+    providerRuntimeState,
+    spawn
+  };
+  await runProbe(deps);
+  await runProbe(deps);
+  await runProbe({ ...deps, refreshReason: 'manual' });
+
+  assert.equal(calls.filter((args) => args[0] === '--version').length, 2);
+  assert.equal(calls.filter((args) => args[0] === '-p').length, 3);
+});
+
+test('probe skips /usage on agy versions older than 1.1.11', async () => {
+  const calls = [];
+  const probeSpawn = fakeProbeSpawn({ version: '1.1.10' });
+  const spawn = (cmd, args) => {
+    if (isAgyCommand(cmd)) calls.push([cmd, args]);
+    return probeSpawn(cmd, args);
+  };
+
+  const error = await runProbe({
+    platform: 'win32',
+    agyCommand: 'agy',
+    spawn
+  }).catch((caught) => caught);
+
+  assert.equal(error.status, 'notConfigured');
+  assert.deepEqual(calls, [['agy', ['--version']]]);
+});
+
+test('probe preserves a transient CLI failure when no RPC source is running', async () => {
+  const error = await runProbe({
+    platform: 'win32',
+    agyCommand: 'agy',
+    spawn: fakeProbeSpawn({ usageExitCode: 1, usageStderr: 'temporary CLI failure' })
+  }).catch((caught) => caught);
+
+  assert.equal(error.status, 'unavailable');
+  assert.equal(error.message, 'temporary CLI failure');
+});
+
+test('probe classifies transient agy spawn errors as unavailable', async () => {
+  const error = await runProbe({
+    platform: 'win32',
+    agyCommand: 'agy',
+    spawn: fakeProbeSpawn({ agyErrorCode: 'EACCES' })
+  }).catch((caught) => caught);
+
+  assert.equal(error.status, 'unavailable');
+});
+
+test('probe supplements CLI quota with plan from a running App, CLI, or IDE RPC', async () => {
+  const rpcPids = [];
+  const processOutput = [
+    '101 C:\\Users\\j\\.antigravity\\agy.exe language-server',
+    '102 C:\\Program Files\\Antigravity\\language_server.exe --app_data_dir antigravity --csrf_token app-token',
+    '103 C:\\Program Files\\Antigravity IDE\\language_server.exe --app_data_dir antigravity-ide --csrf_token ide-token'
+  ].join('\n');
+
+  const result = await runProbe({
+    platform: 'win32',
+    agyCommand: 'agy',
+    spawn: fakeProbeSpawn({ processOutput }),
+    listeningPorts: async (pid) => {
+      rpcPids.push(pid);
+      return [4000 + pid];
+    },
+    callLs: async ({ port, method }) => {
+      assert.equal(method, 'GetUserStatus');
+      if (port === 4102) throw new Error('App RPC unavailable');
+      if (port === 4101) {
+        return { userStatus: { userTier: { name: 'Google AI Pro' } } };
+      }
+      throw new Error('IDE RPC must not be inspected after CLI RPC succeeds');
+    }
+  });
+
+  assert.deepEqual(rpcPids, [102, 101]);
+  assert.equal(result.source, 'cli');
+  assert.equal(result.accountPlan, 'Google AI Pro');
+  assert.equal(result.windows[0].remainingFraction, 0.75);
+});
+
+test('probe keeps CLI quota when every running RPC fails', async () => {
+  let rpcCalls = 0;
+  const processOutput = '102 C:\\Program Files\\Antigravity\\language_server.exe --app_data_dir antigravity --csrf_token app-token';
+  const result = await runProbe({
+    platform: 'win32',
+    agyCommand: 'agy',
+    spawn: fakeProbeSpawn({ processOutput }),
+    listeningPorts: async () => [4102],
+    callLs: async () => {
+      rpcCalls += 1;
+      throw new Error('RPC unavailable');
+    }
+  });
+
+  assert.equal(rpcCalls, 2);
+  assert.equal(result.source, 'cli');
+  assert.equal(result.accountPlan, null);
+  assert.equal(result.windows[0].remainingFraction, 0.75);
+});
 
 test('detectProcessInfo (posix) returns the highest-priority Antigravity source', async () => {
   const stdout = [
@@ -403,7 +604,7 @@ test('_quotaSummaryWindows recognizes cadence aliases and marks disabled buckets
 
 test('probe prefers quota summary and merges identity from GetUserStatus', async () => {
   const methods = [];
-  const result = await probe.probe({
+  const result = await runProbe({
     detectProcessInfo: async () => ({ pid: 1, csrfToken: 'csrf', extensionPort: null }),
     listeningPorts: async () => [54733],
     callLs: async ({ method, body }) => {
@@ -434,7 +635,7 @@ test('probe prefers quota summary and merges identity from GetUserStatus', async
 
 test('parent cancellation during optional grouped identity lookup rejects the probe', async () => {
   const controller = new AbortController();
-  const pending = probe.probe({
+  const pending = runProbe({
     signal: controller.signal,
     detectProcessInfo: async () => ({ pid: 1, csrfToken: 'csrf', extensionPort: null }),
     listeningPorts: async () => [54733],
@@ -460,7 +661,7 @@ test('parent cancellation during optional grouped identity lookup rejects the pr
 
 test('probe checks every endpoint for grouped quota before accepting a legacy response', async () => {
   const calls = [];
-  const result = await probe.probe({
+  const result = await runProbe({
     detectProcessInfo: async () => ({ pid: 1, csrfToken: 'csrf', extensionPort: null }),
     listeningPorts: async () => [54733],
     callLs: async ({ scheme, method }) => {
@@ -502,7 +703,7 @@ test('probe checks every endpoint for grouped quota before accepting a legacy re
 
 test('probe follows app, CLI, then IDE source priority and stops after success', async () => {
   const calls = [];
-  const result = await probe.probe({
+  const result = await runProbe({
     detectProcessInfos: async () => [
       { pid: 30, kind: 'ide', csrfToken: 'ide' },
       { pid: 20, kind: 'cli', csrfToken: '' },
@@ -533,7 +734,7 @@ test('probe follows app, CLI, then IDE source priority and stops after success',
 
 test('probe accepts a valid app legacy response before lower-priority grouped sources', async () => {
   const calledPorts = [];
-  const result = await probe.probe({
+  const result = await runProbe({
     detectProcessInfos: async () => [
       { pid: 20, kind: 'cli', csrfToken: '' },
       { pid: 10, kind: 'app', csrfToken: 'app' }
@@ -566,7 +767,7 @@ test('probe accepts a valid app legacy response before lower-priority grouped so
 
 test('probe exhausts grouped quota across same-source processes before legacy fallback', async () => {
   const calls = [];
-  const result = await probe.probe({
+  const result = await runProbe({
     detectProcessInfos: async () => [
       { pid: 11, kind: 'app', csrfToken: 'first' },
       { pid: 12, kind: 'app', csrfToken: 'second' }
@@ -598,7 +799,7 @@ test('probe exhausts grouped quota across same-source processes before legacy fa
 
 test('probe resolves same-source process endpoints concurrently', async () => {
   const waiting = new Map();
-  const result = await probe.probe({
+  const result = await runProbe({
     probeTimeoutMs: 500,
     detectProcessInfos: async () => [
       { pid: 11, kind: 'app', csrfToken: 'first' },
@@ -634,7 +835,7 @@ test('probe resolves same-source process endpoints concurrently', async () => {
 test('probe enforces one provider-wide deadline and abort signal', async () => {
   let sawAbort = false;
   const startedAt = Date.now();
-  const err = await probe.probe({
+  const err = await runProbe({
     probeTimeoutMs: 40,
     detectProcessInfo: async () => ({ pid: 1, csrfToken: 'csrf', extensionPort: null }),
     listeningPorts: async () => [54733, 54734],
@@ -653,7 +854,7 @@ test('probe enforces one provider-wide deadline and abort signal', async () => {
 
 test('probe selects a reachable endpoint before requesting quota', async () => {
   const quotaTargets = [];
-  const result = await probe.probe({
+  const result = await runProbe({
     detectProcessInfo: async () => ({ pid: 1, csrfToken: 'csrf', extensionPort: null }),
     listeningPorts: async () => [100, 200],
     callLs: async ({ scheme, port, method }) => {
@@ -679,7 +880,7 @@ test('probe selects a reachable endpoint before requesting quota', async () => {
 });
 
 test('probe returns plan + 3 pools when GetUserStatus succeeds', async () => {
-  const result = await probe.probe({
+  const result = await runProbe({
     detectProcessInfo: async () => ({ pid: 1, csrfToken: 'csrf', extensionPort: null }),
     listeningPorts: async () => [54733],
     callLs: async ({ method }) => {
@@ -703,7 +904,7 @@ test('probe returns plan + 3 pools when GetUserStatus succeeds', async () => {
 });
 
 test('probe prefers userTier name and richer planInfo display fields', async () => {
-  const withUserTier = await probe.probe({
+  const withUserTier = await runProbe({
     detectProcessInfo: async () => ({ pid: 1, csrfToken: 'csrf', extensionPort: null }),
     listeningPorts: async () => [54733],
     callLs: async () => ({
@@ -720,7 +921,7 @@ test('probe prefers userTier name and richer planInfo display fields', async () 
   });
   assert.equal(withUserTier.accountPlan, 'Google AI Ultra');
 
-  const withPlanInfoDisplay = await probe.probe({
+  const withPlanInfoDisplay = await runProbe({
     detectProcessInfo: async () => ({ pid: 1, csrfToken: 'csrf', extensionPort: null }),
     listeningPorts: async () => [54733],
     callLs: async () => ({
@@ -739,7 +940,7 @@ test('probe prefers userTier name and richer planInfo display fields', async () 
 
 test('probe falls back to GetCommandModelConfigs when GetUserStatus has no userStatus', async () => {
   const methods = [];
-  const result = await probe.probe({
+  const result = await runProbe({
     detectProcessInfo: async () => ({ pid: 1, csrfToken: 'csrf', extensionPort: null }),
     listeningPorts: async () => [54733],
     callLs: async ({ method }) => {
@@ -766,7 +967,7 @@ test('probe falls back to GetCommandModelConfigs when GetUserStatus has no userS
 });
 
 test('probe rethrows the last error when every endpoint fails', async () => {
-  const err = await probe.probe({
+  const err = await runProbe({
     detectProcessInfo: async () => ({ pid: 1, csrfToken: 'csrf', extensionPort: null }),
     listeningPorts: async () => [54733],
     callLs: async () => { throw probe._errorWithStatus('unauthorized', '401'); }
@@ -775,7 +976,7 @@ test('probe rethrows the last error when every endpoint fails', async () => {
 });
 
 test('probe surfaces notConfigured from detectProcessInfo', async () => {
-  const err = await probe.probe({
+  const err = await runProbe({
     detectProcessInfo: async () => { throw probe._errorWithStatus('notConfigured', 'not running'); }
   }).catch((e) => e);
   assert.equal(err.status, 'notConfigured');

--- a/tests/shared/limitsRuntime.test.js
+++ b/tests/shared/limitsRuntime.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const { performance } = require('node:perf_hooks');
 const test = require('node:test');
 
+const { fetchAntigravityLimits } = require('../../src/shared/limitCollector');
 const { createLimitsRuntime } = require('../../src/shared/limitsRuntime');
 
 function deferred() {
@@ -133,6 +134,30 @@ test('provider probes share runtime-local state across refreshes', async () => {
   assert.equal(runtimeStates.length, 2);
   assert.equal(runtimeStates[0] instanceof Map, true);
   assert.equal(runtimeStates[1], runtimeStates[0]);
+  runtime.stop();
+});
+
+test('Antigravity plan enrichment does not split an anonymous CLI identity', async () => {
+  let accountPlan = 'Google AI Pro';
+  const runtime = createLimitsRuntime({ limitProviders: ['antigravity'] }, runtimeDeps({
+    probeProvider: async () => [await fetchAntigravityLimits({}, {
+      antigravityProbe: async () => ({
+        accountPlan,
+        accountEmail: null,
+        source: 'cli',
+        windows: [{ name: 'Gemini weekly', kind: 'weekly', remainingFraction: 0.8 }]
+      })
+    })]
+  }));
+
+  await runtime.refresh({}, 'with-plan');
+  accountPlan = null;
+  await runtime.refresh({}, 'without-plan');
+
+  const providers = runtime.getSnapshot().providers;
+  assert.equal(providers.length, 1);
+  assert.equal(providers[0].status, 'ok');
+  assert.equal(providers[0].accountKey, '');
   runtime.stop();
 });
 


### PR DESCRIPTION
## Summary

- probe Antigravity quotas through the CLI first, even when no Antigravity App, CLI language server, or IDE process is already running
- run `agy -p "/usage" --output-format json` on supported CLI versions and parse its model quota windows
- cache the detected CLI version for automatic refreshes, while rechecking it after an app restart or manual refresh
- preserve the existing App -> CLI -> IDE RPC fallback for older or unavailable CLI versions
- optionally enrich successful CLI quota results with the account plan exposed by an already-running RPC source
- keep anonymous CLI quota results independent from optional plan enrichment so the same quota does not split into multiple account rows

## Official references

The implementation combines the documented Antigravity CLI surfaces:

- [Model Quotas (`/usage`)](https://antigravity.google/docs/cli/commands/usage/) documents that `/usage` refreshes and displays active model quota information.
- [Headless mode](https://antigravity.google/docs/cli/headless/) documents non-interactive execution with `-p` and machine-readable output through `--output-format json`.

Together, these provide the official command surface used by:

```text
agy -p "/usage" --output-format json
```

## Compatibility

- Antigravity CLI versions older than `1.1.11` skip the headless `/usage` probe and continue through the existing RPC detection path.
- Missing or temporarily failing CLI probes do not remove the existing App, CLI language-server, or IDE RPC fallbacks.
- RPC plan enrichment is best-effort and never replaces a successfully collected CLI quota result.

## Testing

- `npm run verify`
- 3,537 tests passed
- 0 tests failed
- 8 tests skipped


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Probe Antigravity quotas via the CLI first to improve reliability when no RPC process is running, while preserving the existing RPC fallback. Keeps anonymous CLI identities stable across refreshes and optional plan enrichment.

- Run `agy -p "/usage" --output-format json` on CLI >= 1.1.11; parse model quota windows and optional reset times.
- Cache the detected `agy` version for automatic refreshes; recheck on app restart or manual refresh.
- Retain App → CLI language server → IDE RPC fallback when CLI is unavailable or too old; optionally enrich CLI quotas with the plan from a running RPC source.
- Stabilize identity for anonymous CLI results: emit an empty account key and keep plan in `planLabel` so enrichment never splits the same quota into multiple rows.
- Prefer a meaningful CLI failure over an RPC “not configured” error when deciding which error to surface.
- Forward the refresh reason through the limits runtime to enable the manual recheck of the CLI version.

| Area | Before | After |
| --- | --- | --- |
| Probe order | Only RPC (App → CLI LS → IDE) | CLI `/usage` first, then RPC fallback |
| CLI usage | No CLI invocation | Calls `agy` if present; requires >= 1.1.11 for `/usage` |
| Identity for anonymous results | Account key could change when plan enrichment toggled | Empty account key for CLI source; `planLabel` used without splitting rows |
| Source reporting | Always `rpc` | `cli` when CLI probe succeeds; otherwise `rpc` |
| Version checks across refreshes | N/A | Cache `agy --version`; recheck on manual refresh or restart |
| Error precedence | RPC errors only | Prefer CLI error when RPC reports “not configured” |

• Notes for reviewers
- Implementation: resolves `agy` path, gates `/usage` by `agy --version`, caches version in provider-local runtime state, and enriches CLI results with plan via RPC when available. Identity logic updated in `limitCollector` to separate `accountLabel` and `planLabel` for CLI snapshots.
- Tests: Added coverage for CLI probe, version caching and manual rechecks, error classification, stable identity under enrichment, and refresh reason propagation.

<sup>Written for commit 27d7fefaadbf609ac456cb851c8f657a371a1c85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

