### PR TITLE
fix(windows): stop demoting the floating widget behind the taskbar

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -289,7 +289,12 @@ const {
   runManualDeviceRefresh,
   settingsLimitInvalidationPlan
 } = require('./deviceRuntimeCoordinator');
-const { describeWindowBehavior, normalizeWindowBehaviorSettings, windowBehaviorSelection } = require('./windowBehavior');
+const {
+  describeWindowBehavior,
+  floatingAlwaysOnTopLevel,
+  normalizeWindowBehaviorSettings,
+  windowBehaviorSelection
+} = require('./windowBehavior');
 const {
   normalizeWindowToggleShortcut,
   windowToggleShortcutAction,
@@ -1823,7 +1828,7 @@ function applyCollapsedFloatingBubbleLimits(bounds) {
     mainWindow.setMaximumSize(bounds?.width || FLOATING_BUBBLE_HANDLE_WIDTH, bounds?.height || FLOATING_BUBBLE_HANDLE_HEIGHT);
   }
   if (typeof mainWindow.setResizable === 'function') mainWindow.setResizable(false);
-  mainWindow.setAlwaysOnTop(true, process.platform === 'win32' ? 'screen-saver' : 'floating');
+  mainWindow.setAlwaysOnTop(true, floatingAlwaysOnTopLevel());
   if (typeof mainWindow.setSkipTaskbar === 'function') mainWindow.setSkipTaskbar(true);
 }
 
@@ -2453,7 +2458,7 @@ function applyWindowSettings() {
     return;
   }
   const behavior = describeWindowBehavior(settings);
-  mainWindow.setAlwaysOnTop(behavior.alwaysOnTop, 'floating');
+  mainWindow.setAlwaysOnTop(behavior.alwaysOnTop, floatingAlwaysOnTopLevel());
   if (typeof mainWindow.setMovable === 'function') mainWindow.setMovable(behavior.draggable);
   if (typeof mainWindow.setResizable === 'function') mainWindow.setResizable(behavior.resizable);
   if (typeof mainWindow.setIgnoreMouseEvents === 'function') {

--- a/src/electron/windowBehavior.js
+++ b/src/electron/windowBehavior.js
@@ -93,8 +93,21 @@ function normalizeWindowBehaviorSettings(settings = {}, patch = {}) {
   };
 }
 
+// Z-order level for an always-on-top widget. On Windows Electron deliberately
+// demotes the `floating` level (and torn-off-menu/modal-panel/main-menu/status)
+// behind Shell_TrayWnd — SetAlwaysOnTop and every window activation re-run that
+// SetWindowPos — so a `floating` widget overlapping the taskbar disappears
+// behind it. Any level outside that set opts out; on win32 they are all
+// equivalent, and `screen-saver` is the one the collapsed bubble already ships.
+// macOS/Linux keep `floating`, where the level maps to a real NSWindow level.
+// Do not "simplify" this back to a bare 'floating' — that is issue #533.
+function floatingAlwaysOnTopLevel(platform = process.platform) {
+  return platform === 'win32' ? 'screen-saver' : 'floating';
+}
+
 module.exports = {
   describeWindowBehavior,
+  floatingAlwaysOnTopLevel,
   normalizeWindowBehavior,
   normalizeWindowBehaviorSettings,
   windowBehaviorSelection

--- a/tests/electron/windowBehavior.test.js
+++ b/tests/electron/windowBehavior.test.js
@@ -7,6 +7,7 @@ const test = require('node:test');
 
 const {
   describeWindowBehavior,
+  floatingAlwaysOnTopLevel,
   normalizeWindowBehavior,
   normalizeWindowBehaviorSettings,
   windowBehaviorSelection
@@ -106,4 +107,23 @@ test('settings:update hands the mode selection over, not the whole patch', () =>
   const main = fs.readFileSync(path.join(__dirname, '..', '..', 'src/electron/main.js'), 'utf8');
   assert.match(main, /\}, windowBehaviorSelection\(normalizedPatch\)\);/);
   assert.doesNotMatch(main, /\}, normalizedPatch\);/);
