### PR TITLE
feat(qoder): accept a dt- access token for CN credits quota

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -155,6 +155,10 @@ VOLCENGINE_REGION=cn-beijing
 QODER_COOKIE=
 TOKEN_MONITOR_QODER_SITE=global
 
+# Qoder CN access token (dt-...) for big-model credits, used before the cookie.
+# Optional — the widget has a GUI account setting.
+QODER_ACCESS_TOKEN=
+
 # Qoder CN local usage database path override. Optional — auto-detected per platform.
 # macOS: ~/Library/Application Support/QoderCN/SharedClientCache/cache/db/local.db
 # Windows: %APPDATA%/QoderCN/SharedClientCache/cache/db/local.db

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Token Monitor supports token usage, account-limit checks, and session details se
 Qoder CN token usage is read from the app's local SQLite database, not an API — enable it in Settings → tools (opt-in, off by default). The database is auto-detected per platform: macOS `~/Library/Application Support/QoderCN/SharedClientCache/cache/db/local.db`, Windows `%APPDATA%\QoderCN\SharedClientCache\cache\db\local.db`, Linux `~/.config/QoderCN/SharedClientCache/cache/db/local.db` — overridable with `TOKEN_MONITOR_QODER_CN_DB_PATH`.
 
 This is an advanced local integration: reading needs a `sqlite3` CLI on PATH or a Node runtime with unflagged `node:sqlite` (Node ≥ 23.4; the Electron widget may need the CLI). Read failures are logged, and an existing complete snapshot is retained instead of being replaced with zero usage. Costs are estimated from the models.dev catalog for each mapped model; the adapter may break if Qoder changes its database schema.
+
+#### Qoder limits credentials
+
+Qoder limit monitoring works with either of two credentials, both saved in Settings → AI Tool Limits → Qoder: the dashboard session cookie, or a Qoder CN access token (`dt-…`). The token takes precedence over the cookie; the cookie input keeps working unchanged.
+
 </details>
 
 ## Showcase

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -79,7 +79,7 @@ const { customPricingPath } = require('../shared/tokscaleConfig');
 const { applyCustomPricing, normalizeCustomPricingSetting } = require('../shared/tokscaleCustomPricing');
 const { createHub } = require('../hub/server');
 const { probeHubBuild } = require('./hubBuildStatus');
