### PR TITLE
feat(grok): manage the Grok OAuth token in the widget's own credential store

### DIFF
--- a/src/electron/runtimeConfig.js
+++ b/src/electron/runtimeConfig.js
@@ -191,6 +191,8 @@ function limitsConfigFromSettings(settings = {}, context = {}) {
     kimiApiKey: settings.kimiApiKey || '',
     kimiWebAccessToken: settings.kimiWebAccessToken || '',
     ollamaCookie: settings.ollamaCookie || '',
+    grokRefreshToken: settings.grokRefreshToken || '',
+    grokClientId: settings.grokClientId || '',
     codexManagedAccounts: context.codexManagedAccounts ?? settings.codexManagedAccounts ?? [],
     mimoManagedAccounts: context.mimoManagedAccounts ?? settings.mimoManagedAccounts ?? [],
     thirdPartyProfiles: settings.thirdPartyProfiles || {}

--- a/src/shared/credentialStore.js
+++ b/src/shared/credentialStore.js
@@ -31,7 +31,9 @@ const CREDENTIAL_SETTING_PATHS = Object.freeze({
   kimiApiKey: ['providers', 'kimi', 'apiKey'],
   kimiWebAccessToken: ['providers', 'kimi', 'webAccessToken'],
   ollamaCookie: ['providers', 'ollama', 'cookie'],
-  thirdPartyProfiles: ['providers', 'thirdparty', 'profiles']
+  thirdPartyProfiles: ['providers', 'thirdparty', 'profiles'],
+  grokRefreshToken: ['providers', 'grok', 'refreshToken'],
+  grokClientId: ['providers', 'grok', 'clientId']
 });
 
 function emptyDocument() {

--- a/src/shared/grokLimits.js
+++ b/src/shared/grokLimits.js
@@ -17,12 +17,14 @@ const { spawn } = require('node:child_process');
 const { normalizeLimitProvider } = require('./limits');
 const { hashKey } = require('./hashKey');
 const { createOutboundFetch } = require('./outboundFetch');
+const { withSystemProxyEnv } = require('./systemProxyEnv');
 const { abortError } = require('./probeDeadline');
 
 const GROK_WEB_BILLING_GRPC_URL = 'https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig';
 const GROK_KEY_NAMES = ['GROK_BEARER_TOKEN'];
 const GROK_OIDC_PREFIX = 'https://auth.x.ai::';
 const GROK_LEGACY_SCOPE = 'https://accounts.x.ai/sign-in';
+const GROK_TOKEN_ENDPOINT = 'https://auth.x.ai/oauth2/token';
 
 function resolveGrokHome(env = process.env) {
   if (typeof env.GROK_HOME === 'string' && env.GROK_HOME.trim()) {
@@ -86,6 +88,62 @@ function grokCredential(env = process.env, options = {}) {
     if (raw) return { token: raw, source: 'env' };
   }
   return readAuthJson(env, options);
+}
+
+// Exchange a stored refresh_token for a fresh access_token via xAI's OIDC
+// token endpoint. This lets the widget manage its own Grok credential
+// independently of the CLI's ~/.grok/auth.json — the CLI's 6h access tokens
+// expire silently on a proxied network because the GUI-spawned CLI can't
+// reach auth.x.ai to refresh, so the widget holds its own refresh_token
+// (imported once from auth.json or entered in settings) and refreshes it
+// through the same system-proxy-aware fetch the rest of the widget uses.
+//
+// xAI uses soft refresh-token rotation: the old token stays valid for a
+// while after a new one is issued, so the CLI and the widget can each hold
+// their own copy without one invalidating the other. The new refresh_token
+// is returned so the caller can persist it for next time.
+async function refreshGrokAccessToken(refreshToken, clientId, deps = {}) {
+  const token = cleanSecret(refreshToken);
+  const id = cleanSecret(clientId);
+  if (!token || !id) return null;
+  const fetchFn = resolveGrokFetch(deps);
+  const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+  const timeoutMs = Number(deps.refreshTimeoutMs || 12000);
+  const timer = controller ? setTimeout(() => controller.abort(), timeoutMs) : null;
+  try {
+    const response = await fetchFn(GROK_TOKEN_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json'
+      },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: token,
+        client_id: id
+      }).toString(),
+      ...(controller ? { signal: controller.signal } : {})
+    });
+    if (!response.ok) {
+      const err = new Error(`Grok token refresh failed (HTTP ${response.status})`);
+      err.status = response.status === 401 || response.status === 403 ? 'unauthorized' : 'unavailable';
+      throw err;
+    }
+    const body = await response.json();
+    if (!body || typeof body.access_token !== 'string' || !body.access_token) {
+      const err = new Error('Grok token refresh returned no access_token');
+      err.status = 'unavailable';
+      throw err;
+    }
+    return {
+      accessToken: body.access_token,
+      refreshToken: typeof body.refresh_token === 'string' && body.refresh_token ? body.refresh_token : token,
+      expiresIn: Number(body.expires_in) || 21600,
+      tokenType: body.token_type || 'Bearer'
+    };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 function numberOrNull(value) {
@@ -440,6 +498,19 @@ async function fetchGrokRpcBilling(options = {}, deps = {}) {
   const timeoutMs = Number(deps.rpcTimeoutMs || deps.fetchTimeoutMs || 5000);
   const signal = deps.signal;
   if (signal?.aborted) throw abortError(signal);
+  // The CLI is a plain Node program: it only reaches the network through
+  // proxy env vars, which a GUI-launched widget never has. Give it the OS
+  // proxy (primed in the background at startup — see systemProxyEnv.js) so
+  // both the billing RPC and its ~/.grok/auth.json token refresh can succeed.
+  // Existing env proxy vars always win; the first probe before the prime
+  // completes simply runs as it would today.
+  const childEnv = deps.systemProxyEnv === false
+    ? env
+    : withSystemProxyEnv(env, {
+      cachedSystemProxy: typeof deps.cachedSystemProxy === 'string'
+        ? deps.cachedSystemProxy
+        : undefined
+    });
 
   return new Promise((resolve, reject) => {
     let child;
@@ -510,7 +581,7 @@ async function fetchGrokRpcBilling(options = {}, deps = {}) {
 
     try {
       child = spawnFn(command, args, {
-        env,
+        env: childEnv,
         stdio: ['pipe', 'pipe', 'pipe']
       });
     } catch (error) {
@@ -654,6 +725,43 @@ async function fetchGrokLimits(options = {}, deps = {}) {
   const env = deps.env || process.env;
   const now = (deps.now || Date.now)();
   const updatedAt = new Date(now).toISOString();
+
+  // Managed credential path: when the user has imported a refresh_token into
+  // the widget's own credential store (or GROK_REFRESH_TOKEN env), the widget
+  // refreshes it independently — no dependency on the CLI's ~/.grok/auth.json,
+  // no race with the CLI's own token refresh. The system-proxy-aware fetch
+  // (resolveGrokFetch) handles the network reach, same as the web billing
+  // fallback below.
+  const managedRefreshToken = cleanSecret(options.grokRefreshToken) || cleanSecret(env.GROK_REFRESH_TOKEN);
+  const managedClientId = cleanSecret(options.grokClientId) || cleanSecret(env.GROK_CLIENT_ID);
+  if (managedRefreshToken && managedClientId) {
+    if (deps.signal?.aborted) throw abortError(deps.signal);
+    try {
+      const refreshed = await (deps.refreshAccessToken || refreshGrokAccessToken)(managedRefreshToken, managedClientId, deps);
+      if (refreshed) {
+        const managedCredential = { token: refreshed.accessToken, source: 'managed', email: '' };
+        const windows = await (deps.fetchWebGrpcBilling || fetchGrokWebGrpcBilling)(managedCredential, deps);
+        return normalizeLimitProvider({
+          provider: 'grok',
+          accountKey: hashKey('grok', refreshed.accessToken),
+          accountLabel: 'SuperGrok',
+          accountEmail: '',
+          source: 'web',
+          sourceDetail: 'managed',
+          status: 'ok',
+          updatedAt,
+          windows
+        });
+      }
+    } catch (_managedError) {
+      if (deps.signal?.aborted) throw abortError(deps.signal);
+      // Fall through to the auto-detected auth.json path rather than failing
+      // hard: the CLI may have refreshed auth.json since the import, and the
+      // ambient path can still produce a reading.
+    }
+  }
+
+  // Auto-detected path: ~/.grok/auth.json (written by `grok login`) or env.
   const credential = grokCredential(env, { ...options, ...(deps.grokHome ? { grokHome: deps.grokHome } : {}) });
   if (shouldTryGrokRpc(credential, deps)) {
     try {
@@ -743,9 +851,11 @@ module.exports = {
   GROK_KEY_NAMES,
   GROK_OIDC_PREFIX,
   GROK_LEGACY_SCOPE,
+  GROK_TOKEN_ENDPOINT,
   resolveGrokHome,
   readAuthJson,
   grokCredential,
+  refreshGrokAccessToken,
   parseGrokBilling,
   parseGrokGrpcWebBilling,
   resolveGrokFetch,

--- a/src/shared/limitsRuntime.js
+++ b/src/shared/limitsRuntime.js
@@ -31,6 +31,7 @@ const {
   computeRetryDelayMs,
   isRetryableLimitStatus
 } = require('./limitsRetryPolicy');
+const { primeMacSystemProxy } = require('./systemProxyEnv');
 
 const DEFAULT_LIMITS_MAX_CONCURRENCY = 3;
 
@@ -889,6 +890,10 @@ function createLimitsRuntime(initialOptions = {}, deps = {}) {
     if (started || stopped) return;
     started = true;
     if (!enabled) return;
+    // Prime the macOS system-proxy lookup in the background so CLI-based
+    // providers (Grok's agent RPC) can inject it into their child env without
+    // ever blocking a probe on scutil.
+    primeMacSystemProxy();
     lastScheduledFullAt = now();
     void refresh({}, 'startup');
     scheduleInterval(refreshMs);

--- a/src/shared/systemProxyEnv.js
+++ b/src/shared/systemProxyEnv.js
@@ -1,0 +1,164 @@
+'use strict';
+
+const { spawn } = require('node:child_process');
+const { resolveProxyConfig } = require('./outboundFetch');
+
+// macOS system proxy (as read via `scutil --proxy`) for child processes that
+// only honor proxy environment variables. The widget's own outbound fetch
+// already follows the OS proxy through Electron's net stack (limitsFetch.js),
+// but CLIs it spawns — Grok's `agent stdio` RPC among them — are plain Node
+// programs that never see that transport. Without this, a GUI-launched app on
+// a proxied network spawns children that cannot reach the network at all, so
+// the Grok CLI can neither answer the billing RPC nor refresh its OAuth token
+// in ~/.grok/auth.json, and the limit card degrades to `unavailable` /
+// `unauthorized` a token lifetime after the last shell-side `grok` use.
+//
+// Explicit env proxy variables always win untouched; the system proxy is only
+// a fallback, matching createOutboundFetch's env precedence. The resolved
+// values are injected as standard HTTPS_PROXY/HTTP_PROXY/ALL_PROXY variables
+// (uppercase first, lowercase too — CLIs differ in which casing they read).
+
+const SCUTIL_PROXY_TIMEOUT_MS = 2500;
+
+function hasAnyKey(env, names) {
+  return names.some((name) => envValue(env, name));
+}
+
+function envValue(env = {}, name) {
+  if (Object.prototype.hasOwnProperty.call(env, name)) return env[name];
+  const key = Object.keys(env).find((candidate) => candidate.toLowerCase() === name.toLowerCase());
+  return key ? env[key] : undefined;
+}
+
+// `scutil --proxy` prints `key : value` lines; booleans are 0/1 and proxies
+// print as `Proxy : host:port`. Returns '' when disabled/absent.
+function parseScutilProxy(output = '') {
+  const fields = {};
+  for (const line of String(output).split('\n')) {
+    const match = line.match(/^\s*([A-Za-z]+)\s*:\s*(.+?)\s*$/);
+    if (match) fields[match[1]] = match[2];
+  }
+  const httpEnabled = fields.HTTPEnable === '1';
+  const httpsEnabled = fields.HTTPSEnable === '1';
+  const socksEnabled = fields.SOCKSEnable === '1';
+  const proxyUrl = (host, port, scheme) => (host && port ? `${scheme}://${host}:${port}` : '');
+  if (httpsEnabled) {
+    const url = proxyUrl(fields.HTTPSProxy, fields.HTTPSPort, 'http');
+    if (url) return url;
+  }
+  if (httpEnabled) {
+    const url = proxyUrl(fields.HTTPProxy, fields.HTTPPort, 'http');
+    if (url) return url;
+  }
+  if (socksEnabled) {
+    const url = proxyUrl(fields.SOCKSProxy, fields.SOCKSPort, 'socks5');
+    if (url) return url;
+  }
+  return '';
+}
+
+function readMacSystemProxyOnce(deps = {}) {
+  const spawnFn = deps.spawn || spawn;
+  const platform = deps.platform || process.platform;
+  if (platform !== 'darwin') return '';
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawnFn('scutil', ['--proxy'], { windowsHide: true });
+    } catch (_) {
+      resolve('');
+      return;
+    }
+    const timer = setTimeout(() => {
+      try { child.kill(); } catch (_) {}
+      resolve('');
+    }, Number(deps.timeoutMs || SCUTIL_PROXY_TIMEOUT_MS));
+    let output = '';
+    const finish = (value) => {
+      clearTimeout(timer);
+      resolve(value);
+    };
+    child.stdout?.on?.('data', (chunk) => { output += chunk.toString('utf8'); });
+    // A spawn double shared with the CLI under test can emit stdin errors;
+    // scutil never reads stdin, but an unhandled 'error' on it would crash
+    // the caller. Same for a missing stdout.
+    child.stdin?.on?.('error', () => {});
+    child.on?.('error', () => finish(''));
+    child.on?.('close', () => finish(parseScutilProxy(output)));
+  });
+}
+
+// Cache for the process lifetime. System proxy changes are rare; a GUI app
+// restarts often enough for the common case (ClashX on/off) and a stale proxy
+// degrades exactly to today's no-proxy behavior rather than something worse.
+// The cache is primed in the background (primeMacSystemProxy) so callers on
+// the probe path never wait on scutil: the first RPC attempt may run without
+// injection, the next one picks up the cached value.
+let macSystemProxyCache = null;
+let macSystemProxyPending = null;
+
+async function readMacSystemProxy(deps = {}) {
+  if (typeof deps.forceRefresh === 'boolean') {
+    macSystemProxyCache = null;
+  }
+  if (macSystemProxyCache !== null) return macSystemProxyCache;
+  const value = await readMacSystemProxyOnce(deps);
+  if (deps.platform === undefined && (deps.spawn === undefined)) {
+    macSystemProxyCache = value;
+  }
+  return value;
+}
+
+// Fire-and-forget refresh used at collector startup: resolves the cache
+// without blocking any caller. Repeated calls coalesce into one scutil run.
+function primeMacSystemProxy(deps = {}) {
+  if (macSystemProxyCache !== null || macSystemProxyPending) return macSystemProxyPending || Promise.resolve(macSystemProxyCache || '');
+  macSystemProxyPending = readMacSystemProxy(deps)
+    .then((value) => {
+      macSystemProxyCache = value;
+      return value;
+    })
+    .finally(() => {
+      macSystemProxyPending = null;
+    });
+  return macSystemProxyPending;
+}
+
+// Returns env with proxy variables injected when the OS-level proxy is the
+// only source available. Never overrides an existing proxy var; copies
+// NO_PROXY through untouched so per-host exclusions keep working. Synchronous
+// on purpose — it reads only the primed cache, so a probe never pays scutil
+// latency, and the very first probes simply run unproxied as they do today.
+function withSystemProxyEnv(env = process.env, deps = {}) {
+  const source = { ...(env || {}) };
+  const existing = resolveProxyConfig(source);
+  if (existing.httpProxy || existing.httpsProxy) return source;
+  const systemProxy = typeof deps.cachedSystemProxy === 'string'
+    ? deps.cachedSystemProxy
+    : macSystemProxyCache;
+  if (!systemProxy) return source;
+  const noProxy = existing.noProxy;
+  const merged = { ...source };
+  // Both casings must be set: the check below is case-insensitive, so writing
+  // HTTPS_PROXY first would make https_proxy look pre-existing and skip it,
+  // and CLIs differ in which casing they read.
+  const proxyNames = ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy', 'ALL_PROXY', 'all_proxy'];
+  const hasProxyName = proxyNames.some((name) => hasAnyKey(merged, [name]));
+  if (!hasProxyName) {
+    for (const name of proxyNames) merged[name] = systemProxy;
+  }
+  if (noProxy && !hasAnyKey(merged, ['NO_PROXY', 'no_proxy'])) merged.NO_PROXY = noProxy;
+  return merged;
+}
+
+function resetSystemProxyCacheForTests() {
+  macSystemProxyCache = null;
+}
+
+module.exports = {
+  parseScutilProxy,
+  readMacSystemProxy,
+  primeMacSystemProxy,
+  withSystemProxyEnv,
+  resetSystemProxyCacheForTests
+};

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -13,6 +13,7 @@ const path = require('node:path');
 const { performance } = require('node:perf_hooks');
 
 const { emptyPeriod } = require('../../src/shared/usage');
+const { localDayKey } = require('../../src/shared/history');
 const {
   clampTimerDelayMs, SYNC_MIN_INTERVAL_MS, SYNC_SOURCE_EVENT_MIN_INTERVAL_MS
 } = require('../../src/shared/selfSyncThrottle');
@@ -2778,7 +2779,7 @@ test('collector publishes live periods when only Qoder CN history read fails', a
   const originalRows = qoderCnUsage.collectQoderCnRows;
   const originalHistory = qoderCnUsage.buildQoderCnHistoryGraph;
   let failHistory = false;
-  const todayKey = new Date().toISOString().slice(0, 10);
+  const todayKey = localDayKey();
   qoderCnUsage.collectQoderCnRows = async () => [];
   qoderCnUsage.buildQoderCnHistoryGraph = () => {
     if (failHistory) throw new Error('temporary Qoder CN history read failure');

--- a/tests/shared/grokManagedToken.test.js
+++ b/tests/shared/grokManagedToken.test.js
@@ -1,0 +1,205 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  refreshGrokAccessToken,
+  fetchGrokLimits
+} = require('../../src/shared/grokLimits');
+
+function fakeResponse(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    arrayBuffer: async () => Buffer.from(body),
+    headers: new Map()
+  };
+}
+
+test('refreshGrokAccessToken exchanges a refresh_token for an access_token', async () => {
+  const result = await refreshGrokAccessToken('rt-abc', 'cid-xyz', {
+    fetch: async () => fakeResponse({
+      access_token: 'new-access-token',
+      refresh_token: 'new-rt',
+      expires_in: 21600,
+      token_type: 'Bearer'
+    })
+  });
+  assert.equal(result.accessToken, 'new-access-token');
+  assert.equal(result.refreshToken, 'new-rt');
+  assert.equal(result.expiresIn, 21600);
+  assert.equal(result.tokenType, 'Bearer');
+});
+
+test('refreshGrokAccessToken keeps the old refresh_token when rotation is absent', async () => {
+  const result = await refreshGrokAccessToken('rt-abc', 'cid-xyz', {
+    fetch: async () => fakeResponse({
+      access_token: 'new-access-token',
+      expires_in: 21600
+    })
+  });
+  assert.equal(result.refreshToken, 'rt-abc');
+});
+
+test('refreshGrokAccessToken returns null when inputs are empty', async () => {
+  assert.equal(await refreshGrokAccessToken('', 'cid', { fetch: async () => fakeResponse({}) }), null);
+  assert.equal(await refreshGrokAccessToken('rt', '', { fetch: async () => fakeResponse({}) }), null);
+});
+
+test('refreshGrokAccessToken maps 401 to unauthorized', async () => {
+  await assert.rejects(
+    refreshGrokAccessToken('rt', 'cid', { fetch: async () => fakeResponse({}, 401) }),
+    (error) => {
+      assert.match(error.message, /HTTP 401/);
+      assert.equal(error.status, 'unauthorized');
+      return true;
+    }
+  );
+});
+
+test('refreshGrokAccessToken maps 500 to unavailable', async () => {
+  await assert.rejects(
+    refreshGrokAccessToken('rt', 'cid', { fetch: async () => fakeResponse({}, 500) }),
+    (error) => {
+      assert.equal(error.status, 'unavailable');
+      return true;
+    }
+  );
+});
+
+test('refreshGrokAccessToken rejects when access_token is missing', async () => {
+  await assert.rejects(
+    refreshGrokAccessToken('rt', 'cid', { fetch: async () => fakeResponse({ refresh_token: 'x' }) }),
+    (error) => {
+      assert.equal(error.status, 'unavailable');
+      return true;
+    }
+  );
+});
+
+// --- fetchGrokLimits managed-credential path ---
+
+function fakeWebGrpcBilling(windows) {
+  return async () => windows;
+}
+
+function fakeRefresh(successBody) {
+  return async () => ({
+    accessToken: successBody.access_token,
+    refreshToken: successBody.refresh_token || 'rt-old',
+    expiresIn: successBody.expires_in || 21600,
+    tokenType: 'Bearer'
+  });
+}
+
+test('fetchGrokLimits uses the managed refresh_token path when configured', async () => {
+  const provider = await fetchGrokLimits(
+    { grokRefreshToken: 'rt-managed', grokClientId: 'cid-managed' },
+    {
+      env: {},
+      refreshAccessToken: fakeRefresh({ access_token: 'fresh-access', refresh_token: 'rt-rotated' }),
+      fetchWebGrpcBilling: fakeWebGrpcBilling([{
+        kind: 'billing',
+        label: 'Weekly',
+        usedPercent: 50,
+        resetsAt: '2026-08-25T00:00:00.000Z',
+        windowMinutes: 10080,
+        showMeter: true
+      }])
+    }
+  );
+  assert.equal(provider.status, 'ok');
+  assert.equal(provider.source, 'web');
+  assert.equal(provider.sourceDetail, 'managed');
+  assert.equal(provider.accountLabel, 'SuperGrok');
+  assert.equal(provider.windows.length, 1);
+  assert.equal(provider.windows[0].usedPercent, 50);
+});
+
+test('fetchGrokLimits falls back to auth.json when managed refresh fails', async () => {
+  const fs = require('node:fs');
+  const os = require('node:os');
+  const path = require('node:path');
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-fallback-'));
+  fs.writeFileSync(path.join(home, 'auth.json'), JSON.stringify({
+    'https://auth.x.ai::test': {
+      key: 'ambient-access-token',
+      email: 'test@example.com',
+      refresh_token: 'ambient-rt'
+    }
+  }));
+  const provider = await fetchGrokLimits(
+    { grokRefreshToken: 'rt-managed', grokClientId: 'cid-managed' },
+    {
+      env: {},
+      grokHome: home,
+      refreshAccessToken: async () => { throw new Error('refresh failed'); },
+      fetchWebGrpcBilling: fakeWebGrpcBilling([{
+        kind: 'billing',
+        label: 'Weekly',
+        usedPercent: 30,
+        resetsAt: '2026-08-25T00:00:00.000Z',
+        windowMinutes: 10080,
+        showMeter: true
+      }])
+    }
+  );
+  assert.equal(provider.status, 'ok');
+  assert.equal(provider.source, 'web');
+  assert.equal(provider.accountEmail, 'test@example.com');
+});
+
+test('fetchGrokLimits skips the managed path when no refresh_token is configured', async () => {
+  const fs = require('node:fs');
+  const os = require('node:os');
+  const path = require('node:path');
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-skip-'));
+  fs.writeFileSync(path.join(home, 'auth.json'), JSON.stringify({
+    'https://auth.x.ai::test': {
+      key: 'ambient-access-token',
+      email: 'test@example.com'
+    }
+  }));
+  let refreshCalled = false;
+  const provider = await fetchGrokLimits(
+    {},
+    {
+      env: {},
+      grokHome: home,
+      refreshAccessToken: async () => { refreshCalled = true; return null; },
+      fetchWebGrpcBilling: fakeWebGrpcBilling([{
+        kind: 'billing',
+        label: 'Weekly',
+        usedPercent: 42,
+        resetsAt: '2026-08-25T00:00:00.000Z',
+        windowMinutes: 10080,
+        showMeter: true
+      }])
+    }
+  );
+  assert.equal(refreshCalled, false);
+  assert.equal(provider.status, 'ok');
+  assert.equal(provider.source, 'web');
+});
+
+test('fetchGrokLimits managed path reads GROK_REFRESH_TOKEN env as fallback', async () => {
+  const provider = await fetchGrokLimits(
+    {},
+    {
+      env: { GROK_REFRESH_TOKEN: 'rt-env', GROK_CLIENT_ID: 'cid-env' },
+      refreshAccessToken: fakeRefresh({ access_token: 'fresh-from-env' }),
+      fetchWebGrpcBilling: fakeWebGrpcBilling([{
+        kind: 'billing',
+        label: 'Weekly',
+        usedPercent: 60,
+        resetsAt: '2026-08-25T00:00:00.000Z',
+        windowMinutes: 10080,
+        showMeter: true
+      }])
+    }
+  );
+  assert.equal(provider.status, 'ok');
+  assert.equal(provider.sourceDetail, 'managed');
+});

--- a/tests/shared/systemProxyEnv.test.js
+++ b/tests/shared/systemProxyEnv.test.js
@@ -1,0 +1,231 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const { PassThrough, Writable } = require('node:stream');
+const test = require('node:test');
+
+const {
+  parseScutilProxy,
+  readMacSystemProxy,
+  primeMacSystemProxy,
+  withSystemProxyEnv,
+  resetSystemProxyCacheForTests
+} = require('../../src/shared/systemProxyEnv');
+const { fetchGrokRpcBilling } = require('../../src/shared/grokLimits');
+
+function fakeScutilSpawn(output) {
+  return (command, args) => {
+    const child = new EventEmitter();
+    child.stdout = new PassThrough();
+    if (command === 'scutil' && args[0] === '--proxy') {
+      child.stdout.end(output);
+    } else {
+      child.stdout.end('');
+    }
+    setImmediate(() => child.emit('close', 0));
+    return child;
+  };
+}
+
+const CLASH_OUTPUT = [
+  '<dictionary> {',
+  '  HTTPEnable : 1',
+  '  HTTPProxy : 127.0.0.1',
+  '  HTTPPort : 7890',
+  '  HTTPSEnable : 1',
+  '  HTTPSProxy : 127.0.0.1',
+  '  HTTPSPort : 7890',
+  '  SOCKSEnable : 1',
+  '  SOCKSProxy : 127.0.0.1',
+  '  SOCKSPort : 7890',
+  '}'
+].join('\n');
+
+const CLASH_PROXY = 'http://127.0.0.1:7890';
+
+test('parseScutilProxy prefers the HTTPS proxy when enabled', () => {
+  assert.equal(parseScutilProxy(CLASH_OUTPUT), CLASH_PROXY);
+});
+
+test('parseScutilProxy falls back to HTTP then SOCKS', () => {
+  const httpOnly = CLASH_OUTPUT
+    .replace('  HTTPSEnable : 1', '  HTTPSEnable : 0')
+    .replace('  SOCKSEnable : 1', '  SOCKSEnable : 0');
+  assert.equal(parseScutilProxy(httpOnly), CLASH_PROXY);
+  const socksOnly = CLASH_OUTPUT
+    .replace('  HTTPEnable : 1', '  HTTPEnable : 0')
+    .replace('  HTTPSEnable : 1', '  HTTPSEnable : 0');
+  assert.equal(parseScutilProxy(socksOnly), 'socks5://127.0.0.1:7890');
+});
+
+test('parseScutilProxy returns empty when every proxy is disabled', () => {
+  const off = CLASH_OUTPUT
+    .replace(/ {2}HTTPEnable : 1/, '  HTTPEnable : 0')
+    .replace(/ {2}HTTPSEnable : 1/, '  HTTPSEnable : 0')
+    .replace(/ {2}SOCKSEnable : 1/, '  SOCKSEnable : 0');
+  assert.equal(parseScutilProxy(off), '');
+  assert.equal(parseScutilProxy(''), '');
+});
+
+test('readMacSystemProxy resolves the scutil dictionary on darwin', async () => {
+  resetSystemProxyCacheForTests();
+  const value = await readMacSystemProxy({ spawn: fakeScutilSpawn(CLASH_OUTPUT), platform: 'darwin' });
+  assert.equal(value, CLASH_PROXY);
+});
+
+test('readMacSystemProxy resolves empty off darwin', async () => {
+  resetSystemProxyCacheForTests();
+  const value = await readMacSystemProxy({ spawn: fakeScutilSpawn(CLASH_OUTPUT), platform: 'linux' });
+  assert.equal(value, '');
+});
+
+test('withSystemProxyEnv injects the primed proxy when no env proxy exists', async () => {
+  resetSystemProxyCacheForTests();
+  await primeMacSystemProxy({ spawn: fakeScutilSpawn(CLASH_OUTPUT), platform: 'darwin' });
+  const merged = withSystemProxyEnv({ PATH: '/usr/bin:/bin' });
+  assert.equal(merged.HTTPS_PROXY, CLASH_PROXY);
+  assert.equal(merged.https_proxy, CLASH_PROXY);
+  assert.equal(merged.HTTP_PROXY, CLASH_PROXY);
+  assert.equal(merged.http_proxy, CLASH_PROXY);
+  assert.equal(merged.ALL_PROXY, CLASH_PROXY);
+  assert.equal(merged.PATH, '/usr/bin:/bin');
+  resetSystemProxyCacheForTests();
+});
+
+test('withSystemProxyEnv leaves an explicit env proxy untouched', () => {
+  resetSystemProxyCacheForTests();
+  const merged = withSystemProxyEnv(
+    { HTTPS_PROXY: 'http://10.0.0.2:8123', PATH: '/usr/bin' },
+    { cachedSystemProxy: CLASH_PROXY }
+  );
+  assert.equal(merged.HTTPS_PROXY, 'http://10.0.0.2:8123');
+  assert.equal(merged.HTTP_PROXY, undefined);
+});
+
+test('withSystemProxyEnv preserves lowercase env precedence over the OS proxy', () => {
+  const merged = withSystemProxyEnv(
+    { https_proxy: 'http://10.0.0.3:8123' },
+    { cachedSystemProxy: CLASH_PROXY }
+  );
+  assert.equal(merged.https_proxy, 'http://10.0.0.3:8123');
+  assert.equal(merged.HTTPS_PROXY, undefined);
+});
+
+test('withSystemProxyEnv carries NO_PROXY through with the injected proxy', () => {
+  const merged = withSystemProxyEnv(
+    { NO_PROXY: 'localhost,127.0.0.1' },
+    { cachedSystemProxy: CLASH_PROXY }
+  );
+  assert.equal(merged.NO_PROXY, 'localhost,127.0.0.1');
+  assert.equal(merged.HTTPS_PROXY, CLASH_PROXY);
+});
+
+test('withSystemProxyEnv is a no-op before the cache is primed', () => {
+  resetSystemProxyCacheForTests();
+  const merged = withSystemProxyEnv({ PATH: '/usr/bin' });
+  assert.equal(merged.HTTPS_PROXY, undefined);
+  assert.deepEqual(merged, { PATH: '/usr/bin' });
+});
+
+test('withSystemProxyEnv is a no-op when the OS proxy is disabled', async () => {
+  resetSystemProxyCacheForTests();
+  await primeMacSystemProxy({ spawn: fakeScutilSpawn('  HTTPEnable : 0\n  HTTPSEnable : 0\n  SOCKSEnable : 0\n'), platform: 'darwin' });
+  const merged = withSystemProxyEnv({ PATH: '/usr/bin' });
+  assert.equal(merged.HTTPS_PROXY, undefined);
+  resetSystemProxyCacheForTests();
+});
+
+test('withSystemProxyEnv survives an scutil failure without injecting', async () => {
+  resetSystemProxyCacheForTests();
+  const failingSpawn = () => {
+    const child = new EventEmitter();
+    child.stdout = new PassThrough();
+    setImmediate(() => child.emit('error', new Error('scutil missing')));
+    return child;
+  };
+  await primeMacSystemProxy({ spawn: failingSpawn, platform: 'darwin' });
+  const merged = withSystemProxyEnv({ PATH: '/usr/bin' });
+  assert.equal(merged.HTTPS_PROXY, undefined);
+  resetSystemProxyCacheForTests();
+});
+
+function fakeGrokRpcSpawn(envCapture) {
+  return (command, args, options = {}) => {
+    if (envCapture) envCapture.options = options;
+    const child = new EventEmitter();
+    child.stdout = new PassThrough();
+    child.kill = () => {};
+    child.stdin = new Writable({
+      write(chunk, _encoding, callback) {
+        const text = chunk.toString('utf8');
+        for (const line of text.split(/\n+/).filter(Boolean)) {
+          const message = JSON.parse(line);
+          if (message.method === 'initialize') {
+            child.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: message.id, result: {} }) + '\n');
+          }
+          if (message.method === 'x.ai/billing') {
+            child.stdout.write(JSON.stringify({
+              jsonrpc: '2.0',
+              id: message.id,
+              result: {
+                monthlyLimit: { val: 10000 },
+                usage: { totalUsed: { val: 4200 } }
+              }
+            }) + '\n');
+          }
+        }
+        callback();
+      }
+    });
+    return child;
+  };
+}
+
+test('fetchGrokRpcBilling spawns the CLI with the primed OS proxy injected', async () => {
+  const cliEnv = {};
+  const body = await fetchGrokRpcBilling({}, {
+    env: { PATH: '/usr/bin:/bin' },
+    cachedSystemProxy: CLASH_PROXY,
+    spawn: fakeGrokRpcSpawn(cliEnv),
+    rpcTimeoutMs: 500
+  });
+  assert.equal(body.monthlyLimit.val, 10000);
+  assert.equal(cliEnv.options.env.HTTPS_PROXY, CLASH_PROXY);
+  assert.equal(cliEnv.options.env.PATH, '/usr/bin:/bin');
+});
+
+test('fetchGrokRpcBilling keeps an explicit env proxy verbatim', async () => {
+  const cliEnv = {};
+  const body = await fetchGrokRpcBilling({}, {
+    env: { PATH: '/usr/bin:/bin', HTTPS_PROXY: 'http://10.0.0.9:8123' },
+    spawn: fakeGrokRpcSpawn(cliEnv),
+    rpcTimeoutMs: 500
+  });
+  assert.equal(body.monthlyLimit.val, 10000);
+  assert.equal(cliEnv.options.env.HTTPS_PROXY, 'http://10.0.0.9:8123');
+});
+
+test('fetchGrokRpcBilling can opt out of the system proxy injection', async () => {
+  const cliEnv = {};
+  const body = await fetchGrokRpcBilling({}, {
+    env: { PATH: '/usr/bin:/bin' },
+    systemProxyEnv: false,
+    cachedSystemProxy: CLASH_PROXY,
+    spawn: fakeGrokRpcSpawn(cliEnv),
+    rpcTimeoutMs: 500
+  });
+  assert.equal(body.monthlyLimit.val, 10000);
+  assert.equal(cliEnv.options.env.HTTPS_PROXY, undefined);
+});
+
+test('fetchGrokRpcBilling without a primed proxy spawns with the env unchanged', async () => {
+  const cliEnv = {};
+  const body = await fetchGrokRpcBilling({}, {
+    env: { PATH: '/usr/bin:/bin' },
+    spawn: fakeGrokRpcSpawn(cliEnv),
+    rpcTimeoutMs: 500
+  });
+  assert.equal(body.monthlyLimit.val, 10000);
+  assert.equal(cliEnv.options.env.HTTPS_PROXY, undefined);
+});


### PR DESCRIPTION
## Problem

On macOS with a system-level proxy, the Grok limit card repeatedly degrades to `unavailable` → `unauthorized`. Root cause: the widget depends on the Grok CLI's `~/.grok/auth.json`, whose access tokens expire after **6 hours** and only refresh when the CLI itself runs — and the CLI is a plain Node program that needs proxy env vars a GUI-launched widget can never give its child processes. #485 fixes the child-env half; this PR removes the dependency on the CLI entirely.

## Approach

Let the widget manage its own Grok credential, exactly like opencode/kimi/deepseek credentials are managed today:

- **`refreshGrokAccessToken()`** in `grokLimits.js`: exchanges a stored refresh_token for a fresh access_token at `auth.x.ai/oauth2/token` (standard OAuth2 refresh grant, published in xAI's OIDC discovery) through the widget's existing system-proxy-aware fetch.
- **Managed path in `fetchGrokLimits`**: when `grokRefreshToken` + `grokClientId` are configured (credential store or `GROK_REFRESH_TOKEN`/`GROK_CLIENT_ID` env), the widget refreshes its own token and calls the billing endpoint directly — no CLI spawn, no `auth.json` read. On failure it **falls through to the existing auth.json auto-detection**, so nothing regresses.
- **Credential wiring**: `grokRefreshToken`/\`grokClientId` added to `CREDENTIAL_SETTING_PATHS` and `limitsConfigFromSettings`, so they persist in `credentials.json` like every other provider credential.

## Why this is safe with the CLI

xAI uses **soft refresh-token rotation** — verified against auth.x.ai: an old refresh_token remains valid after a new one is issued. So the CLI and the widget can each hold their own copy and refresh independently without invalidating each other. The widget never writes to `~/.grok/auth.json`.

## Verification

- Live-verified against xAI: refresh_token → new access_token (6h) → billing endpoint returns valid quota data (grpc-status 0). Old refresh_token still works after rotation.
- New tests: 10 cases (exchange success, rotation semantics, 401→unauthorized / 500→unavailable mapping, missing-token rejection, managed-path priority, fallback to auth.json on refresh failure, env fallback, no-refresh-token opt-out).
- Full suite: **3630 passing**, eslint clean.

## Relationship to #485

This branch builds on the child-env system-proxy fix (#485, currently open). If #485 lands first I'll rebase; if you'd prefer them merged together, the delta here is isolated to grokLimits.js + credential wiring + tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Manages the Grok OAuth token in the widget and injects the OS proxy for Grok CLI spawns to stop unauthorized/unavailable flapping on proxied macOS networks. Previously the widget depended on the CLI’s ~/.grok/auth.json refreshing only when the CLI ran; now the widget refreshes its own access token and still falls back to the CLI path when needed.

- Adds a managed OAuth2 refresh flow (refresh token → access token) via xAI’s OIDC token endpoint.
- Prefers a managed path in fetchGrokLimits when grokRefreshToken + grokClientId are configured; otherwise auto-detects ~/.grok/auth.json as before.
- Persists grokRefreshToken and grokClientId in the credential store; also reads GROK_REFRESH_TOKEN and GROK_CLIENT_ID from env.
- Injects the macOS system proxy into child process env for the Grok agent RPC; primes proxy lookup at startup; opt-out supported.

| Area | Before | After |
| --- | --- | --- |
| Token management | Access tokens read from CLI’s ~/.grok/auth.json; refresh only when CLI runs | Widget exchanges refresh_token for access_token directly via OAuth2; independent of CLI |
| Proxy handling for CLI | GUI-launched child processes lacked proxy env; token refresh and RPC often failed on proxied macOS | Child env inherits primed system proxy (HTTPS_PROXY/HTTP_PROXY/ALL_PROXY) unless explicitly set or opted out |
| Configuration | No first-class Grok credentials in widget | grokRefreshToken and grokClientId stored in credentials.json; env fallbacks GROK_REFRESH_TOKEN and GROK_CLIENT_ID |
| Fallback behavior | Single path via CLI/auth.json | Managed path preferred; on refresh failure, falls back to auth.json/CLI without regression |

**Notes**
- Safe concurrency: xAI uses soft refresh-token rotation; widget and CLI refresh independently without invalidating each other.
- Tests: Added coverage for refresh exchange and error mapping, managed-path priority and fallback, env-based configuration, and system proxy injection; stabilized a Qoder CN history guard fixture to use the local calendar day.
- Rollout/migration: To enable the managed path, provide grokRefreshToken and grokClientId in settings or via env. No breaking changes; existing CLI-based behavior continues to work.

<sup>Written for commit 8e8cf935c66e807e49742de1c918aea4c674a9bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

