### PR TITLE
fix(widget): stabilize titlebar hover controls

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -12079,7 +12079,11 @@ els.breakdown.addEventListener('click', (event) => {
   });
 });
 
-els.pinButton.addEventListener('click', () => {
+els.pinButton.addEventListener('click', (event) => {
+  // Pointer focus would keep .window-actions:focus-within true after the cursor
+  // leaves, pinning the hover-only controls open. Keyboard activation keeps
+  // focus so the controls remain reachable without a pointer.
+  if (event.detail > 0) els.pinButton.blur();
   saveSettings({ windowBehavior: nextWindowBehavior(currentWindowBehavior()) });
 });
 els.settingsButton.addEventListener('click', (event) => {
@@ -12559,8 +12563,14 @@ els.refreshButton.addEventListener('click', () => {
   // on every one of them.
   else refreshStats({ force: true, forceHistory: true, forceSelfSync: true, feedback: true });
 });
-els.minButton.addEventListener('click', () => window.tokenMonitor.minimize());
-els.closeButton.addEventListener('click', () => window.tokenMonitor.close());
+els.minButton.addEventListener('click', (event) => {
+  if (event.detail > 0) els.minButton.blur();
+  window.tokenMonitor.minimize();
+});
+els.closeButton.addEventListener('click', (event) => {
+  if (event.detail > 0) els.closeButton.blur();
+  window.tokenMonitor.close();
+});
 els.trendsPanel.addEventListener('click', (event) => {
   if (event.target.closest('.trends-spark, .trends-open-hint')) window.tokenMonitor.openDashboard();
 });

--- a/src/electron/renderer/styles.css
+++ b/src/electron/renderer/styles.css
@@ -359,19 +359,23 @@ body.is-windows.floating-bubble-collapsed-right .floating-bubble-tab {
   width: 148px;
   height: 30px;
 }
+/* Cover the whole top-right rounded corner without covering the period tabs:
+   the top arm occupies the 12px shell padding and the right arm continues down
+   through the 14px side padding. The parent's rounded clip supplies the arc. */
 .actions-hotspot {
   position: absolute;
-  top: -14px;
-  right: -12px;
+  top: -12px;
+  right: -14px;
   width: 28px;
-  height: 22px;
+  height: 28px;
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 50% 100%, 50% 42.857%, 0 42.857%);
   z-index: 5;
 }
 .window-actions {
   position: absolute;
   top: 0;
   right: 0;
-  width: 154px;
+  width: 114px;
   height: 30px;
   display: flex;
   justify-content: flex-end;
@@ -379,7 +383,7 @@ body.is-windows.floating-bubble-collapsed-right .floating-bubble-tab {
   opacity: 0;
   pointer-events: none;
   transform: translateY(-2px);
-  transition: opacity 160ms ease 280ms, transform 160ms ease 280ms;
+  transition: opacity 160ms ease 140ms, transform 160ms ease 140ms;
   z-index: 4;
 }
 #footerActionSlot { display: contents; }
@@ -456,7 +460,7 @@ body.is-windows.floating-bubble-collapsed-right .floating-bubble-tab {
   position: absolute;
   inset: 0;
   width: 100%;
-  transition: opacity 160ms ease 280ms, transform 160ms ease 280ms;
+  transition: opacity 160ms ease 140ms, transform 160ms ease 140ms;
 }
 .title-controls:has(.actions-hotspot:hover) .tabs, .title-controls:has(.window-actions:hover) .tabs, .title-controls:has(.window-actions:focus-within) .tabs, .shell.settings-open .title-controls .tabs {
   opacity: 0;

--- a/tests/electron/controlLayoutSwap.test.js
+++ b/tests/electron/controlLayoutSwap.test.js
@@ -68,26 +68,29 @@ test('applyControlLayout keeps both controls in the footer and swaps their roles
   assert.doesNotMatch(body, /titlebarSlot\.appendChild/);
 });
 
-test('window-actions and tabs fade out after a leave grace delay, in instantly', () => {
+test('window-actions and tabs fade out after a short leave grace delay, in instantly', () => {
   const css = readRendererFile('styles.css');
 
   const actions = cssRule(css, '.window-actions');
-  assert.match(declaration(actions, 'transition'), /280ms/, 'window-actions resting state carries the 280ms leave delay');
+  assert.match(declaration(actions, 'transition'), /140ms/, 'window-actions resting state carries the 140ms leave delay');
+  assert.equal(declaration(actions, 'width'), '114px', 'window actions occupy only their three 34px buttons and two 6px gaps');
 
   const reveal = cssRule(css, '.actions-hotspot:hover ~ .window-actions, .window-actions:hover, .window-actions:focus-within, .shell.settings-open .window-actions');
   assert.equal(declaration(reveal, 'transition-delay'), '0ms', 'revealed state shows instantly');
 
   const tabs = cssRule(css, '.title-controls .tabs');
-  assert.match(declaration(tabs, 'transition'), /280ms/, 'tabs restore after the same 280ms grace');
+  assert.match(declaration(tabs, 'transition'), /140ms/, 'tabs restore after the same 140ms grace');
 });
 
-test('hover hotspot stays right-anchored and never extends left over the tabs', () => {
+test('hover hotspot covers the rounded corner without intercepting the period tabs', () => {
   const css = readRendererFile('styles.css');
   const hotspot = cssRule(css, '.actions-hotspot');
-  assert.ok(declaration(hotspot, 'right'), 'hotspot is anchored from the right edge');
+  assert.equal(declaration(hotspot, 'top'), '-12px', 'hotspot starts at the shell top padding');
+  assert.equal(declaration(hotspot, 'right'), '-14px', 'hotspot reaches through the shell right padding');
+  assert.equal(declaration(hotspot, 'width'), '28px', 'hotspot leaves a deliberate 14px corner span inside the content edge');
+  assert.equal(declaration(hotspot, 'height'), '28px', 'hotspot reaches down through the right shell padding');
+  assert.match(declaration(hotspot, 'clip-path'), /polygon/, 'hotspot removes the lower-left area that would cover TOTAL');
   assert.equal(declaration(hotspot, 'left'), '', 'hotspot must not set left (would overlap DAY/MONTH/TOTAL)');
-  const width = parseInt(declaration(hotspot, 'width'), 10);
-  assert.ok(width > 0 && width <= 32, `hotspot width stays small to clear the TOTAL tab (got ${width})`);
 });
 
 test('the reveal trigger is never fired by hovering the period tabs', () => {
@@ -126,6 +129,21 @@ test('pointer-closing Settings clears sticky focus without blurring keyboard act
 
   assert.match(handler, /addEventListener\('click', \(event\) =>/);
   assert.match(handler, /if \(!settingsOpen && event\.detail > 0\) els\.settingsButton\.blur\(\)/);
+});
+
+test('pointer-activated window controls clear sticky focus without blurring keyboard activation', () => {
+  const app = readRendererFile('app.js');
+  const pinStart = app.indexOf("els.pinButton.addEventListener('click'");
+  const pinEnd = app.indexOf("els.settingsButton.addEventListener('click'", pinStart);
+  const pinHandler = app.slice(pinStart, pinEnd);
+  const minStart = app.indexOf("els.minButton.addEventListener('click'");
+  const minEnd = app.indexOf("els.trendsPanel.addEventListener('click'", minStart);
+  const windowHandlers = app.slice(minStart, minEnd);
+
+  assert.match(pinHandler, /addEventListener\('click', \(event\) =>/);
+  assert.match(pinHandler, /if \(event\.detail > 0\) els\.pinButton\.blur\(\)/);
+  assert.match(windowHandlers, /if \(event\.detail > 0\) els\.minButton\.blur\(\)/);
+  assert.match(windowHandlers, /if \(event\.detail > 0\) els\.closeButton\.blur\(\)/);
 });
 
 test('Refresh discloses to the left of Settings on hover and keyboard focus', () => {


### PR DESCRIPTION
## Summary

- restrict the hidden window-control trigger to the rounded top-right corner without overlapping the period tabs
- reduce the window-control hit area and shorten the leave delay so DAY, MONTH, and TOTAL return promptly
- clear pointer focus after window-control actions while preserving keyboard focus and accessibility

The period tabs and window controls continue to share the same compact titlebar space. Moving to the rounded corner reveals the window controls, while leaving them restores the period tabs without the previous sticky focused state.

## Testing

- `npm run verify` (4004 passed, 1 skipped)
- `git diff --check`

## Demo

- Before: see #605
- After: <img width="646" height="246" alt="CleanShot 2026-09-04 at 2 25 10 PM" src="https://github.com/user-attachments/assets/8d510b2d-f891-4912-a35d-2b246b2ac9b3" />

Closes #605


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Summary

- Restrict the window-control hover trigger to the rounded top-right corner so it no longer overlaps the period tabs.
- Shorten the leave delay from 280ms to 140ms so DAY, MONTH, and TOTAL return promptly.
- Clear pointer focus after window-control actions while preserving keyboard focus and accessibility.

| Area | Before | After |
| --- | --- | --- |
| Hover trigger | Rectangular hotspot could overlap the period tabs | Clipped to the rounded corner and never intercepts the tabs |
| Leave delay | 280ms before controls/tabs swapped back | 140ms, so tabs restore promptly |
| Sticky focus after click | Controls stayed pinned open after the cursor left | Controls hide when the cursor leaves; keyboard activation still keeps focus |

## Testing

- `npm run verify` (4004 passed, 1 skipped)
- `git diff --check`

Closes #605.

<sup>Written for commit dd71b3b70c5c46289b2d54906629e1e0feec6474. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

