### PR TITLE
refactor(renderer): drop the settings catch-up repaints

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -6485,14 +6485,15 @@ function openSettingsPanel() {
 
 function openViewFromTray(viewId) {
   if (!availableBreakdownIds().includes(viewId)) return;
-  const settingsWasOpen = isSettingsPanelOpen();
   if (state.viewSwitcherOpen) setViewSwitcherOpen(false);
   stopWindowShortcutRecording();
   resetSettingsListSearch();
   els.settingsPanel?.classList.add('hidden');
   els.shell.classList.remove('settings-open');
   state.openSession = null;
-  if (!renderBreakdownChange(viewId, { allowHidden: true }) && settingsWasOpen) render();
+  // Navigating to the view already on screen changes no breakdown, so it never
+  // repaints on its own — but the open session was just cleared above.
+  if (!renderBreakdownChange(viewId, { allowHidden: true })) render();
   ensureServiceStatusTicker();
 }
 
@@ -12121,10 +12122,15 @@ els.settingsButton.addEventListener('click', (event) => {
   if (state.viewSwitcherOpen) setViewSwitcherOpen(false);
   els.settingsPanel.classList.toggle('hidden');
   const settingsOpen = isSettingsPanelOpen();
-  if (!settingsOpen) resetSettingsListSearch();
-  if (settingsOpen) syncSettingsForm();
-  else render();
-  if (!settingsOpen) stopWindowShortcutRecording();
+  // Settings is an overlay over a surface that keeps rendering behind it, so
+  // closing it needs no catch-up repaint. Only the panel's own DOM has to be
+  // caught up when it opens, because its renderers idle while it is closed.
+  if (settingsOpen) {
+    syncSettingsForm();
+  } else {
+    resetSettingsListSearch();
+    stopWindowShortcutRecording();
+  }
   els.shell.classList.toggle('settings-open', settingsOpen);
   if (!settingsOpen && event.detail > 0) els.settingsButton.blur();
   els.shell.style.transform = 'translateZ(0)';

--- a/tests/electron/statsRenderScheduler.test.js
+++ b/tests/electron/statsRenderScheduler.test.js
@@ -232,6 +232,53 @@ test('Settings remains open while its background view changes', () => {
   assert.match(trayView, /els\.shell\.classList\.remove\('settings-open'\)/);
 });
 
+test('leaving Settings no longer needs a catch-up repaint', () => {
+  const app = fs.readFileSync(path.join(rendererDir, 'app.js'), 'utf8');
+  const settingsToggle = app.slice(
+    app.indexOf("els.settingsButton.addEventListener('click'"),
+    app.indexOf("els.saveSettingsButton.addEventListener('click'")
+  );
+  const trayView = app.slice(
+    app.indexOf('function openViewFromTray('),
+    app.indexOf('\nconst HOME_HISTORY_MAX_RETRIES')
+  );
+
+  // The main surface keeps rendering behind the overlay, so neither exit path
+  // may repaint merely because Settings happened to be open.
+  assert.doesNotMatch(settingsToggle, /render\(\)/);
+  assert.match(settingsToggle, /if \(settingsOpen\) \{\s+syncSettingsForm\(\);\s+\} else \{/);
+  assert.doesNotMatch(trayView, /settingsWasOpen/);
+  // Tray navigation to the view already on screen still repaints, because it
+  // clears the open session and nothing else redraws that.
+  assert.match(trayView, /if \(!renderBreakdownChange\(viewId, \{ allowHidden: true \}\)\) render\(\);/);
+});
+
+test('stats-derived Settings rows refresh behind an open panel', () => {
+  const app = fs.readFileSync(path.join(rendererDir, 'app.js'), 'utf8');
+  const renderBody = app.slice(
+    app.indexOf('function render() {'),
+    app.indexOf('\nfunction setStatus(')
+  );
+  const archiveBody = app.slice(
+    app.indexOf('function renderSessionUsageArchiveStatus()'),
+    app.indexOf('const HUB_DRAFT_FIELDS')
+  );
+  const surfaceBody = app.slice(
+    app.indexOf('function visibleStatsSurface()'),
+    app.indexOf('function isSettingsSurfaceVisible()')
+  );
+
+  // The archived session count is Settings content derived from state.stats, and
+  // the only thing that redraws it is the main render. It goes stale for as long
+  // as anything stops render() from running while the panel is open, which is how
+  // it used to need a close and reopen to catch up.
+  assert.match(archiveBody, /sessionRowsApi\.archivedSessionCount\(state\.stats\)/);
+  assert.doesNotMatch(archiveBody, /isSettingsSurfaceVisible|isSettingsPanelOpen/);
+  assert.match(renderBody, /renderSessionUsageArchiveStatus\(\);/);
+  assert.doesNotMatch(renderBody, /isSettingsSurfaceVisible|isSettingsPanelOpen/);
+  assert.doesNotMatch(surfaceBody, /isSettingsPanelOpen/);
+});
+
 test('a stats update repaints main and the visible Settings overlay', () => {
   const calls = [];
   const settingsRenderers = [


### PR DESCRIPTION
## Summary

#386 treated Settings as an exclusive rendering surface: while the panel was open, `visibleStatsSurface()` reported `settings` and the main `render()` returned early. Two paths compensated by painting the accumulated state at the moment the panel closed, one in the Settings button handler and one in `openViewFromTray()`.

#609 removed that assumption. The main surface now repaints behind the overlay on every path that can change it: stats pushes through `statsRenderScheduler`, settings pushes and `saveSettings()`, floating-bubble expansion, window reveal through `statsRenderScheduler.flush()`, and view switching through `renderBreakdownChange()`. By the time Settings closes, the main surface is already current, so both catch-up renders repaint content that has not changed.

- Drop the catch-up `render()` from the Settings button handler, and fold the three separate `settingsOpen` checks there into one if/else.
- Drop `settingsWasOpen` from `openViewFromTray()`, but keep the repaint and make it unconditional. That path sets `state.openSession = null`, and when the tray targets the view already on screen `setBreakdown()` returns `false`, so `renderBreakdownChange()` never renders and nothing takes the open session detail off screen. Gating the repaint on Settings meant it only worked when the panel happened to be open.
- Pin the archived session count with a regression test. It is Settings content derived from `state.stats` and redrawn only by `render()`, so while the gate existed it froze until the panel was closed and reopened. #609 fixed it, but nothing covered it; the new test fails against `4a280443`, the commit before #609.

## Why spend the render instead of skipping it

Settings is open for a short interactive stretch, on a window that is already awake and drawing. The gate saved a main-surface render for exactly that stretch, which is not a saving worth designing around. Everything in #386 that saves for the long stretches is kept: hidden and minimized windows still defer and coalesce rendering, collapsed floating bubbles still render bubble-only, macOS native material still detaches while hidden, unchanged breakdown layout capture is still skipped, and the Settings panel's own renderers still idle while the panel is closed. #386 also never measured the Settings-open case on its own; its numbers compared foreground against hidden, and the foreground figure covered the row-fingerprint and layout-capture work landing in the same PR.

The cost was not only the stale main view behind the panel. Making Settings a surface that suppresses rendering turned every update path that could reach the panel while it was open into a special case: a `settings` branch in `renderConnectionStatus()`, another on floating-bubble expansion, and a `statsRenderScheduler.clear()` on window reveal whose own comment noted that `syncSettingsForm()` had to cover what the dropped repaint would have drawn. Each of those is a place where content inside the panel can quietly stop updating, and the failure stays invisible until the panel is closed and reopened. #607 is the one that got reported. The archived session count in the collection section is the same failure from the other side of the panel boundary: it is drawn by `render()`, so it silently stopped counting while the panel was open and only caught up on reopen. Nobody filed that one. That class of risk is worth more than a few seconds of skipped rendering, so the gate is gone and the renderer just does the work.

## Behaviour change

- Tray navigation to the view already on screen now repaints, so a session detail opened behind it is cleared. It previously only did that with Settings open.
- Nothing else changes for the user.

## Testing

- `npm run verify` (4055 passed, 1 skipped)
- `git diff --check`
- Confirmed in a local build that the main surface stays live behind an open Settings panel: with the panel open, both the archived session count and the total token readout behind it update on their own. That is what makes the removed catch-up renders unnecessary.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
**Summary**

Removes the catch-up repaints that redrew the main surface when Settings closed, since the main surface already stays current behind the overlay.

- Drops the conditional `render()` from the Settings button handler and folds the settings-open checks into one if/else.
- Drops `settingsWasOpen` from `openViewFromTray()` but keeps the repaint, now unconditional, because clearing the open session still needs a redraw when the target view is already on screen.
- Adds regression tests for the removed gate and for the archived session count refreshing behind an open panel.

| Area | Before | After |
| --- | --- | --- |
| Tray navigation to the view already on screen | Cleared a session detail only when Settings was open | Always repaints and clears the session detail |

**Testing**

- `npm run verify` passes.
- Local build confirms stats-backed Settings rows update while the panel stays open.

<sup>Written for commit babf837919416cf2b2aebdd7b5c2de33d547cf2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

