### PR TITLE
chore(deps): patch transitive security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1289,9 +1289,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2741,9 +2741,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- Patch transitive `fast-uri` and `@xmldom/xmldom` vulnerabilities in the npm lockfile.
- Update `fast-uri` from 3.1.5 to 3.1.7.
- Update `@xmldom/xmldom` from 0.8.13 to 0.8.15.
- Keep the root dependency manifest and application source unchanged.

## Verification

- `npm ci --ignore-scripts`
- `npm run verify` (4055 passed, 1 skipped)
- `npm audit` (0 vulnerabilities)
- `npm audit --omit=dev` (0 vulnerabilities)
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Summary

Patches transitive security vulnerabilities in the npm lockfile by updating `fast-uri` to 3.1.7 and `@xmldom/xmldom` to 0.8.15.

- Updates `fast-uri` from 3.1.5 to 3.1.7.
- Updates `@xmldom/xmldom` from 0.8.13 to 0.8.15.
- Leaves the root manifest and application source unchanged.

## Verification

- `npm audit` and `npm audit --omit=dev` report 0 vulnerabilities.
- `npm run verify` passes (4055 passed, 1 skipped).
- `npm ci --ignore-scripts` and `git diff --check` succeed.

<sup>Written for commit 6a604bfdd5b19452eda2028711f3b037694ad337. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

