### PR TITLE
fix(renderer): retry the two critical init() IPC reads with backoff

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -11560,6 +11560,24 @@ window.addEventListener('blur', () => {
   if (state.viewSwitcherOpen) setViewSwitcherOpen(false);
 });
 
+// A transient IPC failure in init() used to abort the rest of startup and leave
+// the UI on factory defaults — settings never applied, no retry, no error. Retry
+// the critical startup reads with backoff so a single dropped IPC round trip at
+// boot cannot leave the renderer half-initialized.
+async function ipcReadWithRetry(task, { attempts = 3, baseDelayMs = 300, label = 'ipc' } = {}) {
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await task();
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) await new Promise((resolve) => setTimeout(resolve, baseDelayMs * attempt));
+    }
+  }
+  console.error(`[init] ${label} failed after ${attempts} attempts`, lastError);
+  throw lastError;
+}
+
 async function init() {
   // Subscribed before the app-info round trip, not after: a theme flipped while
   // that call is in flight would otherwise be missed until the next flip. The
@@ -11582,11 +11600,11 @@ async function init() {
   // and settings have not loaded yet, so repainting from here would only churn.
   if (!systemUiThemeSeeded) state.systemDarkUi = state.appInfo?.systemDarkUi === true;
   if (els.aboutVersion) els.aboutVersion.textContent = state.appInfo?.version ? `v${state.appInfo.version}` : '—';
-  state.settings = await window.tokenMonitor.getSettings();
+  state.settings = await ipcReadWithRetry(() => window.tokenMonitor.getSettings(), { label: 'getSettings' });
   applyEffectiveCurrencyRates();
   deliverTrayProviderIcons();
 
-  state.appUpdate = await window.tokenMonitor.getAppUpdateState();
+  state.appUpdate = await ipcReadWithRetry(() => window.tokenMonitor.getAppUpdateState(), { label: 'getAppUpdateState' });
   renderAppUpdatePill();
   renderSettingsAppUpdateRow();
   window.tokenMonitor.onAppUpdatePush?.((payload) => {


### PR DESCRIPTION
## Problem

`init()` reads settings and the app-update state with bare `await`s:

```js
state.settings = await window.tokenMonitor.getSettings();
state.appUpdate = await window.tokenMonitor.getAppUpdateState();
```

A single transient IPC failure at boot (renderer ready before the main-process handler, or momentary IPC jitter under heavy startup load) rejects the promise, aborts the rest of `init()`, and leaves the UI on factory defaults: user settings never applied, enabled clients reset to the default list, no retry, and no visible error. The window then stays in that state until the next full relaunch, which looks like "the app lost my settings".

## Fix

Wrap only those two startup reads in a small `ipcReadWithRetry` helper (3 attempts, 300ms × attempt backoff). On success the behavior is byte-identical; on failure it retries and, if all attempts fail, still throws after logging — but a single dropped round trip can no longer half-initialize the renderer.

```js
state.settings = await ipcReadWithRetry(() => window.tokenMonitor.getSettings(), { label: 'getSettings' });
state.appUpdate = await ipcReadWithRetry(() => window.tokenMonitor.getAppUpdateState(), { label: 'getAppUpdateState' });
```

## Testing

- Normal boot: unchanged behavior, no extra latency on the happy path (first attempt succeeds).
- Verified on a patched build where this fix stopped an intermittent "UI shows factory defaults" symptom that had been reproducing several times a day on a Windows machine with many enabled clients (heavier startup IPC traffic).
- `node --check` passes; diff against `main` is exactly the helper plus the two wrapped calls (+880 bytes).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries the two critical IPC reads during renderer startup (`getSettings` and `getAppUpdateState`) so a single transient IPC failure no longer aborts `init()` and leaves the UI on factory defaults.

| Area | Before | After |
| --- | --- | --- |
| Renderer startup | A single dropped IPC round trip at boot aborts `init()`, leaving user settings unapplied and enabled clients reset to the default list until the next relaunch. | The two critical reads retry up to 3 attempts with 300ms × attempt backoff; only a persistent failure aborts startup, after logging an error. |

- The helper only wraps the two startup reads; the happy path is byte-identical with no added latency.
- Verified on a patched build that stopped an intermittent "UI shows factory defaults" symptom reproducing several times a day on Windows with heavy startup IPC traffic; `node --check` passes.

<sup>Written for commit 60e9dafc05330c72c18f7a127295acb8a1fdfa7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

