### PR TITLE
fix(usage): strip provider prefix from claude model keys

### DIFF
--- a/src/shared/hubBuildRegistry.json
+++ b/src/shared/hubBuildRegistry.json
@@ -109,6 +109,10 @@
       {
         "revision": 27,
         "buildId": "sha256:652a99f9f63eaa3901a874e4287cd115f5c1ada6393fc3a19c106ea685386ff7"
+      },
+      {
+        "revision": 28,
+        "buildId": "sha256:bd5906d0d18c7802497e1fb689f7705721326d209280e7d0e61f3b4cde4af103"
       }
     ],
     "node-hub": [

--- a/src/shared/usage.js
+++ b/src/shared/usage.js
@@ -213,9 +213,25 @@ function normalizeModelName(value) {
 
 function normalizeModelNameForClient(value, client) {
   const normalized = normalizeModelName(value);
-  if (!normalized || normalizeClientName(client) !== REASONIX_CLIENT) return normalized;
-  const qualified = normalized.match(/^(?:deepseek|deepseek-flash)\/(.+)$/);
-  return qualified?.[1] || normalized;
+  if (!normalized) return normalized;
+  const clientId = normalizeClientName(client);
+  if (clientId === REASONIX_CLIENT) {
+    const qualified = normalized.match(/^(?:deepseek|deepseek-flash)\/(.+)$/);
+    return qualified?.[1] || normalized;
+  }
+  // Claude Code's transcript records custom models bare (e.g. "MiniMax-M3"),
+  // but tokscale's Claude parser canonicalizes them through its pricing alias
+  // table, which can emit a provider-qualified id (e.g. "minimax/MiniMax-M3",
+  // deliberately pinned so the first-party price resolves instead of a
+  // zero-priced reseller row). The same model used in another tool (mcode,
+  // commandcode, …) is keyed bare, so a leading "<provider>/" segment must be
+  // stripped here or that model's usage/cost splits across two keys. Native
+  // Claude models never contain '/', so they are untouched.
+  if (clientId === 'claude') {
+    const slash = normalized.indexOf('/');
+    if (slash > 0 && slash < normalized.length - 1) return normalized.slice(slash + 1);
+  }
+  return normalized;
 }
 
 function normalizeSessionId(value) {

--- a/tests/shared/usage.test.js
+++ b/tests/shared/usage.test.js
@@ -10,6 +10,7 @@ const {
   mergeDeviceRecord,
   mergePeriods,
   normalizeClientName,
+  normalizeModelNameForClient,
   UNATTRIBUTED_USAGE_CLIENT
 } = require('../../src/shared/usage');
 
@@ -753,6 +754,32 @@ test('extractUsageFromTokscale normalizes MiMo Code and ZCode client ids', () =>
 
   assert.equal(period.clients.micode, 23);
   assert.equal(period.clients.zcode, 29);
+});
+
+test('extractUsageFromTokscale merges provider-qualified claude model ids with bare ids from other tools', () => {
+  // tokscale's Claude parser canonicalizes MiniMax-M3 through its pricing
+  // alias table into the provider-qualified "minimax/MiniMax-M3" (so the
+  // first-party price resolves), while the mcode parsers key the same model
+  // bare. Both must land on one model key or usage/cost split in two.
+  const period = extractUsageFromTokscale([
+    { client: 'claude', model: 'minimax/MiniMax-M3', totalTokens: 40 },
+    { client: 'mcode', model: 'MiniMax-M3', totalTokens: 60 }
+  ]);
+
+  assert.equal(period.models['minimax-m3'], 100);
+  assert.equal(period.models['minimax/minimax-m3'], undefined);
+  assert.equal(period.clientModels.claude['minimax-m3'], 40);
+  assert.equal(period.clientModels.mcode['minimax-m3'], 60);
+});
+
+test('claude provider-prefix strip leaves native and non-claude model keys alone', () => {
+  assert.equal(normalizeModelNameForClient('minimax/MiniMax-M3', 'claude'), 'minimax-m3');
+  assert.equal(normalizeModelNameForClient('minimax/minimax-m3', 'claude'), 'minimax-m3');
+  assert.equal(normalizeModelNameForClient('anthropic/claude-4-6-sonnet', 'claude'), 'claude-4-6-sonnet');
+  assert.equal(normalizeModelNameForClient('openrouter/anthropic/claude-sonnet-4', 'claude'), 'anthropic/claude-sonnet-4');
+  assert.equal(normalizeModelNameForClient('claude-sonnet-4-5', 'claude'), 'claude-sonnet-4-5');
+  assert.equal(normalizeModelNameForClient('deepseek/deepseek-v3', 'codex'), 'deepseek/deepseek-v3');
+  assert.equal(normalizeModelNameForClient('deepseek/deepseek-v4-flash', 'reasonix'), 'deepseek-v4-flash');
 });
 
 test('extractUsageFromTokscale passes zcode input straight through (tokscale normalizes cache upstream)', () => {

--- a/worker/src/shared/hubBuildRegistry.json
+++ b/worker/src/shared/hubBuildRegistry.json
@@ -109,6 +109,10 @@
       {
         "revision": 27,
         "buildId": "sha256:652a99f9f63eaa3901a874e4287cd115f5c1ada6393fc3a19c106ea685386ff7"
+      },
+      {
+        "revision": 28,
+        "buildId": "sha256:bd5906d0d18c7802497e1fb689f7705721326d209280e7d0e61f3b4cde4af103"
       }
     ],
     "node-hub": [

--- a/worker/src/shared/usage.js
+++ b/worker/src/shared/usage.js
@@ -216,9 +216,25 @@ function normalizeModelName(value) {
 
 function normalizeModelNameForClient(value, client) {
   const normalized = normalizeModelName(value);
-  if (!normalized || normalizeClientName(client) !== REASONIX_CLIENT) return normalized;
-  const qualified = normalized.match(/^(?:deepseek|deepseek-flash)\/(.+)$/);
-  return qualified?.[1] || normalized;
+  if (!normalized) return normalized;
+  const clientId = normalizeClientName(client);
+  if (clientId === REASONIX_CLIENT) {
+    const qualified = normalized.match(/^(?:deepseek|deepseek-flash)\/(.+)$/);
+    return qualified?.[1] || normalized;
+  }
+  // Claude Code's transcript records custom models bare (e.g. "MiniMax-M3"),
+  // but tokscale's Claude parser canonicalizes them through its pricing alias
+  // table, which can emit a provider-qualified id (e.g. "minimax/MiniMax-M3",
+  // deliberately pinned so the first-party price resolves instead of a
+  // zero-priced reseller row). The same model used in another tool (mcode,
+  // commandcode, …) is keyed bare, so a leading "<provider>/" segment must be
+  // stripped here or that model's usage/cost splits across two keys. Native
+  // Claude models never contain '/', so they are untouched.
+  if (clientId === 'claude') {
+    const slash = normalized.indexOf('/');
+    if (slash > 0 && slash < normalized.length - 1) return normalized.slice(slash + 1);
+  }
+  return normalized;
 }
 
 function normalizeSessionId(value) {


### PR DESCRIPTION
## Summary

tokscale's Claude parser canonicalizes every model through its pricing alias table, which emits custom models as a provider-qualified id (e.g. `minimax/MiniMax-M3`, deliberately pinned so the first-party litellm price resolves instead of a zero-priced reseller row). The same model used from another tool (mcode, commandcode, …) is keyed bare (`MiniMax-M3`), so one model's usage and cost split across two keys.

This strips a leading `<provider>/` segment for the `claude` client in `normalizeModelNameForClient`, mirroring the existing `reasonix` deepseek strip. Native Claude models never contain `/`, so they are untouched.

## Change

- `src/shared/usage.js` — add the claude provider-prefix strip to `normalizeModelNameForClient`.
- `tests/shared/usage.test.js` — cover the merge plus the native/non-claude untouched cases.
- Regenerated the hub build registry and the Worker shared copy.

## Verification

- `npm run verify` (lint + `node --test`) — passes locally apart from 5 pre-existing DSH timestamp tests that pass in CI.

## Notes

Complements #513 (mcode tracking): once mcode and claude are both reporting, this is what keeps a model like `MiniMax-M3` from splitting into `minimax/MiniMax-M3` (claude) and `MiniMax-M3` (mcode).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes usage/cost splitting for `claude` models: tokscale's Claude parser emits custom models as provider-qualified ids (e.g. `minimax/MiniMax-M3`) while other tools like `mcode` key the same model bare, so one model's usage and cost land on two separate keys. This strips a leading `<provider>/` segment for the `claude` client so those keys merge; native Claude models never contain `/` and are untouched.

- Adds a `claude` provider-prefix strip to `normalizeModelNameForClient` in `src/shared/usage.js`, mirroring the existing `reasonix` deepseek strip.
- Adds tests covering the merge plus untouched native/non-claude cases in `tests/shared/usage.test.js`.
- Regenerates the hub build registry and the worker shared copy.

| Area | Before | After |
| --- | --- | --- |
| Model usage keys for `claude` | `MiniMax-M3` from `claude` splits into `minimax/MiniMax-M3` while `mcode` keys it bare | both normalize to `minimax-m3` and merge into one usage/cost key |

**Verification**
- `npm run verify` passes locally apart from 5 pre-existing DSH timestamp tests that pass in CI.

<sup>Written for commit 0ed0d0f3d4b712e419f38c34ac463ea5a789d5ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

