### PR TITLE
chore(tokscale): update to 4.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "koffi": "^3.1.5",
         "semver": "^7.8.5",
         "tar": "^7.5.22",
-        "tokscale": "^4.14.0",
+        "tokscale": "^4.15.0",
         "undici": "^7.29.0"
       },
       "devDependencies": {
@@ -1029,29 +1029,29 @@
       }
     },
     "node_modules/@tokscale/cli": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli/-/cli-4.14.0.tgz",
-      "integrity": "sha512-2rtRuxPu4OwMj7++801H8eHkmn+YLAV5ASVXoEQUwJZS0jTvm25L9HcN3RWswQ6mHM9IhxKKE5Mi0VYH/Hm5Jw==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli/-/cli-4.15.0.tgz",
+      "integrity": "sha512-JU3KeT5FPBvJH/fQF2xRoQWPUxi845jPMKbj2zK73xkqGPvJNMU4YX7OypuCr8pOp09Of71/DZsE1kmLrK3z5g==",
       "license": "MIT",
       "bin": {
         "tokscale": "bin.js"
       },
       "optionalDependencies": {
-        "@tokscale/cli-android-arm64": "4.14.0",
-        "@tokscale/cli-darwin-arm64": "4.14.0",
-        "@tokscale/cli-darwin-x64": "4.14.0",
-        "@tokscale/cli-linux-arm64-gnu": "4.14.0",
-        "@tokscale/cli-linux-arm64-musl": "4.14.0",
-        "@tokscale/cli-linux-x64-gnu": "4.14.0",
-        "@tokscale/cli-linux-x64-musl": "4.14.0",
-        "@tokscale/cli-win32-arm64-msvc": "4.14.0",
-        "@tokscale/cli-win32-x64-msvc": "4.14.0"
+        "@tokscale/cli-android-arm64": "4.15.0",
+        "@tokscale/cli-darwin-arm64": "4.15.0",
+        "@tokscale/cli-darwin-x64": "4.15.0",
+        "@tokscale/cli-linux-arm64-gnu": "4.15.0",
+        "@tokscale/cli-linux-arm64-musl": "4.15.0",
+        "@tokscale/cli-linux-x64-gnu": "4.15.0",
+        "@tokscale/cli-linux-x64-musl": "4.15.0",
+        "@tokscale/cli-win32-arm64-msvc": "4.15.0",
+        "@tokscale/cli-win32-x64-msvc": "4.15.0"
       }
     },
     "node_modules/@tokscale/cli-android-arm64": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-android-arm64/-/cli-android-arm64-4.14.0.tgz",
-      "integrity": "sha512-WUkX8r2m1pGCqtNECw5MPf9QXdO7accVQ5ukKEjECq7nN40PVZKgBvHfgwloaocTrD1kylxye0n5Kj7teabbuw==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-android-arm64/-/cli-android-arm64-4.15.0.tgz",
+      "integrity": "sha512-ZVUxEDjQC7eZJcDNeOdDRvMRprQKMb9d62OOA1xnY16VtzcNq5E3//9hKGOqes6HkPyrYnjT9BeNzs6jhMSMng==",
       "cpu": [
         "arm64"
       ],
@@ -1062,9 +1062,9 @@
       ]
     },
     "node_modules/@tokscale/cli-darwin-arm64": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-arm64/-/cli-darwin-arm64-4.14.0.tgz",
-      "integrity": "sha512-K3yOmT63PnsgYBtnoRc9O52NFWwZxSiTZec3t64/B5Z/cvGzaXK9TrklhYAn2oQyA8UUZ3dD1j2u2R/IMJv1zA==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-arm64/-/cli-darwin-arm64-4.15.0.tgz",
+      "integrity": "sha512-9YlcvprlplFIU6ZmNH+/O6MkcFiGjRHm1b8ztNkNwfy/GlE2OwuagVhj3lpWAO5FNMkDRePJqPZA+MeQ6ucPQw==",
       "cpu": [
         "arm64"
       ],
