### PR TITLE
fix(grok): read WSL credentials for limits

### DIFF
--- a/src/shared/grokLimits.js
+++ b/src/shared/grokLimits.js
@@ -18,6 +18,7 @@ const { normalizeLimitProvider } = require('./limits');
 const { hashKey } = require('./hashKey');
 const { createOutboundFetch } = require('./outboundFetch');
 const { abortError } = require('./probeDeadline');
+const { listRunningWslDistros } = require('./wslUsage');
 
 const GROK_WEB_BILLING_GRPC_URL = 'https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig';
 const GROK_KEY_NAMES = ['GROK_BEARER_TOKEN'];
@@ -29,6 +30,12 @@ function resolveGrokHome(env = process.env) {
     return path.resolve(env.GROK_HOME.trim());
   }
   return path.join(os.homedir(), '.grok');
+}
+
+function grokAuthPath(home) {
+  return String(home).startsWith('\\\\wsl$\\')
+    ? `${home}\\auth.json`
+    : path.join(home, 'auth.json');
 }
 
 function cleanSecret(value) {
@@ -48,7 +55,7 @@ function cleanSecret(value) {
 // just needs the data ready before issuing the HTTP fetch.
 function readAuthJson(env = process.env, deps = {}) {
   const home = deps.grokHome || resolveGrokHome(env);
-  const filePath = path.join(home, 'auth.json');
+  const filePath = grokAuthPath(home);
   let raw;
   try {
     raw = (deps.readFileSync || fs.readFileSync)(filePath, 'utf8');
@@ -73,10 +80,7 @@ function readAuthJson(env = process.env, deps = {}) {
   };
 }
 
-function grokCredential(env = process.env, options = {}) {
-  // Priority: explicit settings > env > ~/.grok/auth.json (auto).
-  // The widget GUI no longer exposes a token field; env var and auth.json
-  // cover headless / CLI flows.
+function explicitGrokCredential(env = process.env, options = {}) {
   if (options && options.grokBearerToken) {
     const raw = cleanSecret(options.grokBearerToken);
     if (raw) return { token: raw, source: 'settings' };
@@ -85,7 +89,61 @@ function grokCredential(env = process.env, options = {}) {
     const raw = cleanSecret(env[name]);
     if (raw) return { token: raw, source: 'env' };
   }
+  return null;
+}
+
+function grokCredential(env = process.env, options = {}) {
+  // Priority: explicit settings > env > ~/.grok/auth.json (auto).
+  // The widget GUI no longer exposes a token field; env var and auth.json
+  // cover headless / CLI flows.
+  const explicit = explicitGrokCredential(env, options);
+  if (explicit) return explicit;
   return readAuthJson(env, options);
+}
+
+function wslGrokHomes(deps = {}) {
+  const readdirSync = deps.readdirSync || fs.readdirSync;
+  const runningDistros = deps.listRunningWslDistros || listRunningWslDistros;
+  const homes = [];
+  for (const distro of runningDistros(deps)) {
+    const homeRoot = `\\\\wsl$\\${distro}\\home`;
+    try {
+      for (const user of readdirSync(homeRoot)) homes.push(`${homeRoot}\\${user}\\.grok`);
+    } catch (_) { /* distro has no /home or it is unreadable */ }
+    homes.push(`\\\\wsl$\\${distro}\\root\\.grok`);
+  }
+  return homes;
+}
+
+async function resolveGrokCredential(env = process.env, options = {}, deps = {}) {
+  const explicit = explicitGrokCredential(env, options);
+  if (explicit) return explicit;
+
+  const configuredHome = deps.grokHome || options.grokHome;
+  if (configuredHome || (typeof env.GROK_HOME === 'string' && env.GROK_HOME.trim())) {
+    return readAuthJson(env, { ...deps, grokHome: configuredHome || resolveGrokHome(env) });
+  }
+
+  if ((deps.platform || process.platform) !== 'win32') return readAuthJson(env, deps);
+
+  const candidates = [
+    { home: resolveGrokHome(env), wsl: false },
+    ...wslGrokHomes(deps).map((home) => ({ home, wsl: true }))
+  ];
+  const stat = deps.stat || fs.promises.stat;
+  const ranked = [];
+  for (const candidate of candidates) {
+    try {
+      const metadata = await stat(grokAuthPath(candidate.home));
+      ranked.push({ ...candidate, mtimeMs: metadata.mtimeMs });
+    } catch (_) { /* missing or unreadable credential */ }
+  }
+  ranked.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  for (const candidate of ranked) {
+    const credential = readAuthJson(env, { ...deps, grokHome: candidate.home });
+    if (credential) return { ...credential, wsl: candidate.wsl };
+  }
+  return null;
 }
 
 function numberOrNull(value) {
@@ -563,7 +621,8 @@ async function fetchGrokRpcBilling(options = {}, deps = {}) {
 
 function shouldTryGrokRpc(credential, deps = {}) {
   if (typeof deps.fetchRpcBilling === 'function') return true;
-  return credential && typeof credential.source === 'string' && credential.source.startsWith('auth.json');
+  return credential && !credential.wsl
+    && typeof credential.source === 'string' && credential.source.startsWith('auth.json');
 }
 
 function unauthorizedGrokProvider(updatedAt, source = 'web', sourceDetail = '') {
@@ -654,7 +713,7 @@ async function fetchGrokLimits(options = {}, deps = {}) {
   const env = deps.env || process.env;
   const now = (deps.now || Date.now)();
   const updatedAt = new Date(now).toISOString();
-  const credential = grokCredential(env, { ...options, ...(deps.grokHome ? { grokHome: deps.grokHome } : {}) });
+  const credential = await resolveGrokCredential(env, options, deps);
   if (shouldTryGrokRpc(credential, deps)) {
     try {
       const rpcBody = await (deps.fetchRpcBilling || fetchGrokRpcBilling)(options, deps);
@@ -746,6 +805,8 @@ module.exports = {
   resolveGrokHome,
   readAuthJson,
   grokCredential,
+  wslGrokHomes,
+  resolveGrokCredential,
   parseGrokBilling,
   parseGrokGrpcWebBilling,
   resolveGrokFetch,

--- a/tests/shared/grokLimits.test.js
+++ b/tests/shared/grokLimits.test.js
@@ -11,6 +11,7 @@ const test = require('node:test');
 const {
   GROK_WEB_BILLING_GRPC_URL,
   resolveGrokHome,
+  resolveGrokCredential,
   isRetryableNetworkError,
   validateGrokGrpcStatus
 } = require('../../src/shared/grokLimits');
@@ -199,6 +200,50 @@ test('grokCredential returns null when nothing is configured', () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-test-'));
   const c = grokCredential({}, { grokHome: path.join(tmp, 'no-such-dir') });
   assert.equal(c, null);
+});
+
+test('resolveGrokCredential selects the newest native or running-WSL auth.json on Windows', async () => {
+  const nativePath = path.join(os.homedir(), '.grok', 'auth.json');
+  const wslHomeRoot = '\\\\wsl$\\Ubuntu\\home';
+  const wslPath = `${wslHomeRoot}\\alice\\.grok\\auth.json`;
+  const rootPath = '\\\\wsl$\\Ubuntu\\root\\.grok\\auth.json';
+  const credential = await resolveGrokCredential({}, {}, {
+    platform: 'win32',
+    listRunningWslDistros: () => ['Ubuntu'],
+    readdirSync: (target) => {
+      assert.equal(target, wslHomeRoot);
+      return ['alice'];
+    },
+    stat: async (target) => {
+      if (target === nativePath) return { mtimeMs: 100 };
+      if (target === wslPath) return { mtimeMs: 200 };
+      if (target === rootPath) throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+      throw new Error(`unexpected stat: ${target}`);
+    },
+    readFileSync: (target) => {
+      if (target === nativePath) return JSON.stringify({ 'https://auth.x.ai::client': { key: 'native-token' } });
+      if (target === wslPath) return JSON.stringify({ 'https://auth.x.ai::client': { key: 'wsl-token' } });
+      throw new Error(`unexpected read: ${target}`);
+    }
+  });
+
+  assert.equal(credential.token, 'wsl-token');
+  assert.equal(credential.path, wslPath);
+  assert.equal(credential.wsl, true);
+});
+
+test('resolveGrokCredential keeps explicit GROK_HOME ahead of WSL discovery', async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-explicit-home-'));
+  writeAuthJson(home, { 'https://auth.x.ai::client': { key: 'explicit-home-token' } });
+  const credential = await resolveGrokCredential({ GROK_HOME: home }, {}, {
+    platform: 'win32',
+    listRunningWslDistros: () => {
+      throw new Error('WSL discovery should not run for explicit GROK_HOME');
+    }
+  });
+
+  assert.equal(credential.token, 'explicit-home-token');
+  assert.equal(credential.wsl, undefined);
 });
 
 test('readAuthJson prefers OIDC scope entries', () => {
@@ -741,6 +786,46 @@ test('fetchGrokLimits falls back to ~/.grok/auth.json when no env or settings', 
     }
   );
   assert.equal(capturedAuth, 'Bearer eyJfromfile.signature');
+});
+
+test('fetchGrokLimits uses a WSL auth.json without requiring a Windows Grok CLI', async () => {
+  const wslHomeRoot = '\\\\wsl$\\Ubuntu\\home';
+  const wslPath = `${wslHomeRoot}\\alice\\.grok\\auth.json`;
+  let webCredential = null;
+  const result = await fetchGrokLimits({}, {
+    env: {},
+    platform: 'win32',
+    listRunningWslDistros: () => ['Ubuntu'],
+    readdirSync: () => ['alice'],
+    stat: async (target) => {
+      if (target === wslPath) return { mtimeMs: 200 };
+      throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+    },
+    readFileSync: (target) => {
+      assert.equal(target, wslPath);
+      return JSON.stringify({
+        'https://auth.x.ai::client': { key: 'wsl-token', email: 'wsl@example.com' }
+      });
+    },
+    spawn: () => {
+      throw new Error('Windows Grok CLI should not run for a WSL credential');
+    },
+    fetchWebGrpcBilling: async (credential) => {
+      webCredential = credential;
+      return [{
+        kind: 'billing',
+        label: 'Monthly',
+        usedPercent: 42,
+        resetsAt: '2026-09-01T00:00:00.000Z',
+        showMeter: true
+      }];
+    }
+  });
+
+  assert.equal(webCredential.token, 'wsl-token');
+  assert.equal(result.status, 'ok');
+  assert.equal(result.source, 'web');
+  assert.equal(result.accountEmail, 'wsl@example.com');
 });
 
 test('fetchGrokLimits returns notConfigured when real ~/.grok/auth.json has no usable key', async () => {


### PR DESCRIPTION
## Summary

- discover Grok `auth.json` credentials from running WSL distros on Windows
- rank native and WSL credential files by modification time while preserving the existing settings, environment variable, and explicit `GROK_HOME` precedence
- use the existing web billing path for WSL credentials without requiring the Grok CLI on the Windows PATH

## Before and after

| Scenario | Before | After |
|---|---|---|
| Grok is signed in only inside WSL | AI Tool Limits reports Grok as not configured | Token Monitor reads the WSL `~/.grok/auth.json` and loads Grok limits |
| Native and WSL credentials both exist | Only the native Windows credential is considered | The newest valid native or WSL credential is selected |
| `grokBearerToken`, `GROK_BEARER_TOKEN`, or `GROK_HOME` is set | Explicit configuration takes priority | Existing precedence remains unchanged |
| Grok CLI is missing from the Windows PATH | The WSL login cannot provide limits | The WSL bearer token uses the existing web billing fallback directly |
| A stopped WSL distro contains credentials | Not applicable | Stopped distros remain untouched and are not started |
| WSL refreshes its token | A copied Windows credential can become stale | Each limits refresh reads the original WSL credential file |

## Testing

- `node --test tests/shared/grokLimits.test.js` (46 passed)
- `npm run verify` (3710 passed, 1 skipped)
- `git diff --check`

Closes #459


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Grok limit loading on Windows by reading `auth.json` credentials from running WSL distros, so users signed in only inside WSL no longer see Grok as not configured.

- Ranks native and WSL credential files by modification time while keeping precedence for settings, `GROK_BEARER_TOKEN`/`GROK_HOME` env vars, and explicit `GROK_HOME`.
- Routes WSL bearer tokens through the existing web billing path, so the Grok CLI does not need to be on the Windows PATH.
- Leaves stopped WSL distros untouched; each limits refresh reads the original WSL credential file so refreshed tokens stay current.

| Area | Before | After |
| --- | --- | --- |
| Grok signed in only inside WSL | Reports Grok as not configured | Reads WSL `~/.grok/auth.json` and loads limits |
| Native and WSL credentials both exist | Only the native Windows credential is considered | Newest valid native or WSL credential is selected |
| `grokBearerToken`, `GROK_BEARER_TOKEN`, or `GROK_HOME` set | Explicit configuration takes priority | Precedence unchanged |
| Grok CLI missing from Windows PATH | WSL login cannot provide limits | Uses existing web billing fallback directly |
| Stopped WSL distro with credentials | Not applicable | Left untouched, not started |
| WSL refreshes its token | Copied Windows credential can go stale | Each refresh reads the original WSL credential file |

- Tested with `node --test tests/shared/grokLimits.test.js` (46 passed) and `npm run verify` (3710 passed, 1 skipped).
- Closes #459.

<sup>Written for commit bdad093dd8d80eaf5d004e6e0478466500d14b13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

