### PR TITLE
chore(deps): update tokscale to 4.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "koffi": "^3.1.5",
         "semver": "^7.8.5",
         "tar": "^7.5.22",
-        "tokscale": "^4.15.0",
+        "tokscale": "^4.15.1",
         "undici": "^7.29.0"
       },
       "devDependencies": {
@@ -1029,29 +1029,29 @@
       }
     },
     "node_modules/@tokscale/cli": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli/-/cli-4.15.0.tgz",
-      "integrity": "sha512-JU3KeT5FPBvJH/fQF2xRoQWPUxi845jPMKbj2zK73xkqGPvJNMU4YX7OypuCr8pOp09Of71/DZsE1kmLrK3z5g==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli/-/cli-4.15.1.tgz",
+      "integrity": "sha512-NXx8azcDpHGq56vvmBs/yGmOs4bKmzXAsZGCzAYQv/ciPpYbpuiuL4eDJEcd604uTCpmxHIOwLsEJJGZI0DRag==",
       "license": "MIT",
       "bin": {
         "tokscale": "bin.js"
       },
       "optionalDependencies": {
-        "@tokscale/cli-android-arm64": "4.15.0",
-        "@tokscale/cli-darwin-arm64": "4.15.0",
-        "@tokscale/cli-darwin-x64": "4.15.0",
-        "@tokscale/cli-linux-arm64-gnu": "4.15.0",
-        "@tokscale/cli-linux-arm64-musl": "4.15.0",
-        "@tokscale/cli-linux-x64-gnu": "4.15.0",
-        "@tokscale/cli-linux-x64-musl": "4.15.0",
-        "@tokscale/cli-win32-arm64-msvc": "4.15.0",
-        "@tokscale/cli-win32-x64-msvc": "4.15.0"
+        "@tokscale/cli-android-arm64": "4.15.1",
+        "@tokscale/cli-darwin-arm64": "4.15.1",
+        "@tokscale/cli-darwin-x64": "4.15.1",
+        "@tokscale/cli-linux-arm64-gnu": "4.15.1",
+        "@tokscale/cli-linux-arm64-musl": "4.15.1",
+        "@tokscale/cli-linux-x64-gnu": "4.15.1",
+        "@tokscale/cli-linux-x64-musl": "4.15.1",
+        "@tokscale/cli-win32-arm64-msvc": "4.15.1",
+        "@tokscale/cli-win32-x64-msvc": "4.15.1"
       }
     },
     "node_modules/@tokscale/cli-android-arm64": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-android-arm64/-/cli-android-arm64-4.15.0.tgz",
-      "integrity": "sha512-ZVUxEDjQC7eZJcDNeOdDRvMRprQKMb9d62OOA1xnY16VtzcNq5E3//9hKGOqes6HkPyrYnjT9BeNzs6jhMSMng==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-android-arm64/-/cli-android-arm64-4.15.1.tgz",
+      "integrity": "sha512-+B6qj2ET8ZOedochQuRkot9fKw7z2PJLUKp0ngjmTPX/Ix56Ricax4/RRqfVgt69XLtAlQ0aLD4EQT6zuGWg7g==",
       "cpu": [
         "arm64"
       ],
@@ -1062,9 +1062,9 @@
       ]
     },
     "node_modules/@tokscale/cli-darwin-arm64": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-arm64/-/cli-darwin-arm64-4.15.0.tgz",
-      "integrity": "sha512-9YlcvprlplFIU6ZmNH+/O6MkcFiGjRHm1b8ztNkNwfy/GlE2OwuagVhj3lpWAO5FNMkDRePJqPZA+MeQ6ucPQw==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-arm64/-/cli-darwin-arm64-4.15.1.tgz",
+      "integrity": "sha512-qAW/FAg6GkMBdqdnRN1knjnPz5yoCnmvaVEQPmJPLVOcKC/V1v4JSbu6zFFfxoYA1rTJlj+D8rqd/uuBMnIrYw==",
       "cpu": [
         "arm64"
       ],
@@ -1075,9 +1075,9 @@
       ]
     },
     "node_modules/@tokscale/cli-darwin-x64": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-x64/-/cli-darwin-x64-4.15.0.tgz",
