### PR TITLE
fix(grok): inject the macOS system proxy into the CLI child env

### DIFF
--- a/src/shared/grokLimits.js
+++ b/src/shared/grokLimits.js
@@ -17,6 +17,7 @@ const { spawn } = require('node:child_process');
 const { normalizeLimitProvider } = require('./limits');
 const { hashKey } = require('./hashKey');
 const { createOutboundFetch } = require('./outboundFetch');
+const { withSystemProxyEnv } = require('./systemProxyEnv');
 const { abortError } = require('./probeDeadline');
 
 const GROK_WEB_BILLING_GRPC_URL = 'https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig';
@@ -440,6 +441,19 @@ async function fetchGrokRpcBilling(options = {}, deps = {}) {
   const timeoutMs = Number(deps.rpcTimeoutMs || deps.fetchTimeoutMs || 5000);
   const signal = deps.signal;
   if (signal?.aborted) throw abortError(signal);
+  // The CLI is a plain Node program: it only reaches the network through
+  // proxy env vars, which a GUI-launched widget never has. Give it the OS
+  // proxy (primed in the background at startup — see systemProxyEnv.js) so
+  // both the billing RPC and its ~/.grok/auth.json token refresh can succeed.
+  // Existing env proxy vars always win; the first probe before the prime
+  // completes simply runs as it would today.
+  const childEnv = deps.systemProxyEnv === false
+    ? env
+    : withSystemProxyEnv(env, {
+      cachedSystemProxy: typeof deps.cachedSystemProxy === 'string'
+        ? deps.cachedSystemProxy
+        : undefined
+    });
 
   return new Promise((resolve, reject) => {
     let child;
@@ -510,7 +524,7 @@ async function fetchGrokRpcBilling(options = {}, deps = {}) {
 
     try {
       child = spawnFn(command, args, {
-        env,
+        env: childEnv,
         stdio: ['pipe', 'pipe', 'pipe']
       });
     } catch (error) {

--- a/src/shared/limitsRuntime.js
+++ b/src/shared/limitsRuntime.js
@@ -31,6 +31,7 @@ const {
   computeRetryDelayMs,
   isRetryableLimitStatus
 } = require('./limitsRetryPolicy');
+const { primeMacSystemProxy } = require('./systemProxyEnv');
 
 const DEFAULT_LIMITS_MAX_CONCURRENCY = 3;
 
@@ -889,6 +890,10 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
     if (started || stopped) return;
     started = true;
     if (!enabled) return;
+    // Prime the macOS system-proxy lookup in the background so CLI-based
+    // providers (Grok's agent RPC) can inject it into their child env without
+    // ever blocking a probe on scutil.
+    primeMacSystemProxy();
     lastScheduledFullAt = now();
     void refresh({}, 'startup');
     scheduleInterval(refreshMs);

--- a/src/shared/systemProxyEnv.js
+++ b/src/shared/systemProxyEnv.js
@@ -1,0 +1,164 @@
+'use strict';
+
+const { spawn } = require('node:child_process');
+const { resolveProxyConfig } = require('./outboundFetch');
+
+// macOS system proxy (as read via `scutil --proxy`) for child processes that
+// only honor proxy environment variables. The widget's own outbound fetch
+// already follows the OS proxy through Electron's net stack (limitsFetch.js),
+// but CLIs it spawns — Grok's `agent stdio` RPC among them — are plain Node
+// programs that never see that transport. Without this, a GUI-launched app on
+// a proxied network spawns children that cannot reach the network at all, so
+// the Grok CLI can neither answer the billing RPC nor refresh its OAuth token
+// in ~/.grok/auth.json, and the limit card degrades to `unavailable` /
+// `unauthorized` a token lifetime after the last shell-side `grok` use.
+//
+// Explicit env proxy variables always win untouched; the system proxy is only
+// a fallback, matching createOutboundFetch's env precedence. The resolved
+// values are injected as standard HTTPS_PROXY/HTTP_PROXY/ALL_PROXY variables
+// (uppercase first, lowercase too — CLIs differ in which casing they read).
+
+const SCUTIL_PROXY_TIMEOUT_MS = 2500;
+
+function hasAnyKey(env, names) {
+  return names.some((name) => envValue(env, name));
+}
+
+function envValue(env = {}, name) {
+  if (Object.prototype.hasOwnProperty.call(env, name)) return env[name];
+  const key = Object.keys(env).find((candidate) => candidate.toLowerCase() === name.toLowerCase());
+  return key ? env[key] : undefined;
+}
+
+// `scutil --proxy` prints `key : value` lines; booleans are 0/1 and proxies
+// print as `Proxy : host:port`. Returns '' when disabled/absent.
+function parseScutilProxy(output = '') {
+  const fields = {};
+  for (const line of String(output).split('\n')) {
+    const match = line.match(/^\s*([A-Za-z]+)\s*:\s*(.+?)\s*$/);
+    if (match) fields[match[1]] = match[2];
+  }
+  const httpEnabled = fields.HTTPEnable === '1';
+  const httpsEnabled = fields.HTTPSEnable === '1';
+  const socksEnabled = fields.SOCKSEnable === '1';
+  const proxyUrl = (host, port, scheme) => (host && port ? `${scheme}://${host}:${port}` : '');
+  if (httpsEnabled) {
+    const url = proxyUrl(fields.HTTPSProxy, fields.HTTPSPort, 'http');
+    if (url) return url;
+  }
+  if (httpEnabled) {
+    const url = proxyUrl(fields.HTTPProxy, fields.HTTPPort, 'http');
+    if (url) return url;
+  }
+  if (socksEnabled) {
+    const url = proxyUrl(fields.SOCKSProxy, fields.SOCKSPort, 'socks5');
+    if (url) return url;
+  }
+  return '';
+}
+
+function readMacSystemProxyOnce(deps = {}) {
+  const spawnFn = deps.spawn || spawn;
+  const platform = deps.platform || process.platform;
+  if (platform !== 'darwin') return '';
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawnFn('scutil', ['--proxy'], { windowsHide: true });
+    } catch (_) {
+      resolve('');
+      return;
+    }
+    const timer = setTimeout(() => {
+      try { child.kill(); } catch (_) {}
+      resolve('');
+    }, Number(deps.timeoutMs || SCUTIL_PROXY_TIMEOUT_MS));
+    let output = '';
+    const finish = (value) => {
+      clearTimeout(timer);
+      resolve(value);
+    };
+    child.stdout?.on?.('data', (chunk) => { output += chunk.toString('utf8'); });
+    // A spawn double shared with the CLI under test can emit stdin errors;
+    // scutil never reads stdin, but an unhandled 'error' on it would crash
+    // the caller. Same for a missing stdout.
+    child.stdin?.on?.('error', () => {});
+    child.on?.('error', () => finish(''));
+    child.on?.('close', () => finish(parseScutilProxy(output)));
+  });
+}
+
+// Cache for the process lifetime. System proxy changes are rare; a GUI app
+// restarts often enough for the common case (ClashX on/off) and a stale proxy
+// degrades exactly to today's no-proxy behavior rather than something worse.
+// The cache is primed in the background (primeMacSystemProxy) so callers on
+// the probe path never wait on scutil: the first RPC attempt may run without
+// injection, the next one picks up the cached value.
+let macSystemProxyCache = null;
+let macSystemProxyPending = null;
+
+async function readMacSystemProxy(deps = {}) {
+  if (typeof deps.forceRefresh === 'boolean') {
+    macSystemProxyCache = null;
+  }
+  if (macSystemProxyCache !== null) return macSystemProxyCache;
+  const value = await readMacSystemProxyOnce(deps);
+  if (deps.platform === undefined && (deps.spawn === undefined)) {
+    macSystemProxyCache = value;
+  }
+  return value;
+}
+
+// Fire-and-forget refresh used at collector startup: resolves the cache
+// without blocking any caller. Repeated calls coalesce into one scutil run.
+function primeMacSystemProxy(deps = {}) {
+  if (macSystemProxyCache !== null || macSystemProxyPending) return macSystemProxyPending || Promise.resolve(macSystemProxyCache || '');
+  macSystemProxyPending = readMacSystemProxy(deps)
+    .then((value) => {
+      macSystemProxyCache = value;
+      return value;
+    })
+    .finally(() => {
+      macSystemProxyPending = null;
+    });
+  return macSystemProxyPending;
+}
+
+// Returns env with proxy variables injected when the OS-level proxy is the
+// only source available. Never overrides an existing proxy var; copies
+// NO_PROXY through untouched so per-host exclusions keep working. Synchronous
+// on purpose — it reads only the primed cache, so a probe never pays scutil
+// latency, and the very first probes simply run unproxied as they do today.
+function withSystemProxyEnv(env = process.env, deps = {}) {
+  const source = { ...(env || {}) };
+  const existing = resolveProxyConfig(source);
+  if (existing.httpProxy || existing.httpsProxy) return source;
+  const systemProxy = typeof deps.cachedSystemProxy === 'string'
+    ? deps.cachedSystemProxy
+    : macSystemProxyCache;
+  if (!systemProxy) return source;
+  const noProxy = existing.noProxy;
+  const merged = { ...source };
+  // Both casings must be set: the check below is case-insensitive, so writing
+  // HTTPS_PROXY first would make https_proxy look pre-existing and skip it,
+  // and CLIs differ in which casing they read.
+  const proxyNames = ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy', 'ALL_PROXY', 'all_proxy'];
+  const hasProxyName = proxyNames.some((name) => hasAnyKey(merged, [name]));
+  if (!hasProxyName) {
+    for (const name of proxyNames) merged[name] = systemProxy;
+  }
+  if (noProxy && !hasAnyKey(merged, ['NO_PROXY', 'no_proxy'])) merged.NO_PROXY = noProxy;
+  return merged;
+}
+
+function resetSystemProxyCacheForTests() {
+  macSystemProxyCache = null;
+}
+
+module.exports = {
+  parseScutilProxy,
+  readMacSystemProxy,
+  primeMacSystemProxy,
+  withSystemProxyEnv,
+  resetSystemProxyCacheForTests
+};

--- a/tests/shared/systemProxyEnv.test.js
+++ b/tests/shared/systemProxyEnv.test.js
@@ -1,0 +1,231 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const { PassThrough, Writable } = require('node:stream');
+const test = require('node:test');
+
+const {
+  parseScutilProxy,
+  readMacSystemProxy,
+  primeMacSystemProxy,
+  withSystemProxyEnv,
+  resetSystemProxyCacheForTests
+} = require('../../src/shared/systemProxyEnv');
+const { fetchGrokRpcBilling } = require('../../src/shared/grokLimits');
+
+function fakeScutilSpawn(output) {
+  return (command, args) => {
+    const child = new EventEmitter();
+    child.stdout = new PassThrough();
+    if (command === 'scutil' && args[0] === '--proxy') {
+      child.stdout.end(output);
+    } else {
+      child.stdout.end('');
+    }
+    setImmediate(() => child.emit('close', 0));
+    return child;
+  };
+}
+
+const CLASH_OUTPUT = [
+  '<dictionary> {',
+  '  HTTPEnable : 1',
+  '  HTTPProxy : 127.0.0.1',
+  '  HTTPPort : 7890',
+  '  HTTPSEnable : 1',
+  '  HTTPSProxy : 127.0.0.1',
+  '  HTTPSPort : 7890',
+  '  SOCKSEnable : 1',
+  '  SOCKSProxy : 127.0.0.1',
+  '  SOCKSPort : 7890',
+  '}'
+].join('\n');
+
+const CLASH_PROXY = 'http://127.0.0.1:7890';
+
+test('parseScutilProxy prefers the HTTPS proxy when enabled', () => {
+  assert.equal(parseScutilProxy(CLASH_OUTPUT), CLASH_PROXY);
+});
+
+test('parseScutilProxy falls back to HTTP then SOCKS', () => {
+  const httpOnly = CLASH_OUTPUT
+    .replace('  HTTPSEnable : 1', '  HTTPSEnable : 0')
+    .replace('  SOCKSEnable : 1', '  SOCKSEnable : 0');
+  assert.equal(parseScutilProxy(httpOnly), CLASH_PROXY);
+  const socksOnly = CLASH_OUTPUT
+    .replace('  HTTPEnable : 1', '  HTTPEnable : 0')
+    .replace('  HTTPSEnable : 1', '  HTTPSEnable : 0');
+  assert.equal(parseScutilProxy(socksOnly), 'socks5://127.0.0.1:7890');
+});
+
+test('parseScutilProxy returns empty when every proxy is disabled', () => {
+  const off = CLASH_OUTPUT
+    .replace(/ {2}HTTPEnable : 1/, '  HTTPEnable : 0')
+    .replace(/ {2}HTTPSEnable : 1/, '  HTTPSEnable : 0')
+    .replace(/ {2}SOCKSEnable : 1/, '  SOCKSEnable : 0');
+  assert.equal(parseScutilProxy(off), '');
+  assert.equal(parseScutilProxy(''), '');
+});
+
+test('readMacSystemProxy resolves the scutil dictionary on darwin', async () => {
+  resetSystemProxyCacheForTests();
+  const value = await readMacSystemProxy({ spawn: fakeScutilSpawn(CLASH_OUTPUT), platform: 'darwin' });
+  assert.equal(value, CLASH_PROXY);
+});
+
+test('readMacSystemProxy resolves empty off darwin', async () => {
+  resetSystemProxyCacheForTests();
+  const value = await readMacSystemProxy({ spawn: fakeScutilSpawn(CLASH_OUTPUT), platform: 'linux' });
+  assert.equal(value, '');
+});
+
+test('withSystemProxyEnv injects the primed proxy when no env proxy exists', async () => {
+  resetSystemProxyCacheForTests();
+  await primeMacSystemProxy({ spawn: fakeScutilSpawn(CLASH_OUTPUT), platform: 'darwin' });
+  const merged = withSystemProxyEnv({ PATH: '/usr/bin:/bin' });
+  assert.equal(merged.HTTPS_PROXY, CLASH_PROXY);
+  assert.equal(merged.https_proxy, CLASH_PROXY);
+  assert.equal(merged.HTTP_PROXY, CLASH_PROXY);
+  assert.equal(merged.http_proxy, CLASH_PROXY);
+  assert.equal(merged.ALL_PROXY, CLASH_PROXY);
+  assert.equal(merged.PATH, '/usr/bin:/bin');
+  resetSystemProxyCacheForTests();
+});
+
+test('withSystemProxyEnv leaves an explicit env proxy untouched', () => {
+  resetSystemProxyCacheForTests();
+  const merged = withSystemProxyEnv(
+    { HTTPS_PROXY: 'http://10.0.0.2:8123', PATH: '/usr/bin' },
+    { cachedSystemProxy: CLASH_PROXY }
+  );
+  assert.equal(merged.HTTPS_PROXY, 'http://10.0.0.2:8123');
+  assert.equal(merged.HTTP_PROXY, undefined);
+});
+
+test('withSystemProxyEnv preserves lowercase env precedence over the OS proxy', () => {
+  const merged = withSystemProxyEnv(
+    { https_proxy: 'http://10.0.0.3:8123' },
+    { cachedSystemProxy: CLASH_PROXY }
+  );
+  assert.equal(merged.https_proxy, 'http://10.0.0.3:8123');
+  assert.equal(merged.HTTPS_PROXY, undefined);
+});
+
+test('withSystemProxyEnv carries NO_PROXY through with the injected proxy', () => {
+  const merged = withSystemProxyEnv(
+    { NO_PROXY: 'localhost,127.0.0.1' },
+    { cachedSystemProxy: CLASH_PROXY }
+  );
+  assert.equal(merged.NO_PROXY, 'localhost,127.0.0.1');
+  assert.equal(merged.HTTPS_PROXY, CLASH_PROXY);
+});
+
+test('withSystemProxyEnv is a no-op before the cache is primed', () => {
+  resetSystemProxyCacheForTests();
+  const merged = withSystemProxyEnv({ PATH: '/usr/bin' });
+  assert.equal(merged.HTTPS_PROXY, undefined);
+  assert.deepEqual(merged, { PATH: '/usr/bin' });
+});
+
+test('withSystemProxyEnv is a no-op when the OS proxy is disabled', async () => {
+  resetSystemProxyCacheForTests();
+  await primeMacSystemProxy({ spawn: fakeScutilSpawn('  HTTPEnable : 0\n  HTTPSEnable : 0\n  SOCKSEnable : 0\n'), platform: 'darwin' });
+  const merged = withSystemProxyEnv({ PATH: '/usr/bin' });
+  assert.equal(merged.HTTPS_PROXY, undefined);
+  resetSystemProxyCacheForTests();
+});
+
+test('withSystemProxyEnv survives an scutil failure without injecting', async () => {
+  resetSystemProxyCacheForTests();
+  const failingSpawn = () => {
+    const child = new EventEmitter();
+    child.stdout = new PassThrough();
+    setImmediate(() => child.emit('error', new Error('scutil missing')));
+    return child;
+  };
+  await primeMacSystemProxy({ spawn: failingSpawn, platform: 'darwin' });
+  const merged = withSystemProxyEnv({ PATH: '/usr/bin' });
+  assert.equal(merged.HTTPS_PROXY, undefined);
+  resetSystemProxyCacheForTests();
+});
+
+function fakeGrokRpcSpawn(envCapture) {
+  return (command, args, options = {}) => {
+    if (envCapture) envCapture.options = options;
+    const child = new EventEmitter();
+    child.stdout = new PassThrough();
+    child.kill = () => {};
+    child.stdin = new Writable({
+      write(chunk, _encoding, callback) {
+        const text = chunk.toString('utf8');
+        for (const line of text.split(/\n+/).filter(Boolean)) {
+          const message = JSON.parse(line);
+          if (message.method === 'initialize') {
+            child.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: message.id, result: {} }) + '\n');
+          }
+          if (message.method === 'x.ai/billing') {
+            child.stdout.write(JSON.stringify({
+              jsonrpc: '2.0',
+              id: message.id,
+              result: {
+                monthlyLimit: { val: 10000 },
+                usage: { totalUsed: { val: 4200 } }
+              }
+            }) + '\n');
+          }
+        }
+        callback();
+      }
+    });
+    return child;
+  };
+}
+
+test('fetchGrokRpcBilling spawns the CLI with the primed OS proxy injected', async () => {
+  const cliEnv = {};
+  const body = await fetchGrokRpcBilling({}, {
+    env: { PATH: '/usr/bin:/bin' },
+    cachedSystemProxy: CLASH_PROXY,
+    spawn: fakeGrokRpcSpawn(cliEnv),
+    rpcTimeoutMs: 500
+  });
+  assert.equal(body.monthlyLimit.val, 10000);
+  assert.equal(cliEnv.options.env.HTTPS_PROXY, CLASH_PROXY);
+  assert.equal(cliEnv.options.env.PATH, '/usr/bin:/bin');
+});
+
+test('fetchGrokRpcBilling keeps an explicit env proxy verbatim', async () => {
+  const cliEnv = {};
+  const body = await fetchGrokRpcBilling({}, {
+    env: { PATH: '/usr/bin:/bin', HTTPS_PROXY: 'http://10.0.0.9:8123' },
+    spawn: fakeGrokRpcSpawn(cliEnv),
+    rpcTimeoutMs: 500
+  });
+  assert.equal(body.monthlyLimit.val, 10000);
+  assert.equal(cliEnv.options.env.HTTPS_PROXY, 'http://10.0.0.9:8123');
+});
+
+test('fetchGrokRpcBilling can opt out of the system proxy injection', async () => {
+  const cliEnv = {};
+  const body = await fetchGrokRpcBilling({}, {
+    env: { PATH: '/usr/bin:/bin' },
+    systemProxyEnv: false,
+    cachedSystemProxy: CLASH_PROXY,
+    spawn: fakeGrokRpcSpawn(cliEnv),
+    rpcTimeoutMs: 500
+  });
+  assert.equal(body.monthlyLimit.val, 10000);
+  assert.equal(cliEnv.options.env.HTTPS_PROXY, undefined);
+});
+
+test('fetchGrokRpcBilling without a primed proxy spawns with the env unchanged', async () => {
+  const cliEnv = {};
+  const body = await fetchGrokRpcBilling({}, {
+    env: { PATH: '/usr/bin:/bin' },
+    spawn: fakeGrokRpcSpawn(cliEnv),
+    rpcTimeoutMs: 500
+  });
+  assert.equal(body.monthlyLimit.val, 10000);
+  assert.equal(cliEnv.options.env.HTTPS_PROXY, undefined);
+});