-const { claudeWebCookie, deepseekToken, fetchClaudeLimits, normalizeClaudeWebCookieInput, normalizeLimitsRefreshMode, normalizeLimitsRefreshMs, parseBoolean, parseLimitProviders, runCodexLogin, minimaxToken, copilotToken, zaiToken, zaiRegion, zaiTeamToken, volcengineCredentials, qoderCookie, traeAccessToken, traeDeviceId, commandcodeCookie, kimiToken, kimiWebToken, ollamaSessionCookie } = require('../shared/limitCollector');
+const { claudeWebCookie, deepseekToken, fetchClaudeLimits, normalizeClaudeWebCookieInput, normalizeLimitsRefreshMode, normalizeLimitsRefreshMs, parseBoolean, parseLimitProviders, runCodexLogin, minimaxToken, copilotToken, zaiToken, zaiRegion, zaiTeamToken, volcengineCredentials, qoderCookie, qoderAccessToken, traeAccessToken, traeDeviceId, commandcodeCookie, kimiToken, kimiWebToken, ollamaSessionCookie } = require('../shared/limitCollector');
 const { fetchOllamaLimits, rememberOllamaValidation } = require('../shared/ollamaLimits');
 const { copilotLoginErrorMessage, isAllowedVerificationUrl, runCopilotDeviceFlowLogin } = require('../shared/copilotDeviceFlow');
 const {
@@ -551,6 +551,7 @@ function defaultSettings() {
     volcengineSecretAccessKey: '',
     volcengineRegion: '',
     qoderCookie: '',
+    qoderAccessToken: '',
     qoderSite: 'global',
     traeAccessToken: '',
     traeDeviceId: '',
@@ -796,6 +797,10 @@ function normalizeQoderCookie(value) {
   return qoderCookie({}, { qoderCookie: String(value || '') });
 }
 
+function normalizeQoderAccessToken(value) {
+  return qoderAccessToken({}, { qoderAccessToken: String(value || '') });
+}
+
 function normalizeQoderSite(value) {
   const raw = String(value || '').trim().toLowerCase();
   if (raw === 'cn' || raw === 'china' || raw.includes('qoder.com.cn')) return 'cn';
@@ -804,6 +809,10 @@ function normalizeQoderSite(value) {
 
 function currentQoderCookie() {
   return settings?.qoderCookie || qoderCookie(process.env);
+}
+
+function currentQoderAccessToken() {
+  return settings?.qoderAccessToken || qoderAccessToken(process.env);
 }
 
 function normalizeTraeAccessToken(value) {
@@ -4312,6 +4321,11 @@ function settingsForRenderer() {
     : qoderCookie(process.env)
       ? 'env'
       : '';
+  const qoderAccessTokenSource = settings?.qoderAccessToken
+    ? 'settings'
+    : qoderAccessToken(process.env)
+      ? 'env'
+      : '';
   const traeAccessTokenSource = settings?.traeAccessToken
     ? 'settings'
     : traeAccessToken(process.env)
@@ -4373,6 +4387,7 @@ function settingsForRenderer() {
     volcengineAccessKeyId: settings?.volcengineAccessKeyId ? 'set' : '',
     claudeWebCookie: settings?.claudeWebCookie ? 'set' : '',
     qoderCookie: settings?.qoderCookie ? 'set' : '',
+    qoderAccessToken: settings?.qoderAccessToken ? 'set' : '',
     traeAccessToken: settings?.traeAccessToken ? 'set' : '',
     traeDeviceId: settings?.traeDeviceId ? 'set' : '',
     commandcodeCookie: settings?.commandcodeCookie ? 'set' : '',
@@ -4409,6 +4424,12 @@ function settingsForRenderer() {
     volcengineCredentialsSource,
     qoderCookieConfigured: Boolean(currentQoderCookie()),
     qoderCookieSource,
+    qoderAccessTokenConfigured: Boolean(currentQoderAccessToken()),
+    qoderAccessTokenSource,
+    // Either credential links the account: the dt- access token is preferred by
+    // the provider, the cookie stays as the dashboard-session fallback.
+    qoderCredentialConfigured: Boolean(currentQoderAccessToken() || currentQoderCookie()),
+    qoderCredentialSource: qoderAccessTokenSource || qoderCookieSource,
     traeAccessTokenConfigured: Boolean(currentTraeAccessToken()),
     traeAccessTokenSource,
     commandcodeCookieConfigured: Boolean(currentCommandcodeCookie()),
@@ -6128,6 +6149,7 @@ app.whenReady().then(() => {
     if (patch.volcengineSecretAccessKey !== undefined) normalizedPatch.volcengineSecretAccessKey = normalizeSecretSetting(patch.volcengineSecretAccessKey);
     if (patch.volcengineRegion !== undefined) normalizedPatch.volcengineRegion = normalizeVolcengineRegion(patch.volcengineRegion);
     if (patch.qoderCookie !== undefined) normalizedPatch.qoderCookie = normalizeQoderCookie(patch.qoderCookie);
+    if (patch.qoderAccessToken !== undefined) normalizedPatch.qoderAccessToken = normalizeQoderAccessToken(patch.qoderAccessToken);
     if (patch.qoderSite !== undefined) normalizedPatch.qoderSite = normalizeQoderSite(patch.qoderSite);
     if (patch.traeAccessToken !== undefined) normalizedPatch.traeAccessToken = normalizeTraeAccessToken(patch.traeAccessToken);
     if (patch.traeDeviceId !== undefined) normalizedPatch.traeDeviceId = normalizeTraeDeviceId(patch.traeDeviceId);
@@ -6252,6 +6274,7 @@ app.whenReady().then(() => {
       volcengineSecretAccessKey: patch.volcengineSecretAccessKey !== undefined ? normalizeSecretSetting(patch.volcengineSecretAccessKey) : (settings.volcengineSecretAccessKey || ''),
       volcengineRegion: patch.volcengineRegion !== undefined ? normalizeVolcengineRegion(patch.volcengineRegion) : (settings.volcengineRegion || ''),
       qoderCookie: patch.qoderCookie !== undefined ? normalizeQoderCookie(patch.qoderCookie) : (settings.qoderCookie || ''),
+      qoderAccessToken: patch.qoderAccessToken !== undefined ? normalizeQoderAccessToken(patch.qoderAccessToken) : (settings.qoderAccessToken || ''),
       qoderSite: patch.qoderSite !== undefined ? normalizeQoderSite(patch.qoderSite) : normalizeQoderSite(settings.qoderSite || 'global'),
       traeAccessToken: patch.traeAccessToken !== undefined ? normalizeTraeAccessToken(patch.traeAccessToken) : (settings.traeAccessToken || ''),
       traeDeviceId: patch.traeDeviceId !== undefined ? normalizeTraeDeviceId(patch.traeDeviceId) : (settings.traeDeviceId || ''),

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -10021,6 +10021,14 @@ function renderToolPreferencesNow() {
     name.className = 'tool-preference-name';
     name.textContent = label;
     labelGroup.append(name);
+    const noteKey = TOOL_PREFERENCE_NOTES[id];
+    if (noteKey) {
+      labelGroup.classList.add('has-note');
+      const note = document.createElement('div');
+      note.className = 'tool-preference-note';
+      note.textContent = t(noteKey);
+      labelGroup.append(note);
+    }
     if (enabled.has(id)) {
       // A tracked client with no reported status yet (first collect still running)
       // reads as "waiting for data" rather than a bare blank.
@@ -13390,8 +13398,8 @@ const externalLimitAccountConfig = {
     pendingKey: 'volcenginePendingCheckSince'
   },
   qoder: {
-    configuredKey: 'qoderCookieConfigured',
-    sourceKey: 'qoderCookieSource',
+    configuredKey: 'qoderCredentialConfigured',
+    sourceKey: 'qoderCredentialSource',
     pendingKey: 'qoderPendingCheckSince'
   },
   trae: {
@@ -15690,7 +15698,8 @@ function setupCursorAccountUI() {
     });
 
     document.getElementById('qoderLogoutButton').addEventListener('click', async () => {
-      await saveSettings({ qoderCookie: '' });
+      // Either credential can link the account, so unlinking clears both.
+      await saveSettings({ qoderCookie: '', qoderAccessToken: '' });
       clearExternalProviderCheckPending('qoder');
       clearExternalProviderPendingStatus('qoder');
       renderExternalProviderStatus('qoder');
@@ -15714,6 +15723,31 @@ function setupCursorAccountUI() {
       try {
         markExternalProviderCheckPending('qoder');
         await saveSettings({ qoderCookie: input.value, qoderSite: siteInput?.value || 'global' });
+        input.value = '';
+        renderExternalProviderStatus('qoder');
+        await refreshStats({ force: true });
+        setExternalAccountExpanded('qoder', !externalProviderAccountLinked('qoder'));
+        renderExternalProviderStatus('qoder');
+      } catch (err) {
+        clearExternalProviderCheckPending('qoder');
+        errorEl.textContent = t('settings.qoder.saveFailed', { message: err.message });
+        errorEl.classList.remove('hidden');
+      }
+    });
+
+    document.getElementById('qoderAccessTokenSubmit').addEventListener('click', async () => {
+      const input = document.getElementById('qoderAccessTokenInput');
+      const siteInput = document.getElementById('qoderSiteInput');
+      const errorEl = document.getElementById('qoderErrorMessage');
+      errorEl.classList.add('hidden');
+      if (!String(input.value || '').trim()) {
+        errorEl.textContent = t('settings.qoder.statusNotSet');
+        errorEl.classList.remove('hidden');
+        return;
+      }
+      try {
+        markExternalProviderCheckPending('qoder');
+        await saveSettings({ qoderAccessToken: input.value, qoderSite: siteInput?.value || 'global' });
         input.value = '';
         renderExternalProviderStatus('qoder');
         await refreshStats({ force: true });

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -10021,14 +10021,6 @@ function renderToolPreferencesNow() {
     name.className = 'tool-preference-name';
     name.textContent = label;
     labelGroup.append(name);
-    const noteKey = TOOL_PREFERENCE_NOTES[id];
-    if (noteKey) {
-      labelGroup.classList.add('has-note');
-      const note = document.createElement('div');
-      note.className = 'tool-preference-note';
-      note.textContent = t(noteKey);
-      labelGroup.append(note);
-    }
     if (enabled.has(id)) {
       // A tracked client with no reported status yet (first collect still running)
       // reads as "waiting for data" rather than a bare blank.

--- a/src/electron/renderer/index.html
+++ b/src/electron/renderer/index.html
@@ -1016,6 +1016,14 @@
                   <div class="settings-actions">
                     <button id="qoderCookieSubmit" data-i18n="settings.qoder.saveCookie">Save cookie</button>
                   </div>
+                  <div class="settings-row">
+                    <label for="qoderAccessTokenInput" data-i18n="settings.qoder.accessToken">Access token (optional)</label>
+                    <input id="qoderAccessTokenInput" type="password" spellcheck="false" autocomplete="off" placeholder="dt-..." data-i18n-placeholder="settings.qoder.accessTokenPlaceholder" />
+                  </div>
+                  <p class="settings-note"><span data-i18n="settings.qoder.accessTokenHint">Qoder CN access token (dt- …), used ahead of the Cookie.</span></p>
+                  <div class="settings-actions">
+                    <button id="qoderAccessTokenSubmit" data-i18n="settings.qoder.saveAccessToken">Save token</button>
+                  </div>
                 </div>
                 <div id="qoderErrorMessage" class="settings-note error hidden"></div>
               </div>

--- a/src/electron/runtimeConfig.js
+++ b/src/electron/runtimeConfig.js
@@ -66,7 +66,7 @@ const LIMIT_PROVIDER_SETTING_KEYS = Object.freeze({
   zai: ['zaiApiKey', 'zaiApiRegion'],
   zaiteam: ['zaiTeamApiKey', 'zaiTeamOrganizationId', 'zaiTeamProjectId'],
   volcengine: ['volcengineAccessKeyId', 'volcengineSecretAccessKey', 'volcengineRegion'],
-  qoder: ['qoderCookie', 'qoderSite'],
+  qoder: ['qoderCookie', 'qoderAccessToken', 'qoderSite'],
   trae: ['traeAccessToken', 'traeDeviceId'],
   // The desktop widget auto-detects WorkBuddy when the provider itself is
   // enabled. Token and metadata fields remain available to headless/CLI deployments.
@@ -167,6 +167,7 @@ function limitsConfigFromSettings(settings = {}, context = {}) {
     volcengineSecretAccessKey: settings.volcengineSecretAccessKey || '',
     volcengineRegion: settings.volcengineRegion || '',
     qoderCookie: settings.qoderCookie || '',
+    qoderAccessToken: settings.qoderAccessToken || '',
     qoderSite: settings.qoderSite || 'global',
     traeAccessToken: settings.traeAccessToken
       || env.TOKEN_MONITOR_TRAE_ACCESS_TOKEN

--- a/src/shared/credentialStore.js
+++ b/src/shared/credentialStore.js
@@ -25,6 +25,7 @@ const CREDENTIAL_SETTING_PATHS = Object.freeze({
   volcengineAccessKeyId: ['providers', 'volcengine', 'accessKeyId'],
   volcengineSecretAccessKey: ['providers', 'volcengine', 'secretAccessKey'],
   qoderCookie: ['providers', 'qoder', 'cookie'],
+  qoderAccessToken: ['providers', 'qoder', 'accessToken'],
   traeAccessToken: ['providers', 'trae', 'accessToken'],
   traeDeviceId: ['providers', 'trae', 'deviceId'],
   commandcodeCookie: ['providers', 'commandcode', 'cookie'],

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -49,7 +49,7 @@ const { fetchZaiTeamLimits, zaiTeamToken } = zaiTeamLimits;
 const volcengineLimits = require('./volcengineLimits');
 const { volcengineCredentials, fetchVolcengineLimits } = volcengineLimits;
 const qoderLimits = require('./qoderLimits');
-const { qoderCookie, fetchQoderLimits } = qoderLimits;
+const { qoderCookie, qoderAccessToken, fetchQoderLimits } = qoderLimits;
 const commandcodeLimits = require('./commandcodeLimits');
 const { commandcodeCookie, fetchCommandcodeLimits } = commandcodeLimits;
 const ollamaLimits = require('./ollamaLimits');
@@ -4285,6 +4285,7 @@ module.exports = {
   volcengineCredentials,
   fetchVolcengineLimits,
   qoderCookie,
+  qoderAccessToken,
   fetchQoderLimits,
   traeAccessToken: traeLimits.traeAccessToken,
   traeDeviceId: traeLimits.traeDeviceId,

--- a/src/shared/qoderLimits.js
+++ b/src/shared/qoderLimits.js
@@ -27,6 +27,19 @@ function qoderCookie(env = process.env, options = {}) {
   return '';
 }
 
+// IDE access token (the `dt-…` credential the Qoder desktop app sends as
+// `Authorization: Bearer` to its openapi origin). It outlives a dashboard
+// session cookie, so prefer it when both are configured.
+function qoderAccessToken(env = process.env, options = {}) {
+  const explicit = cleanSecret(options.qoderAccessToken);
+  if (explicit) return explicit;
+  for (const name of ['QODER_ACCESS_TOKEN', 'TOKEN_MONITOR_QODER_ACCESS_TOKEN']) {
+    const raw = cleanSecret(env[name]);
+    if (raw) return raw;
+  }
+  return '';
+}
+
 function qoderSite(options = {}, env = process.env) {
   const value = String(options.qoderSite || env.QODER_SITE || env.TOKEN_MONITOR_QODER_SITE || '').trim().toLowerCase();
   if (value === 'cn' || value === 'china' || value.includes('qoder.com.cn')) return 'cn';
@@ -37,12 +50,24 @@ function qoderOrigin(site) {
   return site === 'cn' ? 'https://qoder.com.cn' : 'https://qoder.com';
 }
 
+function qoderApiOrigin(site) {
+  return site === 'cn' ? 'https://openapi.qoder.com.cn' : 'https://openapi.qoder.sh';
+}
+
 function qoderUsageUrl(site = 'global') {
   return `${qoderOrigin(site)}/api/v2/me/usages/big_model_credits`;
 }
 
 function qoderUserPlanUrl(site = 'global') {
   return `${qoderOrigin(site)}/api/v1/me/userplan`;
+}
+
+function qoderApiQuotaUrl(site = 'global') {
+  return `${qoderApiOrigin(site)}/api/v2/quota/usage`;
+}
+
+function qoderApiPlanUrl(site = 'global') {
+  return `${qoderApiOrigin(site)}/api/v2/user/plan`;
 }
 
 function numberOrNull(value) {
@@ -134,6 +159,66 @@ function parseQoderPlanLabel(body) {
   return firstPlanLabel(current);
 }
 
+function planTierLabel(body) {
+  const raw = String(read(body, 'planTierName', 'plan_tier_name') || '').trim();
+  return planText(raw);
+}
+
+// Response of GET {openapi}/api/v2/quota/usage, the endpoint the Qoder desktop
+// app itself polls for its credits meter:
+// { userQuota: { total, used, remaining, unit }, addOnQuota?: {...}, expiresAt }
+// `percentage` in that payload is a 0-1 fraction of used/total, not a percent,
+// so the window percentage is recomputed here.
+function parseQoderApiUsage(body) {
+  const userQuota = read(body, 'userQuota', 'user_quota');
+  const used = numberOrNull(read(userQuota, 'used', 'used'));
+  const total = numberOrNull(read(userQuota, 'total', 'total'));
+  if (used === null || total === null || used < 0 || total < 0) {
+    throw new Error('missing userQuota usage numbers');
+  }
+  let usedCredits = used;
+  let totalCredits = total;
+  let remainingCredits = numberOrNull(read(userQuota, 'remaining', 'remaining'));
+  if (remainingCredits === null) remainingCredits = Math.max(0, total - used);
+  const addOnQuota = read(body, 'addOnQuota', 'add_on_quota');
+  if (addOnQuota && typeof addOnQuota === 'object') {
+    const addOnUsed = numberOrNull(read(addOnQuota, 'used', 'used'));
+    const addOnTotal = numberOrNull(read(addOnQuota, 'total', 'total'));
+    const addOnRemaining = numberOrNull(read(addOnQuota, 'remaining', 'remaining'));
+    if (addOnUsed !== null && addOnTotal !== null && addOnUsed >= 0 && addOnTotal >= 0) {
+      usedCredits += addOnUsed;
+      totalCredits += addOnTotal;
+      remainingCredits += addOnRemaining === null ? Math.max(0, addOnTotal - addOnUsed) : addOnRemaining;
+    }
+  }
+  // Preserve reported usage even when it exceeds the limit: present the
+  // spendable balance as exhausted rather than treating the payload as broken.
+  remainingCredits = Math.max(0, remainingCredits);
+  const usagePercentage = totalCredits > 0 ? (usedCredits / totalCredits) * 100 : 0;
+  // expiresAt is the subscription boundary; monthly credits refresh with it.
+  const resetsAt = toIso(read(body, 'expiresAt', 'expires_at'));
+  const window = {
+    kind: 'billing',
+    label: 'Credits',
+    used: usedCredits,
+    limit: totalCredits,
+    remaining: remainingCredits,
+    usedPercent: usagePercentage,
+    remainingPercent: Math.max(0, Math.min(100, 100 - usagePercentage)),
+    resetsAt,
+    showMeter: true
+  };
+  return {
+    usedCredits,
+    totalCredits,
+    remainingCredits,
+    usagePercentage,
+    unit: String(read(userQuota, 'unit', 'unit') || '').trim(),
+    resetsAt,
+    window
+  };
+}
+
 function quotaSummary(container) {
   return read(container, 'quotaSummary', 'quota_summary') || null;
 }
@@ -200,22 +285,61 @@ function fetchJsonWithDeadline(url, init, deps = {}) {
   );
 }
 
-async function fetchQoderLimits(options = {}, deps = {}) {
-  const env = deps.env || process.env;
-  const now = (deps.now || Date.now)();
-  const updatedAt = new Date(now).toISOString();
-  const cookie = qoderCookie(env, options);
-  const site = qoderSite(options, env);
-  if (!cookie) {
-    return normalizeLimitProvider({
-      provider: 'qoder',
-      source: 'web',
-      status: 'notConfigured',
-      updatedAt,
-      windows: [],
-      region: site === 'cn' ? 'cn' : 'global'
-    });
+function providerStatusFromResponse(status) {
+  return status === 401 || status === 403
+    ? 'unauthorized'
+    : status === 429 ? 'sourceRateLimited' : 'unavailable';
+}
+
+function userTypeLabel(value) {
+  const raw = String(value || '').trim().toLowerCase();
+  if (!raw) return '';
+  if (raw.includes('professional') || raw.includes('pro_plus')) return 'Pro';
+  if (raw.includes('proplus') || raw.includes('pro_plus')) return 'Pro+';
+  if (raw.includes('ultra')) return 'Ultra';
+  if (raw.includes('free') || raw.includes('community')) return 'Community Edition';
+  if (raw.includes('enterprise')) return 'Enterprise';
+  if (raw.includes('team')) return 'Teams';
+  return '';
+}
+
+async function fetchQoderApiLimits(accessToken, site, options, deps, updatedAt) {
+  const headers = {
+    Authorization: `Bearer ${accessToken}`,
+    Accept: 'application/json',
+    'User-Agent': BROWSER_USER_AGENT
+  };
+  const { response, body } = await fetchJsonWithDeadline(qoderApiQuotaUrl(site), { headers }, deps);
+  if (!response.ok) {
+    const error = new Error(`Qoder usage returned ${response.status}`);
+    error.status = providerStatusFromResponse(response.status);
+    throw error;
   }
+  const usage = parseQoderApiUsage(body);
+  let accountLabel = userTypeLabel(read(body, 'userType', 'user_type'));
+  try {
+    const { response: planResponse, body: planBody } = await fetchJsonWithDeadline(
+      qoderApiPlanUrl(site),
+      { headers },
+      deps
+    );
+    if (planResponse.ok) {
+      accountLabel = planTierLabel(planBody) || parseQoderPlanLabel(planBody) || accountLabel;
+    }
+  } catch (_) {}
+  return normalizeLimitProvider({
+    provider: 'qoder',
+    accountKey: hashKey('qoder', accessToken),
+    accountLabel,
+    source: 'api',
+    status: 'ok',
+    updatedAt,
+    windows: [usage.window],
+    region: site === 'cn' ? 'cn' : 'global'
+  });
+}
+
+async function fetchQoderWebLimits(cookie, site, options, deps, updatedAt) {
   const origin = qoderOrigin(site);
   const headers = {
     Cookie: cookie,
@@ -227,41 +351,60 @@ async function fetchQoderLimits(options = {}, deps = {}) {
     'X-Requested-With': 'XMLHttpRequest',
     'Bx-V': '2.5.35'
   };
+  const { response, body } = await fetchJsonWithDeadline(qoderUsageUrl(site), {
+    headers
+  }, deps);
+  if (!response.ok) {
+    const error = new Error(`Qoder usage returned ${response.status}`);
+    error.status = providerStatusFromResponse(response.status);
+    throw error;
+  }
+  const usage = parseQoderUsage(body);
+  let accountLabel = '';
   try {
-    const { response, body } = await fetchJsonWithDeadline(qoderUsageUrl(site), {
-      headers
-    }, deps);
-    if (!response.ok) {
-      const error = new Error(`Qoder usage returned ${response.status}`);
-      error.status = response.status === 401 || response.status === 403
-        ? 'unauthorized'
-        : response.status === 429 ? 'sourceRateLimited' : 'unavailable';
-      throw error;
-    }
-    const usage = parseQoderUsage(body);
-    let accountLabel = '';
-    try {
-      const { response: planResponse, body: planBody } = await fetchJsonWithDeadline(
-        qoderUserPlanUrl(site),
-        { headers },
-        deps
-      );
-      if (planResponse.ok) accountLabel = parseQoderPlanLabel(planBody);
-    } catch (_) {}
+    const { response: planResponse, body: planBody } = await fetchJsonWithDeadline(
+      qoderUserPlanUrl(site),
+      { headers },
+      deps
+    );
+    if (planResponse.ok) accountLabel = parseQoderPlanLabel(planBody);
+  } catch (_) {}
+  return normalizeLimitProvider({
+    provider: 'qoder',
+    accountKey: hashKey('qoder', cookie),
+    accountLabel,
+    source: 'web',
+    status: 'ok',
+    updatedAt,
+    windows: [usage.window],
+    region: site === 'cn' ? 'cn' : 'global'
+  });
+}
+
+async function fetchQoderLimits(options = {}, deps = {}) {
+  const env = deps.env || process.env;
+  const now = (deps.now || Date.now)();
+  const updatedAt = new Date(now).toISOString();
+  const accessToken = qoderAccessToken(env, options).replace(/^bearer\s+/i, '').trim();
+  const cookie = qoderCookie(env, options);
+  const site = qoderSite(options, env);
+  if (!accessToken && !cookie) {
     return normalizeLimitProvider({
       provider: 'qoder',
-      accountKey: hashKey('qoder', cookie),
-      accountLabel,
-      source: 'web',
-      status: 'ok',
+      source: accessToken ? 'api' : 'web',
+      status: 'notConfigured',
       updatedAt,
-      windows: [usage.window],
+      windows: [],
       region: site === 'cn' ? 'cn' : 'global'
     });
+  }
+  try {
+    if (accessToken) return await fetchQoderApiLimits(accessToken, site, options, deps, updatedAt);
+    return await fetchQoderWebLimits(cookie, site, options, deps, updatedAt);
   } catch (error) {
     return normalizeLimitProvider({
       provider: 'qoder',
-      source: 'web',
+      source: accessToken ? 'api' : 'web',
       status: error?.status === 'timeout' ? 'unavailable' : error?.status || 'unavailable',
       updatedAt,
       windows: [],
@@ -273,11 +416,16 @@ async function fetchQoderLimits(options = {}, deps = {}) {
 module.exports = {
   QODER_FETCH_TIMEOUT_MS,
   qoderCookie,
+  qoderAccessToken,
   qoderSite,
   qoderOrigin,
+  qoderApiOrigin,
   qoderUsageUrl,
   qoderUserPlanUrl,
+  qoderApiQuotaUrl,
+  qoderApiPlanUrl,
   parseQoderPlanLabel,
   parseQoderUsage,
+  parseQoderApiUsage,
   fetchQoderLimits
 };

--- a/tests/electron/cursorSettingsLayout.test.js
+++ b/tests/electron/cursorSettingsLayout.test.js
@@ -734,6 +734,7 @@ test('Z.ai, Volcengine, Qoder, Trae, and Ollama account panels are exposed in se
   assert.match(html, /<div id="zaiAccountGroup"[\s\S]*?<select id="zaiApiRegionInput">[\s\S]*?<input id="zaiApiKeyInput" type="password"[\s\S]*?<button id="zaiApiKeySubmit"[\s\S]*data-i18n="settings\.zai\.saveApiKey">/);
   assert.match(html, /<div id="volcengineAccountGroup"[\s\S]*?data-i18n="settings\.volcengine\.accessKeyId">API key \/ Access key ID[\s\S]*?<input id="volcengineAccessKeyInput" type="password"[\s\S]*placeholder="ark-\.\.\. or AKLT\.\.\."[\s\S]*?<input id="volcengineSecretAccessKeyInput" type="password"[\s\S]*?<input id="volcengineRegionInput" type="text"[\s\S]*?<button id="volcengineCredentialsSubmit"[\s\S]*data-i18n="settings\.volcengine\.saveCredentials">/);
   assert.match(html, /<div id="qoderAccountGroup"[\s\S]*?<select id="qoderSiteInput">[\s\S]*?<textarea id="qoderCookieInput"[\s\S]*?<button id="qoderCookieSubmit"[\s\S]*data-i18n="settings\.qoder\.saveCookie">/);
+  assert.match(html, /<input id="qoderAccessTokenInput" type="password"[\s\S]*?placeholder="dt-\.\.\."[\s\S]*?<button id="qoderAccessTokenSubmit"[\s\S]*data-i18n="settings\.qoder\.saveAccessToken">/);
   assert.match(html, /<div id="traeAccountGroup"[\s\S]*?<input id="traeTokenInput" type="password"[\s\S]*?data-i18n-placeholder="settings\.trae\.tokenPlaceholder"[\s\S]*?<input id="traeDeviceIdInput" type="text"[\s\S]*?data-i18n-placeholder="settings\.trae\.deviceIdPlaceholder"[\s\S]*?<button id="traeTokenSubmit"[\s\S]*data-i18n="settings\.trae\.saveCredentials">/);
   const traeDetails = html.match(/<div id="traeSettingsDetails"[\s\S]*?<div id="traeErrorMessage" class="settings-note error hidden"><\/div>/)?.[0] || '';
   assert.match(traeDetails, /<strong>1\.<\/strong> <span data-i18n="settings\.trae\.step1">/);
@@ -766,6 +767,8 @@ test('Z.ai, Volcengine, Qoder, Trae, and Ollama account panels are exposed in se
   assert.match(setupBody, /\/\^AKLT\/i\.test\(accessKeyValue\) && !secretValue/);
   assert.match(setupBody, /saveSettings\(\{\s*volcengineAccessKeyId: accessKeyInput\.value,[\s\S]*?volcengineSecretAccessKey: secretInput\.value,[\s\S]*?volcengineRegion: regionInput\.value \|\| 'cn-beijing'/);
   assert.match(setupBody, /saveSettings\(\{ qoderCookie: input\.value, qoderSite: siteInput\?\.value \|\| 'global' \}\)/);
+  assert.match(setupBody, /saveSettings\(\{ qoderAccessToken: input\.value, qoderSite: siteInput\?\.value \|\| 'global' \}\)/);
+  assert.match(setupBody, /saveSettings\(\{ qoderCookie: '', qoderAccessToken: '' \}\)/);
   assert.match(setupBody, /qoderSiteInput\?\.addEventListener\('change', \(\) => \{[\s\S]*?updateQoderUsagePageHint\(\);[\s\S]*?void saveSettings\(\{ qoderSite: qoderSiteInput\.value \|\| 'global' \}\);[\s\S]*?\}\)/);
   assert.match(setupBody, /window\.tokenMonitor\.openExternal\(zaiPlatformUrl\(\)\)/);
   assert.match(setupBody, /window\.tokenMonitor\.openExternal\(volcenginePlatformUrl\(\)\)/);
@@ -1810,8 +1813,8 @@ test('main collectors share one live GUI limit credential resolver in every widg
   assert.doesNotMatch(renewalPersistence, /queueLimitInvalidation|classifySettingsChange/);
   for (const key of [
     'claudeWebCookie', 'zaiApiKey', 'zaiApiRegion', 'volcengineAccessKeyId', 'volcengineSecretAccessKey',
-    'volcengineRegion', 'qoderCookie', 'qoderSite', 'commandcodeCookie', 'kimiApiKey', 'kimiWebAccessToken',
-    'ollamaCookie'
+    'volcengineRegion', 'qoderCookie', 'qoderAccessToken', 'qoderSite', 'commandcodeCookie', 'kimiApiKey',
+    'kimiWebAccessToken', 'ollamaCookie'
   ]) assert.match(runtimeConfig, new RegExp(`${key}: settings\\.${key}`));
 });
 

--- a/tests/shared/credentialStore.test.js
+++ b/tests/shared/credentialStore.test.js
@@ -45,7 +45,8 @@ test('stores credential settings in a versioned provider document', (t) => {
     zaiTeamOrganizationId: 'organization-id',
     traeAccessToken: 'trae-token',
     traeDeviceId: 'trae-device',
-    qoderCookie: ''
+    qoderCookie: '',
+    qoderAccessToken: 'dt-qoder-token'
   });
 
   const document = JSON.parse(fs.readFileSync(path.join(dataDir, 'credentials.json'), 'utf8'));
@@ -63,7 +64,7 @@ test('stores credential settings in a versioned provider document', (t) => {
   assert.equal(document.credentials.providers.zaiTeam.organizationId, 'organization-id');
   assert.equal(document.credentials.providers.trae.accessToken, 'trae-token');
   assert.equal(document.credentials.providers.trae.deviceId, 'trae-device');
-  assert.equal(document.credentials.providers.qoder, undefined);
+  assert.deepEqual(document.credentials.providers.qoder, { accessToken: 'dt-qoder-token' });
   assert.equal(document.migrations.settings, 1);
 
   assert.deepEqual(store.settingsCredentials(), {
@@ -85,7 +86,8 @@ test('stores credential settings in a versioned provider document', (t) => {
     kimiWebAccessToken: 'kimi-web-token',
     zaiTeamOrganizationId: 'organization-id',
     traeAccessToken: 'trae-token',
-    traeDeviceId: 'trae-device'
+    traeDeviceId: 'trae-device',
+    qoderAccessToken: 'dt-qoder-token'
   });
 });
 
@@ -131,6 +133,8 @@ test('renderer redaction defaults new credential fields to hidden with explicit 
   assert.equal(redacted.thirdPartyProfiles, '');
   assert.equal(redacted.kimiApiKey, '');
   assert.equal(redacted.kimiWebAccessToken, '');
+  assert.equal(redacted.qoderCookie, '');
+  assert.equal(redacted.qoderAccessToken, '');
 });
 
 test('migrates legacy settings once and keeps an existing credential authoritative', (t) => {

--- a/tests/shared/qoderLimits.test.js
+++ b/tests/shared/qoderLimits.test.js
@@ -5,11 +5,15 @@ const test = require('node:test');
 
 const {
   qoderCookie,
+  qoderAccessToken,
   qoderSite,
   qoderUsageUrl,
   qoderUserPlanUrl,
+  qoderApiQuotaUrl,
+  qoderApiPlanUrl,
   parseQoderPlanLabel,
   parseQoderUsage,
+  parseQoderApiUsage,
   fetchQoderLimits
 } = require('../../src/shared/qoderLimits');
 
@@ -18,6 +22,20 @@ test('qoderCookie reads settings before env and trims quoted cookies', () => {
   assert.equal(qoderCookie({ QODER_COOKIE: '  "env-cookie"  ' }), 'env-cookie');
   assert.equal(qoderCookie({ TOKEN_MONITOR_QODER_COOKIE: 'tm-cookie' }), 'tm-cookie');
   assert.equal(qoderCookie({}), '');
+});
+
+test('qoderAccessToken reads settings before env and accepts a Bearer prefix', () => {
+  assert.equal(qoderAccessToken({ QODER_ACCESS_TOKEN: 'env-token' }, { qoderAccessToken: 'dt-settings' }), 'dt-settings');
+  assert.equal(qoderAccessToken({ QODER_ACCESS_TOKEN: 'dt-env' }), 'dt-env');
+  assert.equal(qoderAccessToken({ TOKEN_MONITOR_QODER_ACCESS_TOKEN: 'dt-tm' }), 'dt-tm');
+  assert.equal(qoderAccessToken({}, { qoderAccessToken: 'Bearer dt-bearer' }), 'Bearer dt-bearer');
+  assert.equal(qoderAccessToken({}), '');
+});
+
+test('qoderApiQuotaUrl targets the IDE openapi origin per site', () => {
+  assert.equal(qoderApiQuotaUrl('cn'), 'https://openapi.qoder.com.cn/api/v2/quota/usage');
+  assert.equal(qoderApiQuotaUrl('global'), 'https://openapi.qoder.sh/api/v2/quota/usage');
+  assert.equal(qoderApiPlanUrl('cn'), 'https://openapi.qoder.com.cn/api/v2/user/plan');
 });
 
 test('qoderSite maps global and China dashboard hosts', () => {
@@ -92,6 +110,118 @@ test('fetchQoderLimits returns notConfigured without a cookie', async () => {
   assert.equal(provider.provider, 'qoder');
   assert.equal(provider.source, 'web');
   assert.equal(provider.status, 'notConfigured');
+});
+
+test('parseQoderApiUsage reads the IDE quota payload with add-on credits', () => {
+  const usage = parseQoderApiUsage({
+    userId: 'u1',
+    userType: 'personal_professional',
+    usageType: 'credits',
+    totalUsagePercentage: 0.02,
+    isQuotaExceeded: false,
+    expiresAt: 1790352000000,
+    upgradeUrl: 'https://qoder.com.cn/pricing?client=qoder',
+    userQuota: {
+      total: 2000,
+      used: 38,
+      remaining: 1962,
+      percentage: 0.02,
+      unit: 'credits'
+    },
+    isPlanQuotaProrated: false
+  });
+
+  assert.equal(usage.usedCredits, 38);
+  assert.equal(usage.totalCredits, 2000);
+  assert.equal(usage.remainingCredits, 1962);
+  assert.equal(usage.usagePercentage, 38 / 2000 * 100);
+  assert.equal(usage.unit, 'credits');
+  assert.equal(usage.resetsAt, new Date(1790352000000).toISOString());
+  assert.equal(usage.window.kind, 'billing');
+  assert.equal(usage.window.label, 'Credits');
+  assert.equal(usage.window.used, 38);
+  assert.equal(usage.window.limit, 2000);
+});
+
+test('parseQoderApiUsage merges add-on quota into the window', () => {
+  const usage = parseQoderApiUsage({
+    expiresAt: 1790352000000,
+    userQuota: { total: 2000, used: 1500, remaining: 500, unit: 'credits' },
+    addOnQuota: { total: 500, used: 100, remaining: 400, unit: 'credits' }
+  });
+
+  assert.equal(usage.usedCredits, 1600);
+  assert.equal(usage.totalCredits, 2500);
+  assert.equal(usage.remainingCredits, 900);
+  assert.equal(usage.usagePercentage, 1600 / 2500 * 100);
+});
+
+test('parseQoderApiUsage derives remaining when the payload omits it', () => {
+  const usage = parseQoderApiUsage({
+    userQuota: { total: 100, used: 30, unit: 'credits' }
+  });
+  assert.equal(usage.remainingCredits, 70);
+});
+
+test('parseQoderApiUsage rejects a payload without usage numbers', () => {
+  assert.throws(() => parseQoderApiUsage({ userType: 'personal_professional' }), /missing userQuota/);
+});
+
+test('fetchQoderLimits prefers the access token and hits the IDE openapi endpoint', async () => {
+  const requests = [];
+  const provider = await fetchQoderLimits(
+    { qoderAccessToken: 'dt-abc', qoderCookie: 'session=stale', qoderSite: 'cn' },
+    {
+      env: {},
+      now: () => Date.parse('2026-08-25T00:00:00Z'),
+      fetch: async (url, init) => {
+        requests.push({ url: String(url), init });
+        if (String(url).endsWith('/api/v2/user/plan')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ user_type: 'personal_professional', plan_tier_name: 'Pro' })
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            userId: 'u1',
+            userType: 'personal_professional',
+            expiresAt: 1790352000000,
+            userQuota: { total: 2000, used: 38, remaining: 1962, percentage: 0.02, unit: 'credits' }
+          })
+        };
+      }
+    }
+  );
+
+  assert.equal(provider.status, 'ok');
+  assert.equal(provider.source, 'api');
+  assert.equal(provider.region, 'cn');
+  assert.equal(provider.accountLabel, 'Pro');
+  assert.equal(provider.windows.length, 1);
+  assert.equal(provider.windows[0].used, 38);
+  assert.equal(provider.windows[0].limit, 2000);
+  assert.equal(provider.windows[0].remaining, 1962);
+  assert.equal(requests[0].url, 'https://openapi.qoder.com.cn/api/v2/quota/usage');
+  assert.equal(requests[0].init.headers.Authorization, 'Bearer dt-abc');
+  assert.equal(requests.some((r) => r.url.includes('qoder.com.cn/api/v2/me/usages')), false);
+});
+
+test('fetchQoderLimits reports unauthorized when the access token is rejected', async () => {
+  const provider = await fetchQoderLimits(
+    { qoderAccessToken: 'dt-expired', qoderSite: 'cn' },
+    {
+      env: {},
+      now: () => Date.parse('2026-08-25T00:00:00Z'),
+      fetch: async () => ({ ok: false, status: 401, json: async () => ({}) })
+    }
+  );
+  assert.equal(provider.status, 'unauthorized');
+  assert.equal(provider.source, 'api');
+  assert.equal(provider.windows.length, 0);
 });
 
 test('fetchQoderLimits requests the selected site with the dashboard cookie', async () => {


### PR DESCRIPTION
## Summary

Qoder limit monitoring currently authenticates with the dashboard session cookie only. That cookie expires and has to be re-copied from the browser regularly, which is the main reason a saved Qoder credential goes stale.

This PR adds a second credential: the Qoder CN access token (`dt-…`) that the IDE itself uses. It hits `openapi.qoder.com.cn/api/v2/quota/usage` with `Authorization: Bearer dt-…` and reports the merged personal + add-on credit quota, so no cookie scraping is involved.

- The token takes precedence when both are saved; the cookie path is unchanged and keeps working.
- The plan tier is read from `/api/v2/user/plan` and shown as the account label (e.g. "Pro"), same as other providers.
- Settings → AI Tool Limits → Qoder gains an "Access token" input next to the existing cookie input; the logout button clears both credentials (kimi-style dual-credential handling).
- `QODER_ACCESS_TOKEN` / `TOKEN_MONITOR_QODER_ACCESS_TOKEN` env vars are supported alongside `QODER_COOKIE`, and `.env.example` documents the new key.

## Files

- `src/shared/qoderLimits.js` — token-first auth, `parseQoderApiUsage` (personal + add-on quota merge), plan endpoint
- `src/shared/credentialStore.js` — `qoderAccessToken` credential mapping
- `src/shared/limitCollector.js` — pass the token through to the provider
- `src/electron/main.js` — settings storage, IPC, masked echo, dual-credential configured/source state
- `src/electron/runtimeConfig.js` — settings → collector options
- `src/electron/renderer/index.html` + `src/electron/renderer/app.js` — token input UI, submit handler, dual logout
- `README.md` — "Qoder limits credentials" note
- `.env.example` — `QODER_ACCESS_TOKEN`
- tests: `qoderLimits.test.js` (token-first flow, API response parsing, add-on merge, error paths), `credentialStore.test.js` (round-trip), `cursorSettingsLayout.test.js` (input present, save, logout clears both)

## Testing

- `node --test tests/shared/qoderLimits.test.js` — 17/17
- `node --test tests/electron/cursorSettingsLayout.test.js` — 61/61
- `credentialStore.test.js` — new assertions pass; the file's 9 pre-existing Windows-only `lstat`/`fstat` failures are unchanged from main (verified against a pristine main checkout on the same machine)
- Live-verified against `openapi.qoder.com.cn` with a real `dt-` token: quota, plan label, and add-on merge all render correctly.

Relates to the Qoder limits provider introduced in #84.