### PR TITLE
fix(watcher): keep unconfirmed fallback on polling

### DIFF
--- a/src/shared/watcherHost.js
+++ b/src/shared/watcherHost.js
@@ -26,8 +26,6 @@
 // watch-behaviour tests drive, since the reaction logic is identical on both.
 
 const WORKER_PATH = require.resolve('./watcherWorker');
-const CLOSE_REPORT_GRACE_MS = 30_000;
-
 function inProcessRequested(env = process.env) {
   const raw = String(env.TOKEN_MONITOR_WATCH_IN_PROCESS ?? '').trim().toLowerCase();
   if (!raw) return false;
@@ -61,18 +59,17 @@ function createInProcessWatcherHost(config = {}, handlers = {}) {
 function createWatcherCoordinator(deps = {}) {
   const WorkerClass = deps.Worker || require('node:worker_threads').Worker;
   const workerPath = deps.workerPath || WORKER_PATH;
-  const setTimer = deps.setTimeout || setTimeout;
-  const clearTimer = deps.clearTimeout || clearTimeout;
   // A worker thread keeps its V8/libuv/native allocator inside the Electron
   // browser process. Reusing it after closing a large chokidar tree leaves that
   // tree's allocation high-water charged to the app even though its descriptors
-  // are gone. Production therefore recycles the isolation boundary on a real
-  // owner change. The old graceful-reuse path remains injectable for focused
-  // lifecycle tests and embedders that explicitly prefer spawn latency.
-  const recycleOnClose = deps.recycleOnClose !== false;
+  // are gone, so every real owner change recycles the isolation boundary.
 
   let worker = null;
   let workerDisabled = false;
+  // A rejected terminate does not prove the old native descriptors were
+  // released. Once that happens, every later in-process owner must stay on
+  // polling for the rest of this coordinator's lifetime.
+  let forcePollingFallback = false;
   // Per instance rather than one coordinator-wide flag: a flag would let a
   // terminate we asked for mask a genuine failure of the worker that replaced it.
   const expectedExits = new WeakSet();
@@ -82,7 +79,6 @@ function createWatcherCoordinator(deps = {}) {
   // in between is the overlap the normal and watchdog paths both avoid.
   const workerFailures = new WeakMap();
   let revision = 0;
-  let pendingStopRevision = null;
   // Set while a thread is on its way out. `worker = null` happens synchronously
   // but terminate() only settles once the thread has actually exited, so this
   // gate, not the null, is what keeps a replacement from starting inside that
@@ -90,12 +86,9 @@ function createWatcherCoordinator(deps = {}) {
   let terminating = null;
   let current = null;
   let inProcessHost = null;
-  let graceTimer = null;
 
-  function clearGrace() {
-    if (!graceTimer) return;
-    clearTimer(graceTimer);
-    graceTimer = null;
+  function fallbackConfig(config) {
+    return forcePollingFallback ? { ...config, usePolling: true } : config;
   }
 
   function restoreCurrentWatcher() {
@@ -109,8 +102,6 @@ function createWatcherCoordinator(deps = {}) {
   // done with watching entirely; a wedged teardown is not, and the collector
   // that replaced the stopped one still expects a live watcher.
   function forceTerminate({ restore = false } = {}) {
-    clearGrace();
-    pendingStopRevision = null;
     if (!worker) return;
     const dying = worker;
     worker = null;
@@ -130,7 +121,10 @@ function createWatcherCoordinator(deps = {}) {
         // The thread never confirmed it exited, so its descriptors cannot be
         // assumed released. Watching on this thread is worse for latency but
         // it is the one path that does not depend on that thread.
-        if (restore) fallBackToInProcess(error, null, { forcePolling: true });
+        if (restore) {
+          forcePollingFallback = true;
+          fallBackToInProcess(error);
+        }
       }
     );
   }
@@ -139,41 +133,21 @@ function createWatcherCoordinator(deps = {}) {
   // failure. Without both guards the second call builds a second in-process
   // watcher and abandons the first, reintroducing the descriptor overlap this
   // design exists to prevent.
-  function fallBackToInProcess(error, failedWorker, options = {}) {
+  function fallBackToInProcess(error, failedWorker) {
     if (workerDisabled) return;
     if (failedWorker && worker && worker !== failedWorker) return;
     worker = null;
     workerDisabled = true;
-    clearGrace();
     if (!current) return;
     current.handlers.onHostFallback?.(error);
     // A rejected terminate does not prove the old worker released its native
     // descriptors. Polling is the only safe fallback on that path; ordinary
     // startup/crash failures still retain the configured native mode because
     // their exit event already confirmed release.
-    const fallbackConfig = options.forcePolling
-      ? { ...current.config, usePolling: true }
-      : current.config;
-    inProcessHost = createInProcessWatcherHost(fallbackConfig, current.handlers);
+    inProcessHost = createInProcessWatcherHost(fallbackConfig(current.config), current.handlers);
   }
 
   function onMessage(message) {
-    if (message?.type === 'released') {
-      // Routed before the owner lookup: a normal stop clears `current` by
-      // definition, so gating this on an owner meant the ack could never
-      // arrive and the grace timer always fired.
-      //
-      // Compared as a watermark rather than an exact match. Under latest-wins a
-      // stop issued while an earlier teardown is still running never gets its
-      // own ack, so requiring equality left the watchdog armed against a
-      // release that had already happened, and it went on to terminate a
-      // perfectly healthy worker.
-      if (pendingStopRevision === null) return;
-      if (!(Number(message.throughRevision) >= pendingStopRevision)) return;
-      pendingStopRevision = null;
-      clearGrace();
-      return;
-    }
     const owner = current;
     if (!owner) return;
     // A watcher that is still tearing down can emit between the owner moving on
@@ -231,17 +205,12 @@ function createWatcherCoordinator(deps = {}) {
     revision += 1;
     const owned = revision;
     current = { revision: owned, config, handlers };
-    // Deliberately does not disarm a stop that has not been acknowledged yet.
-    // A runtime restart is stop-then-immediate-acquire, so clearing here would
-    // cancel the watchdog in exactly the path where a wedged teardown would
-    // otherwise pin every descriptor with nothing left to notice.
-
     if (inProcessHost) {
       inProcessHost.close();
       inProcessHost = null;
     }
     if (workerDisabled) {
-      inProcessHost = createInProcessWatcherHost(config, handlers);
+      inProcessHost = createInProcessWatcherHost(fallbackConfig(config), handlers);
       return makeHandle(owned, 'in-process');
     }
 
@@ -277,27 +246,10 @@ function createWatcherCoordinator(deps = {}) {
           forceTerminate();
           return;
         }
-        if (recycleOnClose) {
-          // Confirm the old thread has exited before restoreCurrentWatcher()
-          // applies whichever owner is newest by then. This both bounds native
-          // watcher memory and preserves the no-overlapping-descriptors invariant.
-          forceTerminate({ restore: true });
-          return;
-        }
-        revision += 1;
-        pendingStopRevision = revision;
-        try {
-          worker.postMessage({ type: 'stop', revision });
-        } catch (_) {
-          pendingStopRevision = null;
-          forceTerminate();
-          return;
-        }
-        // Only covers a worker that never answers. A normal stop leaves the
-        // thread idle and reusable, so the next acquire skips spawn cost.
-        clearGrace();
-        graceTimer = setTimer(() => forceTerminate({ restore: true }), CLOSE_REPORT_GRACE_MS);
-        if (typeof graceTimer.unref === 'function') graceTimer.unref();
+        // Confirm the old thread has exited before restoreCurrentWatcher()
+        // applies whichever owner is newest by then. This both bounds native
+        // watcher memory and preserves the no-overlapping-descriptors invariant.
+        forceTerminate({ restore: true });
       }
     };
   }
@@ -308,8 +260,8 @@ function createWatcherCoordinator(deps = {}) {
     inspect: () => ({
       hasWorker: Boolean(worker),
       workerDisabled,
+      forcePollingFallback,
       inProcess: Boolean(inProcessHost),
-      awaitingStopAck: pendingStopRevision !== null,
       terminating: terminating !== null
     })
   };

--- a/src/shared/watcherWorker.js
+++ b/src/shared/watcherWorker.js
@@ -5,10 +5,10 @@
 // owns the collector froze the UI for about a second on every runtime restart.
 //
 // This thread is the only place a chokidar instance ever exists. The production
-// owner normally recycles the whole thread on a collector replacement so its
-// native allocation high-water is released; an in-thread reconfigure (including
-// the explicitly reusable host mode) still closes and awaits the previous
-// watcher before opening the next, so descriptors never overlap.
+// owner recycles the whole thread on a collector replacement so its native
+// allocation high-water is released. A defensive in-thread reconfigure still
+// closes and awaits the previous watcher before opening the next, so descriptors
+// never overlap even if a caller replaces an owner without closing it first.
 //
 // Nothing but the watcher lives here. Roots, attribution, debouncing and every
 // tick decision stay on the owning thread, so there is no collector state to
@@ -68,12 +68,6 @@ async function pump() {
     while (desired && desired.revision !== appliedRevision) {
       const target = desired;
       await closeCurrent();
-      // A watermark, not a per-revision ack. Latest-wins means an intermediate
-      // stop never gets its own turn through this loop, so acking only the
-      // revision being applied would strand the owner's watchdog on a stop that
-      // is already satisfied. Nothing is watched at this point, so every stop up
-      // to the newest request we have seen has been honoured.
-      post({ type: 'released', throughRevision: (desired || target).revision });
       // A newer request arrived while the old tree was closing. Drop this one
       // and apply the newest instead of rebuilding something already stale.
       if (desired !== target) continue;
@@ -109,10 +103,7 @@ async function pump() {
             code: error?.code || ''
           });
         }
-      } else {
-        // The release watermark above already covered this stop.
-        appliedRevision = target.revision;
-      }
+      } else appliedRevision = target.revision;
     }
   } finally {
     running = false;
@@ -122,11 +113,6 @@ async function pump() {
 parentPort.on('message', (message) => {
   if (message?.type === 'configure') {
     desired = { revision: message.revision, config: message.config };
-    void pump();
-    return;
-  }
-  if (message?.type === 'stop') {
-    desired = { revision: message.revision, config: null };
     void pump();
   }
 });

--- a/tests/shared/watcherHost.test.js
+++ b/tests/shared/watcherHost.test.js
@@ -228,172 +228,6 @@ test('messages from a superseded watcher are dropped', () => {
   assert.deepEqual(first, []);
 });
 
-test('the optional reusable mode closes gracefully without terminating', () => {
-  FakeWorker.reset();
-  const coordinator = createWatcherCoordinator({ Worker: FakeWorker, recycleOnClose: false });
-  const host = coordinator.acquire({ dirs: ['/tmp/x'], clients: 'claude' }, {});
-  host.close();
-  const worker = FakeWorker.last();
-  assert.equal(worker.posted.at(-1)?.type, 'stop');
-  // terminate() is the abnormal path only: racing a teardown we asked for
-  // would abandon descriptors the worker is still releasing.
-  assert.equal(worker.terminated, 0);
-});
-
-function fakeTimers() {
-  const timers = [];
-  return {
-    timers,
-    setTimeout: (fn, ms) => { const t = { fn, ms, cleared: false }; timers.push(t); return t; },
-    clearTimeout: (t) => { if (t) t.cleared = true; }
-  };
-}
-
-test('a stop ack clears the grace timer so an idle worker survives', () => {
-  FakeWorker.reset();
-  const clock = fakeTimers();
-  const coordinator = createWatcherCoordinator({
-    Worker: FakeWorker,
-    recycleOnClose: false,
-    setTimeout: clock.setTimeout,
-    clearTimeout: clock.clearTimeout
-  });
-  const host = coordinator.acquire({ dirs: ['/tmp/x'], clients: 'claude' }, {});
-  host.close();
-  const stop = FakeWorker.last().posted.at(-1);
-  assert.equal(stop.type, 'stop');
-  assert.equal(clock.timers.length, 1, 'a grace timer must be armed');
-  assert.equal(coordinator.inspect().awaitingStopAck, true);
-
-  // close() clears `current` by definition, so an ack routed behind the owner
-  // lookup could never arrive and the grace timer always fired, terminating a
-  // worker that had already shut down cleanly and was reusable.
-  FakeWorker.last().emit('message', { type: 'released', throughRevision: stop.revision });
-  assert.equal(clock.timers[0].cleared, true, 'the ack must disarm the grace timer');
-  assert.equal(coordinator.inspect().awaitingStopAck, false);
-  assert.equal(FakeWorker.last().terminated, 0);
-});
-
-test('a stop issued during an unfinished teardown is still satisfied', () => {
-  FakeWorker.reset();
-  const clock = fakeTimers();
-  const coordinator = createWatcherCoordinator({
-    Worker: FakeWorker,
-    recycleOnClose: false,
-    setTimeout: clock.setTimeout,
-    clearTimeout: clock.clearTimeout
-  });
-  // stop A, start B, stop B, start C, all while A is still closing.
-  const a = coordinator.acquire({ dirs: ['/a'], clients: 'claude' }, {});
-  a.close();
-  const b = coordinator.acquire({ dirs: ['/b'], clients: 'claude' }, {});
-  b.close();
-  coordinator.acquire({ dirs: ['/c'], clients: 'claude' }, {});
-  const worker = FakeWorker.last();
-  const stops = worker.posted.filter((m) => m.type === 'stop');
-  assert.equal(stops.length, 2);
-  assert.equal(coordinator.inspect().awaitingStopAck, true);
-
-  // Latest-wins means the second stop never gets its own turn in the worker's
-  // loop, so it can only ever be answered by a watermark. Requiring an exact
-  // revision left this watchdog armed and it went on to kill a healthy worker.
-  const newest = Math.max(...worker.posted.map((m) => m.revision));
-  worker.emit('message', { type: 'released', throughRevision: newest });
-  assert.equal(coordinator.inspect().awaitingStopAck, false, 'the later stop must be satisfied');
-  const live = clock.timers.filter((t) => !t.cleared);
-  assert.equal(live.length, 0, 'no watchdog may outlive a completed release');
-});
-
-test('the grace timer still terminates a worker that never acks', () => {
-  FakeWorker.reset();
-  const clock = fakeTimers();
-  const coordinator = createWatcherCoordinator({
-    Worker: FakeWorker,
-    recycleOnClose: false,
-    setTimeout: clock.setTimeout,
-    clearTimeout: clock.clearTimeout
-  });
-  const host = coordinator.acquire({ dirs: ['/tmp/x'], clients: 'claude' }, {});
-  host.close();
-  clock.timers[0].fn();
-  // The timeout is the only thing standing between a wedged worker and pinned
-  // descriptors, so it has to stay effective.
-  assert.equal(FakeWorker.last().terminated, 1);
-});
-
-test('a late ack from an earlier stop cannot disarm the current one', () => {
-  FakeWorker.reset();
-  const clock = fakeTimers();
-  const coordinator = createWatcherCoordinator({
-    Worker: FakeWorker,
-    recycleOnClose: false,
-    setTimeout: clock.setTimeout,
-    clearTimeout: clock.clearTimeout
-  });
-  const firstHandle = coordinator.acquire({ dirs: ['/a'], clients: 'claude' }, {});
-  firstHandle.close();
-  const staleStop = FakeWorker.last().posted.at(-1);
-  const secondHandle = coordinator.acquire({ dirs: ['/b'], clients: 'claude' }, {});
-  secondHandle.close();
-  const liveStop = FakeWorker.last().posted.at(-1);
-  assert.notEqual(staleStop.revision, liveStop.revision);
-
-  FakeWorker.last().emit('message', { type: 'released', throughRevision: staleStop.revision });
-  assert.equal(coordinator.inspect().awaitingStopAck, true, 'a stale ack must not disarm the live timer');
-});
-
-test('a restart keeps the watchdog armed for the stop it overtook', async () => {
-  FakeWorker.reset();
-  const clock = fakeTimers();
-  const coordinator = createWatcherCoordinator({
-    Worker: FakeWorker,
-    recycleOnClose: false,
-    setTimeout: clock.setTimeout,
-    clearTimeout: clock.clearTimeout
-  });
-  const first = coordinator.acquire({ dirs: ['/a'], clients: 'claude' }, {});
-  first.close();
-  assert.equal(clock.timers.length, 1);
-  // A runtime restart is stop-then-immediate-acquire. Disarming here would drop
-  // the only protection against a teardown that never completes, in the very
-  // path where that teardown runs.
-  coordinator.acquire({ dirs: ['/b'], clients: 'claude' }, {});
-  assert.equal(clock.timers[0].cleared, false, 'the restart must not disarm the in-flight stop');
-  assert.equal(coordinator.inspect().awaitingStopAck, true);
-
-  const wedged = FakeWorker.last();
-  clock.timers[0].fn();
-  assert.equal(wedged.terminated, 1, 'a wedged teardown must still be terminated');
-
-  // ...and the collector that replaced the stopped one must end up watching.
-  await until(() => FakeWorker.instances.length === 2);
-  const replacement = FakeWorker.last();
-  assert.notEqual(replacement, wedged);
-  await until(() => replacement.configures().length === 1);
-  assert.deepEqual(replacement.configures()[0].config.dirs, ['/b'], 'the live owner must be reapplied');
-});
-
-test('a stop acked after a restart disarms without disturbing the new owner', async () => {
-  FakeWorker.reset();
-  const clock = fakeTimers();
-  const coordinator = createWatcherCoordinator({
-    Worker: FakeWorker,
-    recycleOnClose: false,
-    setTimeout: clock.setTimeout,
-    clearTimeout: clock.clearTimeout
-  });
-  const first = coordinator.acquire({ dirs: ['/a'], clients: 'claude' }, {});
-  first.close();
-  const stop = FakeWorker.last().posted.find((m) => m.type === 'stop');
-  coordinator.acquire({ dirs: ['/b'], clients: 'claude' }, {});
-  // The worker acknowledges the release even though a configure overtook it.
-  FakeWorker.last().emit('message', { type: 'released', throughRevision: stop.revision });
-  assert.equal(clock.timers[0].cleared, true);
-  assert.equal(coordinator.inspect().awaitingStopAck, false);
-  assert.equal(FakeWorker.instances.length, 1, 'a healthy restart must not respawn');
-  assert.equal(FakeWorker.last().terminated, 0);
-});
-
 test('no replacement worker starts while the old thread is still exiting', async () => {
   FakeWorker.reset();
   const coordinator = createWatcherCoordinator({ Worker: FakeWorker });
@@ -441,7 +275,20 @@ test('a terminate that never confirms falls back instead of assuming release', a
     assert.equal(FakeWorker.instances.length, 1);
     assert.equal(stub.built.length, 1, 'the owner must still end up watching');
     assert.equal(stub.built[0].options.usePolling, true, 'unconfirmed release must not overlap native descriptors');
+    assert.equal(coordinator.inspect().forcePollingFallback, true);
     assert.equal(fallbacks.length, 1);
+
+    // The unconfirmed native worker may still be alive. Closing this fallback
+    // and acquiring another owner must not silently re-enable native watching.
+    const fallback = coordinator.acquire(
+      { dirs: ['/c'], clients: 'claude', usePolling: false },
+      { onHostFallback: (e) => fallbacks.push(e) }
+    );
+    assert.equal(fallback.kind, 'in-process');
+    assert.equal(stub.built.length, 2);
+    assert.equal(stub.built[0].closed, 1, 'the previous fallback host must close');
+    assert.equal(stub.built[1].options.usePolling, true, 'polling must stay sticky for every later owner');
+    fallback.close();
   } finally {
     stub.restore();
   }
@@ -454,7 +301,7 @@ test('the quit path terminates instead of waiting for the slow teardown', () => 
   host.close({ skipClose: true });
   const worker = FakeWorker.last();
   assert.equal(worker.terminated, 1);
-  assert.ok(!worker.posted.some((m) => m.type === 'stop'), 'quit must not wait on a stop round trip');
+  assert.equal(worker.posted.filter((m) => m.type !== 'configure').length, 0);
 });
 
 test('successive collectors recycle the worker without overlapping', async () => {
@@ -548,7 +395,7 @@ test('a reconfigure issued before the first watcher is ready still lands', async
   }
 });
 
-test('rapid restarts leave no watchdog armed against a live worker', async () => {
+test('rapid restarts leave the latest worker active after every exit barrier', async () => {
   const roots = [tmpTree(), tmpTree(), tmpTree()];
   let ready = 0;
   const coordinator = withoutEnv(() => createWatcherCoordinator());
@@ -560,12 +407,8 @@ test('rapid restarts leave no watchdog armed against a live worker', async () =>
     b.close();
     const c = coordinator.acquire({ dirs: [roots[2]], clients: 'claude', usePolling: false }, handlers);
     assert.ok(await until(() => ready >= 1), 'the latest config never became ready');
-    // An unanswered stop would leave the watchdog armed and terminate this
-    // healthy worker 30 seconds later.
-    assert.ok(
-      await until(() => coordinator.inspect().awaitingStopAck === false),
-      'a stop was never acknowledged across rapid restarts'
-    );
+    assert.equal(coordinator.inspect().terminating, false);
+    assert.equal(coordinator.inspect().hasWorker, true);
     c.close({ skipClose: true });
   } finally {
     for (const root of roots) fs.rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
Follow-up to #495.

## Summary

- keep polling sticky after a worker termination cannot be confirmed
- prevent later watcher owners from re-enabling native descriptors on that coordinator
- remove the unused graceful-reuse `stop` / `released` protocol so production and tests exercise the same recycle-on-close lifecycle

## Verification

- `node --test tests/shared/watcherHost.test.js` — 19 passed
- `npm run verify` — 3628 passed, 0 failed, 1 skipped

## Risk

This only forces polling after `Worker.terminate()` rejects. Confirmed worker exits and ordinary crash fallback continue using the configured watcher mode.
