### PR TITLE
fix(renderer): render floating bubble at device scale

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -8604,6 +8604,13 @@ function refreshFloatingBubbleBitmapForDeviceScale() {
   if (bitmapHeight !== floatingBubbleRenderedBitmapHeight) renderFloatingBubbleContent();
 }
 
+const stopFloatingBubbleDeviceScaleWatcher = window.TokenMonitorTrayComposer.watchDeviceScaleChanges({
+  matchMedia: typeof window.matchMedia === 'function' ? (query) => window.matchMedia(query) : null,
+  getDevicePixelRatio: () => window.devicePixelRatio,
+  onChange: refreshFloatingBubbleBitmapForDeviceScale
+});
+window.addEventListener('unload', stopFloatingBubbleDeviceScaleWatcher, { once: true });
+
 const HOVER_REVEAL_DELAY_MS = 250;
 const HOVER_COLLAPSE_GRACE_MS = 200;
 let floatingBubbleHoverRevealTimer = null;

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -8516,6 +8516,15 @@ function normalizeWindowToggleShortcutValue(value) {
 const BUBBLE_CONTENT_MIN_W = 34;
 const BUBBLE_CONTENT_HEIGHT = 34;
 const BUBBLE_CONTENT_PAD_X = 10;
+const BUBBLE_GENERATED_IMAGE_CSS_HEIGHT = 24;
+let floatingBubbleRenderedBitmapHeight = null;
+
+function currentFloatingBubbleBitmapHeight() {
+  return window.TokenMonitorTrayComposer.floatingBubbleBitmapHeight(
+    window.devicePixelRatio,
+    BUBBLE_GENERATED_IMAGE_CSS_HEIGHT
+  );
+}
 
 function floatingBubbleGeneratedColors() {
   const text = resolvedThemeColor('text');
@@ -8533,8 +8542,12 @@ function renderFloatingBubbleContent() {
   if (!el || !state.floatingBubble.collapsed) return;
   const mode = state.settings?.floatingBubbleContent || 'icon';
   if (window.TokenMonitorTrayText.isGeneratedTrayIconMode(mode)) {
+    // The generated content is a raster image displayed at 24 CSS px. Match its
+    // backing height to the current display scale so Chromium never has to
+    // interpolate already-rasterized text on fractional or high-DPI displays.
+    const bitmapHeight = currentFloatingBubbleBitmapHeight();
     const dataUrl = state.stats
-      ? trayDataUrlForMode(mode, 44, floatingBubbleGeneratedColors(), {
+      ? trayDataUrlForMode(mode, bitmapHeight, floatingBubbleGeneratedColors(), {
           contentOnly: mode === 'barsAllSessions' || mode === 'limitsAllSessions',
           providerContrastHalo: true,
           showProviderBadge: false,
@@ -8549,14 +8562,18 @@ function renderFloatingBubbleContent() {
       img.addEventListener('load', reportFloatingBubbleSize, { once: true });
       img.src = dataUrl;
       el.replaceChildren(img);
+      floatingBubbleRenderedBitmapHeight = bitmapHeight;
       return;
     }
+    floatingBubbleRenderedBitmapHeight = null;
     el.classList.remove('bars');
     el.textContent = (state.stats && window.TokenMonitorTrayText.formatTrayText(state.stats, mode, currentCurrency(), compactTokenDisplayOptions())) || 'Σ';
   } else if (mode === 'icon') {
+    floatingBubbleRenderedBitmapHeight = null;
     el.classList.remove('bars');
     el.textContent = 'Σ';
   } else {
+    floatingBubbleRenderedBitmapHeight = null;
     el.classList.remove('bars');
     el.textContent = state.stats ? (window.TokenMonitorTrayText.formatTrayText(state.stats, mode, currentCurrency(), compactTokenDisplayOptions()) || '0') : '0';
   }
@@ -8574,6 +8591,17 @@ function reportFloatingBubbleSize() {
     width = Math.max(BUBBLE_CONTENT_MIN_W, Math.ceil(el.scrollWidth) + pad);
   }
   window.tokenMonitor.setFloatingBubbleCollapsedSize?.({ width, height: BUBBLE_CONTENT_HEIGHT });
+}
+
+function refreshFloatingBubbleBitmapForDeviceScale() {
+  if (!state.floatingBubble.collapsed || !state.stats) return;
+  const mode = state.settings?.floatingBubbleContent || 'icon';
+  if (!window.TokenMonitorTrayText.isGeneratedTrayIconMode(mode)) return;
+  // Moving the collapsed window between displays can change devicePixelRatio
+  // without changing its CSS dimensions. Repaint only when the backing height
+  // actually changes, which also avoids a size-report/resize loop.
+  const bitmapHeight = currentFloatingBubbleBitmapHeight();
+  if (bitmapHeight !== floatingBubbleRenderedBitmapHeight) renderFloatingBubbleContent();
 }
 
 const HOVER_REVEAL_DELAY_MS = 250;
@@ -12077,7 +12105,10 @@ els.showCompactTotalTokensInput.addEventListener('change', async () => {
 els.compactTokenUnitsInput?.addEventListener('change', async () => {
   await saveAppearanceFromControls();
 });
-window.addEventListener('resize', () => { if (!numberAnimHandle) fitTotalNumber(); });
+window.addEventListener('resize', () => {
+  if (!numberAnimHandle) fitTotalNumber();
+  refreshFloatingBubbleBitmapForDeviceScale();
+});
 els.swapSettingsRefreshInput.addEventListener('change', () => {
   applyControlLayout(els.swapSettingsRefreshInput.checked);
   void saveAppearanceFromControls();
@@ -13405,7 +13436,7 @@ function trayComposerPreview(surface) {
     // icons in colour, so no templateIconColor here — that is a menu-bar-only
     // requirement and would preview the bubble as monochrome.
     return {
-      src: trayDataUrlForMode(mode, 44, floatingBubbleGeneratedColors(), {
+      src: trayDataUrlForMode(mode, currentFloatingBubbleBitmapHeight(), floatingBubbleGeneratedColors(), {
         stats,
         layout: state.settings?.[layoutKey],
         contentOnly: mode === 'barsAllSessions' || mode === 'limitsAllSessions',

--- a/src/electron/renderer/trayComposer.js
+++ b/src/electron/renderer/trayComposer.js
@@ -16,6 +16,14 @@
     return Math.min(max, Math.max(min, value));
   }
 
+  function floatingBubbleBitmapHeight(devicePixelRatio, cssHeight = 24) {
+    const ratio = Number(devicePixelRatio);
+    const resolvedRatio = Number.isFinite(ratio) && ratio > 0 ? ratio : 1;
+    const height = Number(cssHeight);
+    const resolvedHeight = Number.isFinite(height) && height > 0 ? height : 24;
+    return Math.max(1, Math.round(resolvedHeight * resolvedRatio));
+  }
+
   function button(className, text, onClick) {
     const el = document.createElement('button');
     el.type = 'button';
@@ -1338,6 +1346,7 @@
     costDisplayPatch,
     createTrayComposer,
     duplicateTrayLayoutItem,
+    floatingBubbleBitmapHeight,
     handlePickerDocumentScroll,
     moveTrayLayoutItemByKey,
     periodItemPatch,

--- a/src/electron/renderer/trayComposer.js
+++ b/src/electron/renderer/trayComposer.js
@@ -24,6 +24,47 @@
     return Math.max(1, Math.round(resolvedHeight * resolvedRatio));
   }
 
+  function watchDeviceScaleChanges({ matchMedia, getDevicePixelRatio, onChange } = {}) {
+    if (typeof matchMedia !== 'function') return () => {};
+    const readRatio = typeof getDevicePixelRatio === 'function' ? getDevicePixelRatio : () => 1;
+    const notify = typeof onChange === 'function' ? onChange : () => {};
+    let active = true;
+    let mediaQuery = null;
+
+    function removeListener() {
+      if (typeof mediaQuery?.removeEventListener === 'function') {
+        mediaQuery.removeEventListener('change', handleChange);
+      } else {
+        mediaQuery?.removeListener?.(handleChange);
+      }
+    }
+
+    function arm() {
+      if (!active) return;
+      removeListener();
+      const ratio = Number(readRatio());
+      const resolvedRatio = Number.isFinite(ratio) && ratio > 0 ? ratio : 1;
+      mediaQuery = matchMedia(`(resolution: ${resolvedRatio}dppx)`);
+      if (typeof mediaQuery?.addEventListener === 'function') {
+        mediaQuery.addEventListener('change', handleChange);
+      } else {
+        mediaQuery?.addListener?.(handleChange);
+      }
+    }
+
+    function handleChange() {
+      arm();
+      notify();
+    }
+
+    arm();
+    return () => {
+      active = false;
+      removeListener();
+      mediaQuery = null;
+    };
+  }
+
   function button(className, text, onClick) {
     const el = document.createElement('button');
     el.type = 'button';
@@ -1351,6 +1392,7 @@
     moveTrayLayoutItemByKey,
     periodItemPatch,
     syncTrayComposerSurfaces,
-    usageScopePatch
+    usageScopePatch,
+    watchDeviceScaleChanges
   };
 });

--- a/tests/electron/floatingBubble.test.js
+++ b/tests/electron/floatingBubble.test.js
@@ -408,6 +408,30 @@ test('glass surfaces keep the shared tint and blur without decorative chrome', (
   assert.match(css, /html\.floating-bubble-collapsed-left,\s*body\.floating-bubble-collapsed-left\s*\{[\s\S]*border-radius:\s*var\(--floating-bubble-radius\);/);
 });
 
+test('generated floating bubble images use a device-scale-aware bitmap', () => {
+  const css = fs.readFileSync(stylesPath, 'utf8');
+  const app = fs.readFileSync(appPath, 'utf8');
+  const imageBlock = cssBlock(css, '\\.floating-bubble-tab span\\.bars img');
+  const renderStart = app.indexOf('function renderFloatingBubbleContent()');
+  const renderEnd = app.indexOf('function reportFloatingBubbleSize()', renderStart);
+  const renderBody = app.slice(renderStart, renderEnd);
+  const previewStart = app.indexOf('function trayComposerPreview(surface)');
+  const previewEnd = app.indexOf('function activateTrayComposer(surface)', previewStart);
+  const previewBody = app.slice(previewStart, previewEnd);
+
+  assert.match(imageBlock, /height:\s*24px;/);
+  assert.match(app, /const BUBBLE_GENERATED_IMAGE_CSS_HEIGHT = 24;/);
+  assert.match(
+    app,
+    /floatingBubbleBitmapHeight\(\s*window\.devicePixelRatio,\s*BUBBLE_GENERATED_IMAGE_CSS_HEIGHT\s*\)/
+  );
+  assert.match(renderBody, /const bitmapHeight = currentFloatingBubbleBitmapHeight\(\);/);
+  assert.match(renderBody, /trayDataUrlForMode\(mode, bitmapHeight,/);
+  assert.doesNotMatch(renderBody, /trayDataUrlForMode\(mode, 44,/);
+  assert.match(previewBody, /trayDataUrlForMode\(mode, currentFloatingBubbleBitmapHeight\(\),/);
+  assert.match(app, /window\.addEventListener\('resize',[\s\S]*refreshFloatingBubbleBitmapForDeviceScale\(\);/);
+});
+
 test('floatingBubbleCollapsePlan honors a custom handle size', () => {
   const settings = { floatingBubbleEnabled: true };
   const workArea = { x: 0, y: 0, width: 1000, height: 800 };

--- a/tests/electron/floatingBubble.test.js
+++ b/tests/electron/floatingBubble.test.js
@@ -429,6 +429,7 @@ test('generated floating bubble images use a device-scale-aware bitmap', () => {
   assert.match(renderBody, /trayDataUrlForMode\(mode, bitmapHeight,/);
   assert.doesNotMatch(renderBody, /trayDataUrlForMode\(mode, 44,/);
   assert.match(previewBody, /trayDataUrlForMode\(mode, currentFloatingBubbleBitmapHeight\(\),/);
+  assert.match(app, /watchDeviceScaleChanges\(\{[\s\S]*onChange:\s*refreshFloatingBubbleBitmapForDeviceScale/);
   assert.match(app, /window\.addEventListener\('resize',[\s\S]*refreshFloatingBubbleBitmapForDeviceScale\(\);/);
 });
 

--- a/tests/electron/trayComposer.test.js
+++ b/tests/electron/trayComposer.test.js
@@ -11,12 +11,24 @@ const {
   costDisplayPatch,
   createTrayComposer,
   duplicateTrayLayoutItem,
+  floatingBubbleBitmapHeight,
   handlePickerDocumentScroll,
   moveTrayLayoutItemByKey,
   periodItemPatch,
   syncTrayComposerSurfaces,
   usageScopePatch
 } = require('../../src/electron/renderer/trayComposer');
+
+test('floating bubble bitmap height tracks CSS pixels at the current device scale', () => {
+  assert.equal(floatingBubbleBitmapHeight(1), 24);
+  assert.equal(floatingBubbleBitmapHeight(1.25), 30);
+  assert.equal(floatingBubbleBitmapHeight(1.5), 36);
+  assert.equal(floatingBubbleBitmapHeight(2), 48);
+  assert.equal(floatingBubbleBitmapHeight(2.5), 60);
+  assert.equal(floatingBubbleBitmapHeight(0), 24);
+  assert.equal(floatingBubbleBitmapHeight('invalid'), 24);
+  assert.equal(floatingBubbleBitmapHeight(1.5, 20), 30);
+});
 
 function layoutWithIds(...ids) {
   return {

--- a/tests/electron/trayComposer.test.js
+++ b/tests/electron/trayComposer.test.js
@@ -16,7 +16,8 @@ const {
   moveTrayLayoutItemByKey,
   periodItemPatch,
   syncTrayComposerSurfaces,
-  usageScopePatch
+  usageScopePatch,
+  watchDeviceScaleChanges
 } = require('../../src/electron/renderer/trayComposer');
 
 test('floating bubble bitmap height tracks CSS pixels at the current device scale', () => {
@@ -28,6 +29,57 @@ test('floating bubble bitmap height tracks CSS pixels at the current device scal
   assert.equal(floatingBubbleBitmapHeight(0), 24);
   assert.equal(floatingBubbleBitmapHeight('invalid'), 24);
   assert.equal(floatingBubbleBitmapHeight(1.5, 20), 30);
+});
+
+test('device scale watcher rearms its resolution query and notifies on DPR changes', () => {
+  const queries = [];
+  let ratio = 1.5;
+  let notifications = 0;
+  const matchMedia = (media) => {
+    const listeners = new Set();
+    const query = {
+      media,
+      addEventListener(type, listener) {
+        assert.equal(type, 'change');
+        listeners.add(listener);
+      },
+      removeEventListener(type, listener) {
+        assert.equal(type, 'change');
+        listeners.delete(listener);
+      },
+      dispatchChange() {
+        for (const listener of [...listeners]) listener({ matches: false, media });
+      },
+      listenerCount() {
+        return listeners.size;
+      }
+    };
+    queries.push(query);
+    return query;
+  };
+
+  const stop = watchDeviceScaleChanges({
+    matchMedia,
+    getDevicePixelRatio: () => ratio,
+    onChange: () => { notifications += 1; }
+  });
+
+  assert.equal(queries[0].media, '(resolution: 1.5dppx)');
+  assert.equal(queries[0].listenerCount(), 1);
+  assert.equal(notifications, 0);
+
+  ratio = 1;
+  queries[0].dispatchChange();
+  assert.equal(queries[0].listenerCount(), 0);
+  assert.equal(queries[1].media, '(resolution: 1dppx)');
+  assert.equal(queries[1].listenerCount(), 1);
+  assert.equal(notifications, 1);
+
+  stop();
+  assert.equal(queries[1].listenerCount(), 0);
+  queries[1].dispatchChange();
+  assert.equal(queries.length, 2);
+  assert.equal(notifications, 1);
 });
 
 function layoutWithIds(...ids) {


### PR DESCRIPTION
## Summary

- Size generated floating-bubble bitmaps from their 24 CSS px display height and the renderer's current `devicePixelRatio`, so fractional and HiDPI scaling does not interpolate already-rasterized text.
- Watch the active resolution media query and re-arm it when the device scale changes, so moving the bubble between displays rebuilds its backing bitmap even when the viewport does not resize; retain resize as a fallback.
- Keep the tray icon's existing 44 px source and the bubble's layout dimensions unchanged, and make the Settings live preview use the same backing-size contract.

## Verification

- `node --test tests/electron/floatingBubble.test.js tests/electron/trayComposer.test.js` — 39 passed
- `npm run verify` — lint clean; 3,836 passed, 0 failed, 1 skipped
- `git diff --check`
- Automated coverage pins the backing sizes for 100%, 125%, 150%, 200%, and 250% display scaling, plus resolution-query re-arming across a 150% → 100% transition

Closes #429