+});
+
+// Electron places the `floating` z-order level behind the Windows taskbar on
+// purpose, so a widget dragged onto the taskbar vanishes behind it (#533).
+test('always-on-top windows opt out of the Windows behind-taskbar levels', () => {
+  assert.equal(floatingAlwaysOnTopLevel('win32'), 'screen-saver');
+  assert.equal(floatingAlwaysOnTopLevel('darwin'), 'floating');
+  assert.equal(floatingAlwaysOnTopLevel('linux'), 'floating');
+});
+
+// Both always-on-top call sites (the expanded widget and the collapsed bubble)
+// have to go through the helper; a bare 'floating' literal reintroduces #533.
+test('main.js never passes a bare floating level to setAlwaysOnTop', () => {
+  const main = fs.readFileSync(path.join(__dirname, '..', '..', 'src/electron/main.js'), 'utf8');
+  const calls = main.match(/setAlwaysOnTop\([^)]*\)/g) || [];
+  assert.ok(calls.length >= 2);
+  for (const call of calls) {
+    assert.match(call, /floatingAlwaysOnTopLevel\(\)/);
+  }
 });


### PR DESCRIPTION
Refs #533.

### What was happening

On Windows, a floating (always-on-top) widget dragged onto the taskbar ended up behind it, and clicking the widget did not bring it back.

Electron does this deliberately. `NativeWindowViews::SetAlwaysOnTop` treats a fixed set of z-order levels — `floating`, `torn-off-menu`, `modal-panel`, `main-menu`, `status` — as "behind the taskbar" on win32 and calls `SetWindowPos(hwnd, Shell_TrayWnd, …)` for them. That runs both when the level is set and on every window activation, so the widget was pushed under `Shell_TrayWnd` and pushed back under it again each time it was focused or a setting was saved.

We passed `'floating'` for the expanded widget, while the collapsed floating bubble already passed `'screen-saver'` (94969e9e) — outside that set. The two always-on-top paths had quietly drifted apart.

### What this changes

Both paths now go through one helper, `floatingAlwaysOnTopLevel()`: `screen-saver` on Windows, `floating` everywhere else — on macOS the level maps to a real NSWindow level, so it must not change there. `screen-saver` and `pop-up-menu` are equivalent on Windows, since the implementation only checks membership of that behind-taskbar set, so this reuses the level the bubble already ships instead of introducing a third spelling.

Verified on Windows:

| | before | after |
|---|---|---|
| click a taskbar button | covered | covered |
| then click the widget | still covered | back on top |
| save any setting | drops behind the taskbar | unaffected |

A guard test fails if any `setAlwaysOnTop` call in `main.js` goes back to a bare level literal.

### What this does not change

Switching apps from the taskbar still covers the widget once. That part is Windows itself: handing activation to the taskbar raises `Shell_TrayWnd` to the top of the topmost band, and a window is never notified when another window overtakes it. PowerToys has had the same limitation open since 2023 (microsoft/PowerToys#28573).

A re-assert loop — `moveTop()` on blur plus a short interval — was prototyped and measured on Windows. It does keep the widget on top, but every app switch still showed a brief cover-then-restore flicker: the flow this issue was reported on, switching apps without ever focusing the widget, reaches no event of ours and can only be driven by polling. A permanent timer and that flicker are not something to impose on everyone, so this PR stops here and the loop will land behind an opt-in Windows-only setting in a follow-up, which is what `closes #533`.

### Testing

- `npm run verify` (lint + 3738 tests)
- Manual on Windows: widget over the taskbar, app switching via taskbar buttons, focusing the widget, saving settings, collapsed bubble, normal/desktop modes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Windows-only bug where the floating widget went behind the taskbar after being dragged onto it, and clicking it did not bring it back. Electron deliberately demotes certain z-order levels below `Shell_TrayWnd` and re-applies that demotion on every window activation, so the widget kept sinking even when focused.

- Both always-on-top paths (expanded widget and collapsed bubble) now go through a single helper, `floatingAlwaysOnTopLevel()`: `screen-saver` on Windows, `floating` elsewhere.
- `screen-saver` is equivalent to other levels on Windows — the implementation only checks membership of the behind-taskbar set — and is the level the collapsed bubble already shipped, so no new spelling is introduced.
- macOS keeps `floating` because there it maps to a real NSWindow level and must not change.

| Area | Before | After |
| --- | --- | --- |
| Widget over the taskbar | Dragging the widget onto the taskbar pushed it behind; clicking it or saving a setting kept it there. | The widget stays above the taskbar, and saving settings no longer re-demotes it. |

- Added a guard test that fails if any `setAlwaysOnTop` call in `main.js` uses a bare `floating` literal.
- `npm run verify` passes (lint + 3738 tests); manual Windows testing covered app switching, focusing, settings saves, and both collapsed and normal modes.
- Known limitation: switching apps from the taskbar still covers the widget once — Windows raises `Shell_TrayWnd` above topmost windows on activation, and nothing notifies a window when another overtakes it. A follow-up opt-in Windows-only polling loop will close #533.

<sup>Written for commit 6f0a35a9853714b0f7566d4171f512d19bec779a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