@@ -1075,9 +1075,9 @@
       ]
     },
     "node_modules/@tokscale/cli-darwin-x64": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-x64/-/cli-darwin-x64-4.14.0.tgz",
-      "integrity": "sha512-s5LrSxfdtkvi4pqs8OprSEJkVXOvPdIOfab637vZWd+AfCHRsUgUwZO096BDJXHcDIJRI8vuehDOa3l+JjAfHA==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-x64/-/cli-darwin-x64-4.15.0.tgz",
+      "integrity": "sha512-EP7m6dT3ZPxmFlXdged56uTrJ19Y4By663nj4WO9X/rEj6CAM+s+YCPh82RW4X4X1UmfiKST2H/G9ULbCobEJA==",
       "cpu": [
         "x64"
       ],
@@ -1088,9 +1088,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-arm64-gnu": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-4.14.0.tgz",
-      "integrity": "sha512-y6tHc+/ZQ4/+I8F1Xn9i3rhVyIlGeLu0cFEMEffrBfcVnXkuMsBmCY+V3QcLmUc7OFlX5TTr6whpC/oWje3hIw==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-4.15.0.tgz",
+      "integrity": "sha512-V3XTh2eQoJ/bB3XBYHGhmJxTSHyyGwPi9d4Lqszr8M/mKXlHUu2hOqwWmhl6UhbmZciWyIUJTl7C75eKd09YRg==",
       "cpu": [
         "arm64"
       ],
@@ -1101,9 +1101,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-arm64-musl": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-musl/-/cli-linux-arm64-musl-4.14.0.tgz",
-      "integrity": "sha512-zONuZ+e+zcvMt19Kd6gvM8GVTeANsl+8aIGH2dNTJ9o1mcn2NgGJtq6Ov3zuZz3L+ZkXToxoHbnvgcF07BeeLA==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-musl/-/cli-linux-arm64-musl-4.15.0.tgz",
+      "integrity": "sha512-LfAiYPIaou/aZo6eErgnY3aksQbCIHMhOCQP2WKr1X7jmZmeZZHsaL4EY8tGuCVT3rM9I8FP13Gc/Rr4bdnFtQ==",
       "cpu": [
         "arm64"
       ],
@@ -1114,9 +1114,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-x64-gnu": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-gnu/-/cli-linux-x64-gnu-4.14.0.tgz",
-      "integrity": "sha512-5qXgMS+CXXF9lt4IZz+pvzZTxMh7b/LYzyvilhCccdVZWi1VO9NAH9Z/a+ZZGR44utP7w/He5tMeXUqKQhARGg==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-gnu/-/cli-linux-x64-gnu-4.15.0.tgz",
+      "integrity": "sha512-sqoiUSbfPdbEOQASuj2Ovi1/637YIFxxffrvpVmzR4yvON/HUoAbYPnp8hOGH0EtTSPE3wJJ4aE62UR5hA8c9A==",
       "cpu": [
         "x64"
       ],
@@ -1127,9 +1127,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-x64-musl": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-musl/-/cli-linux-x64-musl-4.14.0.tgz",
-      "integrity": "sha512-A98e9DQmbRQ27i1j0x3kC9UCrXjPCaVZcy2qIQXhhqJxx7YucBursfJeGheSDGr+O/d1jEZOJFOAXbsz5GDAEw==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-musl/-/cli-linux-x64-musl-4.15.0.tgz",
+      "integrity": "sha512-uUzM+zhz2wnneRHmWySYh65akFaxdMpf/JzDXl8ZofwY7d4nULQ1nGe0xrNcz8YUYywX9G/z/ey3ST42hrgwDQ==",
       "cpu": [
         "x64"
       ],
@@ -1140,9 +1140,9 @@
       ]
     },
     "node_modules/@tokscale/cli-win32-arm64-msvc": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-4.14.0.tgz",
