### PR TITLE
test(clients): guard presentation coverage against the client catalog

### DIFF
--- a/tests/electron/clientPresentationCoverage.test.js
+++ b/tests/electron/clientPresentationCoverage.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+// Catalog → presentation completeness.
+//
+// Every tracked client needs a colour, a vendor label, an ordering slot and a
+// row icon before it renders correctly, and each of those lives in its own
+// hand-maintained table. This file asserts that each table covers every
+// CLIENT_CATALOG entry, so a client added without its presentation wiring fails
+// CI instead of shipping as an unlabelled grey row.
+//
+// The direction matters: themePresets.test.js already checks that every
+// clientColors brand key has a label and an ordering slot. That starts from the
+// colour table. These checks start from the catalog, which is what catches a
+// client that never reached the colour table at all.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const { CLIENT_IDS } = require('../../src/shared/clientCatalog');
+const { VENDOR_ORDER, VENDOR_LABELS } = require('../../src/electron/renderer/themePresets');
+const { clientColors } = require('../../src/electron/renderer/usageCharts');
+
+const rootDir = path.join(__dirname, '..', '..');
+
+function rendererSource() {
+  return fs.readFileSync(path.join(rootDir, 'src/electron/renderer/app.js'), 'utf8');
+}
+
+function rendererStyles() {
+  return fs.readFileSync(path.join(rootDir, 'src/electron/renderer/styles.css'), 'utf8');
+}
+
+test('every catalog client has a usage chart colour', () => {
+  for (const id of CLIENT_IDS) {
+    assert.ok(clientColors[id], `${id} needs a clientColors entry in usageCharts.js`);
+  }
+});
+
+test('every catalog client has a vendor ordering slot and label', () => {
+  for (const id of CLIENT_IDS) {
+    assert.ok(VENDOR_ORDER.includes(id), `${id} needs a VENDOR_ORDER slot in themePresets.js`);
+    assert.ok(VENDOR_LABELS[id], `${id} needs a VENDOR_LABELS entry in themePresets.js`);
+  }
+});
+
+test('clientsWithIcon covers every catalog client', () => {
+  // Subset, never equality: clientsWithIcon is an icon table, not a client list.
+  // It also carries model-vendor ids and, through limitMarksWithIcon, limits
+  // marks, so requiring the two to match would fail on entries that are
+  // correctly there. Read from source because the Set is still declared inside
+  // app.js; when the renderer boundary is split this can read a module instead,
+  // without the invariant changing.
+  const block = rendererSource().match(/const clientsWithIcon = new Set\(\[([\s\S]*?)\]\)/);
+  assert.ok(block, 'clientsWithIcon declaration should exist in app.js');
+  const iconIds = new Set([...block[1].matchAll(/'([a-z0-9-]+)'/g)].map((match) => match[1]));
+  for (const id of CLIENT_IDS) {
+    assert.ok(iconIds.has(id), `${id} should resolve to an icon row`);
+  }
+});
+
+test('every catalog client resolves to an icon asset through its CSS rule', () => {
+  // The invariant is that a client resolves to an icon, not that the file is
+  // named after the client. Several clients deliberately reuse a vendor mark
+  // (hermes → hermes-agent.svg, grok → xai.svg, micode → xiaomi.svg,
+  // zcode → zai.svg), so the CSS rule is the mapping and the asset is checked
+  // through it rather than assumed from the id.
+  const styles = rendererStyles();
+  for (const id of CLIENT_IDS) {
+    const rule = styles.match(new RegExp(`\\.row-icon-${id}\\b[^{}]*\\{([^}]*)\\}`));
+    assert.ok(rule, `${id} needs a .row-icon-${id} rule in styles.css`);
+    const asset = rule[1].match(/assets\/icons\/([a-z0-9-]+)\.svg/);
+    assert.ok(asset, `.row-icon-${id} should reference an icon under assets/icons/`);
+    assert.ok(
+      fs.existsSync(path.join(rootDir, 'assets', 'icons', `${asset[1]}.svg`)),
+      `.row-icon-${id} references assets/icons/${asset[1]}.svg, which does not exist`
+    );
+  }
+});

