### PR TITLE
test: make local-day fixtures timezone-independent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - run: npm ci
       - name: Run the suite at several UTC offsets
         run: |
-          for tz in Asia/Ho_Chi_Minh Asia/Kathmandu America/Los_Angeles Pacific/Honolulu Pacific/Kiritimati; do
+          for tz in Asia/Ho_Chi_Minh Asia/Kathmandu Pacific/Chatham America/Los_Angeles Pacific/Honolulu Pacific/Pago_Pago Pacific/Kiritimati; do
             echo "::group::TZ=$tz"
             TZ="$tz" npm test
             echo "::endgroup::"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,32 @@ jobs:
       - run: npm run lint
       - run: npm test
 
+  timezones:
+    # Every GitHub-hosted runner sets its clock to UTC on every OS, so the
+    # os × node matrix above varies two axes and still samples a single UTC
+    # offset. Usage periods are cut at *local* midnight, so an assertion written
+    # against a UTC instant is green there by construction and the first person
+    # to see it red is a contributor running `npm run verify` at home.
+    #
+    # This is a list rather than "UTC plus one other" because each offset failed
+    # a different subset of the suite (#481): +02 and +10 were green while +07
+    # was not, and Kathmandu is here because +05:45 is not a whole hour.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
+      - name: Run the suite at several UTC offsets
+        run: |
+          for tz in Asia/Ho_Chi_Minh Asia/Kathmandu America/Los_Angeles Pacific/Honolulu Pacific/Kiritimati; do
+            echo "::group::TZ=$tz"
+            TZ="$tz" npm test
+            echo "::endgroup::"
+          done
+
   mac-widget:
     runs-on: macos-latest
     steps:

--- a/tests/helpers/localTime.js
+++ b/tests/helpers/localTime.js
@@ -1,0 +1,29 @@
+'use strict';
+
+// Fixtures that exercise day or month bucketing have to state their instants in
+// the same clock the product code buckets by, and that clock is local: usage
+// periods are cut at local midnight (`src/shared/qoderCnUsage.js`, the archive
+// modules, the widget trend), because a desktop widget belongs to the calendar
+// the person reading it lives in.
+//
+// A `Z` literal only lands on the calendar day it names at some offsets. Written
+// as `2026-07-17T08:30:00.000Z` it is the 17th at UTC+00 and the 16th at UTC-10,
+// so an assertion built on it is green at some offsets and red at others — and
+// every GitHub-hosted runner sits at UTC+00, so the OS × Node matrix samples
+// exactly the one offset where the mismatch is invisible.
+//
+// Building the instant from local calendar parts states the day the fixture
+// means. The assertion then holds at every offset, and a regression that cut the
+// day at UTC midnight fails everywhere except UTC instead of passing everywhere
+// except a few offsets.
+//
+// `month` is 1-based so a call transcribes the ISO literal it replaces
+// (`2026-07-17` → `2026, 7, 17`), not `Date`'s 0-based monthIndex.
+const localDate = (year, month, day, hour = 0, minute = 0, second = 0, ms = 0) =>
+  new Date(year, month - 1, day, hour, minute, second, ms);
+
+const localMs = (...parts) => localDate(...parts).getTime();
+
+const localIso = (...parts) => localDate(...parts).toISOString();
+
+module.exports = { localDate, localMs, localIso };

--- a/tests/shared/clientUsageArchive.test.js
+++ b/tests/shared/clientUsageArchive.test.js
@@ -14,6 +14,8 @@ const {
   pruneArchivedClientUsage
 } = archiveApi;
 
