### PR TITLE
feat(cursor): align quota pools and add Grok Bot

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -3756,6 +3756,16 @@ function formatLimitAmount(value) {
   return `$${number.toFixed(2)}`;
 }
 
+function formatCursorSpendValue(window) {
+  const used = optionalFiniteNumber(window?.used);
+  const limit = optionalFiniteNumber(window?.limit);
+  if (used === null) return '';
+  const usedText = formatMoney(used, window?.currency || 'USD');
+  return limit !== null && limit > 0
+    ? `${usedText} / ${formatMoney(limit, window?.currency || 'USD')}`
+    : usedText;
+}
+
 function formatBalanceAmount(value, source) {
   return formatMoney(value, source?.currency);
 }
@@ -4613,10 +4623,11 @@ function renderProviderWindows(provider, color) {
     if (resetNode) windows.append(resetNode);
   } else if (provider.provider === 'cursor') {
     windows.classList.add('limit-windows-cursor');
-    const billingWindows = windowsForKind(provider, 'billing');
-    const visibleWindows = billingWindows.length > 0 ? billingWindows : [null];
-    for (const billing of visibleWindows) {
-      const node = limitWindowNode('Billing cycle', billing, color, 0.68);
+    for (const quotaWindow of provider.windows || []) {
+      const valueOverride = quotaWindow.metric === 'spend'
+        ? formatCursorSpendValue(quotaWindow)
+        : null;
+      const node = limitWindowNode(quotaWindow.label || 'Quota', quotaWindow, color, 0.68, valueOverride);
       node.classList.add('limit-window-wide');
       windows.append(node);
     }

--- a/src/shared/cursorProbe.js
+++ b/src/shared/cursorProbe.js
@@ -7,6 +7,8 @@ const { BROWSER_USER_AGENT } = require('./browserUserAgent');
 const USAGE_SUMMARY_URL = 'https://cursor.com/api/usage-summary';
 const AUTH_ME_URL = 'https://cursor.com/api/auth/me';
 const REQUEST_USAGE_URL = 'https://cursor.com/api/usage';
+const SAND_USAGE_URL = 'https://cursor.com/api/dashboard/get-sand-usage-status';
+const SAND_TIMEOUT_MS = 5000;
 
 const DEFAULT_HEADERS = {
   'Accept': '*/*',
@@ -52,6 +54,32 @@ function parseRequestUsage(input) {
   };
 }
 
+function isoTimestampOrNull(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function parseGrokBotUsage(input) {
+  const usage = input && typeof input === 'object' ? input : {};
+  const usedPercent = clampPercent(numberOrNull(usage.usagePercent));
+  const periodStart = isoTimestampOrNull(usage.currentPeriodStart);
+  const resetsAt = isoTimestampOrNull(usage.nextResetTimestampUtc);
+  const startMs = periodStart ? Date.parse(periodStart) : Number.NaN;
+  const resetMs = resetsAt ? Date.parse(resetsAt) : Number.NaN;
+  const windowMinutes = Number.isFinite(startMs) && Number.isFinite(resetMs) && resetMs > startMs
+    ? Math.round((resetMs - startMs) / 60000)
+    : null;
+  return {
+    usedPercent,
+    periodStart,
+    resetsAt,
+    windowMinutes,
+    hasAvailableUsage: typeof usage.hasAvailableUsage === 'boolean' ? usage.hasAvailableUsage : null,
+    hasNonZeroIncludedLimit: usage.hasNonZeroIncludedLimit === true
+  };
+}
+
 function parseUsageSummary(input, { requestUsage = null } = {}) {
   const summary = input && typeof input === 'object' ? input : {};
   const individual = summary.individualUsage && typeof summary.individualUsage === 'object' ? summary.individualUsage : {};
@@ -80,10 +108,7 @@ function parseUsageSummary(input, { requestUsage = null } = {}) {
 
   let planPercent = clampPercent(numberOrNull(plan.totalPercentUsed));
   if (planPercent === null) {
-    if (autoPercent !== null && apiPercent !== null) planPercent = clampPercent((autoPercent + apiPercent) / 2);
-    else if (apiPercent !== null) planPercent = apiPercent;
-    else if (autoPercent !== null) planPercent = autoPercent;
-    else if (planLimit > 0) planPercent = percentFromUsedLimit(planUsed, planLimit);
+    if (planLimit > 0) planPercent = percentFromUsedLimit(planUsed, planLimit);
     else if (overallLimit !== null && overallLimit > 0) planPercent = percentFromUsedLimit(overallUsed, overallLimit);
     else if (teamPooledLimit !== null && teamPooledLimit > 0) planPercent = percentFromUsedLimit(teamPooledUsed, teamPooledLimit);
     else planPercent = 0;
@@ -146,7 +171,14 @@ function parseUserInfo(input) {
   };
 }
 
-function requestJson(url, sessionToken, { timeoutMs = 15000, httpsLib = https, signal } = {}) {
+function requestJson(url, sessionToken, {
+  timeoutMs = 15000,
+  httpsLib = https,
+  signal,
+  method = 'GET',
+  headers = {},
+  body = null
+} = {}) {
   if (signal?.aborted) return Promise.reject(abortError(signal));
   return new Promise((resolve) => {
     const parsed = new URL(url);
@@ -164,11 +196,12 @@ function requestJson(url, sessionToken, { timeoutMs = 15000, httpsLib = https, s
       finish({ ok: false, error: { kind: 'network', message: error.message } });
     };
     req = httpsLib.request({
-      method: 'GET',
+      method,
       hostname: parsed.hostname,
       path: `${parsed.pathname}${parsed.search}`,
       headers: {
         ...DEFAULT_HEADERS,
+        ...headers,
         'Cookie': `WorkosCursorSessionToken=${sessionToken}`
       }
     }, (res) => {
@@ -201,12 +234,25 @@ function requestJson(url, sessionToken, { timeoutMs = 15000, httpsLib = https, s
       onAbort();
       return;
     }
+    if (body !== null && body !== undefined) req.write(String(body));
     req.end();
   });
 }
 
 async function probe(sessionToken, opts = {}) {
   if (!sessionToken) return { ok: false, error: { kind: 'unauthorized', message: 'no session token' } };
+  const configuredTimeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : 15000;
+  const grokBotResultPromise = requestJson(SAND_USAGE_URL, sessionToken, {
+    ...opts,
+    timeoutMs: Math.min(configuredTimeoutMs, SAND_TIMEOUT_MS),
+    method: 'POST',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'Origin': 'https://cursor.com'
+    },
+    body: '{}'
+  });
   const [usageResult, userResult] = await Promise.all([
     requestJson(USAGE_SUMMARY_URL, sessionToken, opts),
     requestJson(AUTH_ME_URL, sessionToken, opts)
@@ -219,17 +265,22 @@ async function probe(sessionToken, opts = {}) {
     const requestUsageResult = await requestJson(url, sessionToken, opts);
     if (requestUsageResult.ok) requestUsage = requestUsageResult.json;
   }
-  const usage = parseUsageSummary(usageResult.json, { requestUsage });
+  const grokBotResult = await grokBotResultPromise;
+  const grokBot = grokBotResult.ok ? parseGrokBotUsage(grokBotResult.json) : null;
+  const usage = { ...parseUsageSummary(usageResult.json, { requestUsage }), grokBot };
   return { ok: true, usage, user };
 }
 
 module.exports = {
   parseUsageSummary,
   parseRequestUsage,
+  parseGrokBotUsage,
   parseUserInfo,
   probe,
   requestJson,
   USAGE_SUMMARY_URL,
   AUTH_ME_URL,
-  REQUEST_USAGE_URL
+  REQUEST_USAGE_URL,
+  SAND_USAGE_URL,
+  SAND_TIMEOUT_MS
 };

--- a/src/shared/hubBuildRegistry.json
+++ b/src/shared/hubBuildRegistry.json
@@ -73,6 +73,10 @@
       {
         "revision": 18,
         "buildId": "sha256:4074b6e85c0cb32e3d8978fbdcfcbcba03a2c1e0b3d95bbc20177e141004a93e"
+      },
+      {
+        "revision": 19,
+        "buildId": "sha256:b37d2c98aa97998a8eb8f9b0fbf5d9bee649df21d8c992a6a550d20246fe8ed8"
       }
     ],
     "node-hub": [

--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -4104,6 +4104,46 @@ function cursorBillingWindow(label, fields = {}) {
   };
 }
 
+function cursorOnDemandWindow(usage, resetsAt) {
+  const personalUsed = finiteNumber(usage.onDemandUsedUsd) ?? 0;
+  const personalLimit = finiteNumber(usage.onDemandLimitUsd);
+  const teamUsed = finiteNumber(usage.teamOnDemandUsedUsd) ?? 0;
+  const teamLimit = finiteNumber(usage.teamOnDemandLimitUsd);
+  let used;
+  let limit = null;
+  let remaining = null;
+
+  if (personalLimit !== null && personalLimit > 0) {
+    used = personalUsed;
+    limit = personalLimit;
+    remaining = finiteNumber(usage.onDemandRemainingUsd);
+  } else if (teamLimit !== null && teamLimit > 0) {
+    used = teamUsed;
+    limit = teamLimit;
+    remaining = finiteNumber(usage.teamOnDemandRemainingUsd);
+  } else if (personalUsed > 0) {
+    used = personalUsed;
+  } else if (teamUsed > 0) {
+    used = teamUsed;
+  } else {
+    return null;
+  }
+
+  if (limit !== null && remaining === null) remaining = Math.max(0, limit - used);
+  return cursorBillingWindow('On-demand spend', {
+    metric: 'spend',
+    currency: 'USD',
+    usedPercent: percentFromUsedLimit(used, limit),
+    used,
+    limit,
+    remaining,
+    resetsAt,
+    windowMinutes: null,
+    resetDescription: '',
+    showMeter: false
+  });
+}
+
 async function fetchCursorAccountLimits(account, deps = {}) {
   const nowMs = (deps.now || Date.now)();
   const updatedAt = new Date(nowMs).toISOString();
@@ -4139,71 +4179,50 @@ async function fetchCursorAccountLimits(account, deps = {}) {
   const hasRequestUsage = finiteNumber(usage.requestsUsed) !== null
     && finiteNumber(usage.requestsLimit) !== null
     && usage.requestsLimit > 0;
-  const totalPercent = hasRequestUsage
-    ? percentFromUsedLimit(usage.requestsUsed, usage.requestsLimit)
-    : usage.planPercent;
-  const windows = [
-    cursorBillingWindow('Total', {
-      usedPercent: totalPercent,
-      used: hasRequestUsage ? usage.requestsUsed : usage.planUsedUsd,
-      limit: hasRequestUsage ? usage.requestsLimit : usage.planLimitUsd,
-      remaining: hasRequestUsage
-        ? Math.max(0, usage.requestsLimit - usage.requestsUsed)
-        : usage.planRemainingUsd,
+  const windows = [];
+
+  if (hasRequestUsage) {
+    windows.push(cursorBillingWindow('Requests', {
+      usedPercent: percentFromUsedLimit(usage.requestsUsed, usage.requestsLimit),
+      used: usage.requestsUsed,
+      limit: usage.requestsLimit,
+      remaining: Math.max(0, usage.requestsLimit - usage.requestsUsed),
       resetsAt,
       windowMinutes: null,
       resetDescription: usage.membershipType ? `Cursor ${usage.membershipType}` : ''
-    })
-  ];
-
-  if (finiteNumber(usage.autoPercent) !== null) {
-    windows.push(cursorBillingWindow('Auto', {
+    }));
+  } else if (finiteNumber(usage.autoPercent) !== null || finiteNumber(usage.apiPercent) !== null) {
+    if (finiteNumber(usage.autoPercent) !== null) windows.push(cursorBillingWindow('Cursor Models', {
       usedPercent: usage.autoPercent,
       resetsAt,
       windowMinutes: null
     }));
-  }
-
-  if (finiteNumber(usage.apiPercent) !== null) {
-    windows.push(cursorBillingWindow('API', {
+    if (finiteNumber(usage.apiPercent) !== null) windows.push(cursorBillingWindow('Other Models', {
       usedPercent: usage.apiPercent,
+      resetsAt,
+      windowMinutes: null
+    }));
+  } else if (usage.hasOverallUsage && finiteNumber(usage.planPercent) !== null) {
+    windows.push(cursorBillingWindow('Overall', {
+      usedPercent: usage.planPercent,
+      used: usage.planUsedUsd,
+      limit: usage.planLimitUsd,
+      remaining: usage.planRemainingUsd,
       resetsAt,
       windowMinutes: null
     }));
   }
 
-  if (usage.hasOnDemandUsage || finiteNumber(usage.onDemandLimitUsd) !== null || (finiteNumber(usage.onDemandUsedUsd) !== null && usage.onDemandUsedUsd > 0)) {
-    const remaining = finiteNumber(usage.onDemandRemainingUsd)
-      ?? (finiteNumber(usage.onDemandLimitUsd) !== null
-        ? Math.max(0, usage.onDemandLimitUsd - (finiteNumber(usage.onDemandUsedUsd) || 0))
-        : null);
-    windows.push(cursorBillingWindow('Credits', {
-      usedPercent: finiteNumber(usage.onDemandPercent) ?? percentFromUsedLimit(usage.onDemandUsedUsd, usage.onDemandLimitUsd),
-      used: usage.onDemandUsedUsd,
-      limit: usage.onDemandLimitUsd,
-      remaining,
-      resetsAt: null,
-      windowMinutes: null,
+  if (usage.grokBot?.hasNonZeroIncludedLimit === true && finiteNumber(usage.grokBot.usedPercent) !== null) {
+    windows.push({
+      kind: 'weekly',
+      label: 'Grok Bot',
+      usedPercent: usage.grokBot.usedPercent,
+      resetsAt: usage.grokBot.resetsAt || null,
+      windowMinutes: finiteNumber(usage.grokBot.windowMinutes),
       resetDescription: '',
-      showMeter: false
-    }));
-  }
-
-  if (usage.hasTeamOnDemandUsage || finiteNumber(usage.teamOnDemandLimitUsd) !== null || (finiteNumber(usage.teamOnDemandUsedUsd) !== null && usage.teamOnDemandUsedUsd > 0)) {
-    const remaining = finiteNumber(usage.teamOnDemandRemainingUsd)
-      ?? (finiteNumber(usage.teamOnDemandLimitUsd) !== null
-        ? Math.max(0, usage.teamOnDemandLimitUsd - (finiteNumber(usage.teamOnDemandUsedUsd) || 0))
-        : null);
-    windows.push(cursorBillingWindow('Team credits', {
-      usedPercent: finiteNumber(usage.teamOnDemandPercent) ?? percentFromUsedLimit(usage.teamOnDemandUsedUsd, usage.teamOnDemandLimitUsd),
-      used: usage.teamOnDemandUsedUsd,
-      limit: usage.teamOnDemandLimitUsd,
-      remaining,
-      resetsAt: null,
-      windowMinutes: null,
-      resetDescription: '',
-      showMeter: false
-    }));
+      showMeter: true
+    });
   }
 
   if (usage.hasTeamPooledUsage || finiteNumber(usage.teamPooledLimitUsd) !== null || (finiteNumber(usage.teamPooledUsedUsd) !== null && usage.teamPooledUsedUsd > 0)) {
@@ -4221,6 +4240,9 @@ async function fetchCursorAccountLimits(account, deps = {}) {
       resetDescription: 'Shared team usage pool.'
     }));
   }
+
+  const onDemandWindow = cursorOnDemandWindow(usage, resetsAt);
+  if (onDemandWindow) windows.push(onDemandWindow);
 
   return {
     provider: 'cursor',

--- a/src/shared/limits.js
+++ b/src/shared/limits.js
@@ -396,6 +396,14 @@ function normalizeOpenCodeAccountKeyAliases(values, accountKey = '') {
     .slice(0, MAX_OPENCODE_ACCOUNT_KEY_ALIASES);
 }
 
+function cursorWindowRank(window) {
+  if (window.metric === 'spend') return 4;
+  if (window.label === 'Requests' || window.label === 'Cursor Models') return 0;
+  if (window.label === 'Other Models') return 1;
+  if (window.label === 'Grok Bot') return 2;
+  return 3;
+}
+
 function normalizeLimitProvider(input) {
   if (!input || typeof input !== 'object') return null;
   const provider = normalizeProviderId(input.provider);
@@ -417,6 +425,11 @@ function normalizeLimitProvider(input) {
     };
     windows.sort((a, b) => groupRank(a) - groupRank(b)
       || WINDOW_ORDER.indexOf(a.kind) - WINDOW_ORDER.indexOf(b.kind));
+  } else if (provider === 'cursor') {
+    // Cursor's official dashboard presents its two monthly model pools first,
+    // followed by the optional Grok Bot allowance and on-demand spend. Generic
+    // kind ordering would incorrectly put the weekly Grok row before both pools.
+    windows.sort((a, b) => cursorWindowRank(a) - cursorWindowRank(b));
   } else {
     windows.sort((a, b) => WINDOW_ORDER.indexOf(a.kind) - WINDOW_ORDER.indexOf(b.kind));
   }

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -199,6 +199,19 @@ function runProviderSpendNode(source, balance) {
   return JSON.parse(JSON.stringify(context.result));
 }
 
+test('Cursor limits render every normalized quota and format on-demand spend explicitly', () => {
+  const app = readRendererFile('app.js');
+  const spendValue = functionBody(app, 'formatCursorSpendValue', 'formatBalanceAmount');
+  const windows = functionBody(app, 'renderProviderWindows', 'renderLimitProviderRow');
+
+  assert.match(spendValue, /formatMoney\(used, window\?\.currency \|\| 'USD'\)/);
+  assert.match(spendValue, /limit !== null && limit > 0/);
+  assert.match(windows, /for \(const quotaWindow of provider\.windows \|\| \[\]\)/);
+  assert.match(windows, /quotaWindow\.metric === 'spend'/);
+  assert.match(windows, /formatCursorSpendValue\(quotaWindow\)/);
+  assert.doesNotMatch(windows, /visibleWindows = billingWindows\.length > 0 \? billingWindows : \[null\]/);
+});
+
 function runHomeLimitModule(rows, resetLabels = {}) {
   const app = readRendererFile('app.js');
   const homeLimits = functionBody(app, 'renderHomeLimitModule', 'renderHomeModelModule');

--- a/tests/shared/cursorLimits.test.js
+++ b/tests/shared/cursorLimits.test.js
@@ -22,7 +22,7 @@ test('fetchCursorLimits returns unauthorized when probe says so', async () => {
   assert.equal(result.status, 'unauthorized');
 });
 
-test('fetchCursorLimits returns ok with Cursor billing dimensions when probe succeeds', async () => {
+test('fetchCursorLimits exposes the official model pools, Grok Bot, and on-demand spend', async () => {
   const result = await fetchCursorLimits({}, {
     readActiveAccount: () => ({ id: 'acct-1', sessionToken: 't', userId: 'u1' }),
     probe: async () => ({
@@ -30,7 +30,13 @@ test('fetchCursorLimits returns ok with Cursor billing dimensions when probe suc
       usage: {
         planPercent: 42, autoPercent: 20, apiPercent: 64,
         planUsedUsd: 8.4, planLimitUsd: 20, onDemandUsedUsd: 0, onDemandLimitUsd: 50,
-        requestsUsed: 7, requestsLimit: 10,
+        grokBot: {
+          usedPercent: 100,
+          resetsAt: '2026-05-28T00:00:00Z',
+          windowMinutes: 10080,
+          hasAvailableUsage: false,
+          hasNonZeroIncludedLimit: true
+        },
         billingCycleEnd: '2026-06-01T00:00:00Z', membershipType: 'pro'
       },
       user: { email: 'a@b.com', name: 'Alice', sub: 'u1' }
@@ -39,18 +45,97 @@ test('fetchCursorLimits returns ok with Cursor billing dimensions when probe suc
   assert.equal(result.status, 'ok');
   assert.equal(result.provider, 'cursor');
   assert.equal(result.source, 'web');
-  assert.deepEqual(result.windows.map((window) => window.label), ['Total', 'Auto', 'API', 'Credits']);
+  assert.deepEqual(result.windows.map((window) => window.label), ['Cursor Models', 'Other Models', 'Grok Bot', 'On-demand spend']);
   assert.equal(result.windows[0].kind, 'billing');
-  assert.equal(result.windows[0].usedPercent, 70);
-  assert.equal(result.windows[0].used, 7);
-  assert.equal(result.windows[0].limit, 10);
+  assert.equal(result.windows[0].usedPercent, 20);
   assert.equal(result.windows[0].resetsAt, '2026-06-01T00:00:00.000Z');
-  assert.equal(result.windows[1].usedPercent, 20);
-  assert.equal(result.windows[2].usedPercent, 64);
-  assert.equal(result.windows[3].usedPercent, 0);
+  assert.equal(result.windows[1].usedPercent, 64);
+  assert.equal(result.windows[2].kind, 'weekly');
+  assert.equal(result.windows[2].usedPercent, 100);
+  assert.equal(result.windows[2].resetsAt, '2026-05-28T00:00:00Z');
+  assert.equal(result.windows[2].windowMinutes, 10080);
+  assert.equal(result.windows[3].metric, 'spend');
+  assert.equal(result.windows[3].currency, 'USD');
+  assert.equal(result.windows[3].used, 0);
+  assert.equal(result.windows[3].limit, 50);
   assert.equal(result.windows[3].showMeter, false);
   assert.equal(result.windows[3].remaining, 50);
   assert.equal(result.windows[3].resetDescription, '');
+});
+
+test('fetchCursorLimits uses Requests for a legacy request-based plan', async () => {
+  const result = await fetchCursorLimits({}, {
+    readActiveAccount: () => ({ id: 'acct-1', sessionToken: 't', userId: 'u1' }),
+    probe: async () => ({
+      ok: true,
+      usage: {
+        planPercent: 42,
+        autoPercent: 20,
+        apiPercent: 64,
+        requestsUsed: 7,
+        requestsLimit: 10,
+        billingCycleEnd: '2026-06-01T00:00:00Z',
+        membershipType: 'pro'
+      },
+      user: { email: 'a@b.com', sub: 'u1' }
+    })
+  });
+
+  assert.deepEqual(result.windows.map((window) => window.label), ['Requests']);
+  assert.equal(result.windows[0].usedPercent, 70);
+  assert.equal(result.windows[0].used, 7);
+  assert.equal(result.windows[0].limit, 10);
+  assert.equal(result.windows[0].remaining, 3);
+});
+
+test('fetchCursorLimits hides Grok Bot only when no included allowance exists', async () => {
+  const result = await fetchCursorLimits({}, {
+    readActiveAccount: () => ({ id: 'acct-1', sessionToken: 't', userId: 'u1' }),
+    probe: async () => ({
+      ok: true,
+      usage: {
+        autoPercent: 0,
+        apiPercent: 0,
+        grokBot: {
+          usedPercent: 100,
+          hasAvailableUsage: false,
+          hasNonZeroIncludedLimit: false
+        },
+        onDemandUsedUsd: 0,
+        onDemandLimitUsd: 0,
+        membershipType: 'free'
+      },
+      user: { email: 'free@example.com', sub: 'u1' }
+    })
+  });
+
+  assert.deepEqual(result.windows.map((window) => window.label), ['Cursor Models', 'Other Models']);
+});
+
+test('fetchCursorLimits shows uncapped positive spend but hides a zero-dollar non-cap', async () => {
+  const baseAccount = () => ({ id: 'acct-1', sessionToken: 't', userId: 'u1' });
+  const positive = await fetchCursorLimits({}, {
+    readActiveAccount: baseAccount,
+    probe: async () => ({
+      ok: true,
+      usage: { autoPercent: 10, apiPercent: 20, onDemandUsedUsd: 3.5, onDemandLimitUsd: 0 },
+      user: { sub: 'u1' }
+    })
+  });
+  const zero = await fetchCursorLimits({}, {
+    readActiveAccount: baseAccount,
+    probe: async () => ({
+      ok: true,
+      usage: { autoPercent: 10, apiPercent: 20, onDemandUsedUsd: 0, onDemandLimitUsd: 0 },
+      user: { sub: 'u1' }
+    })
+  });
+
+  const spend = positive.windows.find((window) => window.metric === 'spend');
+  assert.ok(spend);
+  assert.equal(spend.used, 3.5);
+  assert.equal(spend.limit, null);
+  assert.equal(zero.windows.some((window) => window.metric === 'spend'), false);
 });
 
 test('fetchCursorLimits prefers account identity over the plan for the account label', async () => {

--- a/tests/shared/cursorProbe.test.js
+++ b/tests/shared/cursorProbe.test.js
@@ -4,7 +4,7 @@ const assert = require('node:assert/strict');
 const { EventEmitter } = require('node:events');
 const test = require('node:test');
 
-const { parseUsageSummary, parseUserInfo, probe } = require('../../src/shared/cursorProbe');
+const { parseGrokBotUsage, parseUsageSummary, parseUserInfo, probe } = require('../../src/shared/cursorProbe');
 
 test('parseUsageSummary maps cents to USD and reads billing cycle end', () => {
   const input = {
@@ -37,13 +37,31 @@ test('parseUsageSummary falls back to (used / limit) when totalPercentUsed missi
   assert.equal(result.planPercent, 25);
 });
 
-test('parseUsageSummary falls back to Auto/API average before dollars', () => {
+test('parseUsageSummary never synthesizes a total from the separate model pools', () => {
   const input = {
     billingCycleEnd: '2026-06-01T00:00:00Z',
     individualUsage: { plan: { used: 500, limit: 2000, autoPercentUsed: 10, apiPercentUsed: 50 } }
   };
   const result = parseUsageSummary(input);
-  assert.equal(result.planPercent, 30);
+  assert.equal(result.planPercent, 25);
+});
+
+test('parseGrokBotUsage keeps an exhausted included allowance visible', () => {
+  const result = parseGrokBotUsage({
+    usagePercent: 100,
+    currentPeriodStart: '2026-05-25T00:00:00Z',
+    nextResetTimestampUtc: '2026-06-01T00:00:00Z',
+    hasAvailableUsage: false,
+    hasNonZeroIncludedLimit: true
+  });
+  assert.deepEqual(result, {
+    usedPercent: 100,
+    periodStart: '2026-05-25T00:00:00.000Z',
+    resetsAt: '2026-06-01T00:00:00.000Z',
+    windowMinutes: 7 * 24 * 60,
+    hasAvailableUsage: false,
+    hasNonZeroIncludedLimit: true
+  });
 });
 
 test('parseUsageSummary reads legacy request-based usage', () => {
@@ -120,7 +138,8 @@ test('probe includes legacy request usage when auth returns a user id', async ()
   const calls = [];
   const fakeHttps = {
     request(opts, cb) {
-      calls.push({ path: opts.path, referer: opts.headers.Referer });
+      const call = { path: opts.path, method: opts.method, headers: opts.headers, body: '', timeoutMs: null };
+      calls.push(call);
       let payload;
       if (opts.path === '/api/usage-summary') {
         payload = {
@@ -131,6 +150,14 @@ test('probe includes legacy request usage when auth returns a user id', async ()
         payload = { email: 'a@b.com', name: 'Alice', sub: 'user_1' };
       } else if (opts.path === '/api/usage?user=user_1') {
         payload = { 'gpt-4': { numRequestsTotal: 4, maxRequestUsage: 8 } };
+      } else if (opts.path === '/api/dashboard/get-sand-usage-status') {
+        payload = {
+          usagePercent: 100,
+          currentPeriodStart: '2026-05-25T00:00:00Z',
+          nextResetTimestampUtc: '2026-06-01T00:00:00Z',
+          hasAvailableUsage: false,
+          hasNonZeroIncludedLimit: true
+        };
       } else {
         payload = {};
       }
@@ -143,7 +170,12 @@ test('probe includes legacy request usage when auth returns a user id', async ()
           res.emit('end');
         });
       });
-      return { on() {}, end() {}, write() {}, setTimeout() {} };
+      return {
+        on() {},
+        end() {},
+        write(chunk) { call.body += String(chunk); },
+        setTimeout(timeoutMs) { call.timeoutMs = timeoutMs; }
+      };
     }
   };
 
@@ -151,11 +183,45 @@ test('probe includes legacy request usage when auth returns a user id', async ()
   assert.equal(result.ok, true);
   assert.equal(result.usage.requestsUsed, 4);
   assert.equal(result.usage.requestsLimit, 8);
+  assert.equal(result.usage.grokBot.usedPercent, 100);
+  assert.equal(result.usage.grokBot.hasAvailableUsage, false);
   assert.deepEqual(
     calls.map((call) => call.path).sort(),
-    ['/api/auth/me', '/api/usage-summary', '/api/usage?user=user_1'].sort()
+    ['/api/auth/me', '/api/dashboard/get-sand-usage-status', '/api/usage-summary', '/api/usage?user=user_1'].sort()
   );
-  assert.deepEqual(new Set(calls.map((call) => call.referer)), new Set(['https://cursor.com/dashboard']));
+  assert.deepEqual(new Set(calls.map((call) => call.headers.Referer)), new Set(['https://cursor.com/dashboard']));
+  const sand = calls.find((call) => call.path === '/api/dashboard/get-sand-usage-status');
+  assert.equal(sand.method, 'POST');
+  assert.equal(sand.headers.Origin, 'https://cursor.com');
+  assert.equal(sand.headers['Content-Type'], 'application/json');
+  assert.equal(sand.body, '{}');
+  assert.equal(sand.timeoutMs, 5000);
+});
+
+test('probe treats Grok Bot as a best-effort optional request', async () => {
+  const fakeHttps = {
+    request(opts, cb) {
+      const res = new EventEmitter();
+      res.statusCode = opts.path === '/api/dashboard/get-sand-usage-status' ? 500 : 200;
+      const payload = opts.path === '/api/usage-summary'
+        ? { individualUsage: { plan: { autoPercentUsed: 20, apiPercentUsed: 40 } } }
+        : {};
+      setImmediate(() => {
+        cb(res);
+        if (res.statusCode === 200) setImmediate(() => {
+          res.emit('data', Buffer.from(JSON.stringify(payload)));
+          res.emit('end');
+        });
+      });
+      return { on() {}, end() {}, write() {}, setTimeout() {} };
+    }
+  };
+
+  const result = await probe('tok', { httpsLib: fakeHttps });
+  assert.equal(result.ok, true);
+  assert.equal(result.usage.autoPercent, 20);
+  assert.equal(result.usage.apiPercent, 40);
+  assert.equal(result.usage.grokBot, null);
 });
 
 test('probe destroys in-flight HTTPS requests when the parent signal aborts', async () => {
@@ -165,6 +231,7 @@ test('probe destroys in-flight HTTPS requests when the parent signal aborts', as
     request() {
       const req = new EventEmitter();
       req.end = () => {};
+      req.write = () => {};
       req.setTimeout = () => {};
       req.destroy = () => { req.destroyed = true; };
       requests.push(req);
@@ -178,6 +245,6 @@ test('probe destroys in-flight HTTPS requests when the parent signal aborts', as
   const result = await pending;
   assert.equal(result.ok, false);
   assert.equal(result.error.kind, 'network');
-  assert.equal(requests.length, 2);
+  assert.equal(requests.length, 3);
   assert.ok(requests.every((request) => request.destroyed));
 });

--- a/tests/shared/limits.test.js
+++ b/tests/shared/limits.test.js
@@ -1268,6 +1268,24 @@ test('normalizeLimitProvider preserves daily windows in canonical order', () => 
   assert.deepEqual(provider.windows.map((window) => window.kind), ['session', 'daily', 'weekly', 'billing']);
 });
 
+test('normalizeLimitProvider keeps Cursor dashboard quota order across window kinds', () => {
+  const provider = normalizeLimitProvider({
+    provider: 'cursor',
+    status: 'ok',
+    windows: [
+      { kind: 'billing', metric: 'spend', label: 'On-demand spend', used: 2, limit: 20, showMeter: false },
+      { kind: 'weekly', label: 'Grok Bot', usedPercent: 30 },
+      { kind: 'billing', label: 'Other Models', usedPercent: 20 },
+      { kind: 'billing', label: 'Cursor Models', usedPercent: 10 }
+    ]
+  });
+
+  assert.deepEqual(
+    provider.windows.map((window) => window.label),
+    ['Cursor Models', 'Other Models', 'Grok Bot', 'On-demand spend']
+  );
+});
+
 test('normalizeLimitWindow preserves only documented component sources', () => {
   assert.equal(normalizeLimitWindow({ kind: 'session', source: ' local ' }).source, 'local');
   assert.equal(normalizeLimitWindow({ kind: 'weekly', source: 'WEB' }).source, 'web');

--- a/worker/src/shared/hubBuildRegistry.json
+++ b/worker/src/shared/hubBuildRegistry.json
@@ -73,6 +73,10 @@
       {
         "revision": 18,
         "buildId": "sha256:4074b6e85c0cb32e3d8978fbdcfcbcba03a2c1e0b3d95bbc20177e141004a93e"
+      },
+      {
+        "revision": 19,
+        "buildId": "sha256:b37d2c98aa97998a8eb8f9b0fbf5d9bee649df21d8c992a6a550d20246fe8ed8"
       }
     ],
     "node-hub": [

--- a/worker/src/shared/limits.js
+++ b/worker/src/shared/limits.js
@@ -399,6 +399,14 @@ function normalizeOpenCodeAccountKeyAliases(values, accountKey = '') {
     .slice(0, MAX_OPENCODE_ACCOUNT_KEY_ALIASES);
 }
 
+function cursorWindowRank(window) {
+  if (window.metric === 'spend') return 4;
+  if (window.label === 'Requests' || window.label === 'Cursor Models') return 0;
+  if (window.label === 'Other Models') return 1;
+  if (window.label === 'Grok Bot') return 2;
+  return 3;
+}
+
 function normalizeLimitProvider(input) {
   if (!input || typeof input !== 'object') return null;
   const provider = normalizeProviderId(input.provider);
@@ -420,6 +428,11 @@ function normalizeLimitProvider(input) {
     };
     windows.sort((a, b) => groupRank(a) - groupRank(b)
       || WINDOW_ORDER.indexOf(a.kind) - WINDOW_ORDER.indexOf(b.kind));
+  } else if (provider === 'cursor') {
+    // Cursor's official dashboard presents its two monthly model pools first,
+    // followed by the optional Grok Bot allowance and on-demand spend. Generic
+    // kind ordering would incorrectly put the weekly Grok row before both pools.
+    windows.sort((a, b) => cursorWindowRank(a) - cursorWindowRank(b));
   } else {
     windows.sort((a, b) => WINDOW_ORDER.indexOf(a.kind) - WINDOW_ORDER.indexOf(b.kind));
   }


### PR DESCRIPTION
## Summary

- replace the synthesized Cursor `Total` quota with the official `Cursor Models` and `Other Models` pools
- add Grok Bot quota collection through the existing Cursor session
- keep exhausted Grok Bot allowances visible while hiding accounts without an included allowance
- make Grok Bot collection best-effort so failures do not affect the main Cursor quota result
- show on-demand spend only when the account has a positive spending cap or actual spend
- keep Cursor quota ordering consistent across Limits, Home, tray, widget, Node Hub, and Worker Hub

## Testing

- `node --test tests/shared/cursorProbe.test.js tests/shared/cursorLimits.test.js tests/shared/limits.test.js tests/electron/limitProviderPresentation.test.js`
- `npm run verify` (3,745 passed, 1 skipped)

Closes #516
Closes #531


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Cursor quota tracking with the official dashboard and adds Grok Bot usage collection. The synthesized `Total` quota is replaced by the separate `Cursor Models` and `Other Models` pools, and Grok Bot weekly usage is reported through a best-effort call to the existing Cursor session.

- Replaces the synthesized `Total` pool with the official `Cursor Models` and `Other Models` pools.
- Reports Grok Bot weekly usage, keeping exhausted allowances visible and hiding accounts without an included allowance.
- Treats Grok Bot collection as best-effort so failures do not affect the main Cursor quota result.
- Shows on-demand spend only when the account has a positive spending cap or actual spend.
- Orders Cursor quotas consistently across Limits, Home, tray, widget, Node Hub, and Worker Hub.
- Falls back to a `Requests` pool for legacy request-based plans.

| Area | Before | After |
| --- | --- | --- |
| Cursor quota pools | Single synthesized `Total` from model-pool average | Official `Cursor Models` and `Other Models` pools |
| Grok Bot | Not tracked | Weekly usage shown when an included allowance exists, including when exhausted |
| Accounts without Grok allowance | N/A | Grok Bot row hidden |
| On-demand spend | Always shown as `Credits`/`Team credits` when usage or limit present | Shown only when positive spending cap or actual spend exists |
| Quota ordering | Generic window-kind ordering | Dashboard order across all surfaces |

- Tests added for pool mapping, Grok Bot parsing and best-effort failure, spend visibility, and ordering; `node --test` and `npm run verify` (3,745 passed) both pass.
- The new `POST /api/dashboard/get-sand-usage-status` call is capped at 5s and non-fatal.

<sup>Written for commit b7dfefa46adf99985f521217cee9519203c6e04e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

