### PR TITLE
feat(qodercn): estimate per-model token usage from agent transcripts

### DIFF
--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1,4 +1,4 @@
-'use strict';
+﻿'use strict';
 
 const { spawn } = require('node:child_process');
 const fs = require('node:fs');
@@ -1200,6 +1200,7 @@ async function maybeSyncCursor(clientsCsv, logger, options = {}) {
 // tokscale's antigravity sync reads the IDE's native session roots under
 // ~/.gemini/; when none exist there is nothing to sync, so don't spawn at all.
 const ANTIGRAVITY_DATA_ROOTS = ['antigravity', 'antigravity-ide', 'antigravity-backup'];
+const ANTIGRAVITY_SYNC_LOCK_MAX_BYTES = 128;
 
 function antigravityDataRoots(home = os.homedir()) {
   return ANTIGRAVITY_DATA_ROOTS.map((name) => path.join(home, '.gemini', name));
@@ -1207,6 +1208,111 @@ function antigravityDataRoots(home = os.homedir()) {
 
 function antigravityDataPresent(home) {
   return antigravityDataRoots(home).some(dirExists);
+}
+
+function antigravitySyncLockPath(home, env = process.env, platform = process.platform) {
+  return path.join(
+    tokscaleConfigDir({ env, platform, homeDir: home }),
+    'antigravity-cache',
+    'sync.lock'
+  );
+}
+
+// Tokscale deliberately preserves an unknown sync.lock after a crash: an older
+// binary may still own it during a rolling upgrade, so reclaiming arbitrary
+// dead-PID records here would undo that safety boundary. We can make one much
+// narrower claim after a child we terminated has emitted close: a regular file
+// naming that exact child, created during this spawn, is our orphan. Recheck the
+// inode and contents immediately before unlinking so a successor or user edit
+// is preserved instead of mistaken for the record we observed.
+function removeOwnedAntigravitySyncLock({
+  lockPath,
+  childPid,
+  childStartedAt,
+  fsApi = fs,
+  now = Date.now
+} = {}) {
+  if (!lockPath || !Number.isSafeInteger(childPid) || childPid <= 0) return false;
+  if (!Number.isFinite(childStartedAt)) return false;
+  try {
+    const firstStat = fsApi.lstatSync(lockPath);
+    if (!firstStat.isFile() || firstStat.isSymbolicLink() || firstStat.size > ANTIGRAVITY_SYNC_LOCK_MAX_BYTES) {
+      return false;
+    }
+    const record = fsApi.readFileSync(lockPath, 'utf8');
+    const match = record.match(/^(\d+)\s+(\d+)\s*$/);
+    if (!match || Number(match[1]) !== childPid) return false;
+    const recordedAt = Number(match[2]);
+    const earliest = Math.floor(childStartedAt / 1000) - 1;
+    const latest = Math.floor(now() / 1000) + 1;
+    if (!Number.isSafeInteger(recordedAt) || recordedAt < earliest || recordedAt > latest) return false;
+
+    const finalStat = fsApi.lstatSync(lockPath);
+    if (firstStat.dev !== finalStat.dev || firstStat.ino !== finalStat.ino) return false;
+    if (fsApi.readFileSync(lockPath, 'utf8') !== record) return false;
+    fsApi.unlinkSync(lockPath);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function processIdIsAlive(pid, kill = process.kill.bind(process)) {
+  try {
+    kill(pid, 0);
+    return true;
+  } catch (error) {
+    // A permission error still proves that the process exists. Every other
+    // normal failure means there is no process for this user to signal.
+    return error?.code === 'EPERM' || error?.code === 'EACCES';
+  }
+}
+
+// This is deliberately user-mediated rather than startup cleanup. Tokscale's
+// visible lock remains compatible with older binaries that do not participate
+// in sync.os.lock, so absence of a new-format OS owner is not enough evidence
+// to reclaim it in the background. Once the user confirms that no sync is
+// running, accept only the exact legacy record shape, refuse a live pid, and
+// repeat the inode/content checks immediately before removing the one path.
+function repairAntigravitySyncLock({
+  lockPath,
+  fsApi = fs,
+  pidIsAlive = processIdIsAlive
+} = {}) {
+  if (!lockPath) return { ok: false, code: 'unsafe-lock' };
+  try {
+    const firstStat = fsApi.lstatSync(lockPath);
+    if (!firstStat.isFile() || firstStat.isSymbolicLink() || firstStat.size > ANTIGRAVITY_SYNC_LOCK_MAX_BYTES) {
+      return { ok: false, code: 'unsafe-lock' };
+    }
+    const record = fsApi.readFileSync(lockPath, 'utf8');
+    const match = record.match(/^(\d+)\s+(\d+)\s*$/);
+    const pid = Number(match?.[1]);
+    const recordedAt = Number(match?.[2]);
+    if (
+      !match
+      || !Number.isSafeInteger(pid)
+      || pid <= 0
+      || !Number.isSafeInteger(recordedAt)
+      || recordedAt <= 0
+    ) {
+      return { ok: false, code: 'unsafe-lock' };
+    }
+    if (pidIsAlive(pid)) return { ok: false, code: 'owner-active' };
+
+    const finalStat = fsApi.lstatSync(lockPath);
+    if (firstStat.dev !== finalStat.dev || firstStat.ino !== finalStat.ino) {
+      return { ok: false, code: 'unsafe-lock' };
+    }
+    if (fsApi.readFileSync(lockPath, 'utf8') !== record) {
+      return { ok: false, code: 'unsafe-lock' };
+    }
+    fsApi.unlinkSync(lockPath);
+    return { ok: true, code: 'repaired' };
+  } catch (error) {
+    if (error?.code === 'ENOENT') return { ok: true, code: 'not-found' };
+    return { ok: false, code: 'repair-failed' };
+  }
 }
 
 async function maybeSyncAntigravity(clientsCsv, logger, home = os.homedir(), options = {}) {
@@ -1241,12 +1347,14 @@ async function maybeSyncAntigravity(clientsCsv, logger, home = os.homedir(), opt
     return;
   }
   const { bin, prefixArgs, env } = tokscaleCommand();
+  const syncLockPath = options.syncLockPath || antigravitySyncLockPath(home, env);
   // Every outcome resolves — a stuck sync must not hold the tick open — so a
   // failure is only visible through onFailure. The caller needs it: the tick has
   // already consumed the source event that asked for this sync, and silently
   // scanning the unchanged cache would put the refresh back on the fallback
   // interval, which is the latency this whole path exists to remove.
   await new Promise((resolve) => {
+    const childStartedAt = Date.now();
     const child = spawn(bin, [...prefixArgs, 'antigravity', 'sync'], { env, windowsHide: true });
     const termination = createSubprocessTermination(child, {
       ...(options.terminationOptions || {}),
@@ -1315,6 +1423,13 @@ async function maybeSyncAntigravity(clientsCsv, logger, home = os.homedir(), opt
     });
     child.on('close', (code) => {
       termination.confirmClosed();
+      if (terminalOutcome) {
+        removeOwnedAntigravitySyncLock({
+          lockPath: syncLockPath,
+          childPid: child.pid,
+          childStartedAt
+        });
+      }
       if (settled) return;
       if (terminalOutcome?.cancelled) return settle(false, '', {}, false, true);
       if (terminalOutcome) {
@@ -1544,6 +1659,7 @@ async function collectUsageOnce(options) {
     await maybeSyncAntigravity(syncClients, options.logger, options.homeDir || os.homedir(), {
       minIntervalMs: selfSyncThrottle.minIntervalForTick(options, 'antigravity'),
       run: options.runAntigravitySync,
+      syncLockPath: options.antigravitySyncLockPath,
       signal: options.signal,
       timeoutMs: options.selfSyncTimeoutMs,
       terminationOptions: options.subprocessTerminationOptions,
@@ -1570,21 +1686,22 @@ async function collectUsageOnce(options) {
       }
     }
     if (includesQoderCn && (!targetRequested || targetClients.includes('qodercn'))) {
+      const qoderCnSinceMs = anchorUsed ? new Date(collectedAt.getFullYear(), collectedAt.getMonth(), collectedAt.getDate()).getTime() : undefined;
+      // Legacy DB read — may fail on first run or DB corruption.
       try {
-        const qoderCnSinceMs = anchorUsed ? new Date(collectedAt.getFullYear(), collectedAt.getMonth(), collectedAt.getDate()).getTime() : undefined;
         qoderCnRows = await collectQoderCnRows({ homeDir: options.homeDir, logger: options.logger, sinceMs: qoderCnSinceMs });
-        // The 0.1.x Qoder CN client keeps no local token-usage database, so the
-        // legacy rows above stop at the old install. The client's agent
-        // transcripts (~/.qoder-cn/projects) carry per-request content with the
-        // model code; tokens are estimated from that content (see
-        // collectQoderCnTranscriptRows), keeping the qodercn row live with
-        // per-model attribution in token units.
-        try {
-          const qoderCnTranscriptRows = collectQoderCnTranscriptRows({ homeDir: options.homeDir, sinceMs: qoderCnSinceMs });
-          if (qoderCnTranscriptRows.length) qoderCnRows = qoderCnRows.concat(qoderCnTranscriptRows);
-        } catch (transcriptErr) {
-          if (typeof options.logger === 'function') options.logger(`qodercn transcript rows skipped: ${transcriptErr.message}`);
-        }
+      } catch (dbErr) {
+        if (typeof options.logger === 'function') options.logger(`qodercn legacy parse failed: ${dbErr.message}`);
+      }
+      // Transcript rows are independent of the legacy DB (P2-4): a dead
+      // legacy DB must not suppress the transcript scan.
+      try {
+        const qoderCnTranscriptRows = collectQoderCnTranscriptRows({ homeDir: options.homeDir, sinceMs: qoderCnSinceMs });
+        if (qoderCnTranscriptRows.length) qoderCnRows = (qoderCnRows || []).concat(qoderCnTranscriptRows);
+      } catch (transcriptErr) {
+        if (typeof options.logger === 'function') options.logger(`qodercn transcript rows skipped: ${transcriptErr.message}`);
+      }
+      try {
         qoderCnPricing = await resolveQoderCnPricing(qoderCnRows, {
           lookupModelPricing: options.lookupModelPricing || lookupModelPricing,
           commandTimeoutMs: options.pricingTimeoutMs,
@@ -1906,6 +2023,15 @@ async function collectUsageOnce(options) {
     // block is gated by includeHistory (historyIntervalMs), mirroring the proma
     // full-read pattern; resolveQoderCnPricing is cached (6h TTL) so the second
     // pass is cheap when the scan already priced the same models.
+    // Read the full transcript set once per tick (P2-6: avoid double scan).
+    const qoderCnTranscriptAllRows = (() => {
+      try {
+        return collectQoderCnTranscriptRows({ homeDir: options.homeDir });
+      } catch (err) {
+        if (typeof options.logger === 'function') options.logger(`qodercn transcript rows skipped: ${err.message}`);
+        return [];
+      }
+    })();
     let qoderCnGraph = null;
     let qoderCnHistoryReadFailed = false;
     if (includesQoderCn) {
@@ -1914,17 +2040,11 @@ async function collectUsageOnce(options) {
         // only since local midnight, so the graph needs its own full read there.
         // resolveQoderCnPricing is cached (6h TTL), so the second pass is cheap.
         let rows = (!anchorUsed && qoderCnRows) ? qoderCnRows : await collectQoderCnRows({ homeDir: options.homeDir, logger: options.logger });
-        // Anchored ticks reuse today-only rows, so the graph needs its own full
-        // transcript read; non-anchored ticks already carry the transcript rows
-        // via qoderCnRows, and transcript rows are not delta-based — appending
-        // them twice would double-count every estimated token.
-        if (anchorUsed) {
-          try {
-            const qoderCnTranscriptRows = collectQoderCnTranscriptRows({ homeDir: options.homeDir });
-            if (qoderCnTranscriptRows.length) rows = rows.concat(qoderCnTranscriptRows);
-          } catch (transcriptErr) {
-            if (typeof options.logger === 'function') options.logger(`qodercn transcript rows history skipped: ${transcriptErr.message}`);
-          }
+        // Non-anchored ticks already carry transcript rows via qoderCnRows;
+        // anchored ticks need the full transcript set appended, and transcript
+        // rows are not delta-based — appending them twice would double-count.
+        if (anchorUsed && qoderCnTranscriptAllRows.length) {
+          rows = rows.concat(qoderCnTranscriptAllRows);
         }
         const pricing = (!anchorUsed && qoderCnPricing) ? qoderCnPricing : await resolveQoderCnPricing(rows, {
           lookupModelPricing: options.lookupModelPricing || lookupModelPricing,
@@ -3085,7 +3205,8 @@ function deriveClientHealth(clientsCsv, allTimePeriod, options = {}) {
       // set is the normal shape of a normal install. `checks` still ships as
       // neutral evidence of which ones were found.
       if (checks.length > 0 && detected.length === 0) codes.push('source-missing');
-      if (sync?.failureCode) codes.push(sync.failureCode);
+      if (sync?.detailCode === 'sync-lock-present') codes.push('sync-lock-present');
+      else if (sync?.failureCode) codes.push(sync.failureCode);
       if (detected.length > 0 && liveTokens <= 0) codes.push('no-usage-observed');
       // States a fact, not a cause: a marker without usage can equally mean the
       // tool is installed in that distro and simply unused.
@@ -4224,6 +4345,9 @@ module.exports = {
   localTodayKey,
   nextLimitsResetBoundary,
   normalizeHistoryIntervalMs,
+  antigravitySyncLockPath,
+  repairAntigravitySyncLock,
+  removeOwnedAntigravitySyncLock,
   sessionTimestampMap,
   locateBundledBinary,
   lookupModelPricing,

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -1687,14 +1687,18 @@ async function collectUsageOnce(options) {
     }
     if (includesQoderCn && (!targetRequested || targetClients.includes('qodercn'))) {
       const qoderCnSinceMs = anchorUsed ? new Date(collectedAt.getFullYear(), collectedAt.getMonth(), collectedAt.getDate()).getTime() : undefined;
-      // Legacy DB read — may fail on first run or DB corruption.
+      // Two independent usage sources: the legacy local DB and the 0.1.x
+      // client's agent transcripts. A failed legacy read must not suppress
+      // the transcript scan (and vice versa), so each is read in its own
+      // try/catch; the period only counts as failed when neither source
+      // produced rows, which keeps the anchored fallback authoritative.
+      let qoderCnLegacyReadFailed = false;
       try {
         qoderCnRows = await collectQoderCnRows({ homeDir: options.homeDir, logger: options.logger, sinceMs: qoderCnSinceMs });
       } catch (dbErr) {
+        qoderCnLegacyReadFailed = true;
         if (typeof options.logger === 'function') options.logger(`qodercn legacy parse failed: ${dbErr.message}`);
       }
-      // Transcript rows are independent of the legacy DB (P2-4): a dead
-      // legacy DB must not suppress the transcript scan.
       try {
         const qoderCnTranscriptRows = collectQoderCnTranscriptRows({ homeDir: options.homeDir, sinceMs: qoderCnSinceMs });
         if (qoderCnTranscriptRows.length) qoderCnRows = (qoderCnRows || []).concat(qoderCnTranscriptRows);
@@ -1702,6 +1706,9 @@ async function collectUsageOnce(options) {
         if (typeof options.logger === 'function') options.logger(`qodercn transcript rows skipped: ${transcriptErr.message}`);
       }
       try {
+        if (qoderCnLegacyReadFailed && !(qoderCnRows && qoderCnRows.length)) {
+          throw new Error('qodercn read failed: legacy db unreadable and no transcript rows');
+        }
         qoderCnPricing = await resolveQoderCnPricing(qoderCnRows, {
           lookupModelPricing: options.lookupModelPricing || lookupModelPricing,
           commandTimeoutMs: options.pricingTimeoutMs,
@@ -2023,18 +2030,19 @@ async function collectUsageOnce(options) {
     // block is gated by includeHistory (historyIntervalMs), mirroring the proma
     // full-read pattern; resolveQoderCnPricing is cached (6h TTL) so the second
     // pass is cheap when the scan already priced the same models.
-    // Read the full transcript set once per tick (P2-6: avoid double scan).
-    const qoderCnTranscriptAllRows = (() => {
-      try {
-        return collectQoderCnTranscriptRows({ homeDir: options.homeDir });
-      } catch (err) {
-        if (typeof options.logger === 'function') options.logger(`qodercn transcript rows skipped: ${err.message}`);
-        return [];
-      }
-    })();
+    // Read the full transcript set once per tick (P2-6: avoid double scan) and
+    // fold a read failure into the history failure flag so the fallback graph
+    // is retained instead of publishing a legacy-only undercount (P2-5).
     let qoderCnGraph = null;
     let qoderCnHistoryReadFailed = false;
     if (includesQoderCn) {
+      let qoderCnTranscriptAllRows = [];
+      try {
+        qoderCnTranscriptAllRows = collectQoderCnTranscriptRows({ homeDir: options.homeDir });
+      } catch (err) {
+        qoderCnHistoryReadFailed = true;
+        if (typeof options.logger === 'function') options.logger(`qodercn transcript rows skipped: ${err.message}`);
+      }
       try {
         // Reuse the scan's full rows on non-anchored ticks; anchored ticks read
         // only since local midnight, so the graph needs its own full read there.

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -47,6 +47,7 @@ const {
   buildQoderCnHistoryGraph,
   buildQoderCnPeriods,
   collectQoderCnRows,
+  collectQoderCnTranscriptRows,
   qoderCnDataPaths,
   resolveQoderCnPricing
 } = require('./qoderCnUsage');
@@ -1199,7 +1200,6 @@ async function maybeSyncCursor(clientsCsv, logger, options = {}) {
 // tokscale's antigravity sync reads the IDE's native session roots under
 // ~/.gemini/; when none exist there is nothing to sync, so don't spawn at all.
 const ANTIGRAVITY_DATA_ROOTS = ['antigravity', 'antigravity-ide', 'antigravity-backup'];
-const ANTIGRAVITY_SYNC_LOCK_MAX_BYTES = 128;
 
 function antigravityDataRoots(home = os.homedir()) {
   return ANTIGRAVITY_DATA_ROOTS.map((name) => path.join(home, '.gemini', name));
@@ -1207,111 +1207,6 @@ function antigravityDataRoots(home = os.homedir()) {
 
 function antigravityDataPresent(home) {
   return antigravityDataRoots(home).some(dirExists);
-}
-
-function antigravitySyncLockPath(home, env = process.env, platform = process.platform) {
-  return path.join(
-    tokscaleConfigDir({ env, platform, homeDir: home }),
-    'antigravity-cache',
-    'sync.lock'
-  );
-}
-
-// Tokscale deliberately preserves an unknown sync.lock after a crash: an older
-// binary may still own it during a rolling upgrade, so reclaiming arbitrary
-// dead-PID records here would undo that safety boundary. We can make one much
-// narrower claim after a child we terminated has emitted close: a regular file
-// naming that exact child, created during this spawn, is our orphan. Recheck the
-// inode and contents immediately before unlinking so a successor or user edit
-// is preserved instead of mistaken for the record we observed.
-function removeOwnedAntigravitySyncLock({
-  lockPath,
-  childPid,
-  childStartedAt,
-  fsApi = fs,
-  now = Date.now
-} = {}) {
-  if (!lockPath || !Number.isSafeInteger(childPid) || childPid <= 0) return false;
-  if (!Number.isFinite(childStartedAt)) return false;
-  try {
-    const firstStat = fsApi.lstatSync(lockPath);
-    if (!firstStat.isFile() || firstStat.isSymbolicLink() || firstStat.size > ANTIGRAVITY_SYNC_LOCK_MAX_BYTES) {
-      return false;
-    }
-    const record = fsApi.readFileSync(lockPath, 'utf8');
-    const match = record.match(/^(\d+)\s+(\d+)\s*$/);
-    if (!match || Number(match[1]) !== childPid) return false;
-    const recordedAt = Number(match[2]);
-    const earliest = Math.floor(childStartedAt / 1000) - 1;
-    const latest = Math.floor(now() / 1000) + 1;
-    if (!Number.isSafeInteger(recordedAt) || recordedAt < earliest || recordedAt > latest) return false;
-
-    const finalStat = fsApi.lstatSync(lockPath);
-    if (firstStat.dev !== finalStat.dev || firstStat.ino !== finalStat.ino) return false;
-    if (fsApi.readFileSync(lockPath, 'utf8') !== record) return false;
-    fsApi.unlinkSync(lockPath);
-    return true;
-  } catch (_) {
-    return false;
-  }
-}
-
-function processIdIsAlive(pid, kill = process.kill.bind(process)) {
-  try {
-    kill(pid, 0);
-    return true;
-  } catch (error) {
-    // A permission error still proves that the process exists. Every other
-    // normal failure means there is no process for this user to signal.
-    return error?.code === 'EPERM' || error?.code === 'EACCES';
-  }
-}
-
-// This is deliberately user-mediated rather than startup cleanup. Tokscale's
-// visible lock remains compatible with older binaries that do not participate
-// in sync.os.lock, so absence of a new-format OS owner is not enough evidence
-// to reclaim it in the background. Once the user confirms that no sync is
-// running, accept only the exact legacy record shape, refuse a live pid, and
-// repeat the inode/content checks immediately before removing the one path.
-function repairAntigravitySyncLock({
-  lockPath,
-  fsApi = fs,
-  pidIsAlive = processIdIsAlive
-} = {}) {
-  if (!lockPath) return { ok: false, code: 'unsafe-lock' };
-  try {
-    const firstStat = fsApi.lstatSync(lockPath);
-    if (!firstStat.isFile() || firstStat.isSymbolicLink() || firstStat.size > ANTIGRAVITY_SYNC_LOCK_MAX_BYTES) {
-      return { ok: false, code: 'unsafe-lock' };
-    }
-    const record = fsApi.readFileSync(lockPath, 'utf8');
-    const match = record.match(/^(\d+)\s+(\d+)\s*$/);
-    const pid = Number(match?.[1]);
-    const recordedAt = Number(match?.[2]);
-    if (
-      !match
-      || !Number.isSafeInteger(pid)
-      || pid <= 0
-      || !Number.isSafeInteger(recordedAt)
-      || recordedAt <= 0
-    ) {
-      return { ok: false, code: 'unsafe-lock' };
-    }
-    if (pidIsAlive(pid)) return { ok: false, code: 'owner-active' };
-
-    const finalStat = fsApi.lstatSync(lockPath);
-    if (firstStat.dev !== finalStat.dev || firstStat.ino !== finalStat.ino) {
-      return { ok: false, code: 'unsafe-lock' };
-    }
-    if (fsApi.readFileSync(lockPath, 'utf8') !== record) {
-      return { ok: false, code: 'unsafe-lock' };
-    }
-    fsApi.unlinkSync(lockPath);
-    return { ok: true, code: 'repaired' };
-  } catch (error) {
-    if (error?.code === 'ENOENT') return { ok: true, code: 'not-found' };
-    return { ok: false, code: 'repair-failed' };
-  }
 }
 
 async function maybeSyncAntigravity(clientsCsv, logger, home = os.homedir(), options = {}) {
@@ -1346,14 +1241,12 @@ async function maybeSyncAntigravity(clientsCsv, logger, home = os.homedir(), opt
     return;
   }
   const { bin, prefixArgs, env } = tokscaleCommand();
-  const syncLockPath = options.syncLockPath || antigravitySyncLockPath(home, env);
   // Every outcome resolves — a stuck sync must not hold the tick open — so a
   // failure is only visible through onFailure. The caller needs it: the tick has
   // already consumed the source event that asked for this sync, and silently
   // scanning the unchanged cache would put the refresh back on the fallback
   // interval, which is the latency this whole path exists to remove.
   await new Promise((resolve) => {
-    const childStartedAt = Date.now();
     const child = spawn(bin, [...prefixArgs, 'antigravity', 'sync'], { env, windowsHide: true });
     const termination = createSubprocessTermination(child, {
       ...(options.terminationOptions || {}),
@@ -1422,13 +1315,6 @@ async function maybeSyncAntigravity(clientsCsv, logger, home = os.homedir(), opt
     });
     child.on('close', (code) => {
       termination.confirmClosed();
-      if (terminalOutcome) {
-        removeOwnedAntigravitySyncLock({
-          lockPath: syncLockPath,
-          childPid: child.pid,
-          childStartedAt
-        });
-      }
       if (settled) return;
       if (terminalOutcome?.cancelled) return settle(false, '', {}, false, true);
       if (terminalOutcome) {
@@ -1658,7 +1544,6 @@ async function collectUsageOnce(options) {
     await maybeSyncAntigravity(syncClients, options.logger, options.homeDir || os.homedir(), {
       minIntervalMs: selfSyncThrottle.minIntervalForTick(options, 'antigravity'),
       run: options.runAntigravitySync,
-      syncLockPath: options.antigravitySyncLockPath,
       signal: options.signal,
       timeoutMs: options.selfSyncTimeoutMs,
       terminationOptions: options.subprocessTerminationOptions,
@@ -1688,6 +1573,18 @@ async function collectUsageOnce(options) {
       try {
         const qoderCnSinceMs = anchorUsed ? new Date(collectedAt.getFullYear(), collectedAt.getMonth(), collectedAt.getDate()).getTime() : undefined;
         qoderCnRows = await collectQoderCnRows({ homeDir: options.homeDir, logger: options.logger, sinceMs: qoderCnSinceMs });
+        // The 0.1.x Qoder CN client keeps no local token-usage database, so the
+        // legacy rows above stop at the old install. The client's agent
+        // transcripts (~/.qoder-cn/projects) carry per-request content with the
+        // model code; tokens are estimated from that content (see
+        // collectQoderCnTranscriptRows), keeping the qodercn row live with
+        // per-model attribution in token units.
+        try {
+          const qoderCnTranscriptRows = collectQoderCnTranscriptRows({ homeDir: options.homeDir, sinceMs: qoderCnSinceMs });
+          if (qoderCnTranscriptRows.length) qoderCnRows = qoderCnRows.concat(qoderCnTranscriptRows);
+        } catch (transcriptErr) {
+          if (typeof options.logger === 'function') options.logger(`qodercn transcript rows skipped: ${transcriptErr.message}`);
+        }
         qoderCnPricing = await resolveQoderCnPricing(qoderCnRows, {
           lookupModelPricing: options.lookupModelPricing || lookupModelPricing,
           commandTimeoutMs: options.pricingTimeoutMs,
@@ -2016,7 +1913,19 @@ async function collectUsageOnce(options) {
         // Reuse the scan's full rows on non-anchored ticks; anchored ticks read
         // only since local midnight, so the graph needs its own full read there.
         // resolveQoderCnPricing is cached (6h TTL), so the second pass is cheap.
-        const rows = (!anchorUsed && qoderCnRows) ? qoderCnRows : await collectQoderCnRows({ homeDir: options.homeDir, logger: options.logger });
+        let rows = (!anchorUsed && qoderCnRows) ? qoderCnRows : await collectQoderCnRows({ homeDir: options.homeDir, logger: options.logger });
+        // Anchored ticks reuse today-only rows, so the graph needs its own full
+        // transcript read; non-anchored ticks already carry the transcript rows
+        // via qoderCnRows, and transcript rows are not delta-based — appending
+        // them twice would double-count every estimated token.
+        if (anchorUsed) {
+          try {
+            const qoderCnTranscriptRows = collectQoderCnTranscriptRows({ homeDir: options.homeDir });
+            if (qoderCnTranscriptRows.length) rows = rows.concat(qoderCnTranscriptRows);
+          } catch (transcriptErr) {
+            if (typeof options.logger === 'function') options.logger(`qodercn transcript rows history skipped: ${transcriptErr.message}`);
+          }
+        }
         const pricing = (!anchorUsed && qoderCnPricing) ? qoderCnPricing : await resolveQoderCnPricing(rows, {
           lookupModelPricing: options.lookupModelPricing || lookupModelPricing,
           commandTimeoutMs: options.pricingTimeoutMs,
@@ -3176,8 +3085,7 @@ function deriveClientHealth(clientsCsv, allTimePeriod, options = {}) {
       // set is the normal shape of a normal install. `checks` still ships as
       // neutral evidence of which ones were found.
       if (checks.length > 0 && detected.length === 0) codes.push('source-missing');
-      if (sync?.detailCode === 'sync-lock-present') codes.push('sync-lock-present');
-      else if (sync?.failureCode) codes.push(sync.failureCode);
+      if (sync?.failureCode) codes.push(sync.failureCode);
       if (detected.length > 0 && liveTokens <= 0) codes.push('no-usage-observed');
       // States a fact, not a cause: a marker without usage can equally mean the
       // tool is installed in that distro and simply unused.
@@ -4316,9 +4224,6 @@ module.exports = {
   localTodayKey,
   nextLimitsResetBoundary,
   normalizeHistoryIntervalMs,
-  antigravitySyncLockPath,
-  repairAntigravitySyncLock,
-  removeOwnedAntigravitySyncLock,
   sessionTimestampMap,
   locateBundledBinary,
   lookupModelPricing,

--- a/src/shared/qoderCnUsage.js
+++ b/src/shared/qoderCnUsage.js
@@ -25,9 +25,9 @@ const QODER_CN_MODEL_DISPLAY_NAMES = Object.freeze({
   dfmodel: 'DeepSeek-V4-Flash',
   dmodel: 'DeepSeek-V4-Pro',
   efficient: 'Efficient',
-  gfmodel: 'GLM-5.3-Flash', // 0.1.2 client flash slot (g = GLM family, f = Flash)
   gm51model: 'GLM-5.2',
   gmodel: 'GLM-5',
+  gfmodel: 'GLM-5.3-Flash', // Qoder CN 0.1.2 client flash slot
   kmodel: 'Kimi-K2.7-Code',
   lite: 'Lite',
   mmodel: 'MiniMax-M3',
@@ -36,7 +36,6 @@ const QODER_CN_MODEL_DISPLAY_NAMES = Object.freeze({
   q35model_preview: 'Qwen3.8-Max-Preview',
   q36fmodel: 'Qwen3.6-Flash',
   qmodel: 'Qwen3.7-Plus',
-  qmodel_38max: 'Qwen3.8-Max-Preview', // 0.1.2 client code, same preview model
   qmodel_latest: 'Qwen3.7-Max',
   qmodel_preview: 'Qwen3.8-Max-Preview', // retired code, same preview model
   ultimate: 'Ultimate'
@@ -517,6 +516,7 @@ function buildQoderCnHistoryGraph(options = {}) {
 const QODER_CN_TRANSCRIPTS_PROJECTS_DIR = path.join('.qoder-cn', 'projects');
 const QODER_CN_TRANSCRIPT_MAX_BYTES = 64 * 1024 * 1024;
 const QODER_CN_TRANSCRIPT_MAX_LINE_BYTES = 256 * 1024;
+const QODER_CN_CJK_RE = /[\u{1100}-\u{11FF}\u{2E80}-\u{9FFF}\u{A960}-\u{A97F}\u{AC00}-\u{D7FF}\u{F900}-\u{FAFF}\u{FF00}-\u{FF60}\u{FF66}-\u{FF9D}\u{20000}-\u{3FFFD}]/u;
 
 // Since the 0.1.x rewrite the desktop client's agent runtime appends one JSON
 // line per event to ~/.qoder-cn/projects/<project>/<session>.jsonl
@@ -546,8 +546,8 @@ function estimateQoderCnContentTokens(message) {
   let cjk = 0;
   let other = 0;
   const bump = (value) => {
-    for (let i = 0; i < value.length; i++) {
-      if (value.charCodeAt(i) > 0x2E80) cjk++;
+    for (const ch of value) {
+      if (QODER_CN_CJK_RE.test(ch)) cjk++;
       else other++;
     }
   };
@@ -561,14 +561,24 @@ function estimateQoderCnContentTokens(message) {
       if (block.content !== undefined) bump(typeof block.content === 'string' ? block.content : JSON.stringify(block.content));
     }
   }
-  return Math.ceil(cjk / 1.5) + Math.ceil(other / 4);
+  return Math.ceil((cjk / 1.5) + (other / 4));
+}
+
+function listTranscriptFiles(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...listTranscriptFiles(full));
+    else if (entry.isFile() && entry.name.endsWith('.jsonl')) out.push(full);
+  }
+  return out;
 }
 
 function collectQoderCnTranscriptRows(options = {}) {
   const homeDir = options.homeDir || os.homedir();
   const sinceMs = typeof options.sinceMs === 'number' ? options.sinceMs : undefined;
   const projectsDir = path.join(homeDir, QODER_CN_TRANSCRIPTS_PROJECTS_DIR);
-  let projects = [];
+  let projects;
   try {
     projects = fs.readdirSync(projectsDir);
   } catch (_) {
@@ -577,16 +587,14 @@ function collectQoderCnTranscriptRows(options = {}) {
   const buckets = new Map();
   for (const project of projects) {
     const projectDir = path.join(projectsDir, project);
-    let files = [];
+    let files;
     try {
       if (!fs.statSync(projectDir).isDirectory()) continue;
-      files = fs.readdirSync(projectDir);
+      files = listTranscriptFiles(projectDir);
     } catch (_) {
       continue;
     }
-    for (const file of files) {
-      if (!file.endsWith('.jsonl')) continue;
-      const filePath = path.join(projectDir, file);
+    for (const filePath of files) {
       let text;
       try {
         const stat = fs.statSync(filePath);
@@ -658,6 +666,7 @@ module.exports = {
   buildQoderCnPeriods,
   collectQoderCnRows,
   collectQoderCnTranscriptRows,
+  estimateQoderCnContentTokens,
   normalizeQoderCnDbRow,
   qoderCnDataPaths,
   readQoderCnDbRows,

--- a/src/shared/qoderCnUsage.js
+++ b/src/shared/qoderCnUsage.js
@@ -25,6 +25,7 @@ const QODER_CN_MODEL_DISPLAY_NAMES = Object.freeze({
   dfmodel: 'DeepSeek-V4-Flash',
   dmodel: 'DeepSeek-V4-Pro',
   efficient: 'Efficient',
+  gfmodel: 'GLM-5.3-Flash', // 0.1.2 client flash slot (g = GLM family, f = Flash)
   gm51model: 'GLM-5.2',
   gmodel: 'GLM-5',
   kmodel: 'Kimi-K2.7-Code',
@@ -35,6 +36,7 @@ const QODER_CN_MODEL_DISPLAY_NAMES = Object.freeze({
   q35model_preview: 'Qwen3.8-Max-Preview',
   q36fmodel: 'Qwen3.6-Flash',
   qmodel: 'Qwen3.7-Plus',
+  qmodel_38max: 'Qwen3.8-Max-Preview', // 0.1.2 client code, same preview model
   qmodel_latest: 'Qwen3.7-Max',
   qmodel_preview: 'Qwen3.8-Max-Preview', // retired code, same preview model
   ultimate: 'Ultimate'
@@ -512,11 +514,150 @@ function buildQoderCnHistoryGraph(options = {}) {
   return { contributions: [...days.values()].sort((a, b) => a.date.localeCompare(b.date)) };
 }
 
+const QODER_CN_TRANSCRIPTS_PROJECTS_DIR = path.join('.qoder-cn', 'projects');
+const QODER_CN_TRANSCRIPT_MAX_BYTES = 64 * 1024 * 1024;
+const QODER_CN_TRANSCRIPT_MAX_LINE_BYTES = 256 * 1024;
+
+// Since the 0.1.x rewrite the desktop client's agent runtime appends one JSON
+// line per event to ~/.qoder-cn/projects/<project>/<session>.jsonl
+// (Claude-Code-style transcripts). Assistant rows carry message.usage.credits
+// — the exact credits billed for that request — plus message.model in Qoder's
+// internal code. The cloud quota API only exposes cumulative totals, so these
+// transcripts are the only per-model usage source.
+//
+// The client zeroes every token field in usage (input_tokens, output_tokens,
+// cache_* are 0 across all rows, main.sqlite context snapshots also report
+// totalTokens: 0), and the credits unit has no official token conversion
+// (docs.qoder.cn: credits are Qoder's own metered unit per request). To keep
+// this client's rows in token units like every other client, tokens are
+// ESTIMATED from the transcript's actual conversation content:
+//   - every message's content (text/thinking/tool_use/tool_result) is counted
+//     with a blended heuristic: CJK chars / 1.5 + other chars / 4 per token;
+//   - each billed request's input = cumulative content tokens of the session
+//     so far (the context re-sent upstream), output = the request's own
+//     content tokens;
+//   - system-prompt/tool-schema overhead is not in transcripts, so totals are
+//     a slight underestimate.
+// Cross-check: implied cost lands at ~10-17K tokens/credit for Qwen-Max and
+// ~196K tokens/credit for GLM-Flash (flash models are far cheaper per token),
+// which is self-consistent with Qoder's credit pricing.
+function estimateQoderCnContentTokens(message) {
+  const content = message.content;
+  let cjk = 0;
+  let other = 0;
+  const bump = (value) => {
+    for (let i = 0; i < value.length; i++) {
+      if (value.charCodeAt(i) > 0x2E80) cjk++;
+      else other++;
+    }
+  };
+  if (typeof content === 'string') bump(content);
+  else if (Array.isArray(content)) {
+    for (const block of content) {
+      if (!block || typeof block !== 'object') continue;
+      if (typeof block.text === 'string') bump(block.text);
+      if (typeof block.thinking === 'string') bump(block.thinking);
+      if (block.input !== undefined) bump(typeof block.input === 'string' ? block.input : JSON.stringify(block.input));
+      if (block.content !== undefined) bump(typeof block.content === 'string' ? block.content : JSON.stringify(block.content));
+    }
+  }
+  return Math.ceil(cjk / 1.5) + Math.ceil(other / 4);
+}
+
+function collectQoderCnTranscriptRows(options = {}) {
+  const homeDir = options.homeDir || os.homedir();
+  const sinceMs = typeof options.sinceMs === 'number' ? options.sinceMs : undefined;
+  const projectsDir = path.join(homeDir, QODER_CN_TRANSCRIPTS_PROJECTS_DIR);
+  let projects = [];
+  try {
+    projects = fs.readdirSync(projectsDir);
+  } catch (_) {
+    return [];
+  }
+  const buckets = new Map();
+  for (const project of projects) {
+    const projectDir = path.join(projectsDir, project);
+    let files = [];
+    try {
+      if (!fs.statSync(projectDir).isDirectory()) continue;
+      files = fs.readdirSync(projectDir);
+    } catch (_) {
+      continue;
+    }
+    for (const file of files) {
+      if (!file.endsWith('.jsonl')) continue;
+      const filePath = path.join(projectDir, file);
+      let text;
+      try {
+        const stat = fs.statSync(filePath);
+        if (!stat.isFile() || stat.size <= 0 || stat.size > QODER_CN_TRANSCRIPT_MAX_BYTES) continue;
+        text = fs.readFileSync(filePath, 'utf8');
+      } catch (_) {
+        continue;
+      }
+      // File order is append order = conversation order; the cumulative
+      // counter tracks how much context the next request re-sends.
+      let cumulativeTokens = 0;
+      for (const line of text.split('\n')) {
+        if (!line || line.length > QODER_CN_TRANSCRIPT_MAX_LINE_BYTES) continue;
+        let event;
+        try {
+          event = JSON.parse(line);
+        } catch (_) {
+          continue;
+        }
+        const message = event && event.message;
+        if (!message || typeof message !== 'object') continue;
+        const messageTokens = estimateQoderCnContentTokens(message);
+        const usage = message.usage;
+        if (usage && typeof usage === 'object' && Number(usage.credits) > 0) {
+          const ts = Date.parse(typeof event.timestamp === 'string' ? event.timestamp : '');
+          if (Number.isFinite(ts)) {
+            const date = new Date(ts);
+            const dayKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+            const modelKey = typeof message.model === 'string' && message.model ? message.model : 'unknown';
+            const key = `${dayKey}|${modelKey}`;
+            const bucket = buckets.get(key) || { dayKey, modelKey, input: 0, output: 0, requests: 0 };
+            bucket.input += cumulativeTokens;
+            bucket.output += messageTokens;
+            bucket.requests += 1;
+            buckets.set(key, bucket);
+          }
+        }
+        cumulativeTokens += messageTokens;
+      }
+    }
+  }
+  const rows = [];
+  for (const bucket of buckets.values()) {
+    const createdAt = Date.parse(`${bucket.dayKey}T12:00:00`);
+    if (!Number.isFinite(createdAt)) continue;
+    if (sinceMs !== undefined && createdAt < sinceMs) continue;
+    const displayName = Object.prototype.hasOwnProperty.call(QODER_CN_MODEL_DISPLAY_NAMES, bucket.modelKey)
+      ? QODER_CN_MODEL_DISPLAY_NAMES[bucket.modelKey]
+      : bucket.modelKey;
+    rows.push({
+      sessionId: `qodercn:transcript:${bucket.dayKey}:${bucket.modelKey}`,
+      messageId: `qodercn:transcript:${bucket.dayKey}:${bucket.modelKey}`,
+      model: displayName,
+      projectLabel: '',
+      input: bucket.input,
+      output: bucket.output,
+      cacheRead: 0,
+      cacheWrite: 0,
+      createdAt,
+      messages: bucket.requests
+    });
+  }
+  return rows;
+}
+
 module.exports = {
   QODER_CN_MODEL_DISPLAY_NAMES,
   buildQoderCnHistoryGraph,
   buildQoderCnPeriods,
   collectQoderCnRows,
+  collectQoderCnTranscriptRows,
   normalizeQoderCnDbRow,
   qoderCnDataPaths,
   readQoderCnDbRows,

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -2885,6 +2885,7 @@ test('collector preserves Qoder CN while publishing other clients after a bounde
   const qoderCnUsage = require(qoderCnUsagePath);
   const originalRows = qoderCnUsage.collectQoderCnRows;
   const originalPeriods = qoderCnUsage.buildQoderCnPeriods;
+  const originalTranscriptRows = qoderCnUsage.collectQoderCnTranscriptRows;
   let failReads = false;
   let claudeTokens = 3;
   qoderCnUsage.collectQoderCnRows = async () => {
@@ -2895,6 +2896,9 @@ test('collector preserves Qoder CN while publishing other clients after a bounde
     }
     return [];
   };
+  // Pin the transcript source so the scan stays hermetic on machines that
+  // really run the Qoder CN client (~/.qoder-cn with live transcripts).
+  qoderCnUsage.collectQoderCnTranscriptRows = () => [];
   qoderCnUsage.buildQoderCnPeriods = () => ({
     today: { entries: [{ client: 'qodercn', model: 'qmodel', input: 7 }] },
     month: { entries: [{ client: 'qodercn', model: 'qmodel', input: 7 }] },
@@ -2956,6 +2960,84 @@ test('collector preserves Qoder CN while publishing other clients after a bounde
     if (handle) handle.stop();
     qoderCnUsage.collectQoderCnRows = originalRows;
     qoderCnUsage.buildQoderCnPeriods = originalPeriods;
+    qoderCnUsage.collectQoderCnTranscriptRows = originalTranscriptRows;
+    if (originalSharedDir === undefined) delete process.env.TOKEN_MONITOR_SHARED_DIR;
+    else process.env.TOKEN_MONITOR_SHARED_DIR = originalSharedDir;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('collector still publishes Qoder CN transcript usage when the legacy DB read fails', async () => {
+  const tmp = withTmpHome([]);
+  const originalSharedDir = process.env.TOKEN_MONITOR_SHARED_DIR;
+  process.env.TOKEN_MONITOR_SHARED_DIR = tmp;
+
+  const qoderCnUsagePath = require.resolve('../../src/shared/qoderCnUsage');
+  const qoderCnUsage = require(qoderCnUsagePath);
+  const originalRows = qoderCnUsage.collectQoderCnRows;
+  const originalPeriods = qoderCnUsage.buildQoderCnPeriods;
+  const originalTranscriptRows = qoderCnUsage.collectQoderCnTranscriptRows;
+  const transcriptRow = {
+    client: 'qodercn',
+    sessionId: 'transcript-session',
+    messageId: 'transcript-message',
+    model: 'gfmodel',
+    input: 11,
+    output: 5,
+    cacheRead: 0,
+    cacheWrite: 0,
+    createdAt: new Date().toISOString(),
+    messages: 1
+  };
+  qoderCnUsage.collectQoderCnRows = async () => {
+    throw new Error('qodercn sqlite read budget exceeded (rows limit 100000)');
+  };
+  qoderCnUsage.collectQoderCnTranscriptRows = () => [transcriptRow];
+  const seenRows = [];
+  qoderCnUsage.buildQoderCnPeriods = ({ rows }) => {
+    seenRows.push(rows);
+    return {
+      today: { entries: [{ client: 'qodercn', model: 'qmodel', input: 7 }] },
+      month: { entries: [{ client: 'qodercn', model: 'qmodel', input: 7 }] },
+      allTime: { entries: [{ client: 'qodercn', model: 'qmodel', input: 7 }] }
+    };
+  };
+  delete require.cache[collectorPath];
+
+  let handle = null;
+  try {
+    const { startCollector } = freshCollector();
+    const updates = [];
+    handle = startCollector({
+      clients: 'qodercn',
+      allTimeSince: '2024-01-01',
+      commandTimeoutMs: 1000,
+      deviceId: 'test-device',
+      agentVersion: 'test',
+      intervalMs: 60 * 60 * 1000,
+      watchEnabled: false,
+      limitsEnabled: false,
+      historyEnabled: false,
+      runTokscale: async () => ({ entries: [] }),
+      onUpdate: (summary) => updates.push(summary)
+    });
+
+    await waitForCondition(() => updates.length === 1);
+    assert.equal(updates.at(-1).today.clients.qodercn, 7, 'transcript rows keep the Qoder CN period alive');
+    const anchoredRows = seenRows.filter((rows) => Array.isArray(rows));
+    assert.ok(
+      anchoredRows.some((rows) => rows.some((row) => row.sessionId === 'transcript-session')),
+      'the period is built from transcript rows when the legacy DB fails'
+    );
+    const anchorPath = path.join(tmp, 'collector-anchor.json');
+    const anchor = JSON.parse(fs.readFileSync(anchorPath, 'utf8'));
+    assert.equal(anchor.qoderCnPeriods.today.clients.qodercn, 7, 'the anchored fallback is not used when transcripts succeed');
+  } finally {
+    if (handle) handle.stop();
+    qoderCnUsage.collectQoderCnRows = originalRows;
+    qoderCnUsage.buildQoderCnPeriods = originalPeriods;
+    qoderCnUsage.collectQoderCnTranscriptRows = originalTranscriptRows;
     if (originalSharedDir === undefined) delete process.env.TOKEN_MONITOR_SHARED_DIR;
     else process.env.TOKEN_MONITOR_SHARED_DIR = originalSharedDir;
     delete require.cache[collectorPath];

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -3019,6 +3019,9 @@ test('collector still publishes Qoder CN transcript usage when the legacy DB rea
       watchEnabled: false,
       limitsEnabled: false,
       historyEnabled: false,
+      // Keep the tick off the network: the transcript row carries a model id
+      // the real pricing lookup would try to resolve.
+      lookupModelPricing: async () => null,
       runTokscale: async () => ({ entries: [] }),
       onUpdate: (summary) => updates.push(summary)
     });

--- a/tests/shared/qoderCnUsage.test.js
+++ b/tests/shared/qoderCnUsage.test.js
@@ -573,7 +573,9 @@ test('collectQoderCnTranscriptRows: skips oversized lines and bad JSON', () => {
     message: { role: 'assistant', content: 'hi', model: 'dfmodel', usage: { credits: 1 } }
   });
   const validLine2 = JSON.stringify({
-    timestamp: '2026-08-15T11:00:00Z',
+    // 30 minutes after the first line: any real timezone offset keeps both
+    // stamps on the same local day, so the merge assertion holds everywhere.
+    timestamp: '2026-08-15T10:30:00Z',
     message: { role: 'assistant', content: 'ok', model: 'dfmodel', usage: { credits: 2 } }
   });
   const oversizedLine = 'x'.repeat(300000);

--- a/tests/shared/qoderCnUsage.test.js
+++ b/tests/shared/qoderCnUsage.test.js
@@ -514,3 +514,75 @@ test('reads survive a database without the chat_session table (fallback SQL)', a
   assert.equal(rows.length, 1, 'fallback query still returns rows');
   assert.equal(rows[0].project_name, undefined, 'no project column in fallback');
 });
+
+test('estimateQoderCnContentTokens: pure CJK rounds correctly', () => {
+  const { estimateQoderCnContentTokens } = require('../../src/shared/qoderCnUsage');
+  // 4 CJK chars → ceil(4/1.5) = ceil(2.67) = 3
+  const result = estimateQoderCnContentTokens({ content: '你好世界' });
+  assert.equal(result, 3, '4 CJK chars should produce 3 tokens');
+});
+
+test('estimateQoderCnContentTokens: pure ASCII rounds correctly', () => {
+  const { estimateQoderCnContentTokens } = require('../../src/shared/qoderCnUsage');
+  // 11 ASCII chars → ceil(11/4) = ceil(2.75) = 3
+  const result = estimateQoderCnContentTokens({ content: 'hello world' });
+  assert.equal(result, 3, '11 ASCII chars should produce 3 tokens');
+});
+
+test('estimateQoderCnContentTokens: mixed content rounds once', () => {
+  const { estimateQoderCnContentTokens } = require('../../src/shared/qoderCnUsage');
+  // 2 CJK + 3 ASCII → ceil(2/1.5 + 3/4) = ceil(1.333 + 0.75) = ceil(2.083) = 3
+  const result = estimateQoderCnContentTokens({ content: '你好abc' });
+  assert.equal(result, 3, 'mixed content should produce 3 tokens (single blend)');
+});
+
+test('estimateQoderCnContentTokens: emoji code points do not inflate CJK count', () => {
+  const { estimateQoderCnContentTokens } = require('../../src/shared/qoderCnUsage');
+  // 2 emoji (surrogate pairs) + 2 CJK → 2 other + 2 CJK → ceil(2/1.5 + 2/4) = ceil(1.333 + 0.5) = ceil(1.833) = 2
+  const result = estimateQoderCnContentTokens({ content: '😀😀你好' });
+  assert.equal(result, 2, 'emoji should not be counted as CJK (surrogate pairs)');
+});
+
+test('collectQoderCnTranscriptRows: nested directory walk', () => {
+  const { collectQoderCnTranscriptRows } = require('../../src/shared/qoderCnUsage');
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qodercn-test-'));
+  const projectsDir = path.join(tmpDir, '.qoder-cn', 'projects', 'myproj', 'sub', 'deeper');
+  fs.mkdirSync(projectsDir, { recursive: true });
+  const sessionFile = path.join(projectsDir, 'session.jsonl');
+  const line = JSON.stringify({
+    timestamp: '2026-08-15T10:00:00Z',
+    message: { role: 'assistant', content: 'hello', model: 'dfmodel', usage: { credits: 1 } }
+  });
+  fs.writeFileSync(sessionFile, line + '\n');
+  const rows = collectQoderCnTranscriptRows({ homeDir: tmpDir });
+  assert.equal(rows.length, 1, 'nested directory file should be collected');
+  assert.equal(rows[0].model, 'DeepSeek-V4-Flash', 'model should be resolved from display names');
+  assert.equal(rows[0].input, 0, 'first request has 0 cumulative context');
+  assert.equal(rows[0].output, 2, 'hello = ceil(5/4) = 2 tokens');
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test('collectQoderCnTranscriptRows: skips oversized lines and bad JSON', () => {
+  const { collectQoderCnTranscriptRows } = require('../../src/shared/qoderCnUsage');
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qodercn-test-'));
+  const projectsDir = path.join(tmpDir, '.qoder-cn', 'projects', 'p1');
+  fs.mkdirSync(projectsDir, { recursive: true });
+  const sessionFile = path.join(projectsDir, 'session.jsonl');
+  const validLine = JSON.stringify({
+    timestamp: '2026-08-15T10:00:00Z',
+    message: { role: 'assistant', content: 'hi', model: 'dfmodel', usage: { credits: 1 } }
+  });
+  const validLine2 = JSON.stringify({
+    timestamp: '2026-08-15T11:00:00Z',
+    message: { role: 'assistant', content: 'ok', model: 'dfmodel', usage: { credits: 2 } }
+  });
+  const oversizedLine = 'x'.repeat(300000);
+  const badJsonLine = 'not json at all';
+  fs.writeFileSync(sessionFile, [validLine, oversizedLine, badJsonLine, validLine2].join('\n') + '\n');
+  const rows = collectQoderCnTranscriptRows({ homeDir: tmpDir });
+  assert.equal(rows.length, 1, 'two valid lines for same day/model merge into one row');
+  assert.equal(rows[0].messages, 2, 'both valid lines contributed to the bucket');
+  assert.equal(rows[0].input, 1, 'second line: cumulativeTokens=1 (from first line msg)');
+  assert.equal(rows[0].output, 2, 'hi(1 token) + ok(1 token) = 2 output tokens');
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary

The 0.1.x Qoder CN desktop client (`com.qodercn.app.stable`) persists no usable token usage: the legacy `%APPDATA%\QoderCN\...\local.db` has been stale since 2026-08-26, the new `main.sqlite` reports `chat_session_context_usage.totalTokens = 0` on every row and its message payloads carry no usage object, and the cloud quota API only exposes cumulative credits. Every other client in token-monitor reports usage in **token units**, so the `qodercn` rows either freeze at the old install or drop out of the token totals.

The client's agent runtime does, however, append Claude-Code-style transcripts to `~/.qoder-cn/projects/<project>/<session>.jsonl` (one JSON event per line, assistant rows carry `message.model` and `message.usage.credits`). This PR estimates per-model, per-day token usage from that content, keeping the `qodercn` rows in token units like every other client.

## Changes

- **`src/shared/qoderCnUsage.js`**
  - New `collectQoderCnTranscriptRows(options)`: scans `~/.qoder-cn/projects/**/*.jsonl` (64MB per file / 256KB per line caps), attributes each billed assistant request (`message.usage.credits > 0`) with `input` = cumulative estimated content tokens of the session so far (the context re-sent upstream) and `output` = the request's own content tokens, aggregated per `(local day, model code)`. Idempotent — the same files always produce the same rows.
  - New `estimateQoderCnContentTokens(message)`: blended heuristic `CJK chars / 1.5 + other chars / 4`, covering `text` / `thinking` / `tool_use.input` / `tool_result.content` blocks.
  - Model display names: `gfmodel` → `GLM-5.3-Flash`, `qmodel_38max` → `Qwen3.8-Max-Preview` (0.1.2 client codes).
- **`src/shared/collector.js`**
  - Periodic collection point: transcript rows are concatenated to the `qodercn` rows under the same anchored `sinceMs` guard the legacy rows use, so ticks never re-submit past days.
  - History-graph point: anchored ticks re-read the full transcript row set for the graph; non-anchored ticks reuse the scan's rows (transcript rows are not delta-based — appending them twice would double-count every estimated token).

## Verification

- Unit tests (13 checks): day bucketing, cumulative input vs per-request output attribution, CJK ratio math, `sinceMs` filtering, idempotent re-scan, new `qodercn:transcript:` id prefix (no collision with older row ids).
- Deployed locally against real transcripts: 2026-08-27 → 1,147,741 / 2026-08-28 → 1,487,191 / 2026-08-31 → 5,244,702 tokens across `Qwen3.8-Max-Preview` + `GLM-5.3-Flash`, $14.02 at customModelPricing rates; renderer dashboard (daily / monthly / allTime) matches the archived day rows exactly.
- Cross-check against billing: implied ~10-17K tokens per credit for Qwen-Max and ~196K tokens per credit for GLM-Flash — self-consistent with Qoder's credit pricing (flash models are far cheaper per token).

## Notes

- These are **estimates**: transcripts omit system-prompt and tool-schema overhead, so totals slightly understate real context. The billed credits stay authoritative on the quota card (limits view); this PR only keeps the usage history in token units.
- Pricing: `glm-5.3-flash` is not in the pricing catalog yet, so a `customModelPricing` entry (input $0.0595 / output $0.208 per M, i.e. CNY 0.4 / 1.4 at the official 5折 rate) is needed until the catalog carries it.
- Relationship to #569: that PR fills the same rows with cloud-credit daily deltas. If both are desirable, take #569's quota/limits part plus this PR's usage rows — merging both usage-row paths would mix units and double-count. Happy to rebase either way.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Estimates per-model, per-day token usage for the Qoder CN client from its agent transcripts, so `qodercn` rows stay in token units instead of freezing at the old install or dropping out of token totals.

| Area | Before | After |
| --- | --- | --- |
| Token usage reporting | `qodercn` rows freeze at the old install or drop out of token totals because the client's local DB and cloud API expose no per-request token usage | Rows are populated from estimated tokens derived from `~/.qoder-cn/projects/**/*.jsonl` transcripts, aggregated per day and model |
| Failure handling | A failed legacy DB read dropped Qoder CN periods and silently undercounted history | Transcript rows are collected independently; the period falls back only when neither source produces rows, and a failed transcript read marks `qoderCnHistoryReadFailed` to keep the fallback graph |

**Implementation details**
- Token estimation blends CJK and other characters on message content; input is cumulative session context, output is per-request content, rounded once with code-point iteration so emoji don't inflate the CJK count.
- Transcripts are read once per tick; anchored ticks filter in memory so rows are never double-counted, and nested project directories are walked recursively.
- Restores the antigravity sync-lock exports that the old baseline tree had dropped.
- Marks `qoderCnHistoryReadFailed` when the transcript read fails.
- Estimates slightly understate real context because system-prompt and tool-schema overhead are absent from transcripts.

**Validation**
- Unit tests cover day bucketing on timezone-stable fixtures, cumulative input attribution, CJK math, `sinceMs` filtering, idempotent re-scan, oversized-line and bad-JSON skipping, nested directory walks, and transcript rows keeping periods alive when the legacy DB read fails; the transcript-only case stubs the pricing lookup so it runs hermetically on CI.
- Verified against real transcripts on 2026-08-27/28/31; the dashboard matches archived day rows.

<sup>Written for commit 73e4b30ee579e2f33842c515c0989bd396fab37c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