--- a/tests/electron/clientPresentationCoverage.test.js
+++ b/tests/electron/clientPresentationCoverage.test.js
@@ -68,7 +68,10 @@ test('every catalog client resolves to an icon asset through its CSS rule', () =
   // through it rather than assumed from the id.
   const styles = rendererStyles();
   for (const id of CLIENT_IDS) {
-    const rule = styles.match(new RegExp(`\\.row-icon-${id}\\b[^{}]*\\{([^}]*)\\}`));
+    // The class must be terminated by a selector separator, not just a word
+    // boundary: the renderer applies exactly `row-icon-${client}`, so a suffixed
+    // rule such as .row-icon-<id>-sm would satisfy \b while rendering nothing.
+    const rule = styles.match(new RegExp(`\\.row-icon-${id}(?=[\\s,{])[^{}]*\\{([^}]*)\\}`));
     assert.ok(rule, `${id} needs a .row-icon-${id} rule in styles.css`);
     const asset = rule[1].match(/assets\/icons\/([a-z0-9-]+)\.svg/);
     assert.ok(asset, `.row-icon-${id} should reference an icon under assets/icons/`);

--- a/tests/electron/clientPresentationCoverage.test.js
+++ b/tests/electron/clientPresentationCoverage.test.js
@@ -23,14 +23,8 @@ const { VENDOR_ORDER, VENDOR_LABELS } = require('../../src/electron/renderer/the
 const { clientColors } = require('../../src/electron/renderer/usageCharts');
 
 const rootDir = path.join(__dirname, '..', '..');
-
-function rendererSource() {
-  return fs.readFileSync(path.join(rootDir, 'src/electron/renderer/app.js'), 'utf8');
-}
-
-function rendererStyles() {
-  return fs.readFileSync(path.join(rootDir, 'src/electron/renderer/styles.css'), 'utf8');
-}
+const rendererPath = path.join(rootDir, 'src/electron/renderer/app.js');
+const stylesPath = path.join(rootDir, 'src/electron/renderer/styles.css');
 
 test('every catalog client has a usage chart colour', () => {
   for (const id of CLIENT_IDS) {
@@ -52,9 +46,13 @@ test('clientsWithIcon covers every catalog client', () => {
   // correctly there. Read from source because the Set is still declared inside
   // app.js; when the renderer boundary is split this can read a module instead,
   // without the invariant changing.
-  const block = rendererSource().match(/const clientsWithIcon = new Set\(\[([\s\S]*?)\]\)/);
+  const source = fs.readFileSync(rendererPath, 'utf8');
+  const block = source.match(/const clientsWithIcon = new Set\(\[([\s\S]*?)\]\)/);
   assert.ok(block, 'clientsWithIcon declaration should exist in app.js');
-  const iconIds = new Set([...block[1].matchAll(/'([a-z0-9-]+)'/g)].map((match) => match[1]));
+  // Strip comments first: a commented-out id is absent from the runtime Set, so
+  // counting it would report coverage the renderer does not have.
+  const entries = block[1].replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+  const iconIds = new Set([...entries.matchAll(/'([a-z0-9-]+)'/g)].map((match) => match[1]));
   for (const id of CLIENT_IDS) {
     assert.ok(iconIds.has(id), `${id} should resolve to an icon row`);
   }
@@ -66,18 +64,23 @@ test('every catalog client resolves to an icon asset through its CSS rule', () =
   // (hermes → hermes-agent.svg, grok → xai.svg, micode → xiaomi.svg,
   // zcode → zai.svg), so the CSS rule is the mapping and the asset is checked
   // through it rather than assumed from the id.
-  const styles = rendererStyles();
+  const styles = fs.readFileSync(stylesPath, 'utf8');
   for (const id of CLIENT_IDS) {
-    // The class must be terminated by a selector separator, not just a word
-    // boundary: the renderer applies exactly `row-icon-${client}`, so a suffixed
-    // rule such as .row-icon-<id>-sm would satisfy \b while rendering nothing.
-    const rule = styles.match(new RegExp(`\\.row-icon-${id}(?=[\\s,{])[^{}]*\\{([^}]*)\\}`));
+    // The class must be terminated by a selector separator: the renderer applies
+    // exactly `row-icon-${client}`, so neither a suffixed rule
+    // (.row-icon-<id>-sm) nor a descendant rule (.row-icon-<id> .child) styles
+    // the element this guard is about, and both would otherwise satisfy it.
+    const rule = styles.match(new RegExp(`\\.row-icon-${id}(?=\\s*[,{])[^{}]*\\{([^}]*)\\}`));
     assert.ok(rule, `${id} needs a .row-icon-${id} rule in styles.css`);
-    const asset = rule[1].match(/assets\/icons\/([a-z0-9-]+)\.svg/);
-    assert.ok(asset, `.row-icon-${id} should reference an icon under assets/icons/`);
+    // Resolve the URL the way the browser does — relative to styles.css — so a
+    // wrong number of parent segments fails here instead of rendering a broken
+    // icon. Matching the basename alone would accept any depth.
+    const url = rule[1].match(/url\(\s*['"]?([^'")\s]+\.svg)['"]?\s*\)/);
+    assert.ok(url, `.row-icon-${id} should reference an .svg through url()`);
+    const resolved = path.resolve(path.dirname(stylesPath), url[1]);
     assert.ok(
-      fs.existsSync(path.join(rootDir, 'assets', 'icons', `${asset[1]}.svg`)),
-      `.row-icon-${id} references assets/icons/${asset[1]}.svg, which does not exist`
+      fs.existsSync(resolved),
+      `.row-icon-${id} references ${url[1]}, which resolves to a missing file: ${resolved}`
     );
   }
 });


### PR DESCRIPTION
Adds catalog-backed presentation completeness guards, so a tracked client that is wired without its rendering metadata fails CI instead of shipping as an unlabelled grey row. Second slice of #550, following #614. Pure tests: zero production diff.

## Why

A tracked client needs a chart colour, a vendor label, a vendor ordering slot and a row icon before it renders correctly, and each of those lives in its own hand-maintained table. Nothing checked that a client actually reached all of them.

`themePresets.test.js` already asserts that every `clientColors` brand key has a label and an ordering slot, but that starts from the colour table, so it cannot see a client that never reached the colour table at all. These checks start from `CLIENT_CATALOG` instead, which is the direction that catches a missing entry.

## What is guarded

Every catalog client has a `clientColors` entry, a `VENDOR_ORDER` slot, a `VENDOR_LABELS` entry, a `.row-icon-<id>` rule, and an icon asset that rule resolves to; and `clientsWithIcon` covers every catalog client.

Three details are deliberate. The icon asset is found by resolving the rule's `url()` against the stylesheet's own directory, the way the browser does, rather than by looking up a file named after the client: several clients reuse a vendor mark (`hermes` uses `hermes-agent.svg`, `grok` uses `xai.svg`, `micode` uses `xiaomi.svg`, `zcode` uses `zai.svg`), and matching a basename alone would accept a rule with the wrong number of parent segments. The class must be followed by a selector separator, since the renderer applies exactly `row-icon-${client}` and neither a suffixed rule nor a descendant rule styles that element. And `clientsWithIcon` is asserted as a superset rather than an equality, because that Set is an icon table rather than a client list: it also holds model-vendor ids and, through `limitMarksWithIcon`, limits marks.

## Each check was reproduced failing

The previous slice landed two assertions that compared the catalog with itself, so nothing here was accepted on a green run alone. Every check was first run against an input that violates it — a catalog client absent from each presentation table, a `url()` with the wrong depth, a commented-out entry in `clientsWithIcon`, and a suffixed and a descendant selector — and confirmed to fail before the fix and pass after.

## Scope

Colour and theme data is read by requiring the modules. `clientsWithIcon` is still read from `app.js` source because the Set is declared there; when the renderer boundary is split that mechanism can change without the invariant changing. No metadata moves into the catalog, no production code changes, and the README icon-alias map in `clientTracking.test.js` is left where it is rather than copied.

## Verification

`npm run verify` (lint + 4069 tests) passes. All 28 catalog clients are covered today, so this adds no assets.
