### PR TITLE
fix(trae): handle unconsumed packs and feature entitlements in the credits response

### DIFF
--- a/src/shared/traeLimits.js
+++ b/src/shared/traeLimits.js
@@ -74,18 +74,30 @@ function parseTraeEntUsage(body) {
     const rawLimit = pack?.entitlement_base_info?.quota?.credits_limit
       ?? pack?.entitlementBaseInfo?.quota?.creditsLimit;
     const rawUsed = pack?.usage?.credits_amount ?? pack?.usage?.creditsAmount;
+    const quota = pack?.entitlement_base_info?.quota ?? pack?.entitlementBaseInfo?.quota;
     const packLimit = numberOrNull(rawLimit);
     const packUsed = numberOrNull(rawUsed);
 
+    // A pack whose quota carries no credits_limit is a feature entitlement
+    // (free-tier solo toggles), not balance, and contributes nothing. Usage on
+    // such a pack — or a pack with no quota at all — is a shape whose spend we
+    // cannot sum, so a partial aggregate stays unsafe to publish.
+    if (packLimit === null) {
+      if (quota && packUsed === null) continue;
+      throw new Error('Trae credits response contains an unusable active entitlement pack');
+    }
+    // An untouched pack reports an empty usage object: zero consumed, not malformed.
+    const consumed = packUsed === null ? 0 : packUsed;
+
     // Zero-limit rows do not contribute to the spendable balance. Any other
     // unusable row makes a partial aggregate unsafe to publish.
-    if (packLimit === 0 && packUsed === 0) continue;
+    if (packLimit === 0 && consumed === 0) continue;
     activePackCount += 1;
-    if (packLimit === null || packUsed === null || packLimit <= 0 || packUsed < 0) {
+    if (packLimit <= 0 || consumed < 0) {
       throw new Error('Trae credits response contains an unusable active entitlement pack');
     }
     limit += packLimit;
-    used += packUsed;
+    used += consumed;
   }
 
   if (activePackCount === 0) throw new Error('Trae credits response has no usable entitlement packs');

--- a/tests/shared/traeLimits.test.js
+++ b/tests/shared/traeLimits.test.js
@@ -91,6 +91,31 @@ test('parseTraeEntUsage preserves overage while clamping the spendable balance',
   assert.equal(exhausted.window.remainingPercent, 0);
 });
 
+test('parseTraeEntUsage skips feature entitlements and treats untouched packs as unconsumed', () => {
+  // Real-account shape: a free-tier entitlement toggles solo features without a
+  // credits_limit, and a pack nobody has drawn from yet reports an empty usage.
+  const parsed = parseTraeEntUsage({
+    user_entitlement_pack_list: [
+      { entitlement_base_info: { quota: { credits_limit: 2000 } }, usage: {} },
+      { entitlement_base_info: { quota: { credits_limit: 500, enable_solo_lite: true } }, usage: { credits_amount: 500 } },
+      { entitlement_base_info: { quota: { enable_solo_agent: true, enable_solo_lite: true } }, usage: {} }
+    ]
+  });
+  assert.equal(parsed.packCount, 2);
+  assert.equal(parsed.window.limit, 2500);
+  assert.equal(parsed.window.used, 500);
+  assert.equal(parsed.window.remaining, 2000);
+});
+
+test('parseTraeEntUsage fails closed when a feature entitlement reports spend', () => {
+  assert.throws(() => parseTraeEntUsage({
+    user_entitlement_pack_list: [
+      pack(100, 10),
+      { entitlement_base_info: { quota: { enable_solo_lite: true } }, usage: { credits_amount: 5 } }
+    ]
+  }), /unusable active/);
+});
+
 test('fetchTraeLimits returns notConfigured without a token', async () => {
   const provider = await fetchTraeLimits({}, { env: {}, now: () => 0 });
   assert.equal(provider.provider, 'trae');


### PR DESCRIPTION
## Summary

The Trae CN credits parser shipped in v0.48.0 (#483) fails closed on two pack shapes that real CN accounts return, so the provider shows unavailable instead of a balance:

- **Untouched packs report an empty `usage` object** — a welfare/invite/gift pack nobody has drawn from yet has no `credits_amount` at all. `packUsed === null` currently throws `unusable active entitlement pack`. An untouched pack is zero consumed, not malformed.
- **Free-tier feature entitlements carry a `quota` without `credits_limit`** — e.g. the 免费 pack whose quota only holds `enable_solo_*` toggles. `packLimit === null` currently throws. Those are feature switches, not spendable balance, and should be skipped.

Both shapes appear in the very first response of a CN account holding welfare/invite packs, so the provider never recovers for those users.

## What changed

`parseTraeEntUsage` in `src/shared/traeLimits.js`:

- A pack whose quota has no `credits_limit` and no usage is a feature entitlement and is skipped. If such a pack — or a pack with no quota at all — reports spend, the parser still fails closed: a shape whose spend cannot be summed stays unsafe to publish.
- A pack with a `credits_limit` but an empty `usage` counts as 0 consumed.
- Zero-limit skip, negative-value and overage handling, and every existing fail-closed error case are unchanged.

## Verification

- Live CN account carrying both shapes (5 packs: 2 untouched welfare packs with `usage: {}`, 1 feature entitlement with `enable_solo_*` only, 1 monthly pack mixing `credits_limit` + toggles, 1 partially consumed pack). v0.48.0 throws; with this change the aggregate matches the API's own `usage_summary` exactly — 5000 limit / 777.54 consumed / 4 active packs.
- New tests: real-world shape aggregation, and fail-closed when a feature entitlement reports spend.
- `node --test tests/shared/traeLimits.test.js` — 11/11 (9 existing + 2 new)
- `npx eslint src/shared/traeLimits.js tests/shared/traeLimits.test.js` — clean
