### PR TITLE
fix(codex): label gpt-reserve as Luna Reserve

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -3745,7 +3745,8 @@ function codexAdditionalWindowLabel(window, siblingWindows = []) {
   const matchingWindowCount = siblingWindows.filter((candidate) => (
     String(candidate?.label || '').trim().toLowerCase() === normalizedName
   )).length;
-  return matchingWindowCount > 1 && period ? `${name} · ${period}` : name;
+  const displayName = limitProviderPresentationApi.codexAdditionalQuotaDisplayName(name);
+  return matchingWindowCount > 1 && period ? `${displayName} · ${period}` : displayName;
 }
 
 function codexAdditionalWindowPeriodLabel(window) {

--- a/src/electron/renderer/limitProviderPresentation.js
+++ b/src/electron/renderer/limitProviderPresentation.js
@@ -133,6 +133,11 @@
     return label.replace(/^[a-z]/, (letter) => letter.toUpperCase());
   }
 
+  function codexAdditionalQuotaDisplayName(value) {
+    const name = String(value || '').trim();
+    return normalizeId(name) === 'gpt-reserve' ? 'Luna Reserve' : name;
+  }
+
   function antigravityQuotaWindow(window) {
     const kind = normalizeId(window?.kind);
     const suffix = kind === 'session'
@@ -427,6 +432,7 @@
   return {
     antigravityQuotaWindow,
     apiKeyAccountStatus,
+    codexAdditionalQuotaDisplayName,
     isCodexLiveAccount,
     limitProviderCapabilityTags,
     limitProviderCompactWindowLabel,

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -10,6 +10,7 @@ const accountIdentityApi = require('../../src/electron/renderer/accountIdentity'
 const {
   antigravityQuotaWindow,
   apiKeyAccountStatus,
+  codexAdditionalQuotaDisplayName,
   isCodexLiveAccount,
   limitProviderDisplayLabel,
   limitProviderCapabilityTags,
@@ -53,6 +54,14 @@ test('limitProviderDisplayLabel normalizes short account labels without rewritin
   assert.equal(limitProviderDisplayLabel('Team'), 'Team');
   assert.equal(limitProviderDisplayLabel('primary.user@example.com'), 'primary.user@example.com');
   assert.equal(limitProviderDisplayLabel(''), '');
+});
+
+test('Codex additional quota display names map gpt-reserve and preserve unknown names', () => {
+  assert.equal(codexAdditionalQuotaDisplayName('gpt-reserve'), 'Luna Reserve');
+  assert.equal(codexAdditionalQuotaDisplayName(' GPT-RESERVE '), 'Luna Reserve');
+  assert.equal(codexAdditionalQuotaDisplayName('codex_spark'), 'codex_spark');
+  assert.equal(codexAdditionalQuotaDisplayName('Codex Other'), 'Codex Other');
+  assert.equal(codexAdditionalQuotaDisplayName(''), '');
 });
 
 test('compact Antigravity labels distinguish duplicate periods by model group', () => {
@@ -228,7 +237,8 @@ function runCodexAdditionalWindowLabel(window, siblingWindows) {
   const app = readRendererFile('app.js');
   const formatter = functionBody(app, 'codexAdditionalWindowLabel', 'antigravityQuotaGroups');
   return vm.runInNewContext(
-    `${formatter}\ncodexAdditionalWindowLabel(${JSON.stringify(window)}, ${JSON.stringify(siblingWindows)});`
+    `${formatter}\ncodexAdditionalWindowLabel(${JSON.stringify(window)}, ${JSON.stringify(siblingWindows)});`,
+    { limitProviderPresentationApi: { codexAdditionalQuotaDisplayName } }
   );
 }
 
@@ -1018,7 +1028,8 @@ test('Codex renders Monthly quota and manual reset credits below rolling windows
   assert.match(renderProviderWindows, /codexAdditionalWindowLabel\(additional, additionalWindows\)/);
   assert.match(renderProviderWindows, /additionalNode\.classList\.add\('limit-window-wide'\);/);
   assert.match(codexAdditionalWindowLabel, /if \(!name\) return period \|\| 'Additional limit';/);
-  assert.match(codexAdditionalWindowLabel, /matchingWindowCount > 1 && period \? `\$\{name\} · \$\{period\}` : name/);
+  assert.match(codexAdditionalWindowLabel, /codexAdditionalQuotaDisplayName\(name\)/);
+  assert.match(codexAdditionalWindowLabel, /matchingWindowCount > 1 && period \? `\$\{displayName\} · \$\{period\}` : displayName/);
   assert.match(codexAdditionalWindowLabel, /codexAdditionalWindowPeriodLabel\(window\)/);
   assert.match(codexAdditionalWindowLabel, /minutes % 60 === 0/);
   assert.match(styles, /\.limit-window-text span:first-child \{[\s\S]*text-overflow: ellipsis;/);
@@ -1079,9 +1090,9 @@ test('Codex additional quota labels omit a redundant period unless one name has 
   const hourly = { kind: 'session', label: 'Some quota', windowMinutes: 60 };
   const daily = { kind: 'daily', label: 'Some quota', windowMinutes: 1_440 };
 
-  assert.equal(runCodexAdditionalWindowLabel(weekly, [weekly]), 'gpt-reserve');
-  assert.equal(runCodexAdditionalWindowLabel(session, [session, weekly]), 'gpt-reserve · 5-hour');
-  assert.equal(runCodexAdditionalWindowLabel(weekly, [session, weekly]), 'gpt-reserve · Weekly');
+  assert.equal(runCodexAdditionalWindowLabel(weekly, [weekly]), 'Luna Reserve');
+  assert.equal(runCodexAdditionalWindowLabel(session, [session, weekly]), 'Luna Reserve · 5-hour');
+  assert.equal(runCodexAdditionalWindowLabel(weekly, [session, weekly]), 'Luna Reserve · Weekly');
   assert.equal(runCodexAdditionalWindowLabel(hourly, [hourly, daily]), 'Some quota · 1-hour');
   assert.equal(runCodexAdditionalWindowLabel(daily, [hourly, daily]), 'Some quota · Daily');
 });


### PR DESCRIPTION
## Summary

- Display the `gpt-reserve` quota as `Luna Reserve` in the full Limits view.
- Preserve upstream names for other additional Codex quotas.
- Keep the underlying quota labels and IDs unchanged, including the existing period disambiguation for quotas with multiple windows.

## Testing

- `npm run verify`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Labels the `gpt-reserve` quota as `Luna Reserve` in the full Codex Limits view. All other additional Codex quotas keep their existing display names, and the underlying quota labels and IDs stay unchanged.

| Area | Before | After |
| --- | --- | --- |
| Additional Codex quota label | `gpt-reserve` | `Luna Reserve` |

- Adds unit tests for the display name mapping and preserves unknown names.
- Runs `npm run verify`.

<sup>Written for commit d0876152fa69211cb103c150abebd55f21e521c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