-      "integrity": "sha512-EP7m6dT3ZPxmFlXdged56uTrJ19Y4By663nj4WO9X/rEj6CAM+s+YCPh82RW4X4X1UmfiKST2H/G9ULbCobEJA==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-darwin-x64/-/cli-darwin-x64-4.15.1.tgz",
+      "integrity": "sha512-HA8zg4p3CJYMbsU2S4saxuFT/0hTg5EW7O8+FxH4fL+X4jm12FuwLAmvQ0g3RZWsqgUKhb22+LdMgwvp7dJaqw==",
       "cpu": [
         "x64"
       ],
@@ -1088,9 +1088,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-arm64-gnu": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-4.15.0.tgz",
-      "integrity": "sha512-V3XTh2eQoJ/bB3XBYHGhmJxTSHyyGwPi9d4Lqszr8M/mKXlHUu2hOqwWmhl6UhbmZciWyIUJTl7C75eKd09YRg==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-4.15.1.tgz",
+      "integrity": "sha512-W4YgugkNkh6TeApIbgjA+YYiogYl3NT0GPsTed/V8Qgh7b5Dv52Gp85ALgUvjUtKzPTC4g2wH0oE74w+9DZylg==",
       "cpu": [
         "arm64"
       ],
@@ -1101,9 +1101,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-arm64-musl": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-musl/-/cli-linux-arm64-musl-4.15.0.tgz",
-      "integrity": "sha512-LfAiYPIaou/aZo6eErgnY3aksQbCIHMhOCQP2WKr1X7jmZmeZZHsaL4EY8tGuCVT3rM9I8FP13Gc/Rr4bdnFtQ==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-arm64-musl/-/cli-linux-arm64-musl-4.15.1.tgz",
+      "integrity": "sha512-imbXQEjNdWj1jzZII5Qq/2F1vAVAtbbdrjbUzUAJHFOyD2VfLhBGV1YgpLiJml7efB1kFD7j5NbubT7nFWcxHg==",
       "cpu": [
         "arm64"
       ],
@@ -1114,9 +1114,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-x64-gnu": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-gnu/-/cli-linux-x64-gnu-4.15.0.tgz",
-      "integrity": "sha512-sqoiUSbfPdbEOQASuj2Ovi1/637YIFxxffrvpVmzR4yvON/HUoAbYPnp8hOGH0EtTSPE3wJJ4aE62UR5hA8c9A==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-gnu/-/cli-linux-x64-gnu-4.15.1.tgz",
+      "integrity": "sha512-bJLuRMnDWX4mXjgNma8DSJ6g/+xmSIt+eWrVOKgYcjQY4z2DJe6S0E9pH4trmUqmyTLk7KeynISOXEIBHz1jGw==",
       "cpu": [
         "x64"
       ],
@@ -1127,9 +1127,9 @@
       ]
     },
     "node_modules/@tokscale/cli-linux-x64-musl": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-musl/-/cli-linux-x64-musl-4.15.0.tgz",
-      "integrity": "sha512-uUzM+zhz2wnneRHmWySYh65akFaxdMpf/JzDXl8ZofwY7d4nULQ1nGe0xrNcz8YUYywX9G/z/ey3ST42hrgwDQ==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-linux-x64-musl/-/cli-linux-x64-musl-4.15.1.tgz",
+      "integrity": "sha512-BRKZ3oZaZjG2XeEv3ZJ++UCvgd3bOtd/pj8eC4X+yYU6CUwyNFvs1+9SGQF0J89/zz37kWESi8EpfjSE5j/wuA==",
       "cpu": [
         "x64"
       ],
@@ -1140,9 +1140,9 @@
       ]
     },
     "node_modules/@tokscale/cli-win32-arm64-msvc": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-4.15.0.tgz",
-      "integrity": "sha512-dmOSTptSDxAnt9BNzHagpqLH5/Dx0AbuH56UERq2bdfbOQdY9+8k2v0ilb90ZDyMhA4aeldzLyyjI0VserpMzQ==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-4.15.1.tgz",
+      "integrity": "sha512-BYXfkRnAuPA7ZDK4pP8lnYBehiNSKOBVjtUknacBA3pOt2nmuWvZbRsuUvOZZK5o4Iak4hmuQnpvwPG3W1MoOQ==",
       "cpu": [
         "arm64"
       ],