-      "integrity": "sha512-RrEHzBH9vPvCAGOTudq5U9p58gcn6AhJjjKxF+6REdpXVWq3NSPEO764YEAoTxIileMZwA8gMrOt3Bs6SHl2hw==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-4.15.0.tgz",
+      "integrity": "sha512-dmOSTptSDxAnt9BNzHagpqLH5/Dx0AbuH56UERq2bdfbOQdY9+8k2v0ilb90ZDyMhA4aeldzLyyjI0VserpMzQ==",
       "cpu": [
         "arm64"
       ],
@@ -1153,9 +1153,9 @@
       ]
     },
     "node_modules/@tokscale/cli-win32-x64-msvc": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-x64-msvc/-/cli-win32-x64-msvc-4.14.0.tgz",
-      "integrity": "sha512-btWPW0A8tJrVDBeSbpgj3wGopRmD5/nU0EbaNwPdPI41vyx+IvUZzaaVb+cLoiQtV5zco+vjKacDgtcVTEUQ9w==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-x64-msvc/-/cli-win32-x64-msvc-4.15.0.tgz",
+      "integrity": "sha512-+tVdGdGrKURlJGb/UdTkg81yd4K+Z++QwThCNShJbdgA68RDRiJ0OaENK0N5KMSWm8LHkcWx6DgjaRCf/RrZVg==",
       "cpu": [
         "x64"
       ],
@@ -4677,12 +4677,12 @@
       }
     },
     "node_modules/tokscale": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/tokscale/-/tokscale-4.14.0.tgz",