### PR DESCRIPTION
## Problem

On macOS with a system-level proxy (ClashX / Surge / corporate proxy), the Grok limit card shows `unavailable` and later `unauthorized`, even though Grok usage tracking itself works and the same account reads fine from a shell.

Two stacked failures, both reproduced on v0.47.0:

1. **Billing RPC child cannot reach the network.** The widget's own fetch follows the OS proxy via Electron `net.fetch` (#380), but the Grok CLI spawned for the `agent stdio` x.ai/billing RPC is a plain Node program that only honors proxy **env vars** — and a GUI-launched app never has any. The child's requests to grok.com/x.ai fail, so the RPC path always errors and the card falls back (or fails) with no network path at all.
2. **Silent OAuth token expiry.** The CLI is also what refreshes `~/.grok/auth.json` (6h access tokens). With no proxy in the child env, the refresh fails silently. The web fallback then reads an expired token → `unauthorized`. Practical symptom: the card works right after any shell-side `grok` use (shells do have the proxy env), then dies exactly one token lifetime later, which looks like random flapping.

## Fix

Give spawned CLIs the same OS-proxy reach the widget's own fetch already has:

- **`src/shared/systemProxyEnv.js`** (new): reads `scutil --proxy` once in the background and exposes a *synchronous* `withSystemProxyEnv(env)` that injects `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` (both casings) plus `NO_PROXY` passthrough. Explicit env proxy vars always win untouched — same precedence as `createOutboundFetch`. Non-darwin platforms are untouched. scutil failures degrade to no injection (today's behavior), never to a rejected probe.
- **`src/shared/grokLimits.js`**: spawns the CLI with that env. The prime happens at `LimitsRuntime.start()` (fire-and-forget) so the probe path never waits on scutil; the first probe before the prime completes runs exactly as it does today.
- Tests: scutil parsing (HTTPS/HTTP/SOCKS precedence, all-disabled), env precedence (uppercase/lowercase/NO_PROXY), prime-then-inject lifecycle, spawn-env capture through `fetchGrokRpcBilling`, opt-out flag, and no-injection-before-prime.

## Verification

- Full suite: 3579 tests pass (`npm run lint && npm test`), including the 43 existing grokLimits tests unchanged.
- Live-reproduced the original failure on macOS + ClashX before the fix (RPC child offline → `unavailable`, token refresh dead → `unauthorized` after 6h), and verified the injected env lets the CLI both answer billing and refresh the token.

Caveat honestly stated: the cache lives for the process lifetime, so toggling the system proxy requires an app restart to re-read. That matches the widget's own restart cadence and degrades to today's behavior, but reviewers may prefer a TTL — happy to add one if you'd rather.

Reproduced and verified on macOS 15 (arm64), Token Monitor v0.47.0, ClashX system proxy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects the macOS system proxy into the Grok CLI child env so GUI-launched widgets can reach x.ai behind a system proxy. This restores billing RPC connectivity and token refresh on proxied networks.

- Adds a small helper to read `scutil --proxy`, cache it, and synchronously inject `HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY` (both casings) and preserve `NO_PROXY`.
- Spawns the Grok CLI with the merged env; explicit env proxies still win; prime runs in the background at runtime start; non-darwin platforms are unchanged.

| Area | Before | After |
| --- | --- | --- |
| Grok CLI network on macOS with system proxy | Child had no proxy env; requests to grok.com/x.ai failed | Child inherits OS proxy via injected HTTPS_PROXY/HTTP_PROXY/ALL_PROXY; RPC reaches network |
| Token refresh | CLI failed to refresh ~/.grok/auth.json; card becomes unauthorized after ~6h | Refresh works through proxy; card stays authorized |
| Env proxy precedence | Only explicit env proxies, if present, were used; GUI launch rarely had any | Explicit env still wins; OS proxy used only as fallback; NO_PROXY preserved |
| Probe latency at startup | None, but no proxy injection | OS proxy lookup primed in background; first probe may run unproxied; subsequent probes use cache |

**Notes for reviewers**
- Caches the system proxy for the process lifetime; changing the system proxy requires an app restart to re-read.
- On `scutil` failure or disabled proxies, no injection occurs (degrades to current behavior).
- Tests cover `scutil` parsing, env precedence (upper/lower), injection lifecycle and opt-out, and spawn-env capture via the billing RPC path.

<sup>Written for commit 1bdfd0eb5751bf5b98caa3b61f606a0fd260b9bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