@@ -1153,9 +1153,9 @@
       ]
     },
     "node_modules/@tokscale/cli-win32-x64-msvc": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-x64-msvc/-/cli-win32-x64-msvc-4.15.0.tgz",
-      "integrity": "sha512-+tVdGdGrKURlJGb/UdTkg81yd4K+Z++QwThCNShJbdgA68RDRiJ0OaENK0N5KMSWm8LHkcWx6DgjaRCf/RrZVg==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@tokscale/cli-win32-x64-msvc/-/cli-win32-x64-msvc-4.15.1.tgz",
+      "integrity": "sha512-AYmG1sg26dcNhHnW6N6w6qYNS72OuCIphRCiciR8EnBFh9/OHGOamQbEt5MVdoHFUQMrzcqlR3mOMKI7irMdTw==",
       "cpu": [
         "x64"
       ],
@@ -4677,12 +4677,12 @@
       }
     },
     "node_modules/tokscale": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/tokscale/-/tokscale-4.15.0.tgz",
-      "integrity": "sha512-UMZsjz2CR/kBD4v7uMvpzVXYrFo5bV8KCKJ7cFx2c5w0kIOgjDHrJR4l2MJ8rxgSDG40oylkjlkSCQEoo1VBhA==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/tokscale/-/tokscale-4.15.1.tgz",
+      "integrity": "sha512-9xxZDfhGurx/sQfWfkdCBmETntMcjJ6rsIvdhk2a0khBzx+zUB309Ryzx+HmwALQGY1PFimFTbJxeHtOJJjNEQ==",
       "license": "MIT",
       "dependencies": {
-        "@tokscale/cli": "4.15.0"
+        "@tokscale/cli": "4.15.1"
       },
       "bin": {
         "tokscale": "bin.js"

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "koffi": "^3.1.5",
     "semver": "^7.8.5",
     "tar": "^7.5.22",
-    "tokscale": "^4.15.0",
+    "tokscale": "^4.15.1",
     "undici": "^7.29.0"
   },
   "devDependencies": {

--- a/scripts/vendor/tokscale.json
+++ b/scripts/vendor/tokscale.json
@@ -5,7 +5,7 @@
   "fork": "Javis603/tokscale",
   "commit": "b4abf21f481ea0a58803418f8cdae6733ec68e75",
   "commitTitle": "feat(sessions): add Oh My Pi (omp) as a local session source (#1161)",
-  "baseVersion": "4.15.0",
+  "baseVersion": "4.15.1",
   "baseVersionNote": "The npm-installed @tokscale/cli-<platform> package version this manifest is aligned with. It tracks the dependency in BOTH modes, and two gates enforce that: ensure-vendored-tokscale.js refuses to swap under \"override\" when the installed package reports something else, and verify-vendored-tokscale-release.js (plus its real-manifest test, so npm run verify catches it too) rejects any manifest whose baseVersion disagrees with @tokscale/cli optionalDependencies. So a tokscale bump always has to touch this file — either pin a new build or flip the mode — instead of silently leaving a stale override in place.",
   "releaseRepo": "Javis603/tokscale",
   "releaseTag": "token-monitor-b4abf21f",


### PR DESCRIPTION
## Summary

Updates `tokscale` from 4.15.0 to 4.15.1, which restores Cursor usage collection.

Cursor has silently recorded nothing since v0.49.0. That release shipped tokscale 4.14.0, whose [#1138](https://github.com/junhoyeo/tokscale/pull/1138) moved the workspace to rustls — and cursor.com's bot protection fingerprints the TLS ClientHello, so every `cursor sync` received a challenge page instead of JSON. The failure surfaced as `Cursor session expired. Please run 'tokscale cursor login' to re-authenticate.`, which reads like a credential problem and sent people to re-login instead of reporting a regression. tokscale [#1252](https://github.com/junhoyeo/tokscale/pull/1252) routes only the Cursor client through native TLS and pins every other client explicitly to rustls, so nothing else changes backend.

Affected releases: v0.49.0 (2026-08-28) through v0.52.0.

No Token Monitor code changes are needed. The fix is entirely below our integration surface: `cursor sync --json` still answers `{synced, rows, error}`, so `parseCursorSyncResult()` is unchanged, and no client's source roots moved.

## Verification

Same machine, same credentials, only the tokscale version differs:

| | 4.15.0 | 4.15.1 |
| --- | --- | --- |
| `tokscale cursor sync --json` | `Cursor session expired` | `{"synced": true, "rows": 150}` |
| Clients in a `--month` scan | `claude, codex, opencode` | `claude, codex, cursor, opencode` |

The legacy `usage.csv` is archived into `cursor-cache/archive/` rather than deleted, so pre-migration history survives the switch to the JSON usage-events cache.

JSON smoke test with the production grouping (`--json --client <tracked> --group-by client,session,model --month --no-spinner`): top-level keys and entry keys are identical across versions, and every field `extractUsageFromTokscale()` consumes is present. `graph --json` and `pricing --json` shapes are unchanged — the two new `GraphResult` fields upstream added are `#[serde(skip)]`.

`npm run verify`: lint clean, 4003 tests pass, 1 skipped.

## Upstream changes that move numbers

Three ride along with the Cursor fix and are accepted deliberately:

- **DSH** — compaction summaries now key their dedup on `data.compactionId` instead of `seq`, with `seq` kept as the fallback for older rows. Distinct summarize calls that previously collapsed into one are now counted separately, so DSH totals can rise slightly.
- **Command Code** — v3 transcripts are parsed with authoritative usage and cost, entries orphaned by `/rewind` are dropped to match the vendor's own branch accounting, and `/fork`/`/clone` copies collapse across files.
- **OpenCode** — incremental rows are tracked by provenance and id-less legacy message keys are namespaced.

The parser cache format also bumps 6 → 7, which reparses Cursor, DSH and OpenCode once on the first scan after upgrading. Other clients keep their cache.

Upstream added two clients, `unsloth` and `hindsight`. Neither is exposed here: Unsloth Studio is a fine-tuning/inference studio rather than a coding tool, and Hindsight needs a base URL, tenant and bearer token synced through `tokscale hindsight sync`, which is a Cursor-sized credential integration rather than a table entry.

`scripts/vendor/tokscale.json`'s `baseVersion` moves with the dependency; `verify-vendored-tokscale-release.js` pins it to the installed `@tokscale/cli` optionalDependencies.

Closes #561
Closes #562


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `tokscale` from 4.15.0 to 4.15.1, restoring Cursor usage collection that has silently recorded nothing since v0.49.0.

- tokscale 4.14.0 moved the workspace to rustls, and cursor.com's bot protection fingerprints the TLS ClientHello, so every `cursor sync` received a challenge page instead of JSON.
- The failure surfaced as a misleading `Cursor session expired. Please run 'tokscale cursor login' to re-authenticate.`, which sent users to re-login instead of reporting a regression.
- tokscale 4.15.1 routes only the Cursor client through native TLS and pins every other client explicitly to rustls, so nothing else changes backend.
- No Token Monitor code changes are needed: `cursor sync --json` still answers `{synced, rows, error}`, so `parseCursorSyncResult()` is unchanged.
- Two upstream parser fixes ride along: DSH summaries key dedup on `data.compactionId` instead of `seq`, so distinct summarize calls that previously collapsed are counted separately (DSH totals can rise slightly), and Command Code v3 transcripts are parsed with authoritative usage and cost.
- Parser cache format bumps 6 → 7, so Cursor, DSH, and OpenCode reparse once on the first scan after upgrading; other clients keep their cache.

| Area | Before | After |
| --- | --- | --- |
| `tokscale cursor sync --json` | `Cursor session expired` | `{"synced": true, "rows": 150}` |
| Clients in a `--month` scan | `claude, codex, opencode` | `claude, codex, cursor, opencode` |

Verified on the same machine with the same credentials, only the tokscale version differing. `npm run verify` is clean: lint passes, 4003 tests pass, 1 skipped. The legacy `usage.csv` is archived into `cursor-cache/archive/` rather than deleted, so pre-migration history survives the switch to the JSON usage-events cache. `scripts/vendor/tokscale.json`'s `baseVersion` moves with the dependency and is enforced by `verify-vendored-tokscale-release.js`. Affected releases: v0.49.0 (2026-08-28) through v0.52.0.

<sup>Written for commit 9ad4f50f5fbe0375d66733228b6c058a8f247a2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

