### PR TITLE
refactor(collector): normalize usage lifecycle state

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -277,7 +277,7 @@ const {
   diagnosticConfigurationFromSettings,
   envelopeFromSettings,
   limitsConfigFromSettings,
-  usageSettingsFingerprint,
+  usageConfigFingerprint,
   usageConfigFromSettings
 } = require('./runtimeConfig');
 const {
@@ -3455,7 +3455,7 @@ function startSyncCollector() {
   }, {
     limitsDeps: electronLimitsDeps()
   });
-  usageRuntimeReconciler.setActiveKey(usageSettingsFingerprint(settings));
+  usageRuntimeReconciler.setActiveKey(usageConfigFingerprint(usageOptions));
   drainPendingRuntimeActions(deviceRuntimeHandle);
 }
 
@@ -3502,7 +3502,7 @@ function startHostCollector() {
   }, {
     limitsDeps: electronLimitsDeps()
   });
-  usageRuntimeReconciler.setActiveKey(usageSettingsFingerprint(settings));
+  usageRuntimeReconciler.setActiveKey(usageConfigFingerprint(usageOptions));
   drainPendingRuntimeActions(deviceRuntimeHandle);
 }
 
@@ -4043,7 +4043,7 @@ function startLocalCollector() {
   }, {
     limitsDeps: electronLimitsDeps()
   });
-  usageRuntimeReconciler.setActiveKey(usageSettingsFingerprint(settings));
+  usageRuntimeReconciler.setActiveKey(usageConfigFingerprint(usageOptions));
   drainPendingRuntimeActions(deviceRuntimeHandle);
 }
 
@@ -4904,19 +4904,26 @@ function restartDeviceRuntimeForMode() {
   else startLocalCollector();
 }
 
+function usageCollectorNameForMode() {
+  return mode === 'local'
+    ? 'collector'
+    : (settings.hubMode === 'host' && embeddedHub ? 'host-collector' : 'sync-collector');
+}
+
+function usageConfigForMode() {
+  return electronUsageConfig(usageCollectorNameForMode());
+}
+
 function applyUsageRuntimeForMode() {
   if (!deviceRuntimeHandle?.reconfigureUsage) {
     restartDeviceRuntimeForMode();
     return Boolean(deviceRuntimeHandle);
   }
-  const collectorName = mode === 'local'
-    ? 'collector'
-    : (settings.hubMode === 'host' && embeddedHub ? 'host-collector' : 'sync-collector');
-  return deviceRuntimeHandle.reconfigureUsage(electronUsageConfig(collectorName)) === true;
+  return deviceRuntimeHandle.reconfigureUsage(usageConfigForMode()) === true;
 }
 
 function reconfigureUsageRuntimeForMode() {
-  return usageRuntimeReconciler.schedule(usageSettingsFingerprint(settings));
+  return usageRuntimeReconciler.schedule(usageConfigFingerprint(usageConfigForMode()));
 }
 
 // Quit-path teardown. Every step here must be synchronous, because performQuit

--- a/src/electron/runtimeConfig.js
+++ b/src/electron/runtimeConfig.js
@@ -30,6 +30,24 @@ const USAGE_STRUCTURAL_KEYS = Object.freeze([
   'projectsEnabled',
   'wslScanEnabled'
 ]);
