### PR TITLE
fix(renderer): leave settings overlay when switching views via the switcher

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -6386,13 +6386,14 @@ function isRendererWindowHidden() {
 function visibleStatsSurface() {
   return statsRenderSchedulerApi.visibleStatsSurface(
     isRendererWindowHidden(),
-    state.floatingBubble.collapsed,
-    isSettingsPanelOpen()
+    state.floatingBubble.collapsed
   );
 }
 
 function isSettingsSurfaceVisible() {
-  return visibleStatsSurface() === 'settings';
+  return !isRendererWindowHidden()
+    && !state.floatingBubble.collapsed
+    && isSettingsPanelOpen();
 }
 
 function serviceStatusSurfaceVisible() {
@@ -8061,15 +8062,6 @@ function setBreakdown(breakdown, options = {}) {
 
 function renderBreakdownChange(breakdown, options = {}) {
   if (!setBreakdown(breakdown, options)) return false;
-  // Switching views always leaves the settings overlay. While the panel is
-  // open, visibleStatsSurface() reports 'settings' and render() returns early,
-  // so the view switcher would update its label without repainting the view.
-  if (isSettingsPanelOpen()) {
-    resetSettingsListSearch();
-    stopWindowShortcutRecording();
-    els.settingsPanel.classList.add('hidden');
-    els.shell.classList.remove('settings-open');
-  }
   state.animateBarsFromZero = true;
   state.animateChartsOnRender = true;
   let renderSucceeded = false;
@@ -8576,12 +8568,8 @@ function applyFloatingBubbleState(payload = {}, options = {}) {
   }
   if (options.renderContent === false) return;
   if (wasCollapsed && !state.floatingBubble.collapsed) {
-    if (isSettingsPanelOpen()) {
-      syncSettingsForm();
-      renderConnectionStatus('settings');
-    } else {
-      renderStatsUpdate();
-    }
+    if (isSettingsPanelOpen()) syncSettingsForm();
+    renderStatsUpdate();
   } else {
     renderFloatingBubbleContent();
   }
@@ -11851,7 +11839,7 @@ async function saveSettings(patch) {
     try { state.settings = await window.tokenMonitor.getSettings(); } catch (_) {}
     applyEffectiveCurrencyRates();
     preserveSettingsPanelScroll(syncSettingsForm);
-    if (!isSettingsSurfaceVisible()) statsRenderScheduler.request();
+    if (isSettingsSurfaceVisible()) render(); else statsRenderScheduler.request();
     restartTimer();
     maybeUpdateBarsIcon();
     throw error;
@@ -11863,7 +11851,7 @@ async function saveSettings(patch) {
   // their accordion/switch layout transition.
   if (state.settingsPushRevision === settingsPushRevision) {
     preserveSettingsPanelScroll(syncSettingsForm);
-    if (!isSettingsSurfaceVisible()) statsRenderScheduler.request();
+    if (isSettingsSurfaceVisible()) render(); else statsRenderScheduler.request();
   }
   restartTimer();
   maybeUpdateBarsIcon();
@@ -12689,7 +12677,7 @@ window.tokenMonitor.onSettingsPush?.((next) => {
   state.settings = next;
   applyEffectiveCurrencyRates();
   preserveSettingsPanelScroll(syncSettingsForm);
-  if (!isSettingsSurfaceVisible()) statsRenderScheduler.request();
+  if (isSettingsSurfaceVisible()) render(); else statsRenderScheduler.request();
   maybeUpdateBarsIcon();
 });
 
@@ -12728,25 +12716,23 @@ window.tokenMonitor.onTokscalePush?.((payload) => {
 });
 
 function renderConnectionStatus(surface = visibleStatsSurface()) {
-  if (surface !== 'main' && surface !== 'settings') return;
+  if (surface !== 'main') return;
   setLiveDot(state.streamConnected);
   setStatus(statusTextFor(state.mode, state.streamConnected));
-  if (surface === 'settings') renderSyncClientStatus();
+  if (isSettingsSurfaceVisible()) renderSyncClientStatus();
 }
 
 function renderStatsUpdate() {
   const surface = visibleStatsSurface();
   renderConnectionStatus(surface);
-  if (surface === 'main') {
-    render();
-    return;
-  }
   if (surface === 'bubble') {
     renderFloatingBubbleContent();
     signalContentReady();
     return;
   }
-  if (surface !== 'settings') return;
+  if (surface !== 'main') return;
+  render();
+  if (!isSettingsSurfaceVisible()) return;
   renderCodexAccounts();
   renderSettingsSummaries();
   renderLimitProviderCheckboxes();
@@ -12781,17 +12767,14 @@ function handleWindowVisibilityChange() {
   if (!isRendererWindowHidden() && state.settings?.hubMode === 'client' && hubBuildStatusRefreshDue()) {
     void refreshHubBuildStatus();
   }
-  if (isSettingsSurfaceVisible()) {
-    statsRenderScheduler.clear();
-    syncSettingsForm();
-    renderConnectionStatus('settings');
-    // syncSettingsForm() covers what the dropped catch-up render would have
-    // drawn, but it is not a stats render and never reaches signalContentReady().
-    // A window revealed straight into Settings must still report it has painted.
+  const settingsVisible = isSettingsSurfaceVisible();
+  if (settingsVisible || settingsDomSyncPending) syncSettingsForm();
+  statsRenderScheduler.flush();
+  if (settingsVisible) {
+    renderConnectionStatus();
+    // syncSettingsForm() is not a stats render, so a window revealed straight
+    // into Settings still needs to report that its visible content has painted.
     signalContentReady();
-  } else {
-    if (settingsDomSyncPending) syncSettingsForm();
-    statsRenderScheduler.flush();
   }
   ensureServiceStatusTicker();
 }

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -8061,6 +8061,15 @@ function setBreakdown(breakdown, options = {}) {
 
 function renderBreakdownChange(breakdown, options = {}) {
   if (!setBreakdown(breakdown, options)) return false;
+  // Switching views always leaves the settings overlay. While the panel is
+  // open, visibleStatsSurface() reports 'settings' and render() returns early,
+  // so the view switcher would update its label without repainting the view.
+  if (isSettingsPanelOpen()) {
+    resetSettingsListSearch();
+    stopWindowShortcutRecording();
+    els.settingsPanel.classList.add('hidden');
+    els.shell.classList.remove('settings-open');
+  }
   state.animateBarsFromZero = true;
   state.animateChartsOnRender = true;
   let renderSucceeded = false;

--- a/src/electron/renderer/statsRenderScheduler.js
+++ b/src/electron/renderer/statsRenderScheduler.js
@@ -5,10 +5,10 @@
   if (typeof module === 'object' && module.exports) module.exports = api;
   if (root) root.TokenMonitorStatsRenderScheduler = api;
 })(typeof window !== 'undefined' ? window : null, function createStatsRenderSchedulerApi() {
-  function visibleStatsSurface(rendererHidden, floatingBubbleCollapsed, settingsOpen) {
+  function visibleStatsSurface(rendererHidden, floatingBubbleCollapsed) {
     if (rendererHidden) return null;
     if (floatingBubbleCollapsed) return 'bubble';
-    return settingsOpen ? 'settings' : 'main';
+    return 'main';
   }
 
   function createStatsRenderScheduler({ isHidden, render }) {
@@ -32,10 +32,6 @@
       renderPending = false;
     }
 
-    function clear() {
-      renderPending = false;
-    }
-
     function visibilityChanged() {
       const hidden = isHidden();
       if (hidden === rendererHidden) return false;
@@ -44,7 +40,6 @@
     }
 
     return {
-      clear,
       flush,
       request,
       visibilityChanged

--- a/tests/electron/limitProviderPresentation.test.js
+++ b/tests/electron/limitProviderPresentation.test.js
@@ -2038,7 +2038,7 @@ test('provider option rerenders reuse the existing switch DOM', () => {
   assert.doesNotMatch(renderList, /renderLimits\(\);/);
 });
 
-test('settings pushes do not trigger a second full settings sync after save', () => {
+test('settings pushes sync once while repainting the background main view', () => {
   const app = readRendererFile('app.js');
   const save = functionBody(app, 'saveSettings', 'renderHomeIfVisible');
   const syncSettings = functionBody(app, 'syncSettingsForm', 'enabledClientSet');
@@ -2049,7 +2049,8 @@ test('settings pushes do not trigger a second full settings sync after save', ()
   assert.match(settingsPush, /state\.settingsPushRevision \+= 1;/);
   assert.match(syncSettings, /if \(!isSettingsSurfaceVisible\(\)\) return;/);
   assert.doesNotMatch(syncSettings, /\b(?:render|renderLimits|applyFloatingBubbleState)\(/);
-  assert.match(settingsPush, /if \(!isSettingsSurfaceVisible\(\)\) statsRenderScheduler\.request\(\);/);
+  assert.match(settingsPush, /if \(isSettingsSurfaceVisible\(\)\) render\(\); else statsRenderScheduler\.request\(\);/);
+  assert.equal([...settingsPush.matchAll(/syncSettingsForm/g)].length, 1);
 });
 
 test('main limits rerenders coalesce identical visible provider data', () => {

--- a/tests/electron/statsRenderScheduler.test.js
+++ b/tests/electron/statsRenderScheduler.test.js
@@ -52,21 +52,6 @@ test('visible stats updates continue rendering every push', () => {
   assert.equal(renders, 2);
 });
 
-test('clearing a hidden update prevents a redundant catch-up render', () => {
-  let hidden = true;
-  let renders = 0;
-  const scheduler = createStatsRenderScheduler({
-    isHidden: () => hidden,
-    render: () => { renders += 1; }
-  });
-
-  scheduler.request();
-  scheduler.clear();
-  hidden = false;
-  scheduler.flush();
-  assert.equal(renders, 0);
-});
-
 test('page and native visibility signals report each combined edge once', () => {
   let pageHidden = false;
   let nativeVisible = true;
@@ -92,12 +77,11 @@ test('page and native visibility signals report each combined edge once', () => 
   }
 });
 
-test('visible stats update only the exposed surface', () => {
-  assert.equal(visibleStatsSurface(false, false, false), 'main');
-  assert.equal(visibleStatsSurface(false, false, true), 'settings');
-  assert.equal(visibleStatsSurface(false, true, false), 'bubble');
-  assert.equal(visibleStatsSurface(true, false, false), null);
-  assert.equal(visibleStatsSurface(true, true, false), null);
+test('visible stats update only the primary exposed surface', () => {
+  assert.equal(visibleStatsSurface(false, false), 'main');
+  assert.equal(visibleStatsSurface(false, true), 'bubble');
+  assert.equal(visibleStatsSurface(true, false), null);
+  assert.equal(visibleStatsSurface(true, true), null);
 });
 
 test('a hidden floating-bubble state update changes state without touching DOM', () => {
@@ -175,7 +159,8 @@ test('renderer wires visibility scheduling without deferring tray icon updates',
   assert.match(app, /document\.addEventListener\('visibilitychange', handleWindowVisibilityChange\)/);
   assert.match(visibilityListener, /cancelTokenRateBoost\(\)/);
   assert.match(visibilityListener, /!isRendererWindowHidden\(\)[\s\S]*hubBuildStatusRefreshDue\(\)[\s\S]*refreshHubBuildStatus\(\)/);
-  assert.match(visibilityListener, /if \(isSettingsSurfaceVisible\(\)\)[\s\S]*statsRenderScheduler\.clear\(\)[\s\S]*syncSettingsForm\(\)[\s\S]*else[\s\S]*statsRenderScheduler\.flush\(\)/);
+  assert.match(visibilityListener, /const settingsVisible = isSettingsSurfaceVisible\(\);[\s\S]*if \(settingsVisible \|\| settingsDomSyncPending\) syncSettingsForm\(\);[\s\S]*statsRenderScheduler\.flush\(\)/);
+  assert.doesNotMatch(visibilityListener, /statsRenderScheduler\.clear\(\)/);
   assert.match(app, /isHidden: isRendererWindowHidden/);
   assert.match(app, /onWindowVisibilityPush\?\.\(\(visible\) => \{/);
   assert.match(
@@ -222,15 +207,66 @@ test('a window revealed straight into Settings still reports painted content', (
     app.indexOf('function handleWindowVisibilityChange()'),
     app.indexOf("document.addEventListener('visibilitychange'")
   );
-  const settingsBranch = visibilityHandler.slice(
-    visibilityHandler.indexOf('if (isSettingsSurfaceVisible())'),
-    visibilityHandler.indexOf('} else {')
+  // Settings is an overlay, so revealing into it must flush the pending main
+  // repaint as well as syncing the visible form and reporting painted content.
+  assert.match(visibilityHandler, /if \(settingsVisible \|\| settingsDomSyncPending\) syncSettingsForm\(\);/);
+  assert.match(visibilityHandler, /statsRenderScheduler\.flush\(\);/);
+  assert.match(visibilityHandler, /if \(settingsVisible\) \{[\s\S]*signalContentReady\(\);/);
+  assert.doesNotMatch(visibilityHandler, /statsRenderScheduler\.clear\(\)/);
+});
+
+test('Settings remains open while its background view changes', () => {
+  const app = fs.readFileSync(path.join(rendererDir, 'app.js'), 'utf8');
+  const changeView = app.slice(
+    app.indexOf('function renderBreakdownChange('),
+    app.indexOf('\nfunction restartTimer(')
+  );
+  const trayView = app.slice(
+    app.indexOf('function openViewFromTray('),
+    app.indexOf('\nconst HOME_HISTORY_MAX_RETRIES')
   );
 
-  // clear() drops the catch-up render that would otherwise have signalled, and
-  // syncSettingsForm() is not a stats render, so the signal has to be explicit.
-  assert.match(settingsBranch, /statsRenderScheduler\.clear\(\)/);
-  assert.match(settingsBranch, /signalContentReady\(\);/);
+  assert.doesNotMatch(changeView, /settingsPanel|settings-open|resetSettingsListSearch|stopWindowShortcutRecording/);
+  assert.match(changeView, /setBreakdown\([\s\S]*render\(\)/);
+  assert.match(trayView, /settingsPanel\?\.classList\.add\('hidden'\)/);
+  assert.match(trayView, /els\.shell\.classList\.remove\('settings-open'\)/);
+});
+
+test('a stats update repaints main and the visible Settings overlay', () => {
+  const calls = [];
+  const settingsRenderers = [
+    'renderCodexAccounts',
+    'renderSettingsSummaries',
+    'renderLimitProviderCheckboxes',
+    'renderToolPreferences',
+    'renderWslPanel',
+    'updateOpenRouterProfilesStatus',
+    'updateThirdPartyProfilesStatus',
+    'renderDeepseekStatus',
+    'renderMinimaxStatus',
+    'renderCopilotStatus'
+  ];
+  const context = {
+    visibleStatsSurface: () => 'main',
+    renderConnectionStatus: (surface) => calls.push(`connection:${surface}`),
+    render: () => calls.push('main'),
+    isSettingsSurfaceVisible: () => true,
+    renderFloatingBubbleContent: () => calls.push('bubble'),
+    signalContentReady: () => calls.push('ready')
+  };
+  for (const name of settingsRenderers) context[name] = () => calls.push(name);
+  context.renderExternalProviderStatus = (provider) => calls.push(`external:${provider}`);
+
+  const renderStatsUpdate = rendererFunction(
+    'renderStatsUpdate',
+    '\nconst statsRenderScheduler =',
+    context
+  );
+  renderStatsUpdate();
+
+  assert.deepEqual(calls.slice(0, 2), ['connection:main', 'main']);
+  assert.ok(calls.indexOf('renderSettingsSummaries') > calls.indexOf('main'));
+  assert.equal(calls.at(-1), 'ready');
 });
 
 test('the closed-Settings guard does not strand main-surface controls', () => {
@@ -313,7 +349,7 @@ test('a hidden Session detail result waits for the main surface to return', () =
   assert.deepEqual(rendered, []);
   assert.equal(request.renderOptions, options);
 
-  surface = 'settings';
+  surface = 'bubble';
   applySessionDetailResult(request, options);
   assert.equal(scheduled, 1);
   assert.deepEqual(rendered, []);
@@ -332,7 +368,7 @@ test('a hidden Session detail result waits for the main surface to return', () =
 });
 
 test('a direct main render defers only while the window is hidden', () => {
-  let surface = 'settings';
+  let surface = 'bubble';
   let scheduled = 0;
   const render = rendererFunction('render', '\nfunction setStatus(', {
     visibleStatsSurface: () => surface,
@@ -340,8 +376,6 @@ test('a direct main render defers only while the window is hidden', () => {
     state: { stats: null }
   });
 
-  render();
-  surface = 'bubble';
   render();
   assert.equal(scheduled, 0);
 
@@ -368,8 +402,8 @@ test('hidden event sources defer DOM work and visible surfaces catch up', () => 
   assert.doesNotMatch(statsPush, /\b(?:setLiveDot|setStatus|renderSyncClientStatus)\(/);
   assert.match(statsPush, /if \(isRendererWindowHidden\(\)\) statsRenderScheduler\.request\(\);[\s\S]*else renderConnectionStatus\(\);/);
   assert.match(statsRender, /renderConnectionStatus\(surface\)/);
-  assert.match(bubbleState, /isSettingsPanelOpen\(\)[\s\S]*syncSettingsForm\(\)[\s\S]*renderStatsUpdate\(\)/);
-  assert.match(bubbleState, /syncSettingsForm\(\);[\s\S]*renderConnectionStatus\('settings'\)/);
+  assert.match(bubbleState, /if \(isSettingsPanelOpen\(\)\) syncSettingsForm\(\);[\s\S]*renderStatsUpdate\(\)/);
+  assert.doesNotMatch(bubbleState, /renderConnectionStatus\('settings'\)/);
   assert.ok(hiddenGuard < settingsSync.indexOf('applyInitialBreakdownPreference()'));
   assert.ok(settingsSync.indexOf('applyInitialBreakdownPreference()') < hiddenReturn);
   assert.ok(hiddenGuard < settingsSync.indexOf('applyVendorColorOverrides('));
@@ -379,7 +413,7 @@ test('hidden event sources defer DOM work and visible surfaces catch up', () => 
   }
   assert.match(settingsSync, /if \(isRendererWindowHidden\(\)\) \{[\s\S]*settingsDomSyncPending = true;[\s\S]*return;/);
   assert.match(visibilityHandler, /else applyFloatingBubbleState\(state\.floatingBubble, \{ renderContent: false \}\);/);
-  assert.match(visibilityHandler, /else \{[\s\S]*if \(settingsDomSyncPending\) syncSettingsForm\(\);[\s\S]*statsRenderScheduler\.flush\(\);/);
+  assert.match(visibilityHandler, /if \(settingsVisible \|\| settingsDomSyncPending\) syncSettingsForm\(\);[\s\S]*statsRenderScheduler\.flush\(\);/);
 });
 
 test('all stats refreshes use visibility-aware rendering', () => {


### PR DESCRIPTION
Fixes #607.

## Summary

Switching views with the bottom-left view switcher did nothing while the settings panel was open: the switcher label updated, but the UI stayed on the settings panel.

While the settings panel is open, `visibleStatsSurface()` reports `settings`, so `render()` returns early before painting the new view. The tray path (`openViewFromTray`) already leaves the settings overlay before calling `renderBreakdownChange()`, but the view-switcher click handlers (both the current-view button and the menu items) call `renderBreakdownChange()` directly, so the panel stayed open and blocked the repaint.

This change moves that cleanup into `renderBreakdownChange()` itself: when the settings panel is open, it is hidden (and the list search / shortcut-recording state reset, same as `openViewFromTray`) before rendering. This also keeps the two entry points from drifting apart, mirroring the invariant elsewhere in the codebase that a single function owns each behavioural rule.

## Behaviour change

- View switcher (button click and menu items) now exits the settings overlay and switches views, matching the tray behaviour.
- No changes to settings persistence or to the tray path's own handling.

## Verification

- `npm run lint` — clean.
- `node --test "tests/electron/*.test.js"` — 1668 pass, 1 fail. The single failure (`macWidgetLaunchServicesRecovery`) is pre-existing and environment-specific: creating a symlink without admin/developer-mode privileges on Windows fails with `EPERM` before any test logic runs; it does not touch this change.
- Full `npm test` was also started locally but exceeds a reasonable local run time on this Windows ARM64 machine; CI covers the full matrix on Node 22 & 24.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #607: switching views via the view switcher while the settings panel is open now repaints the main view behind the settings overlay instead of leaving the UI stuck on the old content.

- Settings is no longer a separate stats surface; `visibleStatsSurface()` only reports `null`, `'bubble'`, or `'main'`, and settings visibility is tracked separately.
- Stats updates always repaint the main view and refresh the settings panels when the overlay is open; the `statsRenderScheduler.clear()` path is gone so pending repaints flush even with settings visible.

| Area | Before | After |
| --- | --- | --- |
| View switcher with settings open | Label updated, main view never repainted | Main view repaints behind settings; settings stays open |
| Stats while settings open | Main view not repainted until settings closed | Main view stays live behind the overlay |

- The tray path and settings persistence are unchanged.
- Lint passes; the only test failure is the pre-existing Windows-specific `macWidgetLaunchServicesRecovery` case, unrelated to this change.

<sup>Written for commit 77a63bb614f50360d16be1904127408d73d02f31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

