### PR TITLE
test(volcengine): cover a real Agent Plan response

### DIFF
--- a/tests/shared/volcengineLimits.test.js
+++ b/tests/shared/volcengineLimits.test.js
@@ -350,32 +350,44 @@ test('fetchVolcengineLimits keeps the response body read inside the deadline', a
 // share the AK/SK, so fetchVolcengineLimits reports them as two rows of a single
 // provider rather than as two providers.
 
-test('parseVolcengineAgentPlanUsage maps every Agent Plan quota window', () => {
+test('parseVolcengineAgentPlanUsage maps a real Agent Plan Medium response', () => {
   const usage = parseVolcengineAgentPlanUsage({
+    ResponseMetadata: {
+      Action: 'GetAFPUsage',
+      Version: '2024-01-01',
+      Service: 'ark',
+      Region: 'cn-beijing'
+    },
     Result: {
-      PlanType: 'Medium',
-      AFPFiveHour: { Quota: 200, Used: 50, ResetTime: 1_783_314_000 },
-      AFPDaily: { Quota: 1000, Used: 250, ResetTime: 1_783_382_400 },
-      AFPWeekly: { Quota: 5000, Used: 1000, ResetTime: 1_783_900_800 },
-      AFPMonthly: { Quota: 20000, Used: 2000, ResetTime: 1_785_542_400 }
+      PlanType: 'medium',
+      AFPFiveHour: { Quota: 10000, Used: 0, SubscribeTime: -1, ResetTime: -1 },
+      AFPWeekly: { Quota: 35000, Used: 11239.7161, SubscribeTime: 1787500800000, ResetTime: 1788105600000 },
+      AFPMonthly: { Quota: 100000, Used: 11239.7161, SubscribeTime: 1787708301000, ResetTime: 1790438399000 },
+      AFPDaily: { Quota: 50000, Used: 0, SubscribeTime: 1787846400000, ResetTime: 1787932800000 }
     }
   });
 
   assert.equal(usage.plan, 'Medium');
   assert.deepEqual(usage.windows.map((w) => w.kind), ['session', 'daily', 'weekly', 'billing']);
   assert.deepEqual(usage.windows.map((w) => w.label), ['5-hour', 'Daily', 'Weekly', 'Monthly']);
+  const session = usage.windows[0];
+  assert.equal(session.used, 0);
+  assert.equal(session.remaining, 10000);
+  assert.equal(session.resetsAt, null);
   const daily = usage.windows[1];
-  assert.equal(daily.used, 250);
-  assert.equal(daily.limit, 1000);
-  assert.equal(daily.remaining, 750);
-  assert.equal(daily.usedPercent, 25);
+  assert.equal(daily.used, 0);
+  assert.equal(daily.limit, 50000);
+  assert.equal(daily.remaining, 50000);
+  assert.equal(daily.usedPercent, 0);
+  assert.equal(daily.resetsAt, '2026-08-28T16:00:00.000Z');
   assert.equal(daily.windowMinutes, 1440);
   const weekly = usage.windows[2];
-  assert.equal(weekly.used, 1000);
-  assert.equal(weekly.limit, 5000);
-  assert.equal(weekly.remaining, 4000);
-  assert.equal(weekly.usedPercent, 20);
-  assert.equal(weekly.resetsAt, '2026-07-13T00:00:00.000Z');
+  assert.equal(weekly.used, 11239.7161);
+  assert.equal(weekly.limit, 35000);
+  assert.ok(Math.abs(weekly.remaining - 23760.2839) < 1e-9);
+  assert.ok(Math.abs(weekly.usedPercent - 32.11347457142857) < 1e-12);
+  assert.equal(weekly.resetsAt, '2026-08-30T16:00:00.000Z');
+  assert.equal(usage.windows[3].resetsAt, '2026-09-26T15:59:59.000Z');
 });
 
 test('parseVolcengineAgentPlanUsage drops windows the plan tier does not include', () => {


### PR DESCRIPTION
## Summary

- replace the synthetic `GetAFPUsage` fixture with the sanitized Agent Plan Medium response shared in #519
- verify lowercase plan labels, canonical quota-window ordering, decimal usage values, and millisecond reset timestamps
- cover an idle `AFPFiveHour` window where Volcengine reports `ResetTime: -1`

## Verification

- `node --test tests/shared/volcengineLimits.test.js` — 23 passed
- `npm run verify` — 3,764 passed, 1 skipped

Refs #519


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Summary

- Replaces the synthetic `GetAFPUsage` fixture with the sanitized real Agent Plan Medium response shared in #519.
- Verifies lowercase plan labels, canonical quota-window ordering, decimal usage values, and millisecond reset timestamps.
- Covers an idle `AFPFiveHour` window where Volcengine reports `ResetTime: -1`.

## Verification

- `node --test tests/shared/volcengineLimits.test.js` — 23 passed.
- `npm run verify` — 3,764 passed, 1 skipped.

Refs #519

<sup>Written for commit fa43854c45e842e9643cfa4e4f3d3cf96b764c97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

