### PR TITLE
refactor(clients): derive client identity from one catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,22 +73,22 @@ Per-setting precedence for the agent and hub: `CLI flag → env var (real or .en
 
 ### Adding a tracked client
 
-The default client CSV lives in **one** place: `DEFAULT_CLIENTS` in `src/shared/clientTracking.js` (`src/electron/main.js` and `src/agent/agent.js` both derive from it). But adding a *new* client means touching several spots that must all agree on the id:
+Tracked-client identity lives in **one** place: `CLIENT_CATALOG` in `src/shared/clientCatalog.js`. `src/shared/clientTracking.js` projects it into the CSV shapes settings and the collector already speak (`src/electron/main.js` and `src/agent/agent.js` derive from those). But adding a *new* client means touching several spots that must all agree on the id:
 
 | Touch point | Where |
 |---|---|
-| Default client list | `DEFAULT_CLIENTS` in `src/shared/clientTracking.js` |
+| Client identity | one entry in `CLIENT_CATALOG` (`src/shared/clientCatalog.js`): id, label, display position, `defaultTracked`, `locallyParsed`. `DEFAULT_CLIENTS` / `KNOWN_CLIENTS` / `PARSE_LOCAL_CLIENTS` in `clientTracking.js` and the renderer's `clientLabels` / `KNOWN_CLIENTS` are all derived from it, so the tracked-client id, label and display order used by tracking and the widget renderer are declared once — Discord's `CLIENT_LABELS` and `themePresets`'s `VENDOR_LABELS` still carry their own |
 | Source roots | the `add(...)` call in `clientSourceRoots()` (`src/shared/collector.js`) — one `[checkId, dir]`, or `[checkId, watchDir, sourcePath]` when tokscale reads one exact file. `clientWatchCandidates()` is only a projection of this table; nothing is declared there |
 | Source check ids | every `checkId` above must be in `CLIENT_SOURCE_CHECK_IDS` (`src/shared/clientHealth.js`), kept alphabetical, then `npm run sync:worker` for the Worker copy. An id missing from that allowlist makes `normalizeClientHealth` drop the client's whole `checks` array, not just the unknown entry |
 | XDG vs home-relative | mirror tokscale, do not guess: a root is XDG-derived only if `clients.rs` declares it `PathRoot::XdgData` or `scanner.rs` resolves it through the `dirs` crate. Those `dirs` lookups are invisible to `strings` on the binary and to `tokscale clients`, so read the Rust at the version tag (`tmp/tokscale`). Roots spelled as home-relative literals upstream must stay home-relative here |
 | Name normalization | the `normalizeClientName()` branch in `src/shared/usage.js` |
-| Renderer maps | `clientLabels` / `clientsWithIcon` / `KNOWN_CLIENTS` in `src/electron/renderer/app.js`; provider artwork in `src/electron/renderer/trayProviderIcons.js`; `VENDOR_ORDER` / `VENDOR_LABELS` in `themePresets.js`; `clientColors` in `usageCharts.js` |
+| Renderer maps | `clientsWithIcon` in `src/electron/renderer/app.js` — deliberately not catalog-derived: it also holds model-vendor ids and (via `limitMarksWithIcon`) limits marks, so it is an icon table, not a client list; provider artwork in `src/electron/renderer/trayProviderIcons.js`; `VENDOR_ORDER` / `VENDOR_LABELS` in `themePresets.js`; `clientColors` in `usageCharts.js` |
 | Discord RPC | `KNOWN_CLIENT_ASSETS` / `CLIENT_LABELS` in `src/electron/discordRpc.js` |
 | Row icon CSS | the `.row-icon-<id>` rule in `src/electron/renderer/styles.css` |
 | Icon assets | `assets/icons/<id>.svg` + `.github/assets/tools-icon/<id>.png` |
 | WSL discovery | marker(s) in `WSL_DATA_MARKERS` **and** the marker→id mapping in `MARKER_CLIENTS` (`src/shared/wslUsage.js`) — use the exact roots tokscale reads, including alternate roots. A marker without a `MARKER_CLIENTS` entry attributes to nothing, so a WSL home holding only that client's data would be skipped |
 | Docs & env examples | the supported-tools table in `README.md` and its translations (`README.*.md`) + the client CSV in `.env.example`. Every locale's prose tool/provider counts must match its own table — `tests/docs/readmeConsistency.test.js` fails on a stale count or a table that drifts between locales |
-| Guard tests | the expected-client lists in `tests/shared/clientTracking.test.js` |
+| Guard tests | the expected-client lists in `tests/shared/clientTracking.test.js`, plus the pinned CSVs in `tests/shared/clientCatalog.test.js` (they guard a persisted-settings surface, so update them deliberately) |
 
 One caveat on top of the table:
 

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -1,6 +1,9 @@
 'use strict';
 
-const clientLabels = { claude: 'Claude Code', codex: 'Codex', hermes: 'Hermes Agent', gemini: 'Gemini', cursor: 'Cursor', opencode: 'OpenCode', openclaw: 'OpenClaw', antigravity: 'Antigravity', cline: 'Cline', kimi: 'Kimi', qwen: 'Qwen', grok: 'Grok Build', copilot: 'GitHub Copilot', pi: 'Pi', zed: 'Zed', kilocode: 'Kilo Code', commandcode: 'Command Code', micode: 'MiMo Code', zcode: 'ZCode', kiro: 'Kiro', codebuddy: 'CodeBuddy', workbuddy: 'WorkBuddy', proma: 'Proma', qodercn: 'Qoder CN', reasonix: 'Reasonix', dsh: 'DeepSeek Harness', cherrystudio: 'Cherry Studio', lmstudio: 'LM Studio', unsloth: 'Unsloth' };
+// Client identity — ids, labels and display order — comes from the shared
+// catalog (loaded as a script before this file). Destructured to the bare
+// names the call sites below already use.
+const { CLIENT_LABELS: clientLabels, KNOWN_CLIENT_LIST: KNOWN_CLIENTS } = window.TokenMonitorClientCatalog;
 const reasonixSessionGuard = window.TokenMonitorReasonixSessionGuard;
 const { clientColors, fallbackModelColors, modelVendorFor, modelColor } = window.TokenMonitorUsageCharts;
 const motionPreferenceApi = window.TokenMonitorMotionPreference;
@@ -50,36 +53,6 @@ function iconKindFor(rowData, breakdown) {
     : { kind: 'dot' };
 }
 
-const KNOWN_CLIENTS = [
-  { id: 'claude', label: 'Claude Code' },
-  { id: 'codex', label: 'Codex' },
-  { id: 'opencode', label: 'OpenCode' },
-  { id: 'hermes', label: 'Hermes Agent' },
-  { id: 'openclaw', label: 'OpenClaw' },
-  { id: 'cursor', label: 'Cursor' },
-  { id: 'antigravity', label: 'Antigravity' },
-  { id: 'cline', label: 'Cline' },
-  { id: 'kimi', label: 'Kimi' },
-  { id: 'qwen', label: 'Qwen' },
-  { id: 'grok', label: 'Grok Build' },
-  { id: 'copilot', label: 'GitHub Copilot' },
-  { id: 'pi', label: 'Pi' },
-  { id: 'zed', label: 'Zed' },
-  { id: 'kilocode', label: 'Kilo Code' },
-  { id: 'commandcode', label: 'Command Code' },
-  { id: 'micode', label: 'MiMo Code' },
-  { id: 'zcode', label: 'ZCode' },
-  { id: 'kiro', label: 'Kiro' },
-  { id: 'codebuddy', label: 'CodeBuddy' },
-  { id: 'workbuddy', label: 'WorkBuddy' },
-  { id: 'proma', label: 'Proma' },
-  { id: 'qodercn', label: 'Qoder CN' },
-  { id: 'reasonix', label: 'Reasonix' },
-  { id: 'dsh', label: 'DeepSeek Harness' },
-  { id: 'cherrystudio', label: 'Cherry Studio' },
-  { id: 'lmstudio', label: 'LM Studio' },
-  { id: 'unsloth', label: 'Unsloth' }
-];
 const LIMIT_PROVIDERS = [
   { id: 'claude', label: 'Claude', settingsLabel: 'Claude Code' },
   { id: 'codex', label: 'Codex' },

--- a/src/electron/renderer/index.html
+++ b/src/electron/renderer/index.html
@@ -1751,6 +1751,7 @@
     <button id="floatingBubbleTab" class="floating-bubble-tab" type="button" title="Show Token Monitor" aria-label="Show Token Monitor" data-i18n-title="floatingBubble.expand" data-i18n-aria-label="floatingBubble.expand">
       <span id="floatingBubbleContent" aria-hidden="true">Σ</span>
     </button>
+    <script src="../../shared/clientCatalog.js"></script>
     <script src="../../shared/limitBalanceDisplay.js"></script>
     <script src="trayBars.js"></script>
     <script src="usageCharts.js"></script>

--- a/src/shared/clientCatalog.js
+++ b/src/shared/clientCatalog.js
@@ -101,7 +101,7 @@
     CLIENT_CATALOG.filter((client) => client.locallyParsed).map((client) => client.id)
   );
 
-  // Renderer-facing projections. CLIENT_LABELS carries the legacy ids too
+  // Renderer-facing projections. CLIENT_LABELS carries the non-catalog ids too
   // because it is a lookup, while KNOWN_CLIENT_LIST is a display list.
   const CLIENT_LABELS = Object.freeze(Object.fromEntries([
     ...CLIENT_CATALOG.map((client) => [client.id, client.label]),

--- a/src/shared/clientCatalog.js
+++ b/src/shared/clientCatalog.js
@@ -1,0 +1,123 @@
+'use strict';
+
+// The tracked-client catalog: one entry per wired usage client, in display order.
+//
+// This is the single source of truth for a client's *identity* — id, label,
+// display position, whether it is tracked on a fresh install, and whether its
+// usage is parsed locally instead of by tokscale. Before this file, that data
+// lived in two hand-maintained lists (this module's CSVs and the renderer's
+// own KNOWN_CLIENTS/clientLabels) that had to be kept in the same order by
+// hand; the shared copy even rebuilt the order procedurally to match the
+// renderer's.
+//
+// Deliberately NOT here: source roots, WSL markers, icons, CSS, theme colours
+// and limits-provider metadata. Those are separate concerns with their own
+// tables, and folding them in would trade two honest lists for one god object.
+// Adding a client still means touching those (see AGENTS.md) — this file only
+// removes the duplication of identity itself.
+//
+// Pure data, no DOM and no Node built-ins, so the widget renderer can load it
+// as a plain <script> and node:test can require it.
+(function exposeClientCatalog(root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  if (root) root.TokenMonitorClientCatalog = api;
+})(typeof window !== 'undefined' ? window : null, function createClientCatalogApi() {
+  // Order here IS the display order, shared by the settings list, the renderer
+  // and the README table (tests/shared/clientTracking.test.js enforces that).
+  //
+  // `defaultTracked: false` keeps a client wired and selectable but off on a
+  // fresh install. micode (MiMo Code) is opt-in because mimocode.db auto-imports
+  // Claude Code sessions (its claude-import service), so scanning it
+  // double-counts the `claude` client: tokscale fixed the scan path but does not
+  // dedup imports, and the imported rows aren't cleanly separable (MiMo is
+  // multi-model). qodercn is opt-in per the upstream tool-support boundary — a
+  // local adapter that may break when Qoder changes its DB schema.
+  //
+  // `locallyParsed: true` means the client is excluded from the tokscale client
+  // filter and read by a local adapter instead (collector.js). This is an axis
+  // of its own, not a collection "mode": self-synced clients (cursor,
+  // antigravity) still go through tokscale and are tracked separately in
+  // collector.js.
+  const CLIENT_CATALOG = Object.freeze([
+    { id: 'claude', label: 'Claude Code' },
+    { id: 'codex', label: 'Codex' },
+    { id: 'opencode', label: 'OpenCode' },
+    { id: 'hermes', label: 'Hermes Agent' },
+    { id: 'openclaw', label: 'OpenClaw' },
+    { id: 'cursor', label: 'Cursor' },
+    { id: 'antigravity', label: 'Antigravity' },
+    { id: 'cline', label: 'Cline' },
+    { id: 'kimi', label: 'Kimi' },
+    { id: 'qwen', label: 'Qwen' },
+    { id: 'grok', label: 'Grok Build' },
+    { id: 'copilot', label: 'GitHub Copilot' },
+    { id: 'pi', label: 'Pi' },
+    { id: 'zed', label: 'Zed' },
+    { id: 'kilocode', label: 'Kilo Code' },
+    { id: 'commandcode', label: 'Command Code' },
+    { id: 'micode', label: 'MiMo Code', defaultTracked: false },
+    { id: 'zcode', label: 'ZCode' },
+    { id: 'kiro', label: 'Kiro' },
+    { id: 'codebuddy', label: 'CodeBuddy' },
+    { id: 'workbuddy', label: 'WorkBuddy' },
+    { id: 'proma', label: 'Proma', locallyParsed: true },
+    { id: 'qodercn', label: 'Qoder CN', defaultTracked: false, locallyParsed: true },
+    { id: 'reasonix', label: 'Reasonix' },
+    { id: 'dsh', label: 'DeepSeek Harness' },
+    { id: 'cherrystudio', label: 'Cherry Studio' },
+    { id: 'lmstudio', label: 'LM Studio' },
+    { id: 'unsloth', label: 'Unsloth' }
+  ].map((client) => Object.freeze({
+    defaultTracked: true,
+    locallyParsed: false,
+    ...client
+  })));
+
+  // Display labels for client ids the code recognizes but the catalog does not
+  // manage. The tracked-client list is not an allowlist: clientsCsvForSetting()
+  // only normalizes CSV, so TOKEN_MONITOR_CLIENTS or the agent's --clients can
+  // put any id tokscale supports into a scan, tokscaleClientFilter() passes it
+  // through, and normalizeClientName() keys the resulting rows under it. Such a
+  // row would otherwise render as the bare id.
+  //
+  // `gemini` has never been a catalog client here. Promoting it is a product
+  // decision — settings surface, source roots, health checks, icons, README, WSL
+  // — not a rename. Note this is a *client* id: the Gemini model vendor is a
+  // separate domain keyed off the same string in modelVendorFor()/clientColors
+  // (usageCharts.js), clientsWithIcon (app.js) and VENDOR_LABELS
+  // (themePresets.js), and does not depend on this map.
+  //
+  // Keep it minimal: subscriptionUsageCostUsd() in app.js reads a key in the
+  // merged CLIENT_LABELS as "this provider id names a client", so every id added
+  // here widens that test too.
+  const NON_CATALOG_CLIENT_LABELS = Object.freeze({ gemini: 'Gemini' });
+
+  const CLIENT_IDS = Object.freeze(CLIENT_CATALOG.map((client) => client.id));
+  const DEFAULT_CLIENT_IDS = Object.freeze(
+    CLIENT_CATALOG.filter((client) => client.defaultTracked).map((client) => client.id)
+  );
+  const LOCALLY_PARSED_CLIENT_IDS = Object.freeze(
+    CLIENT_CATALOG.filter((client) => client.locallyParsed).map((client) => client.id)
+  );
+
+  // Renderer-facing projections. CLIENT_LABELS carries the legacy ids too
+  // because it is a lookup, while KNOWN_CLIENT_LIST is a display list.
+  const CLIENT_LABELS = Object.freeze(Object.fromEntries([
+    ...CLIENT_CATALOG.map((client) => [client.id, client.label]),
+    ...Object.entries(NON_CATALOG_CLIENT_LABELS)
+  ]));
+  const KNOWN_CLIENT_LIST = Object.freeze(
+    CLIENT_CATALOG.map((client) => Object.freeze({ id: client.id, label: client.label }))
+  );
+
+  return {
+    CLIENT_CATALOG,
+    NON_CATALOG_CLIENT_LABELS,
+    CLIENT_IDS,
+    DEFAULT_CLIENT_IDS,
+    LOCALLY_PARSED_CLIENT_IDS,
+    CLIENT_LABELS,
+    KNOWN_CLIENT_LIST
+  };
+});

--- a/src/shared/clientTracking.js
+++ b/src/shared/clientTracking.js
@@ -1,31 +1,27 @@
 'use strict';
 
-// micode (MiMo Code) is intentionally NOT default-tracked: mimocode.db auto-imports
-// Claude Code sessions (its claude-import service), so scanning it double-counts the
-// `claude` client. tokscale 4.0.5 fixed the scan path but does not dedup imports, and
-// the imported rows aren't cleanly separable (MiMo is multi-model). It stays a known
-// client — one click to enable in Settings → tools — until tokscale dedups upstream.
-const PARSE_LOCAL_CLIENTS = Object.freeze(['proma', 'qodercn']);
-const DEFAULT_CLIENTS = 'claude,codex,opencode,hermes,openclaw,cursor,antigravity,cline,kimi,qwen,grok,copilot,pi,zed,kilocode,commandcode,zcode,kiro,codebuddy,workbuddy,proma,reasonix,dsh,cherrystudio,lmstudio,unsloth';
+// Tracked-client CSV helpers. The client list itself lives in clientCatalog.js;
+// this module only projects it into the CSV shape that settings, the
+// TOKEN_MONITOR_CLIENTS env var and the collector already speak. Those CSV
+// values are a compatibility surface — they are persisted in user settings, so
+// the derivations below must keep producing the same ids in the same order.
+const {
+  CLIENT_IDS,
+  DEFAULT_CLIENT_IDS,
+  LOCALLY_PARSED_CLIENT_IDS
+} = require('./clientCatalog');
 
-function insertClientBefore(clientsCsv, clientId, beforeClientId) {
-  const clients = clientsCsv.split(',');
-  const index = clients.indexOf(beforeClientId);
-  clients.splice(index >= 0 ? index : clients.length, 0, clientId);
-  return clients.join(',');
-}
+// Clients read by a local adapter instead of tokscale (collector.js excludes
+// these from the tokscale client filter).
+const PARSE_LOCAL_CLIENTS = LOCALLY_PARSED_CLIENT_IDS;
 
-// Every wired client id, including opt-in ones kept out of DEFAULT_CLIENTS (micode,
-// qodercn). Display-preference normalization (hide/pin/reorder) keys off this list,
-// so an opt-in client's prefs survive a round-trip instead of being silently dropped.
-// Mirror the renderer's KNOWN_CLIENTS; add any future opt-in ids here too.
-// qodercn (Qoder CN local SQLite adapter) stays opt-in per the upstream tool-support
-// boundary — a local adapter that may break when Qoder changes its DB schema.
-const KNOWN_CLIENTS = insertClientBefore(
-  insertClientBefore(DEFAULT_CLIENTS, 'micode', 'zcode'),
-  'qodercn',
-  'reasonix'
-);
+// Tracked on a fresh install.
+const DEFAULT_CLIENTS = DEFAULT_CLIENT_IDS.join(',');
+
+// Every wired client id, including the opt-in ones kept out of DEFAULT_CLIENTS.
+// Display-preference normalization (hide/pin/reorder) keys off this list, so an
+// opt-in client's prefs survive a round-trip instead of being silently dropped.
+const KNOWN_CLIENTS = CLIENT_IDS.join(',');
 
 function normalizeClientsCsv(value) {
   return String(value ?? '').split(',').map((client) => client.trim().toLowerCase()).filter(Boolean).join(',');

--- a/tests/electron/rendererClientLabels.test.js
+++ b/tests/electron/rendererClientLabels.test.js
@@ -27,11 +27,16 @@ function knownClientIds() {
   return [...CLIENT_IDS];
 }
 
-test('renderer client labels cover every known client', () => {
-  const labels = clientLabelIds();
-  const missing = knownClientIds().filter((id) => !labels.has(id));
-
-  assert.deepEqual(missing, []);
+test('app.js takes client identity from the catalog and keeps no copy of it', () => {
+  // An ownership boundary, not a data layout: that CLIENT_LABELS covers every
+  // catalog id is asserted in tests/shared/clientCatalog.test.js, so repeating it
+  // here would only compare the catalog with itself. What is worth guarding is
+  // that the renderer still sources identity from the catalog and has not grown a
+  // second copy of the list.
+  const source = rendererSource();
+  assert.match(source, /window\.TokenMonitorClientCatalog/);
+  assert.doesNotMatch(source, /const clientLabels = \{/);
+  assert.doesNotMatch(source, /const KNOWN_CLIENTS = \[/);
 });
 
 test('renderer known clients include current tokscale-supported tools', () => {

--- a/tests/electron/rendererClientLabels.test.js
+++ b/tests/electron/rendererClientLabels.test.js
@@ -5,6 +5,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
 const { sessionRowsForPeriod } = require('../../src/electron/renderer/sessionRows');
+const { CLIENT_LABELS, CLIENT_IDS } = require('../../src/shared/clientCatalog');
 
 function rendererSource() {
   return fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'electron', 'renderer', 'app.js'), 'utf8');
@@ -14,28 +15,27 @@ function rendererStyles() {
   return fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'electron', 'renderer', 'styles.css'), 'utf8');
 }
 
-function clientLabelIds(source) {
-  const match = source.match(/const clientLabels = \{([^}]+)\};/);
-  assert.ok(match, 'clientLabels declaration should exist');
-  return new Set([...match[1].matchAll(/([a-z0-9_-]+)\s*:/g)].map((item) => item[1]));
+// clientLabels and KNOWN_CLIENTS are destructured out of the shared catalog
+// now, so read that contract directly instead of regex-scraping app.js for
+// declarations that have moved. The clientsWithIcon and styles.css checks below
+// still scrape on purpose — that wiring has not been migrated.
+function clientLabelIds() {
+  return new Set(Object.keys(CLIENT_LABELS));
 }
 
-function knownClientIds(source) {
-  const match = source.match(/const KNOWN_CLIENTS = \[([\s\S]*?)\];/);
-  assert.ok(match, 'KNOWN_CLIENTS declaration should exist');
-  return [...match[1].matchAll(/id:\s*'([^']+)'/g)].map((item) => item[1]);
+function knownClientIds() {
+  return [...CLIENT_IDS];
 }
 
 test('renderer client labels cover every known client', () => {
-  const source = rendererSource();
-  const labels = clientLabelIds(source);
-  const missing = knownClientIds(source).filter((id) => !labels.has(id));
+  const labels = clientLabelIds();
+  const missing = knownClientIds().filter((id) => !labels.has(id));
 
   assert.deepEqual(missing, []);
 });
 
 test('renderer known clients include current tokscale-supported tools', () => {
-  const clients = knownClientIds(rendererSource());
+  const clients = knownClientIds();
   for (const client of ['cline', 'kimi', 'qwen', 'grok', 'copilot', 'pi', 'zed', 'kilocode', 'commandcode', 'micode', 'zcode', 'kiro', 'codebuddy', 'workbuddy', 'reasonix', 'dsh']) {
     assert.ok(clients.includes(client), `${client} should be a known renderer client`);
   }
@@ -159,7 +159,7 @@ test('LM Studio has a label and uses the standard mask-safe icon path', () => {
   const source = rendererSource();
   const styles = rendererStyles();
 
-  assert.ok(clientLabelIds(source).has('lmstudio'));
+  assert.ok(clientLabelIds().has('lmstudio'));
   assert.match(source, /clientsWithIcon = new Set\([\s\S]*'lmstudio'/);
   assert.match(styles, /\.row-icon-lmstudio\s*\{[^}]*mask-image:\s*url\([^)]*assets\/icons\/lmstudio\.svg\)/s);
   assert.doesNotMatch(styles, /\.row-icon-lmstudio\s*\{[^}]*background-image:/s);
@@ -170,7 +170,7 @@ test('LM Studio has a label and uses the standard mask-safe icon path', () => {
 test('Unsloth has a label and uses the standard mask-safe icon path', () => {
   const source = rendererSource();
   const styles = rendererStyles();
-  assert.ok(clientLabelIds(source).has('unsloth'));
+  assert.ok(clientLabelIds().has('unsloth'));
   assert.match(source, /clientsWithIcon = new Set\([\s\S]*'unsloth'/);
   assert.match(styles, /\.row-icon-unsloth\s*\{[^}]*mask-image:\s*url\([^)]*assets\/icons\/unsloth\.svg\)/s);
   assert.doesNotMatch(styles, /\.row-icon-unsloth\s*\{[^}]*background-image:/s);

--- a/tests/shared/clientCatalog.test.js
+++ b/tests/shared/clientCatalog.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+// Invariants over the tracked-client catalog and the lists derived from it.
+//
+// Two kinds of check live here. The structural ones (unique ids, non-empty
+// labels, complete label coverage) protect the catalog shape itself. The three
+// pinned literals are a migration safety net: DEFAULT_CLIENTS and KNOWN_CLIENTS
+// are persisted in user settings and accepted from TOKEN_MONITOR_CLIENTS, so a
+// derivation that silently reorders or drops an id would change the tracked
+// tools of every existing install. Adding a client is expected to update those
+// literals deliberately.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  CLIENT_CATALOG,
+  NON_CATALOG_CLIENT_LABELS,
+  CLIENT_IDS,
+  DEFAULT_CLIENT_IDS,
+  LOCALLY_PARSED_CLIENT_IDS,
+  CLIENT_LABELS,
+  KNOWN_CLIENT_LIST
+} = require('../../src/shared/clientCatalog');
+const { DEFAULT_CLIENTS, KNOWN_CLIENTS, PARSE_LOCAL_CLIENTS } = require('../../src/shared/clientTracking');
+
+const rootDir = path.join(__dirname, '..', '..');
+
+test('catalog ids are unique and labels are non-empty', () => {
+  assert.equal(new Set(CLIENT_IDS).size, CLIENT_IDS.length, 'duplicate client id in the catalog');
+  for (const client of CLIENT_CATALOG) {
+    assert.match(client.id, /^[a-z0-9-]+$/, `${client.id} is not a plain client id`);
+    assert.equal(typeof client.label, 'string');
+    assert.ok(client.label.trim().length > 0, `${client.id} has an empty label`);
+  }
+});
+
+test('resolved catalog entries expose boolean tracking flags', () => {
+  // Entries omit the flags they do not override, so the catalog fills both in.
+  // What this guards is the override: a truthy-but-not-boolean value such as
+  // defaultTracked: 'false' would flip a derived list without failing anywhere.
+  for (const client of CLIENT_CATALOG) {
+    assert.equal(typeof client.defaultTracked, 'boolean', `${client.id} defaultTracked`);
+    assert.equal(typeof client.locallyParsed, 'boolean', `${client.id} locallyParsed`);
+  }
+});
+
+test('derived KNOWN_CLIENTS keeps the established id order', () => {
+  assert.equal(KNOWN_CLIENTS, CLIENT_IDS.join(','));
+  assert.equal(
+    KNOWN_CLIENTS,
+    'claude,codex,opencode,hermes,openclaw,cursor,antigravity,cline,kimi,qwen,grok,copilot,pi,zed,kilocode,commandcode,micode,zcode,kiro,codebuddy,workbuddy,proma,qodercn,reasonix,dsh,cherrystudio,lmstudio,unsloth'
+  );
+});
+
+test('derived DEFAULT_CLIENTS keeps the existing default-tracked CSV', () => {
+  assert.equal(DEFAULT_CLIENTS, DEFAULT_CLIENT_IDS.join(','));
+  assert.equal(
+    DEFAULT_CLIENTS,
+    'claude,codex,opencode,hermes,openclaw,cursor,antigravity,cline,kimi,qwen,grok,copilot,pi,zed,kilocode,commandcode,zcode,kiro,codebuddy,workbuddy,proma,reasonix,dsh,cherrystudio,lmstudio,unsloth'
+  );
+});
+
+test('derived PARSE_LOCAL_CLIENTS still lists exactly the local adapters', () => {
+  assert.deepEqual([...PARSE_LOCAL_CLIENTS], ['proma', 'qodercn']);
+  assert.deepEqual([...LOCALLY_PARSED_CLIENT_IDS], ['proma', 'qodercn']);
+});
+
+test('default-tracked clients are a subset of the catalog, in catalog order', () => {
+  const known = CLIENT_IDS;
+  for (const client of DEFAULT_CLIENT_IDS) {
+    assert.ok(known.includes(client), `${client} is default-tracked but not in the catalog`);
+  }
+  assert.deepEqual(DEFAULT_CLIENT_IDS, known.filter((id) => DEFAULT_CLIENT_IDS.includes(id)));
+});
+
+test('CLIENT_LABELS covers every catalog id plus the non-catalog ids', () => {
+  for (const client of CLIENT_CATALOG) {
+    assert.equal(CLIENT_LABELS[client.id], client.label);
+  }
+  for (const [id, label] of Object.entries(NON_CATALOG_CLIENT_LABELS)) {
+    assert.equal(CLIENT_LABELS[id], label);
+    assert.ok(!CLIENT_IDS.includes(id), `${id} is a non-catalog label but also a catalog client`);
+  }
+  assert.equal(
+    Object.keys(CLIENT_LABELS).length,
+    CLIENT_IDS.length + Object.keys(NON_CATALOG_CLIENT_LABELS).length
+  );
+});
+
+test('KNOWN_CLIENT_LIST is the catalog projection the renderer consumes', () => {
+  assert.deepEqual(KNOWN_CLIENT_LIST, CLIENT_CATALOG.map(({ id, label }) => ({ id, label })));
+});
+
+test('the widget renderer loads the catalog before app.js', () => {
+  // app.js destructures window.TokenMonitorClientCatalog at its top level, so a
+  // missing or late script tag is a blank-window failure at load time.
+  const html = fs.readFileSync(path.join(rootDir, 'src/electron/renderer/index.html'), 'utf8');
+  const catalogTag = html.indexOf('shared/clientCatalog.js');
+  const appTag = html.indexOf('src="app.js"');
+  assert.ok(catalogTag > -1, 'index.html must load shared/clientCatalog.js');
+  assert.ok(appTag > -1, 'index.html must load app.js');
+  assert.ok(catalogTag < appTag, 'clientCatalog.js must load before app.js');
+});

--- a/tests/shared/clientRegistrationConsistency.test.js
+++ b/tests/shared/clientRegistrationConsistency.test.js
@@ -1,22 +1,20 @@
 'use strict';
 
-// Consistency checks over the *existing* per-client wiring — no registry, no
-// codegen, no file moves. Per the maintainer's scoping on the proposal issue
-// (#496): "Please keep the PR scoped to consistency checks over the existing
-// wiring: orphan or missing client metadata, source check ids and WSL markers
-// that do not resolve back to a known client, and the other duplicated
-// client ids that are expected to agree today."
+// Consistency checks over the per-client wiring that is still maintained
+// independently of the tracked-client catalog. Client identity itself now comes
+// from CLIENT_CATALOG (src/shared/clientCatalog.js), but Discord's asset/label
+// maps and the WSL marker tables are separate sources that must still agree with
+// it by hand — those are what this file guards.
 //
-// Each check here tests an *invariant* between two independently-maintained
-// lists, not a pinned snapshot of either list's contents — so a check keeps
-// protecting the eventual registry migration even after the lists' contents
-// change, per the same guidance ("testing invariants rather than pinning the
-// current file layout").
+// Each check tests an *invariant* between two independently-maintained lists
+// rather than a pinned snapshot of either one's contents, so it keeps protecting
+// the remaining #550 steps even after those lists change.
 //
-// clientTracking.test.js already covers: DEFAULT_CLIENTS/KNOWN_CLIENTS shape,
-// and the renderer/README/KNOWN_CLIENTS shared display-order agreement.
-// clientHealth.test.js already covers: CLIENT_SOURCE_CHECK_IDS vs. the ids
-// clientSourceRoots() actually emits. Neither is duplicated here.
+// clientTracking.test.js already covers: DEFAULT_CLIENTS/KNOWN_CLIENTS shape and
+// the defaults/README display-order agreement. clientCatalog.test.js covers the
+// catalog's own invariants and the renderer's use of it. clientHealth.test.js
+// covers CLIENT_SOURCE_CHECK_IDS vs. the ids clientSourceRoots() actually emits.
+// None of those are duplicated here.
 
 const assert = require('node:assert/strict');
 const fs = require('node:fs');

--- a/tests/shared/clientTracking.test.js
+++ b/tests/shared/clientTracking.test.js
@@ -11,12 +11,15 @@ try {
 } catch (_) {}
 
 const { DEFAULT_CLIENTS, KNOWN_CLIENTS, clientsCsvForSetting } = trackingApi;
+const { KNOWN_CLIENT_LIST } = require('../../src/shared/clientCatalog');
 const rootDir = path.join(__dirname, '..', '..');
 
+// The renderer no longer keeps its own copy of this list — it destructures
+// KNOWN_CLIENT_LIST out of the same catalog. Assert that projection instead of
+// scraping app.js, so this keeps checking the contract rather than a file
+// layout that the later #550 steps are expected to move.
 function rendererClientIds() {
-  const app = fs.readFileSync(path.join(rootDir, 'src/electron/renderer/app.js'), 'utf8');
-  const block = app.slice(app.indexOf('const KNOWN_CLIENTS = ['), app.indexOf('const LIMIT_PROVIDERS'));
-  return [...block.matchAll(/\{ id: '([^']+)'/g)].map((match) => match[1]);
+  return KNOWN_CLIENT_LIST.map((client) => client.id);
 }
 
 function readmeTrackedClientIds() {

--- a/tests/shared/clientTracking.test.js
+++ b/tests/shared/clientTracking.test.js
@@ -11,16 +11,7 @@ try {
 } catch (_) {}
 
 const { DEFAULT_CLIENTS, KNOWN_CLIENTS, clientsCsvForSetting } = trackingApi;
-const { KNOWN_CLIENT_LIST } = require('../../src/shared/clientCatalog');
 const rootDir = path.join(__dirname, '..', '..');
-
-// The renderer no longer keeps its own copy of this list — it destructures
-// KNOWN_CLIENT_LIST out of the same catalog. Assert that projection instead of
-// scraping app.js, so this keeps checking the contract rather than a file
-// layout that the later #550 steps are expected to move.
-function rendererClientIds() {
-  return KNOWN_CLIENT_LIST.map((client) => client.id);
-}
 
 function readmeTrackedClientIds() {
   const iconToClient = {
@@ -71,9 +62,13 @@ test('KNOWN_CLIENTS is a superset of DEFAULT_CLIENTS and still includes opt-in m
   }
 });
 
-test('tracked client defaults, renderer, and README share one display order', () => {
+// The renderer is no longer a third party to compare against: it destructures
+// the same catalog these CSVs are projected from, so asserting it here would be
+// the catalog against itself. That the renderer actually consumes the catalog is
+// guarded in tests/electron/rendererClientLabels.test.js. README stays a real
+// cross-check because it is hand-authored.
+test('tracked client defaults and README share one display order', () => {
   const known = KNOWN_CLIENTS.split(',');
-  assert.deepEqual(rendererClientIds(), known);
   assert.deepEqual(readmeTrackedClientIds(), known);
   assert.deepEqual(DEFAULT_CLIENTS.split(','), known.filter((client) => !['micode', 'qodercn'].includes(client)));
 });


### PR DESCRIPTION
Introduces a shared tracked-client catalog and derives the existing tracking and renderer identity projections from it, without changing which clients are supported or how they are collected. First slice of #550; the identity half of what #496 proposed.

## Why

A client's id, label, display position and tracking defaults lived in two hand-maintained lists: the CSVs in `clientTracking.js` and the renderer's own `clientLabels` / `KNOWN_CLIENTS` in `app.js`. Keeping them in the same order was manual — `clientTracking.js` rebuilt the order procedurally with two `insertClientBefore()` calls purely to mirror the renderer, under a comment saying so — and the only thing checking the result was a test that regex-scraped `app.js`.

## What changed

`CLIENT_CATALOG` in the new `src/shared/clientCatalog.js` is now the single declaration: one entry per client with `id`, `label`, `defaultTracked` and `locallyParsed`, where array order is display order. `DEFAULT_CLIENTS`, `KNOWN_CLIENTS` and `PARSE_LOCAL_CLIENTS` become projections of it, and `insertClientBefore()` is gone.

The catalog uses the same UMD wrapper as the other browser-safe shared modules, so the renderer loads it as a script and destructures `clientLabels` / `KNOWN_CLIENTS` out of it. The bare names its call sites already use are unchanged.

`NON_CATALOG_CLIENT_LABELS` holds display labels for client ids the code recognizes but the catalog does not manage — currently just `gemini`. The tracked-client list is not an allowlist: `clientsCsvForSetting()` only normalizes CSV, so `TOKEN_MONITOR_CLIENTS` or the agent's `--clients` can put any id tokscale supports into a scan and `normalizeClientName()` will key rows under it. Whether `gemini` should become a real catalog entry is a product decision (settings surface, source roots, health checks, icons, README, WSL) and is deliberately out of scope here.

## Behaviour preservation

`DEFAULT_CLIENTS`, `KNOWN_CLIENTS` and `PARSE_LOCAL_CLIENTS` were captured before the change and compared after: all three are byte-identical, and `clientTracking.js`'s export surface is unchanged, so `main.js` and `agent.js` are untouched. Those CSVs are persisted in settings and accepted from `TOKEN_MONITOR_CLIENTS`, so `tests/shared/clientCatalog.test.js` pins them as a migration safety net alongside the structural invariants (unique ids, non-empty labels, boolean tracking flags, label coverage, and that `index.html` loads the catalog before `app.js` — a missing script tag is a blank window at load).

The two tests that regex-scraped `app.js` for these declarations now read the catalog instead. Their assertions are unchanged; only the mechanism moved.

## Deliberately not in the catalog

Source roots, WSL markers, credentials, Discord maps, CSS, theme colours and limits-provider metadata keep their own tables. So does `clientsWithIcon`, which despite the name is an icon table rather than a client list: it also holds model-vendor ids and, via `limitMarksWithIcon`, limits marks. Folding those in would trade several honest tables for one god object. `AGENTS.md`'s "Adding a tracked client" table is updated to match.

## Verification

`npm run verify` (lint + 4065 tests) passes. No user-visible behaviour change, so no screenshots.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a single tracked-client catalog (`CLIENT_CATALOG`) and derives every existing tracking CSV and the renderer's client lists from it, with no change to which clients are supported, their order, labels, or tracking defaults.

- Client identity previously lived in two manually synced places: the CSVs in `clientTracking.js` and the renderer's own `clientLabels`/`KNOWN_CLIENTS` in `app.js`, which `clientTracking.js` rebuilt procedurally with two `insertClientBefore()` calls purely to mirror the renderer.
- `src/shared/clientCatalog.js` is now the single declaration; `DEFAULT_CLIENTS`, `KNOWN_CLIENTS`, and `PARSE_LOCAL_CLIENTS` are derived projections of it, and `insertClientBefore()` is gone.
- The renderer loads the catalog as a script and destructures the same bare `clientLabels`/`KNOWN_CLIENTS` names, so its call sites are untouched.
- The derived CSVs are byte-identical to before and the `clientTracking.js` export surface is unchanged, so `main.js` and `agent.js` are untouched.
- `NON_CATALOG_CLIENT_LABELS` covers ids the code recognizes but the catalog doesn't manage (currently `gemini`); promoting it to a catalog entry is deliberately out of scope.

| Area | Before | After |
| --- | --- | --- |
| Client identity | id/label/display order duplicated between `clientTracking.js` CSVs and the renderer's `clientLabels`/`KNOWN_CLIENTS` | declared once in `CLIENT_CATALOG`; both sides derive from it |
| Renderer data source | `app.js` defined client lists inline | loads `clientCatalog.js` as a script and destructures the same names from it |
| CSV order maintenance | `clientTracking.js` used `insertClientBefore()` calls to mirror the renderer's order | order is simply catalog array order |

**Design decisions**
- `defaultTracked` and `locallyParsed` are resolved per-client flags on catalog entries, with `locallyParsed` matching the wording the collector already uses.
- Kept out of the catalog: source roots, WSL markers, icons, CSS, theme colours, and limits-provider metadata; `clientsWithIcon` stays an icon table because it also covers model-vendor ids and limits marks.

**Verification & risks**
- `npm run verify` (lint + 4065 tests) passes, and the three derived CSVs were captured before and after and are byte-identical.
- Tests that previously regex-scraped `app.js` now guard the ownership boundary: app.js must source identity from the catalog and keep no second copy, which the pre-refactor code fails. The README cross-check stays because it is hand-authored.
- The renderer now requires `index.html` to load the catalog before `app.js`; a missing script tag is a blank window, and a new test pins that load order.
- No migration is needed, but because `DEFAULT_CLIENTS`/`KNOWN_CLIENTS` are persisted in settings and accepted from `TOKEN_MONITOR_CLIENTS`, the catalog test pins their exact CSV values as a safety net.

<sup>Written for commit adcd803f0d28d5e446fef96761e1fe8a2aaa5f90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