+const { localDate } = require('../helpers/localTime');
+
 function deviceRecord() {
   return {
     deviceId: 'macbook',
@@ -163,11 +165,15 @@ test('archived client usage is added back while the client remains untracked', (
 });
 
 test('archived day and month usage follow calendar boundaries', () => {
-  const archive = captureArchivedClientUsage({}, deviceRecord(), ['hermes'], new Date('2026-05-30T12:00:00.000Z'));
+  // The day and month windows are cut at local midnight, so the three clocks
+  // below are stated in local time: a `Z` noon is already the next calendar day
+  // past UTC+12, which walks the capture and both reads a day forward together
+  // and takes the month rollover with them.
+  const archive = captureArchivedClientUsage({}, deviceRecord(), ['hermes'], localDate(2026, 5, 30, 12));
 
   const nextDay = applyArchivedClientUsage(liveSummaryWithoutHermes(), archive, {
     activeClients: 'codex',
-    now: new Date('2026-05-31T12:00:00.000Z')
+    now: localDate(2026, 5, 31, 12)
   });
   assert.equal(nextDay.today.clients.hermes, undefined);
   assert.equal(nextDay.today.models['claude-3-5-sonnet'], undefined);
@@ -181,7 +187,7 @@ test('archived day and month usage follow calendar boundaries', () => {
 
   const nextMonth = applyArchivedClientUsage(liveSummaryWithoutHermes(), archive, {
     activeClients: 'codex',
-    now: new Date('2026-06-01T12:00:00.000Z')
+    now: localDate(2026, 6, 1, 12)
   });
   assert.equal(nextMonth.today.clients.hermes, undefined);
   assert.equal(nextMonth.month.clients.hermes, undefined);

--- a/tests/shared/macWidgetSnapshot.test.js
+++ b/tests/shared/macWidgetSnapshot.test.js
@@ -11,8 +11,14 @@ const {
   serializeMacWidgetSnapshot
 } = require('../../src/shared/macWidgetSnapshot');
 const { aggregateDevices } = require('../../src/shared/usage');
+const { localIso } = require('../helpers/localTime');
 
-const NOW = '2026-07-17T08:30:00.000Z';
+// The trend series is bucketed by *local* calendar day, so the clock has to be
+// stated in local time: `2026-07-17T08:30:00.000Z` is already the 16th at UTC-10
+// and the trend then ends a day early. The freshness stamps below move with it,
+// because `status.dataAgeSeconds` is the distance between the two.
+const NOW = localIso(2026, 7, 17, 8, 30);
+const SOURCE_UPDATED_AT = localIso(2026, 7, 17, 8, 25);
 
 function dailyHistory(count, start = '2026-01-01') {
   const startMs = Date.parse(`${start}T00:00:00.000Z`);
@@ -32,7 +38,7 @@ function buildSnapshot(stats, options = {}) {
 
 function sampleStats() {
   return {
-    updatedAt: '2026-07-17T08:25:00.000Z',
+    updatedAt: SOURCE_UPDATED_AT,
     periods: {
       today: {
         totalTokens: 1_200_000,
@@ -90,7 +96,7 @@ test('builds schema v6 overview, quota, models, activity, trend and presentation
   assert.equal(MAC_WIDGET_SCHEMA_VERSION, 6);
   assert.deepEqual(snapshot.overview, {
     currentPeriod: 'today', totalTokens: 1_200_000, costUsd: 1.25,
-    primaryTool: 'codex', updatedAt: '2026-07-17T08:25:00.000Z'
+    primaryTool: 'codex', updatedAt: SOURCE_UPDATED_AT
   });
   assert.equal(snapshot.periods.day.overview.totalTokens, 1_200_000);
   assert.equal(snapshot.periods.month.overview.totalTokens, 9_000_000);
@@ -188,13 +194,13 @@ test('keeps multi-account provider identities stable without exporting account d
       {
         provider: 'codex', accountKey: 'workspace-a', accountEmail: 'a@example.com',
         authPath: '/Users/private/.codex/auth.json', token: 'secret-a', workspaceId: 'private-a',
-        status: 'ok', updatedAt: '2026-07-17T08:25:00.000Z',
+        status: 'ok', updatedAt: SOURCE_UPDATED_AT,
         windows: [{ kind: 'weekly', remainingPercent: 70 }]
       },
       {
         provider: 'codex', accountKey: 'workspace-b', accountEmail: 'b@example.com',
         authPath: '/Users/private/.codex/auth-b.json', token: 'secret-b', workspaceId: 'private-b',
-        status: 'ok', updatedAt: '2026-07-17T08:25:00.000Z',
+        status: 'ok', updatedAt: SOURCE_UPDATED_AT,
         windows: [{ kind: 'weekly', remainingPercent: 60 }]
       }
     ]}
@@ -220,14 +226,14 @@ test('keeps anonymous Provider IDs stable when quota status and values change', 
       status: 'ok',
       balance: { amount: 12.5, currency: 'USD' },
       windows: [{ kind: 'billing', remaining: 12.5 }],
-      updatedAt: '2026-07-17T08:25:00.000Z'
+      updatedAt: SOURCE_UPDATED_AT
     }] }
   };
   const first = buildSnapshot(stats, { now: NOW });
   stats.limits.providers[0].status = 'unavailable';
   stats.limits.providers[0].balance.amount = 3.25;
   stats.limits.providers[0].windows[0].remaining = 3.25;
-  stats.limits.providers[0].updatedAt = '2026-07-17T09:25:00.000Z';
+  stats.limits.providers[0].updatedAt = localIso(2026, 7, 17, 9, 25);
   const second = buildSnapshot(stats, { now: NOW });
 
   assert.equal(first.quota[0].instanceId, 'openrouter-single');
@@ -403,7 +409,7 @@ test('returns a complete empty schema and stale status for missing or old data',
   assert.deepEqual(empty.models, []);
   assert.equal(empty.status.noData, true);
 
-  const stale = buildSnapshot({ updatedAt: '2026-07-17T07:00:00Z' }, { now: NOW });
+  const stale = buildSnapshot({ updatedAt: localIso(2026, 7, 17, 7, 0) }, { now: NOW });
   assert.equal(stale.status.isStale, true);
   assert.equal(stale.status.dataAgeSeconds, 5400);
 });
@@ -612,8 +618,11 @@ test('provider status summarizes configuration and login requirements without id
 
 test('fingerprints business content while ignoring snapshot clock fields', () => {
   const stats = sampleStats();
-  const first = buildSnapshot(stats, { now: '2026-07-17T08:30:00Z' });
-  const later = buildSnapshot(stats, { now: '2026-07-17T09:30:00Z' });
+  // Two clocks an hour apart on the same *local* day: the claim is that the
+  // clock does not reach the fingerprint, so the pair must not also step the
+  // trend's day — which is what a `Z` pair does against a local-time `NOW`.
+  const first = buildSnapshot(stats, { now: NOW });
+  const later = buildSnapshot(stats, { now: localIso(2026, 7, 17, 9, 30) });
   assert.equal(macWidgetSnapshotFingerprint(first), macWidgetSnapshotFingerprint(later));
 
   const tokenChange = structuredClone(stats);

--- a/tests/shared/promaUsage.test.js
+++ b/tests/shared/promaUsage.test.js
@@ -8,6 +8,7 @@ const test = require('node:test');
 
 const { buildPromaHistoryGraph, buildTokscaleJson, buildPromaPeriods, PROMA_ROOT } = require('../../src/shared/promaUsage');
 const { extractUsageFromTokscale, mergePeriods } = require('../../src/shared/usage');
+const { localIso } = require('../helpers/localTime');
 
 function writeJsonl(filePath, rows) {
   fs.writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`);
@@ -188,8 +189,10 @@ test('Proma keeps undated usage out of bounded periods and Trends', () => {
 test('Proma history keeps per-day and per-model token attribution', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'proma-usage-'));
   writeJsonl(path.join(root, 'session.jsonl'), [
-    assistantRow({ id: 'first', model: 'Claude-Sonnet', createdAt: '2026-07-08T12:00:00.000Z', input: 10, output: 2 }),
-    assistantRow({ id: 'second', model: 'gpt-5', createdAt: '2026-07-09T12:00:00.000Z', input: 20 })
+    // `contributions` is keyed by local calendar day, so the rows are stated in
+    // local time — a `Z` noon lands on the neighbouring day past ±12.
+    assistantRow({ id: 'first', model: 'Claude-Sonnet', createdAt: localIso(2026, 7, 8, 12), input: 10, output: 2 }),
+    assistantRow({ id: 'second', model: 'gpt-5', createdAt: localIso(2026, 7, 9, 12), input: 20 })
   ]);
   const graph = buildPromaHistoryGraph({ roots: [root] });
   assert.deepEqual(graph.contributions, [

--- a/tests/shared/promaUsage.test.js
+++ b/tests/shared/promaUsage.test.js
@@ -122,15 +122,19 @@ test('Proma periods read each session file once before deriving all windows', ()
 
 test('Proma periods preserve JSONL session attribution across models', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'proma-usage-'));
+  const alphaStartedAt = localIso(2026, 7, 9, 10);
+  const alphaLastUsedAt = localIso(2026, 7, 9, 11);
+  const betaStartedAt = localIso(2026, 7, 9, 12);
+  const now = localIso(2026, 7, 9, 13);
   writeJsonl(path.join(root, 'session-alpha.jsonl'), [
-    assistantRow({ id: 'first', model: 'claude-sonnet', createdAt: '2026-07-09T10:00:00.000Z', input: 10 }),
-    assistantRow({ id: 'second', model: 'gpt-5', createdAt: '2026-07-09T11:00:00.000Z', output: 4 })
+    assistantRow({ id: 'first', model: 'claude-sonnet', createdAt: alphaStartedAt, input: 10 }),
+    assistantRow({ id: 'second', model: 'gpt-5', createdAt: alphaLastUsedAt, output: 4 })
   ]);
   writeJsonl(path.join(root, 'session-beta.jsonl'), [
-    assistantRow({ id: 'third', model: 'gpt-5', createdAt: '2026-07-09T12:00:00.000Z', input: 20 })
+    assistantRow({ id: 'third', model: 'gpt-5', createdAt: betaStartedAt, input: 20 })
   ]);
 
-  const periods = buildPromaPeriods({ now: '2026-07-09T13:00:00.000Z', allTimeSince: '2026-01-01', roots: [root] });
+  const periods = buildPromaPeriods({ now, allTimeSince: '2026-01-01', roots: [root] });
   assert.equal(periods.today.groupBy, 'client,session,model');
   const alphaId = periods.today.entries.find((entry) => entry.sessionId.startsWith('session-alpha@')).sessionId;
   const betaId = periods.today.entries.find((entry) => entry.sessionId.startsWith('session-beta@')).sessionId;
@@ -140,22 +144,25 @@ test('Proma periods preserve JSONL session attribution across models', () => {
   assert.equal(usage.sessions[`proma:${alphaId}`].totalTokens, 14);
   assert.equal(usage.sessions[`proma:${alphaId}`].messageCount, 2);
   assert.deepEqual(usage.sessions[`proma:${alphaId}`].models, { 'claude-sonnet': 10, 'gpt-5': 4 });
-  assert.equal(usage.sessions[`proma:${alphaId}`].startedAt, '2026-07-09T10:00:00.000Z');
-  assert.equal(usage.sessions[`proma:${alphaId}`].lastUsedAt, '2026-07-09T11:00:00.000Z');
+  assert.equal(usage.sessions[`proma:${alphaId}`].startedAt, alphaStartedAt);
+  assert.equal(usage.sessions[`proma:${alphaId}`].lastUsedAt, alphaLastUsedAt);
   assert.equal(usage.sessions[`proma:${betaId}`].totalTokens, 20);
 });
 
 test('Proma namespaces equal filenames from separate homes without exposing paths', () => {
   const firstRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'proma-home-a-'));
   const secondRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'proma-home-b-'));
+  const firstCreatedAt = localIso(2026, 7, 9, 10);
+  const secondCreatedAt = localIso(2026, 7, 9, 11);
+  const now = localIso(2026, 7, 9, 13);
   writeJsonl(path.join(firstRoot, 'session.jsonl'), [
-    assistantRow({ id: 'first', createdAt: '2026-07-09T10:00:00.000Z', input: 10 })
+    assistantRow({ id: 'first', createdAt: firstCreatedAt, input: 10 })
   ]);
   writeJsonl(path.join(secondRoot, 'session.jsonl'), [
-    assistantRow({ id: 'second', createdAt: '2026-07-09T11:00:00.000Z', input: 20 })
+    assistantRow({ id: 'second', createdAt: secondCreatedAt, input: 20 })
   ]);
 
-  const options = { now: '2026-07-09T13:00:00.000Z', allTimeSince: '2026-01-01' };
+  const options = { now, allTimeSince: '2026-01-01' };
   const host = extractUsageFromTokscale(buildPromaPeriods({ ...options, roots: [firstRoot] }).today);
   const wsl = extractUsageFromTokscale(buildPromaPeriods({ ...options, roots: [secondRoot] }).today);
   const usage = mergePeriods(host, wsl);

--- a/tests/shared/qoderCnUsage.test.js
+++ b/tests/shared/qoderCnUsage.test.js
@@ -22,6 +22,8 @@ const {
   resetQoderCnPricingCache
 } = require('../../src/shared/qoderCnUsage');
 
+const { localMs } = require('../helpers/localTime');
+
 const QODER_CN_DB_FIXTURE = path.join(__dirname, '..', 'fixtures', 'qoder-cn-local.db');
 
 test('QODER_CN_MODEL_DISPLAY_NAMES covers every official model code and the retired preview', () => {
@@ -76,19 +78,9 @@ test('normalizeQoderCnDbRow does not resolve inherited model names', () => {
   }
 });
 
-// buildQoderCnPeriods cuts "today" and "month" at *local* midnight, so a fixture
-// pinned to a UTC instant only lands on the day it means at some offsets: at
-// UTC+07 `2026-07-29T18:00:00Z` is already the 30th locally and a row two hours
-// behind it drops out of "today". Deriving the rows from the local midnight of
-// `now` instead states the boundary the code actually applies, so the same
-// assertion holds at every offset — and a rule that cut the day at UTC midnight
-// would fail everywhere except UTC rather than passing everywhere except a few.
-const localNoon = (year, monthIndex, day) => new Date(year, monthIndex, day, 12, 0, 0, 0).getTime();
-const localMidnight = (year, monthIndex, day) => new Date(year, monthIndex, day, 0, 0, 0, 0).getTime();
-
 test('buildQoderCnPeriods keeps day boundaries and tokscale-compatible totals', () => {
-  const now = localNoon(2026, 6, 29);
-  const dayStart = localMidnight(2026, 6, 29);
+  const now = localMs(2026, 7, 29, 12);
+  const dayStart = localMs(2026, 7, 29);
   const rows = [
     // One minute either side of the local day boundary: m1 belongs to the 28th
     // and only m2 to "today", whatever timezone the suite runs in.
@@ -192,10 +184,10 @@ test('Qoder CN cost uses input, output, cache-read, and cache-write rates', () =
 });
 
 test('undated Qoder CN rows count for allTime only, mirroring the proma includeUndated rule', () => {
-  const now = localNoon(2026, 6, 29);
+  const now = localMs(2026, 7, 29, 12);
   const rows = [
     { sessionId: 's1', messageId: 'm1', model: 'qmodel', input: 10, output: 2, cacheRead: 0, cacheWrite: 0, createdAt: 0, messages: 1 },
-    { sessionId: 's1', messageId: 'm2', model: 'qmodel', input: 20, output: 4, cacheRead: 0, cacheWrite: 0, createdAt: localMidnight(2026, 6, 29) + 60_000, messages: 1 }
+    { sessionId: 's1', messageId: 'm2', model: 'qmodel', input: 20, output: 4, cacheRead: 0, cacheWrite: 0, createdAt: localMs(2026, 7, 29) + 60_000, messages: 1 }
   ];
   const periods = buildQoderCnPeriods({ now: new Date(now).toISOString(), allTimeSince: '2026-01-01', rows });
   assert.equal(periods.today.totalInput, 20, 'undated row must not leak into today');

--- a/tests/shared/qoderCnUsage.test.js
+++ b/tests/shared/qoderCnUsage.test.js
@@ -76,11 +76,24 @@ test('normalizeQoderCnDbRow does not resolve inherited model names', () => {
   }
 });
 
+// buildQoderCnPeriods cuts "today" and "month" at *local* midnight, so a fixture
+// pinned to a UTC instant only lands on the day it means at some offsets: at
+// UTC+07 `2026-07-29T18:00:00Z` is already the 30th locally and a row two hours
+// behind it drops out of "today". Deriving the rows from the local midnight of
+// `now` instead states the boundary the code actually applies, so the same
+// assertion holds at every offset — and a rule that cut the day at UTC midnight
+// would fail everywhere except UTC rather than passing everywhere except a few.
+const localNoon = (year, monthIndex, day) => new Date(year, monthIndex, day, 12, 0, 0, 0).getTime();
+const localMidnight = (year, monthIndex, day) => new Date(year, monthIndex, day, 0, 0, 0, 0).getTime();
+
 test('buildQoderCnPeriods keeps day boundaries and tokscale-compatible totals', () => {
-  const now = Date.parse('2026-07-29T18:00:00Z');
+  const now = localNoon(2026, 6, 29);
+  const dayStart = localMidnight(2026, 6, 29);
   const rows = [
-    { sessionId: 's1', messageId: 'm1', model: 'qmodel', input: 10, output: 2, cacheRead: 3, cacheWrite: 0, createdAt: now - 24 * 60 * 60 * 1000, messages: 1 },
-    { sessionId: 's1', messageId: 'm2', model: 'qmodel', input: 20, output: 4, cacheRead: 5, cacheWrite: 0, createdAt: now - 2 * 60 * 60 * 1000, messages: 1 }
+    // One minute either side of the local day boundary: m1 belongs to the 28th
+    // and only m2 to "today", whatever timezone the suite runs in.
+    { sessionId: 's1', messageId: 'm1', model: 'qmodel', input: 10, output: 2, cacheRead: 3, cacheWrite: 0, createdAt: dayStart - 60_000, messages: 1 },
+    { sessionId: 's1', messageId: 'm2', model: 'qmodel', input: 20, output: 4, cacheRead: 5, cacheWrite: 0, createdAt: dayStart + 60_000, messages: 1 }
   ];
   const periods = buildQoderCnPeriods({ now: new Date(now).toISOString(), allTimeSince: '2026-01-01', rows });
   assert.equal(periods.today.totalInput, 20);
@@ -179,10 +192,10 @@ test('Qoder CN cost uses input, output, cache-read, and cache-write rates', () =
 });
 
 test('undated Qoder CN rows count for allTime only, mirroring the proma includeUndated rule', () => {
-  const now = Date.parse('2026-07-29T18:00:00Z');
+  const now = localNoon(2026, 6, 29);
   const rows = [
     { sessionId: 's1', messageId: 'm1', model: 'qmodel', input: 10, output: 2, cacheRead: 0, cacheWrite: 0, createdAt: 0, messages: 1 },
-    { sessionId: 's1', messageId: 'm2', model: 'qmodel', input: 20, output: 4, cacheRead: 0, cacheWrite: 0, createdAt: now - 2 * 60 * 60 * 1000, messages: 1 }
+    { sessionId: 's1', messageId: 'm2', model: 'qmodel', input: 20, output: 4, cacheRead: 0, cacheWrite: 0, createdAt: localMidnight(2026, 6, 29) + 60_000, messages: 1 }
   ];
   const periods = buildQoderCnPeriods({ now: new Date(now).toISOString(), allTimeSince: '2026-01-01', rows });
   assert.equal(periods.today.totalInput, 20, 'undated row must not leak into today');

--- a/tests/shared/reasonixSessionDetail.test.js
+++ b/tests/shared/reasonixSessionDetail.test.js
@@ -16,6 +16,7 @@ const {
   REASONIX_EVENT_REPLAY_LIMITS,
   REASONIX_EVENT_REPLAY_PROBE_MAX_BYTES
 } = require('../../src/shared/reasonixSessionDetail');
+const { localIso, localMs } = require('../helpers/localTime');
 
 function writeJson(filePath, value) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -55,19 +56,23 @@ test('Reasonix legacy typed model.final compatibility still maps prompts/turns/t
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'reasonix-detail-'));
   const stateHome = path.join(root, 'state');
   const projectDirectory = path.join('projects', 'opaque-project', 'sessions');
-  const firstTurn = '2026-08-08T10:00:00.000Z';
-  const oldTurn = '2026-07-31T10:00:00.000Z';
+  // `readReasonix`'s clock below is local (`new Date(2026, 7, 8, 12, 0)`) and the
+  // today/month reads bucket against it in local time, so the turns are stated
+  // the same way: as `Z` literals the recent turn crosses into the next local day
+  // past UTC+12 and drops out of both windows.
+  const firstTurn = localIso(2026, 8, 8, 10);
+  const oldTurn = localIso(2026, 7, 31, 10);
   writeSidecarSession(stateHome, projectDirectory, 'filename-is-not-the-id', {
     id: 'branch-123',
     scope: 'project',
     workspace_root: path.join(root, 'private-workspace')
   }, [
     JSON.stringify({ type: 'user.message', ts: firstTurn, text: '测试一下' }),
-    JSON.stringify({ type: 'model.turn.started', ts: '2026-08-08T10:00:01.000Z', turn: 1 }),
-    JSON.stringify({ type: 'tool.intent', ts: '2026-08-08T10:00:02.000Z', turn: 1, name: 'read_file' }),
+    JSON.stringify({ type: 'model.turn.started', ts: localIso(2026, 8, 8, 10, 0, 1), turn: 1 }),
+    JSON.stringify({ type: 'tool.intent', ts: localIso(2026, 8, 8, 10, 0, 2), turn: 1, name: 'read_file' }),
     JSON.stringify({
       type: 'model.final',
-      ts: '2026-08-08T10:00:03.000Z',
+      ts: localIso(2026, 8, 8, 10, 0, 3),
       turn: 1,
       usage: {
         prompt_tokens: 30696,
@@ -82,7 +87,7 @@ test('Reasonix legacy typed model.final compatibility still maps prompts/turns/t
     JSON.stringify({ type: 'user.message', ts: oldTurn, text: '上个月的请求' }),
     JSON.stringify({
       type: 'model.final',
-      ts: '2026-07-31T10:00:03.000Z',
+      ts: localIso(2026, 7, 31, 10, 0, 3),
       turn: 2,
       usage: {
         prompt_tokens: 10,
@@ -133,39 +138,44 @@ test('Reasonix official schema replays replace/append, timestamps messages, and 
   const directory = path.join(stateHome, 'sessions');
   fs.mkdirSync(directory, { recursive: true });
   writeJson(path.join(directory, 'filename-is-not-the-id.jsonl.meta'), { BranchMeta: { ID: 'snapshot-1' } });
+  // Same local clock as the test above, and the epoch literals these messages
+  // used to carry (`1786179601000` = `2026-08-08T09:00:01Z`) name a UTC instant.
+  // Deriving them from local time keeps every message on the clock's local day,
+  // which is the day the today/month reads below assert against.
+  const dayBase = localMs(2026, 8, 8, 9);
   const initial = {
     schema_version: 1,
     type: 'replace',
-    created_at: '2026-08-08T09:00:00.000Z',
+    created_at: localIso(2026, 8, 8, 9),
     messages: [
       { id: 'system', role: 'system', content: 'internal' },
       {
         id: 'user-1',
         role: 'user',
-        createdAt: 1786179601000,
+        createdAt: dayBase + 1_000,
         raw_content: '<response-language>English</response-language><reasoning-language>English</reasoning-language><active-goal>internal</active-goal>\n真实输入<memory-recall>internal recall</memory-recall>',
         content: '<reasoning-language>English</reasoning-language>\nprovider-visible wrapper'
       },
-      { id: 'assistant-1', role: 'assistant', createdAt: 1786179602000, tool_calls: [{ name: 'search' }] },
-      { id: 'tool-1', role: 'tool', createdAt: 1786179602500, name: 'search' },
+      { id: 'assistant-1', role: 'assistant', createdAt: dayBase + 2_000, tool_calls: [{ name: 'search' }] },
+      { id: 'tool-1', role: 'tool', createdAt: dayBase + 2_500, name: 'search' },
       {
         id: 'old-user',
         role: 'user',
-        createdAt: '2026-07-31T10:00:01.000Z',
+        createdAt: localIso(2026, 7, 31, 10, 0, 1),
         raw_content: '上个月的请求',
         content: 'provider old request'
       },
-      { id: 'old-assistant', role: 'assistant', createdAt: '2026-07-31T10:00:02.000Z' }
+      { id: 'old-assistant', role: 'assistant', createdAt: localIso(2026, 7, 31, 10, 0, 2) }
     ]
   };
   const append = {
     schema_version: 1,
     type: 'append',
     message_index: 6,
-    created_at: '2026-08-08T09:01:00.000Z',
+    created_at: localIso(2026, 8, 8, 9, 1),
     messages: [
-      { id: 'user-2', role: 'user', createdAt: 1786179661000, raw_content: '推送远端', content: 'provider request' },
-      { id: 'assistant-2', role: 'assistant', createdAt: 1786179662000, tool_calls: [{ function: { name: 'write_file' } }] }
+      { id: 'user-2', role: 'user', createdAt: dayBase + 61_000, raw_content: '推送远端', content: 'provider request' },
+      { id: 'assistant-2', role: 'assistant', createdAt: dayBase + 62_000, tool_calls: [{ function: { name: 'write_file' } }] }
     ]
   };
   fs.writeFileSync(path.join(directory, 'filename-is-not-the-id.events.jsonl'), `${JSON.stringify(initial)}\n${JSON.stringify(append)}\n`);

--- a/tests/shared/reasonixSessions.test.js
+++ b/tests/shared/reasonixSessions.test.js
@@ -23,6 +23,7 @@ const { collectUsageOnce, projectIdentity, watchIgnoreMatcher, watchPathsForClie
 const { syncPayload } = require('../../src/shared/syncPayload');
 const { createDeviceState } = require('../../src/shared/deviceState');
 const { captureSessionUsageArchive } = require('../../src/shared/sessionUsageArchive');
+const { localIso, localMs } = require('../helpers/localTime');
 const { projectRowsForPeriod } = require('../../src/electron/renderer/projectRows');
 const { sessionRowsForPeriod } = require('../../src/electron/renderer/sessionRows');
 const { composeLocalSyncStats } = require('../../src/electron/syncDisplayStats');
@@ -167,22 +168,28 @@ test('Reasonix native adapter derives msg count from the trusted official transc
   const sessionsDir = path.join(stateHome, 'sessions');
   const metaPath = path.join(sessionsDir, 'official.jsonl.meta');
   const eventsPath = path.join(sessionsDir, 'official.events.jsonl');
+  // `getView`'s clock below is local, and the epoch literals this fixture used to
+  // carry (`1786179601000` = `2026-08-08T09:00:01Z`) name a UTC instant, so the
+  // messages left the clock's local day past ±9 and the session dropped out of
+  // `today`. The rest of the file already states its fixtures this way
+  // (`localDateIso`); these two tests were the ones that did not.
+  const dayBase = localMs(2026, 8, 8, 9);
   writeJson(metaPath, {
     BranchMeta: { ID: 'branch-from-official-meta' },
     schema_version: 1,
-    created_at: '2026-08-08T09:00:00.000Z',
-    updated_at: '2026-08-08T09:02:00.000Z',
+    created_at: localIso(2026, 8, 8, 9),
+    updated_at: localIso(2026, 8, 8, 9, 2),
     model: 'deepseek/deepseek-v4-flash'
   });
   fs.writeFileSync(eventsPath, `${JSON.stringify({
     schema_version: 1,
     type: 'replace',
-    created_at: '2026-08-08T09:00:00.000Z',
+    created_at: localIso(2026, 8, 8, 9),
     messages: [
-      { role: 'user', raw_content: 'first', createdAt: 1786179601000 },
-      { role: 'assistant', createdAt: 1786179602000, tool_calls: [{ name: 'search' }] },
-      { role: 'tool', name: 'search', createdAt: 1786179602500 },
-      { role: 'assistant', createdAt: 1786179603000 }
+      { role: 'user', raw_content: 'first', createdAt: dayBase + 1_000 },
+      { role: 'assistant', createdAt: dayBase + 2_000, tool_calls: [{ name: 'search' }] },
+      { role: 'tool', name: 'search', createdAt: dayBase + 2_500 },
+      { role: 'assistant', createdAt: dayBase + 3_000 }
     ]
   })}\n`);
 
@@ -204,11 +211,18 @@ test('Reasonix resumed sessions use the latest trusted event message for live pe
   const stateHome = path.join(root, 'state');
   const sessionsDir = path.join(stateHome, 'projects', '-home-global-workspace', 'sessions');
   const id = 'resumed-with-events';
+  // The point of the test is that one session spans two local days and the live
+  // periods take their date from the *later* message, so all four stamps have to
+  // be local: as `Z` literals the pair collapses onto one local day at some
+  // offsets and splits across two different ones at others.
+  const yesterdayMessage = localIso(2026, 8, 8, 13);
+  const yesterdayReply = localIso(2026, 8, 8, 13, 0, 1);
+  const todayMessage = localIso(2026, 8, 9, 3);
   const paths = sidecars(sessionsDir, id, {
     id,
     schema_version: 1,
-    created_at: '2026-08-08T13:00:00.000Z',
-    updated_at: '2026-08-09T03:00:00.000Z',
+    created_at: yesterdayMessage,
+    updated_at: todayMessage,
     scope: 'global',
     model: 'deepseek-flash/deepseek-v4-flash'
   }, nativeTelemetry({ totalTokens: 320 }));
@@ -217,32 +231,32 @@ test('Reasonix resumed sessions use the latest trusted event message for live pe
     {
       schema_version: 1,
       type: 'replace',
-      created_at: '2026-08-08T13:00:00.000Z',
+      created_at: yesterdayMessage,
       messages: [
-        { role: 'user', raw_content: '昨天的输入', content: '<reasoning-language>内部包装</reasoning-language>昨天的输入', createdAt: Date.parse('2026-08-08T13:00:00.000Z') },
-        { role: 'assistant', createdAt: Date.parse('2026-08-08T13:00:01.000Z') }
+        { role: 'user', raw_content: '昨天的输入', content: '<reasoning-language>内部包装</reasoning-language>昨天的输入', createdAt: Date.parse(yesterdayMessage) },
+        { role: 'assistant', createdAt: Date.parse(yesterdayReply) }
       ]
     },
     {
       schema_version: 1,
       type: 'append',
       message_index: 2,
-      created_at: '2026-08-09T03:00:00.000Z',
+      created_at: todayMessage,
       messages: [
-        { role: 'user', raw_content: '今天继续', createdAt: Date.parse('2026-08-09T03:00:00.000Z') },
+        { role: 'user', raw_content: '今天继续', createdAt: Date.parse(todayMessage) },
         { role: 'assistant' }
       ]
     }
   ].map((record) => JSON.stringify(record)).join('\n') + '\n');
 
   const session = readReasonixNativeSession(paths.metaPath, paths.telemetryPath, { eventPath });
-  assert.equal(session.lastMessageAt, '2026-08-09T03:00:00.000Z');
+  assert.equal(session.lastMessageAt, todayMessage);
   assert.equal(session.model, 'deepseek-v4-flash');
   assert.equal(session.reportedCostUsd, 0.25);
   assert.equal(session.sessionDetailAvailable, false);
 
   const view = cacheFor(stateHome, projectIdentity).getView({
-    now: new Date('2026-08-09T12:00:00.000Z')
+    now: new Date(2026, 7, 9, 12, 0, 0)
   });
   assert.ok(view.sessions.today[`reasonix:${id}`]);
   assert.ok(view.sessions.month[`reasonix:${id}`]);

--- a/tests/shared/sessionDetail.test.js
+++ b/tests/shared/sessionDetail.test.js
@@ -137,6 +137,7 @@ test('parseClaudeTranscript counts one reply once across content-block splits an
 });
 
 const { groupEvents, filterExchangesByPeriod, distributeCost } = require('../../src/shared/sessionDetail');
+const { localDate, localIso } = require('../helpers/localTime');
 
 function turn(ts, total, tools = []) {
   return { kind: 'turn', timestamp: ts, tokens: { input: total, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0, total }, tools };
@@ -168,12 +169,15 @@ test('turns before any prompt go in a leading exchange', () => {
 });
 
 test('filterExchangesByPeriod keeps only in-period turns and drops empties', () => {
-  const now = new Date('2026-05-30T12:00:00.000Z');
+  // `today` is cut at local midnight, so the clock and both exchanges are stated
+  // in local time. Written as `Z` instants the two exchanges share one local day
+  // at some offsets, and then the filter has nothing to exclude.
+  const now = localDate(2026, 5, 30, 12);
   const ex = groupEvents([
-    { kind: 'prompt', timestamp: '2026-05-29T06:00:00.000Z', text: 'yesterday' },
-    turn('2026-05-29T06:00:01.000Z', 999),
-    { kind: 'prompt', timestamp: '2026-05-30T06:00:00.000Z', text: 'today' },
-    turn('2026-05-30T06:00:01.000Z', 100)
+    { kind: 'prompt', timestamp: localIso(2026, 5, 29, 6), text: 'yesterday' },
+    turn(localIso(2026, 5, 29, 6, 0, 1), 999),
+    { kind: 'prompt', timestamp: localIso(2026, 5, 30, 6), text: 'today' },
+    turn(localIso(2026, 5, 30, 6, 0, 1), 100)
   ]);
   const today = filterExchangesByPeriod(ex, 'today', now);
   assert.equal(today.length, 1);

--- a/tests/shared/sessionUsageArchive.test.js
+++ b/tests/shared/sessionUsageArchive.test.js
@@ -21,6 +21,8 @@ const {
   writeSessionUsageArchive
 } = archiveApi;
 
+const { localDate } = require('../helpers/localTime');
+
 function liveSummary() {
   return {
     deviceId: 'macbook',
@@ -213,9 +215,13 @@ test('captures and reapplies missing sessions for any client without double-coun
 });
 
 test('archive day and month windows expire while all-time stays available', () => {
-  const archive = captureSessionUsageArchive({}, liveSummary(), new Date('2026-07-09T08:15:00.000Z'));
+  // The month window expires on the local calendar month, and this is the one
+  // pair in the file that straddles a month edge: `2026-08-01T00:20Z` is still
+  // July locally at every negative offset, so as a `Z` literal the read lands in
+  // the same month it was captured in and the window under test never expires.
+  const archive = captureSessionUsageArchive({}, liveSummary(), localDate(2026, 7, 9, 8, 15));
   const nextMonth = applySessionUsageArchive(summaryAfterOpenCodeDelete(), archive, {
-    now: new Date('2026-08-01T00:20:00.000Z')
+    now: localDate(2026, 8, 1, 0, 20)
   });
 
   assert.equal(nextMonth.today.sessions['opencode:o1'], undefined);


### PR DESCRIPTION
## Summary

Makes the local-day and local-month test fixtures reported in #481 timezone-independent while preserving their intended boundary coverage.

- Adds shared local-time fixture helpers in `tests/helpers/localTime.js`.
- Converts the affected Qoder CN, Proma, Reasonix, session archive/detail, client archive, and macOS Widget fixtures to use local calendar parts.
- Keeps the boundary-sensitive cases immediately before and after local midnight.
- Adds full-suite CI coverage across representative positive, negative, extreme, and fractional timezone offsets.

No runtime code or API behavior changed.

## Coverage

The fixtures now express the local calendar day they intend to test instead of relying on UTC `Z` literals. Mutating the production logic to cut periods at UTC midnight is caught outside UTC, so the change removes timezone-dependent failures without weakening local-midnight coverage.

## Validation

- `npm run verify`: 3577 passed, 0 failed, 1 skipped
- All GitHub CI jobs passed, including the timezone and macOS Widget jobs
- Proma tests passed across UTC and all seven additional CI timezones

Closes #481

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins day/month boundary and trend fixtures to local time to match production bucketing and prevent false failures at non-UTC offsets; expands CI to sample negative and fractional timezones.

- Adds `tests/helpers/localTime.js` (`localDate`, `localMs`, `localIso`) and converts fixtures in `qoderCnUsage`, `promaUsage`, `macWidgetSnapshot`, `reasonixSessionDetail`, `reasonixSessions`, `sessionDetail`, `clientUsageArchive`, and `sessionUsageArchive` to local time.
- Anchors select fixtures one minute on either side of local midnight to assert boundaries.
- Adds a `timezones` job in `.github/workflows/ci.yml` to run tests under several `TZ` values, including fractional and negative offsets.

| Area | Before | After |
| --- | --- | --- |
| Test fixture clocks | UTC instants that silently shift calendar days at different offsets | Instants derived from local calendar parts via `localTime` helpers |
| Boundary coverage | Some boundary assertions only held at UTC; UTC-midnight regression could pass | Fixtures straddle local midnight; UTC-midnight regression fails across offsets (except UTC) |
| CI timezone sampling | All jobs ran at UTC only | `timezones` job runs the suite at several offsets (+07, +05:45, +12:45, -07/-08, -10, -11, +14) |

- Implementation: runtime unchanged; centralize timezone reasoning in `tests/helpers/localTime.js`.
- Validation: suite passes across listed `TZ`s; mutants that cut days at UTC midnight now fail outside UTC.
- Migration: when asserting day/month windows, use `localDate`/`localMs`/`localIso`; avoid `Z` literals for boundary-sensitive cases.
- Risk: slightly longer CI from the added job; no runtime or API changes.

<sup>Written for commit 0b862d9edaa60d11d67323858ed9587326fd898b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