-      "integrity": "sha512-mmIvBogoIy7iu3EmAJDKVuwn/8vUx9a2OHeQj0DZXnzMc/rauxpRuMXyich0yZb11o7bNJGvrpC4+g8t/0YKMw==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/tokscale/-/tokscale-4.15.0.tgz",
+      "integrity": "sha512-UMZsjz2CR/kBD4v7uMvpzVXYrFo5bV8KCKJ7cFx2c5w0kIOgjDHrJR4l2MJ8rxgSDG40oylkjlkSCQEoo1VBhA==",
       "license": "MIT",
       "dependencies": {
-        "@tokscale/cli": "4.14.0"
+        "@tokscale/cli": "4.15.0"
       },
       "bin": {
         "tokscale": "bin.js"

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "koffi": "^3.1.5",
     "semver": "^7.8.5",
     "tar": "^7.5.22",
-    "tokscale": "^4.14.0",
+    "tokscale": "^4.15.0",
     "undici": "^7.29.0"
   },
   "devDependencies": {

--- a/scripts/vendor/tokscale.json
+++ b/scripts/vendor/tokscale.json
@@ -5,7 +5,7 @@
   "fork": "Javis603/tokscale",
   "commit": "b4abf21f481ea0a58803418f8cdae6733ec68e75",
   "commitTitle": "feat(sessions): add Oh My Pi (omp) as a local session source (#1161)",
-  "baseVersion": "4.14.0",
+  "baseVersion": "4.15.0",
   "baseVersionNote": "The npm-installed @tokscale/cli-<platform> package version this manifest is aligned with. It tracks the dependency in BOTH modes, and two gates enforce that: ensure-vendored-tokscale.js refuses to swap under \"override\" when the installed package reports something else, and verify-vendored-tokscale-release.js (plus its real-manifest test, so npm run verify catches it too) rejects any manifest whose baseVersion disagrees with @tokscale/cli optionalDependencies. So a tokscale bump always has to touch this file — either pin a new build or flip the mode — instead of silently leaving a stale override in place.",
   "releaseRepo": "Javis603/tokscale",
   "releaseTag": "token-monitor-b4abf21f",


### PR DESCRIPTION
## Summary

Update Tokscale from 4.14.0 to 4.15.0 and keep the upstream vendor manifest aligned with the installed CLI packages.

- bump `tokscale` from `^4.14.0` to `^4.15.0`
- update `@tokscale/cli` and all nine native optional packages to 4.15.0
- update `scripts/vendor/tokscale.json` `baseVersion` to `4.15.0`

The vendor mode remains `upstream`, so the npm-installed binary continues to be authoritative. No Token Monitor runtime source, Worker, documentation, Hub build, or app-version changes are required.

## Upstream behavior reaching Token Monitor

| Upstream change | Effect in Token Monitor |
|---|---|
| Incremental OpenCode SQLite rescans | Improves warm-scan performance. Existing local OpenCode data produced matching warm and cold results. |
| Bounded scanner parallelism | Reduces filesystem contention and excessive scan threads. |
| CodeBuddy log-tree pruning | Avoids traversing unrelated VS Code extension logs. |
| DSH served-model attribution | Attributes usage to the model actually served by the provider. |
| Copilot parser optimizations and pricing fixes | Compatible internal accuracy and performance improvements. |
| LM Studio parser | Available upstream but not exposed as a Token Monitor tracked client in this PR, so #526 remains open. |
| Devin CLI Windows AppData discovery | No current effect because Devin is not a Token Monitor tracked client. |

Tokscale documents three rare OpenCode incremental-cache edge cases in `junhoyeo/tokscale#1230`. They require message-key mutation, parser-disqualifying row rewrites, or non-monotonic imported timestamps rather than normal append/update usage. The upstream reference database and the local database tested here contained no instances, so the incremental path remains enabled and the risk is accepted for this upgrade.

## Verification

```text
npm run verify
# lint + 3,745 passed, 0 failed, 1 skipped

node --test \
  tests/shared/verifyVendoredTokscaleClients.test.js \
  tests/shared/verifyVendoredTokscaleRelease.test.js \
  tests/shared/ensureVendoredTokscale.test.js \
  tests/shared/tokscaleCapabilities.test.js \
  tests/shared/dsh.test.js \
  tests/shared/tokscalePricingCatalog.test.js
# 65 passed

node scripts/verify-vendored-tokscale-clients.js
# all 25 effective client ids supported

node scripts/verify-vendored-tokscale.js
# DSH fixture passed

node scripts/verify-vendored-tokscale-release.js
# all 9 native target mappings verified

git diff --check
```

A non-empty OpenCode JSON smoke test using the production `client,session,model` grouping returned valid JSON and was successfully consumed by `extractUsageFromTokscale()`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `tokscale` from 4.14.0 to 4.15.0 and aligns the vendor manifest with the installed CLI packages.

- Bump `tokscale` from `^4.14.0` to `^4.15.0` in `package.json` and `package-lock.json`.
- Update `@tokscale/cli` and all nine native optional packages to 4.15.0.
- Update `scripts/vendor/tokscale.json` `baseVersion` to `4.15.0`; vendor mode stays `upstream`.
- No Token Monitor runtime, Worker, documentation, Hub build, or app-version changes required.

| Area | Before | After |
| --- | --- | --- |
| OpenCode warm scans | Full rescans of local data | Incremental SQLite rescans improve warm-scan performance |
| Scanner parallelism | Unbounded scan threads | Bounded parallelism reduces filesystem contention |
| CodeBuddy log traversal | Traversed unrelated VS Code extension logs | Pruned log-tree limits traversal to relevant logs |
| DSH served-model attribution | Usage not attributed to the served model | Usage attributed to the model the provider actually served |
| Copilot parsing | Prior parser behavior | Optimizations and pricing fixes with compatible accuracy and performance |

**Verification**
- `npm run verify` passes with 3,745 tests; the five vendoring, capability, DSH, and pricing suites pass (65 tests total).
- All 25 effective client IDs and all 9 native target mappings verified.

**Risks**
- Upstream documents three rare OpenCode incremental-cache edge cases requiring message-key mutation, row rewrites, or non-monotonic timestamps; none appeared in upstream or local test data, so the incremental path stays enabled.

<sup>Written for commit 0cb2b8d5e3f225d434ce6a05f12df550ae26885f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

