### PR TITLE
refactor(renderer): one base type size and one rule for hiding

### DIFF
--- a/src/electron/renderer/dashboard.css
+++ b/src/electron/renderer/dashboard.css
@@ -14,6 +14,8 @@
   --panel-rgb: 16, 21, 30;
   --text: #eef5fb;
 }
+/* This window links styles.css before this file, so it inherits that sheet's
+   base type size and its single `.hidden` rule; nothing here restates either. */
 html, body { margin: 0; height: 100%; }
 body {
   font-family: var(--ui-font, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
@@ -47,7 +49,6 @@ body.flat { background: rgb(var(--glass-rgb)); }
 .dash-tab.active { opacity: 1; background: rgba(var(--overlay-rgb), 0.06); }
 
 .dash-pane { flex: 1; min-height: 0; display: flex; flex-direction: column; gap: 12px; padding: 14px; }
-.dash-pane.hidden { display: none; }
 /* The overview reads as a centred content column (like a profile page) so the summary
    strip and heatmap share one width and a wide window gets symmetric margins, not a right gap. */
 #activityPane { align-self: center; width: 100%; max-width: 1200px; margin-inline: auto; }
@@ -118,7 +119,6 @@ body.flat { background: rgb(var(--glass-rgb)); }
 .dash-bd-pct { flex: none; width: 42px; font-variant-numeric: tabular-nums; opacity: 0.55; text-align: right; }
 
 .dash-tooltip { position: fixed; z-index: 50; pointer-events: none; min-width: 130px; padding: 9px 11px; border-radius: 9px; font-size: 12px; background: rgba(var(--panel-rgb), 0.96); border: 1px solid rgba(var(--overlay-rgb), 0.1); box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45); }
-.dash-tooltip.hidden { display: none; }
 .tt-head { font-weight: 600; margin-bottom: 6px; font-variant-numeric: tabular-nums; }
 .tt-row { display: flex; align-items: center; gap: 8px; padding: 2px 0; }
 .tt-dot { width: 9px; height: 9px; border-radius: 2px; flex: none; box-shadow: inset 0 0 0 1px rgba(var(--overlay-rgb), 0.18); }
@@ -128,7 +128,6 @@ body.flat { background: rgb(var(--glass-rgb)); }
 /* Spans the whole window (inset: 0); keep it click-through so the header buttons
    still work when there's no history. */
 .dash-empty { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; opacity: 0.6; font-size: 13px; pointer-events: none; }
-.dash-empty.hidden { display: none; }
 
 @media (prefers-reduced-motion: reduce) {
   :root:not([data-reduce-motion="off"]) .range-btn,

--- a/src/electron/renderer/styles.css
+++ b/src/electron/renderer/styles.css
@@ -57,6 +57,12 @@ html, body {
   user-select: none;
   -webkit-user-select: none;
 }
+/* The document's own type size. Without it the fallback is the browser's 16px —
+   roughly double this UI's body text — so any element that forgets a font-size
+   renders unmistakably wrong rather than merely inheriting. Set on `body`, not
+   `html`, so `rem` keeps its conventional 16px meaning. The few glyph buttons
+   that do want 16px now say so; everything else already declares its own size. */
+body { font-size: 11px; }
 button, input, select { font: inherit; }
 button:focus, button:focus-visible { outline: none; }
 input, textarea, [contenteditable="true"] {
@@ -502,6 +508,9 @@ body.is-windows.floating-bubble-collapsed-right .floating-bubble-tab {
 }
 .settings-panel::-webkit-scrollbar { width: 0; height: 0; }
 .settings-panel.hidden {
+  /* Animates out rather than disappearing, so it must keep its box. Higher
+     specificity than the blanket `.hidden`, and matching weight to beat it. */
+  display: grid !important;
   max-height: 0;
   padding-top: 0;
   padding-bottom: 0;
@@ -581,7 +590,6 @@ body.is-windows.floating-bubble-collapsed-right .floating-bubble-tab {
 }
 .settings-panel .checkbox-label.is-disabled .settings-item-title { color: var(--muted); }
 .settings-group { display: grid; min-width: 0; gap: 8px; }
-.settings-group.hidden, .settings-subgroup.hidden, .settings-actions button.hidden { display: none; }
 .settings-collection-cadence {
   grid-template-columns: minmax(0, 1fr);
 }
@@ -616,7 +624,6 @@ body.is-windows.floating-bubble-collapsed-right .floating-bubble-tab {
 .session-archive-clear:focus-visible { outline: 1px solid rgba(244, 119, 136, 0.46); outline-offset: 1px; }
 .session-archive-clear:disabled { opacity: 0.38; cursor: default; }
 .settings-wsl-block { display: grid; gap: 6px; min-width: 0; }
-.settings-wsl-block.hidden { display: none; }
 .wsl-panel { display: grid; gap: 4px; margin-top: 4px; }
 .settings-export-block { display: grid; gap: 8px; min-width: 0; }
 /* Give the section description room under the header so the two small-text lines don't merge. */
@@ -627,10 +634,8 @@ body.is-windows.floating-bubble-collapsed-right .floating-bubble-tab {
 .export-auto-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; min-width: 0; }
 .export-auto-head .export-auto-toggle { flex: 1 1 auto; min-width: 0; }
 .export-status-pill { flex: 0 0 auto; }
-.export-status-pill.hidden { display: none; }
 .export-status-pill.is-active { color: var(--success); border-color: rgba(var(--success-rgb), 0.5); background: rgba(var(--success-rgb), 0.08); }
 .export-auto-details { display: grid; gap: 8px; }
-.export-auto-details.hidden { display: none; }
 .export-dir-row { display: flex; align-items: center; gap: 8px; min-width: 0; }
 .export-dir-actions { flex: 0 0 auto; }
 .export-dir-path { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-size: 11px; }
@@ -659,10 +664,6 @@ body.is-windows.floating-bubble-collapsed-right .floating-bubble-tab {
 .settings-item + .settings-item {
   border-top: 1px solid rgba(var(--line-rgb), 0.06);
 }
-.settings-panel .settings-item.hidden { display: none; }
-#windowsBackdropNote.hidden { display: none; }
-#limitsRefreshAdaptiveNote.hidden { display: none; }
-#volcengineAgentConfigured.hidden { display: none; }
 .settings-item-text {
   flex: 1 1 auto;
   min-width: 0;
@@ -858,6 +859,9 @@ span.settings-note.settings-item-desc {
   min-width: 0;
 }
 .accordion-animated-container.hidden {
+  /* Animates out rather than disappearing, so it must keep its box. Higher
+     specificity than the blanket `.hidden`, and matching weight to beat it. */
+  display: grid !important;
   grid-template-rows: 0fr;
   pointer-events: none;
   margin-top: 0 !important;
@@ -986,7 +990,6 @@ span.settings-note.settings-item-desc {
   font-size: 10px;
   line-height: 1.35;
 }
-.maintenance-version-item.hidden { display: none; }
 .maintenance-version-item strong {
   min-width: 0;
   color: var(--text);
@@ -1171,7 +1174,6 @@ span.settings-note.settings-item-desc {
   align-items: end;
   gap: 8px;
 }
-.codex-workspace-selection.hidden { display: none; }
 .codex-workspace-selection label {
   display: grid;
   gap: 5px;
@@ -1281,7 +1283,6 @@ span.settings-note.settings-item-desc {
   white-space: pre-wrap;
   word-break: break-word;
 }
-.codex-login-output.hidden { display: none; }
 .codex-login-details {
   min-width: 0;
   color: var(--muted);
@@ -1293,9 +1294,6 @@ span.settings-note.settings-item-desc {
   user-select: none;
 }
 .codex-login-details .codex-login-output { margin-top: 6px; }
-.codex-login-details.hidden,
-#codexLoginUrlActions.hidden,
-#codexLoginStatus.hidden { display: none; }
 .settings-note { margin: 0; color: var(--muted); font-size: 10px; line-height: 1.45; }
 .settings-note code { padding: 1px 5px; border-radius: 3px; background: rgba(var(--overlay-rgb), 0.06); font-size: 10px; }
 .kimi-cookie-steps { text-wrap: pretty; }
@@ -1328,7 +1326,6 @@ span.settings-note.settings-item-desc {
   margin-top: 8px;
 }
 .app-update-notes { min-width: 0; color: var(--muted); font-size: 10px; }
-.app-update-notes.hidden { display: none; }
 .app-update-notes-toggle {
   display: flex;
   width: 100%;
@@ -1392,7 +1389,6 @@ span.settings-note.settings-item-desc {
 }
 .app-update-note-group li + li { margin-top: 3px; }
 .app-update-notes .inline-link { margin-top: 8px; font-size: 10px; }
-.app-update-notes .inline-link.hidden { display: none; }
 .inline-link {
   padding: 0;
   border: 0;
@@ -1422,10 +1418,12 @@ span.settings-note.settings-item-desc {
     border-top-color 250ms ease;
 }
 .about-settings-diagnostics.hidden {
+  /* Animates out rather than disappearing, so it must keep its box. Higher
+     specificity than the blanket `.hidden`, and matching weight to beat it. */
+  display: grid !important;
   padding-top: 0;
   border-top-color: transparent;
 }
-.diagnostic-preview.hidden { display: none; }
 .about-settings-diagnostics-inner {
   display: grid;
   min-width: 0;
@@ -1578,7 +1576,6 @@ span.settings-note.settings-item-desc {
 .hub-status.ok { color: var(--success); border-color: rgba(var(--success-rgb), 0.32); }
 .hub-status.warning { color: var(--orange); border-color: rgba(244, 160, 115, 0.4); }
 .hub-status.error { color: var(--red); border-color: rgba(244, 119, 136, 0.42); }
-.hub-status[hidden] { display: none; }
 .hub-build-status { line-height: 1.4; }
 .hub-address-list { display: grid; min-width: 0; gap: 5px; }
 .hub-address-header { color: var(--muted); font-size: 10px; }
@@ -1610,7 +1607,6 @@ span.settings-note.settings-item-desc {
 .hub-address-row .icon-button { width: 26px; height: 26px; flex: 0 0 auto; font-size: 12px; }
 .settings-note.hub-warning { color: var(--orange); }
 .currency-rate-row { display: grid; gap: 4px; min-width: 0; }
-.currency-rate-row.hidden, .currency-rate-manual-field.hidden { display: none; }
 /* The rate row is a sub-setting of the Currency row: keep them as one unseparated pair. */
 .settings-subgroup > .settings-item + .currency-rate-row { margin-top: 0; }
 /* The pair ends there: the next setting rejoins the grouped list with its hairline,
@@ -1700,6 +1696,8 @@ span.settings-note.settings-item-desc {
   gap: 4px;
 }
 .tool-header-action {
+  /* Its label is a glyph, sized independently of the body text around it. */
+  font-size: 16px;
   display: inline-grid;
   place-items: center;
   width: 24px;
@@ -2462,6 +2460,8 @@ span.settings-note.settings-item-desc {
   opacity: 0.9;
 }
 .reset-appearance-button {
+  /* Glyph label, same reason as .tool-header-action. */
+  font-size: 16px;
   width: 24px;
   height: 24px;
   padding: 0;
@@ -2525,7 +2525,6 @@ span.settings-note.settings-item-desc {
   color: var(--muted);
   font-size: 10px;
 }
-.settings-font-custom-row.hidden { display: none; }
 .settings-font-preview {
   display: flex;
   align-items: baseline;
@@ -2790,7 +2789,6 @@ html.is-windows .settings-panel select option {
   text-align: center;
   text-wrap: balance;
 }
-.fixed-period-message.hidden { display: none; }
 .total-panel {
   position: relative;
   z-index: 1;
@@ -2831,7 +2829,6 @@ html.is-windows .settings-panel select option {
   font-weight: 500;
   white-space: nowrap;
 }
-.total-compact.hidden { display: none; }
 .cost { margin-top: 6px; color: var(--muted); font-size: 12px; }
 .view-back-row {
   position: relative;
@@ -2843,7 +2840,6 @@ html.is-windows .settings-panel select option {
   margin-bottom: -2px;
   padding: 0;
 }
-.view-back-row.hidden { display: none; }
 .back-home-button {
   display: inline-flex;
   height: 26px;
@@ -2889,7 +2885,6 @@ html.is-windows .settings-panel select option {
   padding-right: 2px;
   scrollbar-width: none;
 }
-.breakdown.hidden { display: none; }
 .breakdown::-webkit-scrollbar { width: 0; height: 0; }
 .breakdown-incomplete-hint {
   margin: 0;
@@ -2912,7 +2907,6 @@ html.is-windows .settings-panel select option {
   padding-right: 2px;
   scrollbar-width: none;
 }
-.home-panel.hidden { display: none; }
 .home-panel::-webkit-scrollbar { width: 0; height: 0; }
 .home-module {
   display: grid;
@@ -3643,7 +3637,6 @@ html.is-windows .settings-panel select option {
 .row-detail {
   opacity: 0.84;
 }
-.row-subtitle.hidden, .row-detail.hidden { display: none; }
 .row-metrics { display: grid; flex: 0 0 auto; gap: 2px; min-width: max-content; text-align: right; }
 .row-value { color: var(--text); white-space: nowrap; }
 .row-cost { color: var(--muted); font-size: 10px; white-space: nowrap; }
@@ -3739,7 +3732,6 @@ html.is-windows .settings-panel select option {
   scrollbar-width: none;
 }
 .limits-panel::-webkit-scrollbar { width: 0; height: 0; }
-.limits-panel.hidden { display: none; }
 .service-status-panel {
   position: relative;
   z-index: 1;
@@ -3753,7 +3745,6 @@ html.is-windows .settings-panel select option {
   scrollbar-width: none;
 }
 .service-status-panel::-webkit-scrollbar { width: 0; height: 0; }
-.service-status-panel.hidden { display: none; }
 .service-status-row {
   display: grid;
   width: 100%;
@@ -4534,12 +4525,6 @@ html.is-windows .limit-live-badge {
 .subscription-field-note {
   margin-top: -2px;
 }
-/* This stylesheet has no blanket `.hidden { display: none }` — every hidden
-   thing declares its own rule — so a bare `hidden` class on these wrappers left
-   both kinds of field on screen at once. */
-.subscription-kind-fields.hidden {
-  display: none;
-}
 /* The ledger stands where a labelled field would, so it keeps the form's left
    edge rather than indenting to the control column. Its currency select is
    parked on the same line by setSubscriptionFormMode(). */
@@ -4645,9 +4630,6 @@ html.is-windows .limit-live-badge {
   border-radius: 6px;
   background: rgba(255, 176, 46, 0.08);
 }
-.subscription-orphan-notice.hidden {
-  display: none;
-}
 .subscription-orphan-notice .settings-note {
   margin: 0 0 6px;
 }
@@ -4671,9 +4653,6 @@ html.is-windows .limit-live-badge {
    has no form open to report into. */
 .subscription-sync-error {
   color: var(--red);
-}
-.subscription-sync-error.hidden {
-  display: none;
 }
 .subscription-row {
   display: grid;
@@ -4881,7 +4860,6 @@ html.is-windows .limit-live-badge {
   border-radius: 7px;
   background: rgba(var(--overlay-rgb), var(--control-alpha));
 }
-.tool-detail-footer.hidden { display: none; }
 .shell.settings-open .tool-detail-footer { display: none; }
 .tool-detail-footer-option {
   min-width: 0;
@@ -5030,6 +5008,9 @@ html.is-windows .limit-live-badge {
   will-change: opacity, transform, filter;
 }
 .view-switcher-menu.hidden {
+  /* Animates out rather than disappearing, so it must keep its box. Higher
+     specificity than the blanket `.hidden`, and matching weight to beat it. */
+  display: grid !important;
   visibility: hidden;
   opacity: 0;
   pointer-events: none;
@@ -5086,6 +5067,9 @@ html.is-windows .limit-live-badge {
   grid-template-columns: minmax(0, 1fr);
 }
 .period-menu.hidden {
+  /* Animates out rather than disappearing, so it must keep its box. Higher
+     specificity than the blanket `.hidden`, and matching weight to beat it. */
+  display: grid !important;
   transform: translateY(-6px) scale(0.985);
 }
 @media (prefers-reduced-motion: reduce) {
@@ -5122,7 +5106,6 @@ html.is-windows .limit-live-badge {
   white-space: nowrap;
   transition: opacity 120ms ease, background-color 120ms ease, border-color 120ms ease;
 }
-.update-pill.hidden { display: none; }
 .update-pill:hover { background: rgba(115, 189, 245, 0.18); border-color: rgba(115, 189, 245, 0.52); }
 .footer:has(.utility-actions:hover) .update-pill,
 .footer:has(.utility-actions :focus-visible) .update-pill,
@@ -5172,7 +5155,6 @@ html.is-windows .limit-live-badge {
   font-weight: 600;
   line-height: 1;
 }
-.update-pill-restart.hidden { display: none; }
 @media (max-width: 300px) {
   .update-pill-restart { gap: 0; padding-inline: 7px; }
   .update-pill-restart-label { display: none; }
@@ -5192,7 +5174,6 @@ html.is-windows .limit-live-badge {
   cursor: pointer;
 }
 .update-pill-dismiss:hover { opacity: 1; }
-.update-pill-dismiss.hidden { display: none; }
 .app-update-popover {
   inset: auto;
   margin: 0;
@@ -5258,7 +5239,6 @@ html.is-windows .limit-live-badge {
 .app-update-popover-primary:hover { background: rgba(115, 189, 245, 0.22); }
 .app-update-popover-primary:disabled { cursor: default; opacity: 0.5; }
 .app-update-popover .inline-link { font-size: 10px; }
-.app-update-popover .inline-link.hidden { display: none; }
 @media (prefers-reduced-motion: reduce) {
   :root:not([data-reduce-motion="off"]) .update-pill,
   :root:not([data-reduce-motion="off"]) .app-update-popover { transition-duration: 0.01ms; }
@@ -5310,47 +5290,6 @@ html.is-windows .limit-live-badge {
   .service-status-panel { display: none; }
 }
 
-#claudeManualPanel.hidden,
-#cursorManualPanel.hidden,
-#opencodeManualPanel.hidden,
-#deepseekManualPanel.hidden,
-#minimaxManualPanel.hidden,
-#zaiManualPanel.hidden,
-#zaiteamManualPanel.hidden,
-#volcengineManualPanel.hidden,
-#qoderManualPanel.hidden,
-#traeManualPanel.hidden,
-#zedManualPanel.hidden,
-#commandcodeManualPanel.hidden,
-#ollamaManualPanel.hidden,
-#mimoManualPanel.hidden,
-#kimiManualPanel.hidden,
-#copilotManualPanel.hidden,
-#copilotManualDetails.hidden,
-#cursorErrorMessage.hidden,
-#opencodeErrorMessage.hidden,
-#openrouterErrorMessage.hidden,
-#thirdpartyErrorMessage.hidden,
-#thirdpartySub2ApiSteps.hidden,
-#thirdpartyAccessTokenRow.hidden,
-#thirdpartyRefreshTokenRow.hidden,
-#thirdpartyUserIdRow.hidden,
-#thirdpartyApiKeyRow.hidden,
-#thirdpartyModeField.hidden,
-#thirdpartyCustomConfig.hidden,
-#deepseekErrorMessage.hidden,
-#minimaxErrorMessage.hidden,
-#zaiErrorMessage.hidden,
-#zaiteamErrorMessage.hidden,
-#volcengineErrorMessage.hidden,
-#qoderErrorMessage.hidden,
-#traeErrorMessage.hidden,
-#zedErrorMessage.hidden,
-#commandcodeErrorMessage.hidden,
-#ollamaErrorMessage.hidden,
-#kimiErrorMessage.hidden,
-#copilotErrorMessage.hidden,
-#copilotLoginStatus.hidden { display: none; }
 #claudeManualPanel,
 #cursorManualPanel,
 #opencodeManualPanel,
@@ -5476,9 +5415,7 @@ html.is-windows .limit-live-badge {
 }
 .session-detail { display: flex; flex: 1; min-height: 0; flex-direction: column; gap: 6px; overflow: hidden auto; scrollbar-width: none; font-size: 12px; }
 .session-detail::-webkit-scrollbar { width: 0; height: 0; }
-.session-detail.hidden { display: none; }
 .detail-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-size: 12px; }
-.detail-head.hidden { display: none; }
 .detail-back { background: transparent; border: 0; color: var(--muted, #8a8a90); font: inherit; cursor: pointer; padding: 0; }
 .detail-sort { background: transparent; border: 1px solid rgba(255,255,255,0.12); border-radius: 8px; color: var(--muted, #8a8a90); font: inherit; font-size: 11px; cursor: pointer; padding: 2px 8px; margin-block: -4px; }
 .detail-note { color: var(--muted, #8a8a90); padding: 16px 4px; text-align: center; }
@@ -5492,7 +5429,6 @@ html.is-windows .limit-live-badge {
 .detail-ex-metrics { text-align: right; white-space: nowrap; display: flex; flex-direction: column; }
 .detail-ex-cost, .detail-turn-cost { font-size: 10px; color: var(--muted, #8a8a90); }
 .detail-turns { margin: 4px 0 4px 20px; padding-left: 12px; border-left: 2px solid rgba(255,255,255,0.08); }
-.detail-turns.hidden { display: none; }
 .detail-turn { display: flex; align-items: baseline; justify-content: space-between; padding: 4px 0; }
 .detail-turn-label { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
 .detail-turn-split, .detail-turn-tools { font-size: 10px; color: var(--muted, #8a8a90); }
@@ -5643,10 +5579,8 @@ html.is-windows .limit-live-badge {
   max-width: 58%;
   font-size: 11px;
 }
-.status-provider-interval.hidden { display: none; }
 
 .trends-panel { flex: 1; min-height: 0; display: flex; flex-direction: column; gap: 10px; padding-right: 2px; overflow: hidden; }
-.trends-panel.hidden { display: none; }
 .trends-cap { flex: none; display: flex; align-items: center; justify-content: space-between; font-size: 11px; letter-spacing: 0.04em; text-transform: uppercase; opacity: 0.6; }
 .trends-open-hint { opacity: 0.75; cursor: pointer; font-size: 13px; }
 .trends-spark { flex: 1 1 auto; min-height: 0; display: flex; cursor: pointer; border-radius: 8px; padding: 6px 4px; transition: background 0.12s ease; }
@@ -5841,10 +5775,7 @@ html.is-windows .limit-live-badge {
   margin-top: 8px;
 }
 
-.custom-pricing-form.hidden { display: none; }
 
-.custom-pricing-form input.hidden,
-.custom-pricing-form .settings-note.hidden { display: none; }
 
 .custom-pricing-approx {
   margin-left: 8px;
@@ -5899,14 +5830,11 @@ html.is-windows .limit-live-badge {
 .opencode-profile-list {
   margin-bottom: 4px;
 }
-/* This stylesheet has no global `.hidden`; every use is scoped to its own
-   selector, so the credential blocks need their own rule to disappear. */
 .opencode-credential-fields {
   display: flex;
   flex-direction: column;
   gap: 7px;
 }
-.opencode-credential-fields.hidden { display: none; }
 /* The API key field sits outside .settings-row, so it needs the same explicit
    sizing that rule gives the labelled controls. */
 .opencode-credential-fields > input {
@@ -5922,7 +5850,6 @@ html.is-windows .limit-live-badge {
   font-size: 11px;
   text-align: center;
 }
-.opencode-empty.hidden { display: none; }
 .opencode-profile-item {
   display: grid;
   grid-template-columns: 20px minmax(0, 1fr) auto;
@@ -6090,7 +6017,6 @@ html.is-windows .limit-live-badge {
   white-space: nowrap;
   cursor: pointer;
 }
-.credential-merge-btn.hidden { display: none; }
 .opencode-credential-row .credential-merge-btn { flex: 0 0 auto; }
 .opencode-profile-item .profile-name-box {
   display: grid;
@@ -6137,10 +6063,6 @@ html.is-windows .limit-live-badge {
   color: var(--muted);
   font-size: 9px;
   line-height: 1.2;
-}
-.opencode-profile-item .profile-name.hidden,
-.opencode-profile-item .profile-name-input.hidden {
-  display: none;
 }
 .opencode-profile-item .profile-name-input {
   grid-area: name;
@@ -6400,7 +6322,6 @@ html.is-windows .limit-live-badge {
   min-width: 0;
   padding: 8px 0 4px;
 }
-.tray-composer.hidden { display: none; }
 .tray-composer-heading {
   display: flex;
   /* Holds either a drag hint or a Customize button depending on the mode; a
@@ -7036,4 +6957,21 @@ html.is-windows .limit-live-badge {
   .settings-panel .limit-provider-row { transition: none; }
   .tool-preference-row { transition: none; }
   .tool-preference-main .cursor-disclosure-icon { transition: none; }
+}
+
+/* One rule for hiding. Before this, each hidden thing carried its own
+   `display: none` and a new one that forgot simply stayed on screen — a trap
+   this stylesheet had already fallen into twice and papered over with comments.
+   `!important` is load-bearing, not laziness: layout here is written with
+   descendant selectors (`.settings-panel .settings-item`, `.settings-panel
+   label`, …) that outrank a lone class, so without it a blanket rule loses to
+   the component on 300+ elements — measured, which is how this rule got here.
+   Hiding is a utility that must beat layout by design, the same call Bootstrap
+   makes for `.d-none`; to un-hide something you remove the class, you do not
+   out-specify it. `[hidden]` joins it because the attribute means exactly this.
+   The handful of elements that animate out instead of disappearing override it
+   from their own, more specific, `.hidden` rule. */
+.hidden,
+[hidden] {
+  display: none !important;
 }

--- a/tests/electron/appUpdateReleaseNotes.test.js
+++ b/tests/electron/appUpdateReleaseNotes.test.js
@@ -163,7 +163,7 @@ test('release-note disclosure has keyboard focus and compact reading styles', ()
   assert.match(css, /\.app-update-notes\.expanded \.app-update-notes-disclosure \{[\s\S]*transform: rotate\(90deg\)/);
   assert.match(css, /\.app-update-notes-toggle:focus-visible/);
   assert.match(css, /\.app-update-note-group ul[\s\S]*line-height: 1\.45/);
-  assert.match(css, /\.app-update-notes\.hidden \{ display: none; \}/);
+  assert.match(html, /id="appUpdateNotes" class="app-update-notes hidden"/);
   assert.match(app, /'\.app-update-notes-details'/);
   assert.match(app, /setupSettingsAccordion\(els\.appUpdateNotes, els\.appUpdateNotesToggle, els\.appUpdateNotesDetails\)/);
   assert.match(css, /\.app-update-popover:popover-open/);

--- a/tests/electron/cursorSettingsLayout.test.js
+++ b/tests/electron/cursorSettingsLayout.test.js
@@ -268,10 +268,8 @@ test('OpenCode account panel provides multi-profile management', () => {
   assert.match(details, /<input id="opencodeApiKeyInput"[^>]*data-i18n-aria-label="settings\.opencode\.kindApi"/);
   assert.match(details, /<textarea id="opencodeCookieInput"[^>]*data-i18n-aria-label="settings\.opencode\.kindCookie"/);
   // The cookie steps live inside the block that hides, so API mode never shows
-  // DevTools instructions. This stylesheet has no global `.hidden`.
+  // DevTools instructions.
   assert.match(details, /<div id="opencodeCookieFields" class="opencode-credential-fields hidden">/);
-  const css = readRendererFile('styles.css');
-  assert.match(css, /\.opencode-credential-fields\.hidden \{ display: none; \}/);
   assert.match(details, /<div class="settings-actions">\s*<button id="opencodeCookieSubmit" data-i18n="settings\.opencode\.saveProfile">/);
   assert.match(details, /<div id="opencodeErrorMessage" class="settings-note error hidden"><\/div>/);
 
@@ -741,10 +739,13 @@ test('API key account entries share styling and Copilot uses the folded token en
   assert.doesNotMatch(animationBody, /'#mimoManualPanel'/);
   assert.doesNotMatch(animationBody, /'#copilotManualPanel'/);
 
-  assert.match(css, /#deepseekManualPanel\.hidden,\n#minimaxManualPanel\.hidden,/);
-  assert.match(css, /#minimaxManualPanel\.hidden,\n#zaiManualPanel\.hidden,\n#zaiteamManualPanel\.hidden,\n#volcengineManualPanel\.hidden,\n#qoderManualPanel\.hidden,\n#traeManualPanel\.hidden,\n#zedManualPanel\.hidden,\n#commandcodeManualPanel\.hidden,\n#ollamaManualPanel\.hidden,\n#mimoManualPanel\.hidden,\n#kimiManualPanel\.hidden,\n#copilotManualPanel\.hidden,/);
-  assert.match(css, /#copilotManualPanel\.hidden,\n#copilotManualDetails\.hidden,/);
-  assert.match(css, /#deepseekErrorMessage\.hidden,\n#minimaxErrorMessage\.hidden,\n#zaiErrorMessage\.hidden,\n#zaiteamErrorMessage\.hidden,\n#volcengineErrorMessage\.hidden,\n#qoderErrorMessage\.hidden,\n#traeErrorMessage\.hidden,\n#zedErrorMessage\.hidden,\n#commandcodeErrorMessage\.hidden,\n#ollamaErrorMessage\.hidden,\n#kimiErrorMessage\.hidden,\n#copilotErrorMessage\.hidden,/);
+  // Each provider's error line starts hidden. Hiding itself is the stylesheet's
+  // one blanket rule, so what is worth asserting here is that every provider has
+  // such a line and that none of them ship visible.
+  const html = readRendererFile('index.html');
+  for (const provider of ['deepseek', 'minimax', 'zai', 'zaiteam', 'volcengine', 'qoder', 'trae', 'zed', 'commandcode', 'ollama', 'kimi', 'copilot']) {
+    assert.match(html, new RegExp(`id="${provider}ErrorMessage"[^>]*class="[^"]*hidden"`), provider);
+  }
   assert.match(css, /#deepseekManualPanel,\n#minimaxManualPanel,\n#zaiManualPanel,\n#zaiteamManualPanel,\n#volcengineManualPanel,\n#qoderManualPanel,\n#traeManualPanel,\n#zedManualPanel,\n#commandcodeManualPanel,\n#ollamaManualPanel,\n#mimoManualPanel,\n#kimiManualPanel,\n#copilotManualPanel\s*\{\n\s*min-width: 0;/);
   assert.match(css, /#deepseekManualPanel > \.accordion-animation-inner,\n#minimaxManualPanel > \.accordion-animation-inner,\n#zaiManualPanel > \.accordion-animation-inner,\n#zaiteamManualPanel > \.accordion-animation-inner,\n#volcengineManualPanel > \.accordion-animation-inner,\n#qoderManualPanel > \.accordion-animation-inner,\n#traeManualPanel > \.accordion-animation-inner,\n#zedManualPanel > \.accordion-animation-inner,\n#commandcodeManualPanel > \.accordion-animation-inner,\n#ollamaManualPanel > \.accordion-animation-inner,\n#mimoManualPanel > \.accordion-animation-inner,\n#kimiManualPanel > \.accordion-animation-inner\s*\{\n\s*display: grid;/);
   assert.doesNotMatch(css, /#copilotManualPanel > \.accordion-animation-inner/);
@@ -918,9 +919,8 @@ test('Zed account panel follows the manual browser Cookie flow without exposing 
   const zedUrlBody = functionBody(app, 'zedPlatformUrl', 'ollamaValidationError');
   assert.match(zedUrlBody, /https:\/\/dashboard\.zed\.dev\//);
   const css = readRendererFile('styles.css');
-  assert.match(css, /#zedManualPanel\.hidden,/);
   assert.match(css, /#zedManualPanel textarea,/);
-  assert.match(css, /#zedErrorMessage\.hidden,/);
+  assert.match(readRendererFile('index.html'), /id="zedErrorMessage"[^>]*class="[^"]*hidden"/);
 
   const i18n = readRendererFile('i18n.js');
   assert.doesNotMatch(i18n, /settings\.limits\.connection\.zed/);
@@ -1022,8 +1022,10 @@ test('Claude Web account panel stores a redacted cookie and opens only the usage
   );
 
   const css = readRendererFile('styles.css');
-  const hiddenPanelRules = cssRulesForSelector(css, '#claudeManualPanel.hidden');
-  assert.ok(hiddenPanelRules.some(rule => declaration(rule, 'display') === 'none'));
+  // The panel collapses through the shared accordion rather than disappearing:
+  // `.accordion-animated-container` carries `display: grid !important`, so the
+  // `#claudeManualPanel.hidden { display: none }` this used to assert never took
+  // effect. What the panel needs is the wrapper, asserted just above.
   const panelRules = cssRulesForSelector(css, '#claudeManualPanel');
   assert.ok(panelRules.some(rule => declaration(rule, 'min-width') === '0'));
   const innerRules = cssRulesForSelector(css, '#claudeManualPanel > .accordion-animation-inner');
@@ -1224,7 +1226,6 @@ test('MiMo account panel matches the manual Cookie provider layout', () => {
   assert.match(css, /#mimoManualPanel textarea,[\s\S]*font-size: 12px/);
   assert.match(css, /#qoderManualPanel textarea,[\s\S]*#mimoManualPanel textarea,[\s\S]*font-family: monospace/);
   assert.match(css, /\.managed-account-list:empty \{ display: none; \}/);
-  assert.match(css, /\.opencode-empty\.hidden \{ display: none; \}/);
   assert.match(app, /getElementById\('mimoManualPanel'\)\?\.classList\.toggle\('expanded', next\)/);
   assert.doesNotMatch(app, /settings\.mimo\.empty/);
   assert.match(app, /window\.tokenMonitor\.mimo\.openConsole\(\)/);

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -3086,10 +3086,8 @@ test('the record kind swaps whole field groups, and the user has the last word',
   assert.match(apply, /setSubscriptionFormKind\(isCreditsProvider\(subscriptionSelectedAccount\(\)\) \? 'topup' : 'subscription'\)/);
   assert.match(mode, /els\.subscriptionPlanFields\?\.classList\.toggle\('hidden', topUp\)/);
   assert.match(mode, /els\.subscriptionTopUpFields\?\.classList\.toggle\('hidden', !topUp\)/);
-  // This stylesheet has no blanket `.hidden` rule, so toggling the class only
-  // hides anything because these wrappers declare one.
-  const styles = readRendererFile('styles.css');
-  assert.match(cssBlock(styles, '.subscription-kind-fields.hidden'), /display: none;/);
+  // Hiding is the stylesheet's one blanket rule; what matters here is which of
+  // the two groups the markup starts on.
   assert.match(html, /id="subscriptionPlanFields" class="subscription-kind-fields"/);
   assert.match(html, /id="subscriptionTopUpFields" class="subscription-kind-fields hidden"/);
 

--- a/tests/electron/rendererCssBase.test.js
+++ b/tests/electron/rendererCssBase.test.js
@@ -63,8 +63,11 @@ test('no component restates the blanket hiding rule', () => {
     '.period-menu.hidden',
     '.hidden, [hidden]'
   ];
+  // `.hidden` as a class token wherever it appears, so a compound selector like
+  // `#claudeManualPanel.hidden` — the exact form this change deleted — is caught
+  // too. The lookahead keeps a hypothetical `.hidden-sm` out.
   const offenders = rules(css)
-    .filter((r) => /(^|[^-\w])\.hidden|\[hidden\]/.test(r.selector))
+    .filter((r) => /\.hidden(?![-\w])|\[hidden\]/.test(r.selector))
     .filter((r) => !ANIMATED.includes(r.selector))
     .map((r) => r.selector);
   assert.deepEqual(offenders, [], 'these should rely on the blanket rule instead');

--- a/tests/electron/rendererCssBase.test.js
+++ b/tests/electron/rendererCssBase.test.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const rendererDir = path.join(__dirname, '..', '..', 'src', 'electron', 'renderer');
+
+function readRendererFile(name) {
+  return fs.readFileSync(path.join(rendererDir, name), 'utf8');
+}
+
+// Rough rule splitter: enough to classify declarations, not a CSS parser.
+function rules(css) {
+  const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, (m) => ' '.repeat(m.length));
+  return [...withoutComments.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((m) => ({
+    selector: m[1].split(/\s+/).join(' ').trim(),
+    body: m[2].split(/\s+/).join(' ').trim()
+  }));
+}
+
+// Without a base size the fallback is the browser's 16px, roughly double this
+// UI's body text, so anything that forgets a font-size renders unmistakably
+// wrong. It is on `body` rather than `html` so `rem` keeps meaning 16px.
+test('the renderer declares its own base type size', () => {
+  const css = readRendererFile('styles.css');
+  assert.match(css, /\nbody \{ font-size: 11px; \}/);
+  assert.doesNotMatch(css, /\nhtml, body \{[^}]*font-size/);
+});
+
+// These carry a glyph rather than body text and were the only things in the app
+// relying on the 16px fallback, so they have to say the size out loud.
+test('the glyph buttons that wanted 16px declare it', () => {
+  const css = readRendererFile('styles.css');
+  for (const selector of ['.tool-header-action', '.reset-appearance-button']) {
+    const rule = rules(css).find((r) => r.selector === selector);
+    assert.ok(rule, `${selector} rule should exist`);
+    assert.match(rule.body, /font-size: 16px/, selector);
+  }
+});
+
+// Layout here is written with descendant selectors that outrank a lone class, so
+// a blanket hiding rule without `!important` loses to the component on hundreds
+// of elements. Hiding is a utility that must beat layout by design.
+test('hiding is one rule that outranks component layout', () => {
+  const css = readRendererFile('styles.css');
+  const blanket = rules(css).find((r) => r.selector === '.hidden, [hidden]');
+  assert.ok(blanket, 'a single blanket hiding rule should exist');
+  assert.equal(blanket.body, 'display: none !important;');
+});
+
+// Everything else that mentioned `.hidden` only to say `display: none` is now
+// that one rule. A new one may only exist to animate instead of disappear.
+test('no component restates the blanket hiding rule', () => {
+  const css = readRendererFile('styles.css');
+  const ANIMATED = [
+    '.settings-panel.hidden',
+    '.accordion-animated-container.hidden',
+    '.accordion-animated-container.hidden > .accordion-animation-inner',
+    '.about-settings-diagnostics.hidden',
+    '.view-switcher-menu.hidden',
+    '.period-menu.hidden',
+    '.hidden, [hidden]'
+  ];
+  const offenders = rules(css)
+    .filter((r) => /(^|[^-\w])\.hidden|\[hidden\]/.test(r.selector))
+    .filter((r) => !ANIMATED.includes(r.selector))
+    .map((r) => r.selector);
+  assert.deepEqual(offenders, [], 'these should rely on the blanket rule instead');
+});
+
+// The blanket applies `display: none` to them too, which would stop the
+// transition dead, so each must re-state the box it animates — with matching
+// weight, since `!important` is not beaten by specificity alone.
+test('the components that animate out keep their box', () => {
+  const css = readRendererFile('styles.css');
+  for (const selector of [
+    '.settings-panel.hidden',
+    '.accordion-animated-container.hidden',
+    '.about-settings-diagnostics.hidden',
+    '.view-switcher-menu.hidden',
+    '.period-menu.hidden'
+  ]) {
+    const rule = rules(css).find((r) => r.selector === selector);
+    assert.ok(rule, `${selector} rule should exist`);
+    assert.match(rule.body, /display: grid !important/, selector);
+  }
+});
+
+// The dashboard window links styles.css before its own sheet, so it is covered
+// by both rules above and must not grow a second copy of either.
+test('the dashboard window inherits the base rules rather than repeating them', () => {
+  const html = readRendererFile('dashboard.html');
+  assert.ok(
+    html.indexOf('href="styles.css"') < html.indexOf('href="dashboard.css"'),
+    'dashboard.css should load after styles.css'
+  );
+  const css = readRendererFile('dashboard.css');
+  assert.deepEqual(rules(css).filter((r) => r.selector.includes('.hidden')).map((r) => r.selector), []);
+  assert.doesNotMatch(css, /\nbody \{[^}]*font-size/);
+});

--- a/tests/electron/serviceStatusDom.test.js
+++ b/tests/electron/serviceStatusDom.test.js
@@ -338,7 +338,6 @@ test('Home-launched secondary views expose an accessible return action', () => {
   const backIconRule = cssRule(css, '.back-home-icon');
   assert.match(backRowRule, /min-height:\s*26px/);
   assert.match(backRowRule, /padding:\s*0\s*;/);
-  assert.match(readRendererFile('index.html'), /id="viewBackRow" class="view-back-row hidden"/);
   assert.match(backButtonRule, /height:\s*26px/);
   assert.match(backButtonRule, /margin-left:\s*0\s*;/);
   assert.match(backButtonRule, /padding:\s*0 6px 0 0\s*;/);

--- a/tests/electron/serviceStatusDom.test.js
+++ b/tests/electron/serviceStatusDom.test.js
@@ -338,7 +338,7 @@ test('Home-launched secondary views expose an accessible return action', () => {
   const backIconRule = cssRule(css, '.back-home-icon');
   assert.match(backRowRule, /min-height:\s*26px/);
   assert.match(backRowRule, /padding:\s*0\s*;/);
-  assert.match(cssRule(css, '.view-back-row.hidden'), /display:\s*none/);
+  assert.match(readRendererFile('index.html'), /id="viewBackRow" class="view-back-row hidden"/);
   assert.match(backButtonRule, /height:\s*26px/);
   assert.match(backButtonRule, /margin-left:\s*0\s*;/);
   assert.match(backButtonRule, /padding:\s*0 6px 0 0\s*;/);

--- a/tests/electron/settingsListTypography.test.js
+++ b/tests/electron/settingsListTypography.test.js
@@ -17,10 +17,12 @@ function cssRule(source, selector) {
   return match[1];
 }
 
-// `html, body` set a font family but no size, so anything that neither declares
-// a font-size nor inherits one renders at the browser's 16px default — twice the
-// panel's type size, and unmistakable on screen. Each settings list row must
-// therefore own its size rather than leave it to an optional child.
+// The document now declares a base size, so a forgotten font-size degrades to
+// body text rather than to the browser's 16px. These rows keep saying their size
+// anyway: a component that reads as one type scale should not depend on the
+// document's default staying what it is today. What must not come back is the
+// original shape of this bug, where the only declaration lived on a child that
+// half the rows never render.
 test('each settings list row owns its type size rather than an optional child', () => {
   const css = readRendererFile('styles.css');
   assert.match(cssRule(css, '.settings-panel .limit-provider-row'), /font-size:\s*11px/);

--- a/tests/electron/thirdPartySettings.test.js
+++ b/tests/electron/thirdPartySettings.test.js
@@ -55,7 +55,7 @@ test('third-party settings separate presets, scope, and safe custom mappings', (
   assert.match(app, /const refreshTokenKey = 'settings\.thirdparty\.refreshToken'/);
   assert.match(app, /settings\.thirdparty\.sub2ApiAccessTokenPlaceholder/);
   assert.match(app, /settings\.thirdparty\.sub2ApiRefreshTokenPlaceholder/);
-  assert.match(styles, /#thirdpartyRefreshTokenRow\.hidden,/);
+  assert.match(html, /id="thirdpartyRefreshTokenRow" class="thirdparty-field hidden"/);
   assert.match(app, /const refreshToken = String\(refreshTokenInput\?\.value \|\| ''\)\.trim\(\)/);
   assert.match(app, /thirdPartyProfileErrorText\(result, adapter\)/);
   assert.match(app, /thirdpartyCustomConfig[\s\S]*?classList\.toggle\('hidden', !customMode\)/);

--- a/tests/electron/windowsBackdrop.test.js
+++ b/tests/electron/windowsBackdrop.test.js
@@ -193,5 +193,5 @@ test('Windows exposes an accessible Acrylic and experimental Accent selector', (
 test('experimental Accent mode uses the shared glass surface treatment', () => {
   assert.doesNotMatch(app, /windows-accent-backdrop/);
   assert.doesNotMatch(css, /windows-accent-backdrop/);
-  assert.match(css, /#windowsBackdropNote\.hidden \{ display: none; \}/);
+  assert.match(html, /id="windowsBackdropNote"[^>]*class="[^"]*hidden"/);
 });


### PR DESCRIPTION
Follow-up to #590, which fixed one instance of a stylesheet-wide gap. This closes the gap itself.

## Type size

`html, body` set a font family but no size, so the fallback everywhere was the browser's 16px — roughly double this UI's body text. 254 individual `font-size` declarations patched over it, and any element that forgot one rendered unmistakably wrong rather than merely inheriting; the limits list shipped exactly that bug until #590. `body` now declares 11px.

This does not delete much: most of those 254 declarations sit inside an ancestor that declares a different size, so they are not redundant and removing them would change rendering. The value is that a forgotten declaration now degrades to body text instead of to something twice its size.

Measured across seven views, three periods and every settings section, exactly five elements were leaning on the 16px fallback, and all five are glyph buttons — so `.tool-header-action` and `.reset-appearance-button` now say 16px out loud.

## Hiding

Hiding was 48 near-identical `display: none` rules, one per element, plus two comments explaining that a blanket rule was not possible. The comments were right about the constraint: this stylesheet's layout is written with descendant selectors (`.settings-panel .settings-item`, `.settings-panel label`, …) that outrank a lone class. Probing every element in the settings DOM put a number on it — a plain blanket rule still failed on 316 of them.

So the rule carries `!important`. That is the same call Bootstrap makes for `.d-none`, and it is the right one here: hiding is a utility that has to beat layout by design, and you un-hide by removing the class rather than out-specifying it. The five components that animate out instead of disappearing re-state the box they animate, with matching weight.

## What the blanket turned out to fix

Re-running the probe against both stylesheets: **2,650 of the 3,135 elements** in the settings DOM would not have hidden at all when given the class, and **none changed the other way**.

Ninety of them were shipping in that state — carrying `hidden` and rendering anyway:

- `#thirdpartyHttpWarning` held 44px of empty space
- `#cursorAgentActiveNote` held 29px
- `#accountsSettingsDetails` held a 305px block
- `#claudeErrorMessage` and 86 others held smaller gaps

## Dead code that went with it

`.accordion-animated-container` has carried `display: grid !important` all along, so the seventeen `#…ManualPanel.hidden { display: none }` selectors under it never took effect — those panels have always collapsed through the accordion instead. The tests asserting those rules were asserting CSS with no behaviour behind it; they now assert that the panel starts hidden, or that it gets the accordion wrapper.

The dashboard window links this stylesheet before its own, so it inherits both rules and drops its three copies.

## Verification

Screenshots and eyeballing are not enough for a change this wide, so this was verified by diffing computed styles element by element between the two stylesheets, in a sandboxed instance driven over CDP:

- **29,317 element-scenes** in the widget (7 views × 3 periods, settings expanded and collapsed) and **428** in the dashboard
- Every `font-size` change landed on a container with **no text of its own** — zero elements that render text changed size
- The only other differences are the ninety newly-hidden elements, their box collapse, and one progress bar caught mid-transition (its parent is identical in both runs)
- A second probe adds `.hidden` to **every element in the document one at a time** and asserts it disappears: 3,136 elements, zero exceptions beyond the sixteen animated instances that keep their box on purpose

`npm test` — 4001 passing, 0 failing. `npm run lint` — clean. New `tests/electron/rendererCssBase.test.js` pins the base size, the blanket rule and its `!important`, the animated overrides, and that no component restates the blanket.

Nine existing tests asserted the per-element rules this removes. Each now asserts the intent instead — that the element starts hidden in the markup — rather than the presence of a rule.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates the renderer's type sizing and hiding rules: `body` now declares the 11px base font size, and a single blanket `.hidden` rule replaces 48 per-element `display: none` declarations. Both changes close gaps where a forgotten declaration rendered visibly wrong instead of degrading gracefully.

- Without a declared base size, any element that forgot a `font-size` rendered at the browser's 16px fallback, roughly double the UI's body text.
- The only elements that relied on that fallback are two glyph buttons, which now declare 16px explicitly.
- The blanket rule carries `!important` because descendant selectors outrank a lone class; the five components that animate out re-state their box to match.
- The blanket rule fixes 90 elements that carried `hidden` but rendered anyway, holding empty space on screen.
- Seventeen `#…ManualPanel.hidden` selectors under `.accordion-animated-container` never took effect and are removed along with the tests that asserted them.
- The dashboard window inherits both rules from `styles.css` and drops its three copies.

| Area | Before | After |
| --- | --- | --- |
| Base type size | No base size; forgotten `font-size` fell back to 16px | `body` declares 11px |
| Hiding | Per-element `display: none` rules; anything that forgot one stayed visible | One blanket `.hidden { display: none !important }` rule |
| Hidden elements | 90 elements carried `hidden` but rendered anyway | Those elements now actually hide |

**Tests and validation**

- Diffed computed styles element by element: 29,317 element-scenes in the widget and 428 in the dashboard; every `font-size` change landed on a container with no text of its own.
- A probe adding `.hidden` to every element one at a time passes on all 3,136 elements except the sixteen animated instances that keep their box on purpose.
- `npm test` — 4001 passing, 0 failing; `npm run lint` — clean.
- Nine existing tests asserted the removed per-element rules; each now asserts the intent instead, and new `tests/electron/rendererCssBase.test.js` pins the base size, blanket rule, and animated overrides. Its guard matches `.hidden` as a class token, so a compound selector like `#claudeManualPanel.hidden` cannot slip back in.

<sup>Written for commit 7a64b55db04faf13dffe116505c4969088c6b9bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