+// Functions and identity fields deliberately stay out: this key answers only
+// whether replacing the active usage runtime would change its collection work.
+// Values arrive from usageConfigFromSettings() after mode-specific normalization.
+const USAGE_CONFIG_FINGERPRINT_KEYS = Object.freeze([
+  'clients',
+  'allTimeSince',
+  'intervalMs',
+  'historyEnabled',
+  'dailyHistoryArchiveEnabled',
+  'projectsEnabled',
+  'historyIntervalMs',
+  'watchEnabled',
+  'watchUsePolling',
+  'watchTriggersCollection',
+  'intervalRequiresActivity',
+  'watchDebounceMs',
+  'wslScanEnabled'
+]);
 const LIMITS_RECONFIGURE_KEYS = Object.freeze([
   'limitsEnabled',
   'limitProviders',
@@ -72,8 +90,8 @@ function changedAny(previous, next, keys) {
   return keys.some((key) => !equalSetting(previous?.[key], next?.[key]));
 }
 
-function usageSettingsFingerprint(settings = {}) {
-  return JSON.stringify(USAGE_STRUCTURAL_KEYS.map((key) => [key, settings?.[key] ?? null]));
+function usageConfigFingerprint(config = {}) {
+  return JSON.stringify(USAGE_CONFIG_FINGERPRINT_KEYS.map((key) => [key, config?.[key] ?? null]));
 }
 
 function normalizeAllTimeSince(value, fallback = DEFAULT_ALL_TIME_SINCE) {
@@ -249,6 +267,6 @@ module.exports = {
   envelopeFromSettings,
   limitsConfigFromSettings,
   normalizeAllTimeSince,
-  usageSettingsFingerprint,
+  usageConfigFingerprint,
   usageConfigFromSettings
 };

--- a/src/electron/runtimeConfig.js
+++ b/src/electron/runtimeConfig.js
@@ -262,6 +262,7 @@ function classifySettingsChange(previous = {}, next = {}) {
 
 module.exports = {
   LIMIT_PROVIDER_SETTING_KEYS,
+  USAGE_STRUCTURAL_KEYS,
   classifySettingsChange,
   diagnosticConfigurationFromSettings,
   envelopeFromSettings,

--- a/src/shared/abortSignal.js
+++ b/src/shared/abortSignal.js
@@ -1,0 +1,17 @@
+'use strict';
+
+function abortReason(signal, fallback = 'operation aborted') {
+  if (signal?.reason instanceof Error) return signal.reason;
+  const error = new Error(String(signal?.reason || fallback));
+  error.name = 'AbortError';
+  return error;
+}
+
+function throwIfAborted(signal, fallback) {
+  if (signal?.aborted) throw abortReason(signal, fallback);
+}
+
+module.exports = {
+  abortReason,
+  throwIfAborted
+};

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -65,7 +65,8 @@ const {
   clampTimerDelayMs,
   createSelfSyncThrottle,
   createSourceSyncQueue,
-  mergeSelfSyncSelection
+  mergeSelfSyncSelection,
+  SELF_SYNC_KINDS
 } = require('./selfSyncThrottle');
 const {
   LIMITS_RESET_BOUNDARY_MAX_TIMER_MS,
@@ -360,9 +361,6 @@ function waitForSharedCapabilityProbe(probe, signal) {
       (supported) => finish(resolve, supported),
       (error) => finish(reject, error)
     );
-    // Close the race where abort happens after the first check but before the
-    // listener is installed.
-    if (signal.aborted) onAbort();
   });
 }
 
@@ -2303,7 +2301,7 @@ function clientWatchCandidates(clientsCsv) {
 
 // Clients whose dirs are tokscale caches written only by our own maybeSync* calls.
 // Watching them turns every tick into the trigger for the next one (issue #15).
-const SELF_SYNCED_CLIENTS = new Set(['cursor', 'antigravity']);
+const SELF_SYNCED_CLIENTS = new Set(SELF_SYNC_KINDS);
 
 // The Antigravity CLI's parse-local data dir (honors GEMINI_CLI_HOME like tokscale).
 // It belongs to the umbrella `antigravity` client but, unlike that client's IDE

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -5,6 +5,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const semver = require('semver');
+const { abortReason, throwIfAborted } = require('./abortSignal');
 const { readJson, sharedDataDir } = require('./config');
 const { appVersion } = require('./appVersion');
 const { normalizeClientsCsv, PARSE_LOCAL_CLIENTS } = require('./clientTracking');
@@ -166,17 +167,6 @@ function parseJsonOutput(stdout) {
     }
   }
   throw new Error(`Could not parse tokscale JSON output: ${text.slice(0, 300)}`);
-}
-
-function abortReason(signal, fallback = 'operation aborted') {
-  if (signal?.reason instanceof Error) return signal.reason;
-  const error = new Error(String(signal?.reason || fallback));
-  error.name = 'AbortError';
-  return error;
-}
-
-function throwIfAborted(signal) {
-  if (signal?.aborted) throw abortReason(signal);
 }
 
 function spawnTokscaleJson(userArgs, commandTimeoutMs, command = tokscaleCommand(), signal, options = {}) {

--- a/src/shared/cursorAuth.js
+++ b/src/shared/cursorAuth.js
@@ -5,6 +5,7 @@ const os = require('node:os');
 const path = require('node:path');
 const crypto = require('node:crypto');
 const { spawn } = require('node:child_process');
+const { abortReason } = require('./abortSignal');
 const {
   createSubprocessTermination,
   terminationUnconfirmedError
@@ -103,7 +104,7 @@ function runTokscaleSubcommand(args, {
   terminationOptions,
   onTerminationUnconfirmed
 } = {}) {
-  if (signal?.aborted) return Promise.reject(signal.reason instanceof Error ? signal.reason : new Error('Cursor sync aborted'));
+  if (signal?.aborted) return Promise.reject(abortReason(signal, 'Cursor sync aborted'));
   return new Promise((resolve, reject) => {
     const tokscaleCommand = resolveTokscaleCommand || require('./collector').tokscaleCommand;
     const { bin, prefixArgs, env } = tokscaleCommand();
@@ -133,7 +134,7 @@ function runTokscaleSubcommand(args, {
 
     function onAbort() {
       if (terminalError) return;
-      terminalError = signal.reason instanceof Error ? signal.reason : new Error('Cursor sync aborted');
+      terminalError = abortReason(signal, 'Cursor sync aborted');
       clearTimeout(timer);
       termination.request();
     }

--- a/src/shared/selfSyncThrottle.js
+++ b/src/shared/selfSyncThrottle.js
@@ -96,61 +96,34 @@ function mergeSelfSyncSelection(left, right) {
 // it is read per call, never captured, so patching Date.now still works.
 function createSelfSyncThrottle(options = {}) {
   const now = () => (typeof options.now === 'function' ? options.now() : Date.now());
-  const lastSyncAt = {};
-  // Whether the last attempt for this kind failed. The short source floor is a
-  // reward for a sync that works: once one fails there is nothing upstream to
-  // say whether the cause is transient, so the client drops to the idle cadence
-  // until an attempt succeeds. Expressed as the floor itself rather than as a
-  // longer timer, because the floor is read from three places — the drain, the
-  // catch-up arm, and the sync decision — and a backoff that only moved the
-  // timer still let an unrelated client's watch event drain the failed one
-  // straight back out.
-  const lastSyncFailed = {};
-  // A collector replacement may cancel an in-flight sync, while two explicit
-  // refreshes can still overlap. Latest attempt wins: a completion only writes
-  // the flag while it is still the newest attempt for its kind. Cancellation
-  // invalidates its attempt token and restores the claim it consumed, so the
-  // replacement collector may take that allowance without turning a lifecycle
-  // event into failure backoff.
-  const attemptSeq = {};
-  // Reporting state, kept apart from the three fields above because those decide
-  // behaviour and these only describe it. `lastSyncAt` in particular is the
-  // rate-limit anchor — `claim()` moves it, and a completion deliberately does
-  // not — so it answers "when may the next sync run", never "when did one last
-  // work". A diagnostic that reads it as the latter is the mistake this exists
-  // to prevent.
-  const lastAttemptAt = {};
-  const lastSuccessAt = {};
-  const lastFailureCode = {};
-  const lastFailureStage = {};
-  const lastDetailCode = {};
-  const lastExitCode = {};
-  const pendingAttemptSeq = {};
-  const hasCompletedAttempt = {};
-  const pendingClaimPreviousSyncAt = {};
-  const attemptPreviousSyncAt = {};
-  const attemptPreviousLastAttemptAt = {};
-  for (const kind of SELF_SYNC_KINDS) {
-    lastSyncAt[kind] = 0;
-    lastSyncFailed[kind] = false;
-    attemptSeq[kind] = 0;
-    lastAttemptAt[kind] = 0;
-    lastSuccessAt[kind] = 0;
-    lastFailureCode[kind] = '';
-    lastFailureStage[kind] = '';
-    lastDetailCode[kind] = '';
-    lastExitCode[kind] = null;
-    pendingAttemptSeq[kind] = 0;
-    hasCompletedAttempt[kind] = false;
-    pendingClaimPreviousSyncAt[kind] = null;
-    attemptPreviousSyncAt[kind] = 0;
-    attemptPreviousLastAttemptAt[kind] = 0;
-  }
+  // Keep every field for one client together. These values form one state
+  // machine: splitting them into parallel maps made adding cancellation state
+  // depend on every method updating the same growing list of containers.
+  const states = Object.fromEntries(SELF_SYNC_KINDS.map((kind) => [kind, {
+    // Rate-limit state. `lastSyncAt` is moved by claim(), not completion.
+    lastSyncAt: 0,
+    lastSyncFailed: false,
+    // Latest-attempt fence and the rollback snapshot for cancellation.
+    attemptSeq: 0,
+    pendingAttemptSeq: 0,
+    pendingClaimPreviousSyncAt: null,
+    attemptPreviousSyncAt: 0,
+    attemptPreviousLastAttemptAt: 0,
+    // Reporting state. It never decides whether a sync may run.
+    hasCompletedAttempt: false,
+    lastAttemptAt: 0,
+    lastSuccessAt: 0,
+    lastFailureCode: '',
+    lastFailureStage: '',
+    lastDetailCode: '',
+    lastExitCode: null
+  }]));
 
   // Claims the right to sync `kind` now, stamping the clock when it grants one.
   function claim(kind, minIntervalMs = SYNC_MIN_INTERVAL_MS) {
+    const state = states[kind];
     const nowMs = now();
-    const elapsed = nowMs - lastSyncAt[kind];
+    const elapsed = nowMs - state.lastSyncAt;
     // A backwards clock step (an NTP correction, a VM resume) leaves a stamp in
     // the future, and a negative elapsed compares below every floor — including
     // the zero floor, which would refuse the manual refresh outright. The stamp
@@ -159,8 +132,8 @@ function createSelfSyncThrottle(options = {}) {
     // other deadline in the collector is wall-clock too, and one hybrid would be
     // worse than this guard.
     if (elapsed >= 0 && elapsed < minIntervalMs) return false;
-    pendingClaimPreviousSyncAt[kind] = lastSyncAt[kind];
-    lastSyncAt[kind] = nowMs;
+    state.pendingClaimPreviousSyncAt = state.lastSyncAt;
+    state.lastSyncAt = nowMs;
     return true;
   }
 
@@ -171,51 +144,54 @@ function createSelfSyncThrottle(options = {}) {
   // claim — a stamp from a clock that no longer exists is not something to wait
   // out.
   function msUntilDue(kind, minIntervalMs) {
-    const elapsed = now() - lastSyncAt[kind];
+    const elapsed = now() - states[kind].lastSyncAt;
     if (elapsed < 0) return 0;
     return Math.max(0, minIntervalMs - elapsed);
   }
 
   function beginAttempt(kind) {
-    attemptSeq[kind] += 1;
-    pendingAttemptSeq[kind] = attemptSeq[kind];
-    attemptPreviousSyncAt[kind] = pendingClaimPreviousSyncAt[kind] ?? lastSyncAt[kind];
-    pendingClaimPreviousSyncAt[kind] = null;
-    attemptPreviousLastAttemptAt[kind] = lastAttemptAt[kind];
-    lastAttemptAt[kind] = now();
-    return attemptSeq[kind];
+    const state = states[kind];
+    state.attemptSeq += 1;
+    state.pendingAttemptSeq = state.attemptSeq;
+    state.attemptPreviousSyncAt = state.pendingClaimPreviousSyncAt ?? state.lastSyncAt;
+    state.pendingClaimPreviousSyncAt = null;
+    state.attemptPreviousLastAttemptAt = state.lastAttemptAt;
+    state.lastAttemptAt = now();
+    return state.attemptSeq;
   }
 
   function completeAttempt(kind, attempt, failed, code = '', details = {}) {
-    if (attempt !== attemptSeq[kind] || pendingAttemptSeq[kind] !== attempt) return;
-    pendingAttemptSeq[kind] = 0;
-    hasCompletedAttempt[kind] = true;
-    lastSyncFailed[kind] = failed;
+    const state = states[kind];
+    if (attempt !== state.attemptSeq || state.pendingAttemptSeq !== attempt) return;
+    state.pendingAttemptSeq = 0;
+    state.hasCompletedAttempt = true;
+    state.lastSyncFailed = failed;
     if (!failed) {
-      lastSuccessAt[kind] = now();
-      lastFailureCode[kind] = '';
-      lastFailureStage[kind] = '';
-      lastDetailCode[kind] = '';
-      lastExitCode[kind] = null;
+      state.lastSuccessAt = now();
+      state.lastFailureCode = '';
+      state.lastFailureStage = '';
+      state.lastDetailCode = '';
+      state.lastExitCode = null;
       return;
     }
     const requestedStage = normalizeClientSyncFailureStage(details?.failureStage);
     const failureStage = requestedStage || FAILURE_STAGE_BY_CODE[code] || 'unknown';
-    lastFailureCode[kind] = SELF_SYNC_FAILURE_CODES.has(code)
+    state.lastFailureCode = SELF_SYNC_FAILURE_CODES.has(code)
       ? code
       : (FAILURE_CODE_BY_STAGE[failureStage] || 'sync-failed');
-    lastFailureStage[kind] = failureStage;
-    lastDetailCode[kind] = normalizeClientSyncDetailCode(details?.detailCode) || 'unknown';
-    lastExitCode[kind] = normalizeClientSyncExitCode(details?.exitCode);
+    state.lastFailureStage = failureStage;
+    state.lastDetailCode = normalizeClientSyncDetailCode(details?.detailCode) || 'unknown';
+    state.lastExitCode = normalizeClientSyncExitCode(details?.exitCode);
   }
 
   function cancelAttempt(kind, attempt) {
-    if (attempt !== attemptSeq[kind] || pendingAttemptSeq[kind] !== attempt) return false;
-    lastSyncAt[kind] = attemptPreviousSyncAt[kind];
-    lastAttemptAt[kind] = attemptPreviousLastAttemptAt[kind];
-    pendingAttemptSeq[kind] = 0;
+    const state = states[kind];
+    if (attempt !== state.attemptSeq || state.pendingAttemptSeq !== attempt) return false;
+    state.lastSyncAt = state.attemptPreviousSyncAt;
+    state.lastAttemptAt = state.attemptPreviousLastAttemptAt;
+    state.pendingAttemptSeq = 0;
     // Fence a late subprocess completion without reusing the cancelled token.
-    attemptSeq[kind] += 1;
+    state.attemptSeq += 1;
     return true;
   }
 
@@ -223,22 +199,23 @@ function createSelfSyncThrottle(options = {}) {
   // completed state (or idle when there was none), so a collector replacement
   // never surfaces as a provider failure or a permanently pending attempt.
   function syncStatus(kind) {
+    const current = states[kind];
     let state = 'idle';
-    if (pendingAttemptSeq[kind]) state = 'pending';
-    else if (hasCompletedAttempt[kind]) state = lastSyncFailed[kind] ? 'failed' : 'ok';
+    if (current.pendingAttemptSeq) state = 'pending';
+    else if (current.hasCompletedAttempt) state = current.lastSyncFailed ? 'failed' : 'ok';
     return {
       state,
-      lastAttemptAt: lastAttemptAt[kind] || 0,
-      lastSuccessAt: lastSuccessAt[kind] || 0,
-      failureCode: lastFailureCode[kind] || '',
-      failureStage: lastFailureStage[kind] || '',
-      detailCode: lastDetailCode[kind] || '',
-      exitCode: lastExitCode[kind]
+      lastAttemptAt: current.lastAttemptAt || 0,
+      lastSuccessAt: current.lastSuccessAt || 0,
+      failureCode: current.lastFailureCode || '',
+      failureStage: current.lastFailureStage || '',
+      detailCode: current.lastDetailCode || '',
+      exitCode: current.lastExitCode
     };
   }
 
   function sourceFloorMs(kind) {
-    return lastSyncFailed[kind] ? SYNC_MIN_INTERVAL_MS : SYNC_SOURCE_EVENT_MIN_INTERVAL_MS;
+    return states[kind].lastSyncFailed ? SYNC_MIN_INTERVAL_MS : SYNC_SOURCE_EVENT_MIN_INTERVAL_MS;
   }
 
   // How long this kind must have been idle before a tick may sync it. An

--- a/src/shared/selfSyncThrottle.js
+++ b/src/shared/selfSyncThrottle.js
@@ -100,7 +100,9 @@ function createSelfSyncThrottle(options = {}) {
   // machine: splitting them into parallel maps made adding cancellation state
   // depend on every method updating the same growing list of containers.
   const states = Object.fromEntries(SELF_SYNC_KINDS.map((kind) => [kind, {
-    // Rate-limit state. `lastSyncAt` is moved by claim(), not completion.
+    // Rate-limit state. `lastSyncAt` is moved by claim(), not completion. A
+    // failure selects the longer floor everywhere so another client's event
+    // cannot bypass the failed client's backoff.
     lastSyncAt: 0,
     lastSyncFailed: false,
     // Latest-attempt fence and the rollback snapshot for cancellation.
@@ -109,7 +111,9 @@ function createSelfSyncThrottle(options = {}) {
     pendingClaimPreviousSyncAt: null,
     attemptPreviousSyncAt: 0,
     attemptPreviousLastAttemptAt: 0,
-    // Reporting state. It never decides whether a sync may run.
+    // Reporting state. It never decides whether a sync may run; lastAttemptAt
+    // is the completed-attempt timestamp, while lastSyncAt is only the allowance
+    // anchor above.
     hasCompletedAttempt: false,
     lastAttemptAt: 0,
     lastSuccessAt: 0,
@@ -200,6 +204,17 @@ function createSelfSyncThrottle(options = {}) {
   // never surfaces as a provider failure or a permanently pending attempt.
   function syncStatus(kind) {
     const current = states[kind];
+    if (!current) {
+      return {
+        state: 'idle',
+        lastAttemptAt: 0,
+        lastSuccessAt: 0,
+        failureCode: '',
+        failureStage: '',
+        detailCode: '',
+        exitCode: null
+      };
+    }
     let state = 'idle';
     if (current.pendingAttemptSeq) state = 'pending';
     else if (current.hasCompletedAttempt) state = current.lastSyncFailed ? 'failed' : 'ok';

--- a/src/shared/wslUsage.js
+++ b/src/shared/wslUsage.js
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs');
 const { execFileSync } = require('node:child_process');
+const { throwIfAborted } = require('./abortSignal');
 const { emptyPeriod, extractUsageFromTokscale, mergePeriods } = require('./usage');
 const { REASONIX_CLIENT } = require('./reasonixPaths');
 const { buildPromaPeriods, collectPromaRows } = require('./promaUsage');
@@ -205,7 +206,7 @@ async function collectWslUsage(options = {}, deps = {}) {
   const readdirSync = deps.readdirSync || fs.readdirSync;
   const bundle = emptyWslBundle();
   const detected = new Set();
-  if (options.signal?.aborted) throw options.signal.reason;
+  throwIfAborted(options.signal, 'WSL usage scan aborted');
   if (!trackedClients) return { bundle, detected: [] };
   // Only attribute markers for clients the user is actually tracking — a marker
   // for an untracked client must not surface in the panel.
@@ -218,7 +219,7 @@ async function collectWslUsage(options = {}, deps = {}) {
     .filter((client) => client !== REASONIX_CLIENT)
     .join(',');
   for (const home of wslUsageHomes(deps)) {
-    if (options.signal?.aborted) throw options.signal.reason;
+    throwIfAborted(options.signal, 'WSL usage scan aborted');
     // Attribution is marker-based, independent of whether a parser returns data.
     const homeDataClients = homeHasData(home, existsSync, readdirSync);
     for (const id of homeDataClients) {
@@ -257,11 +258,11 @@ async function collectWslUsage(options = {}, deps = {}) {
     try {
       // Serial on purpose (issue #15): never run these concurrently.
       const todayJson = await runTokscale({ clients: clientsCsv, flags: ['--today', '--home', home], commandTimeoutMs, signal: options.signal });
-      if (options.signal?.aborted) throw options.signal.reason;
+      throwIfAborted(options.signal, 'WSL usage scan aborted');
       const monthJson = await runTokscale({ clients: clientsCsv, flags: ['--month', '--home', home], commandTimeoutMs, signal: options.signal });
-      if (options.signal?.aborted) throw options.signal.reason;
+      throwIfAborted(options.signal, 'WSL usage scan aborted');
       const allTimeJson = await runTokscale({ clients: clientsCsv, flags: ['--since', allTimeSince, '--home', home], commandTimeoutMs, signal: options.signal });
-      if (options.signal?.aborted) throw options.signal.reason;
+      throwIfAborted(options.signal, 'WSL usage scan aborted');
       const periods = {
         today: extractUsageFromTokscale(todayJson),
         month: extractUsageFromTokscale(monthJson),
@@ -272,7 +273,7 @@ async function collectWslUsage(options = {}, deps = {}) {
       bundle.month = mergePeriods(bundle.month, periods.month);
       bundle.allTime = mergePeriods(bundle.allTime, periods.allTime);
     } catch (error) {
-      if (options.signal?.aborted) throw options.signal.reason;
+      throwIfAborted(options.signal, 'WSL usage scan aborted');
       if (typeof logger === 'function') logger(`wsl usage scan failed for ${home}: ${error.message}`);
     }
   }

--- a/tests/electron/runtimeConfig.test.js
+++ b/tests/electron/runtimeConfig.test.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 const test = require('node:test');
 
 const {
+  USAGE_STRUCTURAL_KEYS,
   classifySettingsChange,
   diagnosticConfigurationFromSettings,
   envelopeFromSettings,
@@ -14,6 +15,33 @@ const {
   usageConfigFingerprint,
   usageConfigFromSettings
 } = require('../../src/electron/runtimeConfig');
+
+const BASE_USAGE_SETTINGS = Object.freeze({
+  clients: 'claude',
+  allTimeSince: '2024-01-01',
+  collectionIntervalMs: 5 * 60 * 1000,
+  collectionMode: 'smart',
+  historyEnabled: true,
+  historyIntervalMs: 15 * 60 * 1000,
+  sessionUsageArchiveEnabled: true,
+  projectsEnabled: true,
+  wslScanEnabled: true
+});
+
+function fingerprintContext(settings) {
+  const mode = settings.collectionMode;
+  return {
+    intervalMs: mode === 'smart' ? 10 * 60 * 1000 : settings.collectionIntervalMs,
+    historyIntervalMs: settings.historyIntervalMs,
+    watchEnabled: mode !== 'interval',
+    watchTriggersCollection: mode === 'live',
+    intervalRequiresActivity: mode === 'smart'
+  };
+}
+
+function fingerprintForSettings(settings) {
+  return usageConfigFingerprint(usageConfigFromSettings(settings, fingerprintContext(settings)));
+}
 
 test('all-time dates are normalized before entering the usage runtime', () => {
   assert.equal(normalizeAllTimeSince('2026-02-28'), '2026-02-28');
@@ -81,6 +109,31 @@ test('usage config fingerprint dedupes raw settings with the same effective runt
     usageConfigFingerprint(explicitDefaults),
     usageConfigFingerprint(usageConfigFromSettings({ historyEnabled: false }, smartContext))
   );
+});
+
+test('every usage structural setting maps to an effective fingerprint change', () => {
+  const cases = {
+    clients: { clients: 'claude,codex' },
+    allTimeSince: { allTimeSince: '2025-01-01' },
+    collectionIntervalMs: {
+      previous: { collectionMode: 'fixed' },
+      next: { collectionMode: 'fixed', collectionIntervalMs: 15 * 60 * 1000 }
+    },
+    collectionMode: { collectionMode: 'live' },
+    historyEnabled: { historyEnabled: false },
+    historyIntervalMs: { historyIntervalMs: 30 * 60 * 1000 },
+    sessionUsageArchiveEnabled: { sessionUsageArchiveEnabled: false },
+    projectsEnabled: { projectsEnabled: false },
+    wslScanEnabled: { wslScanEnabled: false }
+  };
+
+  assert.deepEqual(Object.keys(cases).sort(), [...USAGE_STRUCTURAL_KEYS].sort());
+  for (const [key, entry] of Object.entries(cases)) {
+    const previous = { ...BASE_USAGE_SETTINGS, ...(entry.previous || {}) };
+    const next = { ...previous, ...(entry.next || entry) };
+    assert.equal(classifySettingsChange(previous, next).usageStructural, true, key);
+    assert.notEqual(fingerprintForSettings(previous), fingerprintForSettings(next), key);
+  }
 });
 
 test('diagnostic configuration projects effective normalized values without credentials', () => {

--- a/tests/electron/runtimeConfig.test.js
+++ b/tests/electron/runtimeConfig.test.js
@@ -11,7 +11,7 @@ const {
   envelopeFromSettings,
   limitsConfigFromSettings,
   normalizeAllTimeSince,
-  usageSettingsFingerprint,
+  usageConfigFingerprint,
   usageConfigFromSettings
 } = require('../../src/electron/runtimeConfig');
 
@@ -21,19 +21,65 @@ test('all-time dates are normalized before entering the usage runtime', () => {
   assert.equal(normalizeAllTimeSince('not-a-date'), '2024-01-01');
 });
 
-test('usage settings fingerprint ignores display-only changes and tracks structural ones', () => {
+test('usage config fingerprint tracks only effective structural values', () => {
   const base = {
     clients: 'claude,codex',
     historyEnabled: true,
     hiddenClients: 'codex'
   };
+  const context = {
+    intervalMs: 10 * 60 * 1000,
+    historyIntervalMs: 15 * 60 * 1000,
+    watchEnabled: true,
+    watchTriggersCollection: false,
+    intervalRequiresActivity: true
+  };
+  const baseConfig = usageConfigFromSettings(base, {
+    ...context,
+    onError: () => 'first',
+    logger: () => 'first'
+  });
+  const displayConfig = usageConfigFromSettings({ ...base, hiddenClients: 'claude', glassBlur: 80 }, {
+    ...context,
+    onError: () => 'second',
+    logger: () => 'second'
+  });
   assert.equal(
-    usageSettingsFingerprint(base),
-    usageSettingsFingerprint({ ...base, hiddenClients: 'claude', glassBlur: 80 })
+    usageConfigFingerprint(baseConfig),
+    usageConfigFingerprint(displayConfig),
+    'callbacks and display-only settings do not identify collection work'
   );
   assert.notEqual(
-    usageSettingsFingerprint(base),
-    usageSettingsFingerprint({ ...base, clients: 'claude' })
+    usageConfigFingerprint(usageConfigFromSettings(base, context)),
+    usageConfigFingerprint(usageConfigFromSettings({ ...base, clients: 'claude' }, context))
+  );
+});
+
+test('usage config fingerprint dedupes raw settings with the same effective runtime', () => {
+  const smartContext = {
+    intervalMs: 10 * 60 * 1000,
+    historyIntervalMs: 15 * 60 * 1000,
+    watchEnabled: true,
+    watchTriggersCollection: false,
+    intervalRequiresActivity: true
+  };
+  const omittedDefaults = usageConfigFromSettings({ collectionIntervalMs: 5 * 60 * 1000 }, smartContext);
+  const explicitDefaults = usageConfigFromSettings({
+    collectionIntervalMs: 30 * 60 * 1000,
+    historyEnabled: true,
+    sessionUsageArchiveEnabled: true,
+    projectsEnabled: true,
+    wslScanEnabled: true
+  }, smartContext);
+
+  assert.equal(
+    usageConfigFingerprint(omittedDefaults),
+    usageConfigFingerprint(explicitDefaults),
+    'smart mode ignores raw intervals and explicit true defaults'
+  );
+  assert.notEqual(
+    usageConfigFingerprint(explicitDefaults),
+    usageConfigFingerprint(usageConfigFromSettings({ historyEnabled: false }, smartContext))
   );
 });
 

--- a/tests/electron/toolTrackingToggle.test.js
+++ b/tests/electron/toolTrackingToggle.test.js
@@ -31,7 +31,7 @@ test('usage-structural changes replace usage without restarting limits', () => {
   const handler = mainSource.slice(start, end);
   assert.match(handler, /if \(runtimeChange\.usageStructural\) \{\s*reconfigureUsageRuntimeForMode\(\);\s*\}/);
   assert.doesNotMatch(handler, /runtimeChange\.usageStructural \|\| runtimeChange\.sinkStructural/);
-  assert.match(mainSource, /usageRuntimeReconciler\.schedule\(usageSettingsFingerprint\(settings\)\)/);
+  assert.match(mainSource, /usageRuntimeReconciler\.schedule\(usageConfigFingerprint\(usageConfigForMode\(\)\)\)/);
 });
 
 test('exhausted usage replacement retries are visible in diagnostics', () => {

--- a/tests/shared/abortSignal.test.js
+++ b/tests/shared/abortSignal.test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { abortReason, throwIfAborted } = require('../../src/shared/abortSignal');
+
+test('abort helpers preserve an Error reason exactly', () => {
+  const controller = new AbortController();
+  const reason = new Error('collector stopped');
+  controller.abort(reason);
+
+  assert.equal(abortReason(controller.signal), reason);
+  assert.throws(() => throwIfAborted(controller.signal), (error) => error === reason);
+});
+
+test('abort helpers normalize missing and non-Error reasons', () => {
+  const missingError = abortReason({ aborted: true }, 'fallback');
+  assert.equal(missingError.name, 'AbortError');
+  assert.equal(missingError.message, 'fallback');
+
+  const text = new AbortController();
+  text.abort('superseded');
+  assert.throws(
+    () => throwIfAborted(text.signal, 'fallback'),
+    (error) => error.name === 'AbortError' && error.message === 'superseded'
+  );
+});
+
+test('throwIfAborted is a no-op for a live signal', () => {
+  assert.doesNotThrow(() => throwIfAborted(new AbortController().signal));
+  assert.doesNotThrow(() => throwIfAborted());
+});

--- a/tests/shared/selfSyncThrottle.test.js
+++ b/tests/shared/selfSyncThrottle.test.js
@@ -14,9 +14,23 @@ const {
   createSourceSyncQueue,
   mergeSelfSyncSelection,
   selfSyncSelected,
+  SELF_SYNC_KINDS,
   SYNC_MIN_INTERVAL_MS,
   SYNC_SOURCE_EVENT_MIN_INTERVAL_MS
 } = require('../../src/shared/selfSyncThrottle');
+
+test('self-sync kinds are unique and unknown diagnostic kinds stay idle', () => {
+  assert.deepEqual([...new Set(SELF_SYNC_KINDS)], SELF_SYNC_KINDS);
+  assert.deepEqual(createSelfSyncThrottle().syncStatus('future-client'), {
+    state: 'idle',
+    lastAttemptAt: 0,
+    lastSuccessAt: 0,
+    failureCode: '',
+    failureStage: '',
+    detailCode: '',
+    exitCode: null
+  });
+});
 
 // A clock and a timer wheel the tests own outright, so a deadline can be
 // asserted at the millisecond without sleeping or patching a global.


### PR DESCRIPTION
Follow-up to #495.

## Summary

- fingerprint the effective normalized usage configuration so equivalent raw settings do not replace the runtime
- centralize collector, Cursor, and WSL abort handling while preserving existing `Error` reasons
- store self-sync throttle state as one per-client record instead of parallel maps

## Verification

- focused runtime and cancellation tests — 102 passed
- `npm run verify` — 3641 passed, 0 failed, 1 skipped

## Risk

The fingerprint covers settings-controlled structural fields and excludes callbacks and identity values that do not change collection work. Existing self-sync cadence, cancellation rollback, and late-attempt fencing remain covered by the test suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dedupes usage runtime replacements by fingerprinting the normalized effective usage configuration and centralizes abort handling; self‑sync throttle state is unified per client without changing cadence or cancellation semantics.

- Use `usageConfigFingerprint(...)` to key the reconciler with mode‑normalized usage config, not raw settings; `setActiveKey` and `schedule` now pass the effective config for the current mode.
- Add `src/shared/abortSignal.js` with `abortReason`/`throwIfAborted`, and update collector, Cursor, and WSL paths to use it.
- Store all self‑sync throttle fields in one per‑client record; cancellation fences and rate‑limits remain the same; diagnostics report idle for unknown kinds.

| Area | Before | After |
| --- | --- | --- |
| Usage runtime reconciliation | Fingerprint created from raw settings structural fields; equivalent settings variants could trigger runtime replacement. | Fingerprint created from normalized effective usage config via `usageConfigFingerprint(...)`; equivalent raw settings no longer replace the runtime. |
| Abort error normalization | Call sites constructed abort errors ad hoc; reason shapes varied. | `abortReason`/`throwIfAborted` centralize behavior; aborted ops throw a consistent `AbortError` and preserve an Error reason when provided. |

**Validation and risk**
- Tests: runtime and cancellation tests; unit tests for fingerprinting, abort helpers, and throttle diagnostics.
- Risk: Fingerprint excludes callbacks and identity-only fields; it covers settings-controlled structural values only. Cadence, cancellation rollback, and late-attempt fencing are unchanged.

<sup>Written for commit b9e8a05b4140a95a647c99fa13a6c7064172991d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

