### PR TITLE
test(limits): guard provider coverage against the catalog

### DIFF
--- a/src/shared/limitCollector.js
+++ b/src/shared/limitCollector.js
@@ -4397,6 +4397,7 @@ module.exports = {
   resolveProviderFetch,
   createLimitsCollector,
   probeLimitProvider,
+  providerFetchers,
   providerPhysicalBoundMs,
   fetchAntigravityLimits,
   fetchOpenCodeLimits,

--- a/tests/electron/limitProviderCoverage.test.js
+++ b/tests/electron/limitProviderCoverage.test.js
@@ -57,24 +57,34 @@ test('every account group reports its state through a status pill', () => {
 });
 
 test('every catalog provider reaches an account group or a connection explainer', () => {
-  // renderLimitProviderCheckboxes gates the whole options block on
-  // `accountGroup || settings || connectionDetailKey`, so a provider in neither
-  // map has nothing to expand into. The two are deliberately not exclusive —
-  // antigravity carries both, an explainer above its account group — so this
-  // asserts the union rather than a partition.
+  // A deliberate contract, and stricter than the renderer's own
+  // `accountGroup || settings || connectionDetailKey` gate. LIMIT_PROVIDER_SETTINGS
+  // is that third path, but it holds display toggles — Claude prepaid balance,
+  // Codex additional limits, OpenCode local limits — so a provider carrying only
+  // a toggle would expand into options that cannot connect it. What is asserted
+  // here is that every provider offers somewhere to put a credential, or an
+  // explanation of how it connects without one.
+  // The two maps are deliberately not exclusive — antigravity carries an
+  // explainer above its account group — so this is a union, not a partition.
   const configured = new Set([...Object.keys(accountGroups), ...Object.keys(connectionDetails)]);
   assert.deepEqual([...configured].sort(), [...LIMIT_PROVIDER_IDS].sort());
 });
 
 test('every mapped settings element exists in index.html', () => {
-  const html = read('index.html');
+  // Strip comments first: getElementById cannot see a commented-out element, so
+  // matching inside one would report a surface the settings page has not got.
+  const html = read('index.html').replace(/<!--[\s\S]*?-->/g, '');
+  // Require whitespace before the attribute. A bare `id="x"` also matches
+  // data-id="x", and so does `\bid="x"` — the hyphen is a word boundary — and
+  // neither is an element the renderer can look up.
+  const tagWithId = (elementId) => html.match(new RegExp(`<[^>]*\\sid="${elementId}"[^>]*>`));
   for (const [provider, groupId] of Object.entries(accountGroups)) {
-    assert.match(html, new RegExp(`id="${groupId}"`), `${provider} maps to a missing #${groupId}`);
+    assert.ok(tagWithId(groupId), `${provider} maps to a missing #${groupId}`);
   }
   for (const [provider, statusId] of Object.entries(accountStatuses)) {
     // Match the tag, then its attributes separately: the pill class is the
     // contract, the order it is written in is not.
-    const tag = html.match(new RegExp(`<[^>]*\\bid="${statusId}"[^>]*>`));
+    const tag = tagWithId(statusId);
     assert.ok(tag, `${provider} maps to a missing #${statusId}`);
     assert.match(tag[0], /class="[^"]*\bcursor-status-pill\b/, `#${statusId} should render as a status pill`);
   }

--- a/tests/electron/limitProviderCoverage.test.js
+++ b/tests/electron/limitProviderCoverage.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+// Catalog → settings completeness.
+//
+// A limits provider is only usable once the settings page gives it somewhere to
+// go: an account group, whose state is reported by a status pill, or — for the
+// providers detected without a credential — a connection explainer. Both live in
+// hand-maintained maps in app.js keyed by provider id. Nothing asserted that a
+// catalog entry reached either, so a provider added without its settings wiring
+// shipped as a row that expands into nothing.
+//
+// The direction matters, as in clientPresentationCoverage.test.js: the account
+// group check in limitProviderPresentation.test.js starts from a written-out
+// list of providers, so it cannot see one that never reached the maps at all.
+//
+// This proves coverage, not correctness. It says every provider resolves to some
+// configurable or explained path; it cannot say the path it resolves to suits
+// how that provider actually authenticates.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const { LIMIT_PROVIDER_IDS } = require('../../src/shared/limitProviders');
+const { MESSAGES } = require('../../src/electron/renderer/i18n');
+
+const rendererDir = path.join(__dirname, '..', '..', 'src', 'electron', 'renderer');
+const read = (file) => fs.readFileSync(path.join(rendererDir, file), 'utf8');
+
+// Read from source because these maps are still declared inside app.js, which
+// only loads in a browser. When the renderer boundary is split they can be
+// required instead, without any invariant here changing.
+function providerMap(source, name) {
+  const start = source.indexOf(`const ${name} = {`);
+  assert.notEqual(start, -1, `${name} should be declared in app.js`);
+  const end = source.indexOf('\n};', start);
+  assert.notEqual(end, -1, `${name} should be a closed object literal`);
+  // Strip comments first: a commented-out entry is absent from the runtime map,
+  // so counting it would report coverage the renderer does not have.
+  const body = source.slice(start, end).replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+  return Object.fromEntries(
+    [...body.matchAll(/^\s+([A-Za-z0-9_]+):\s*'([^']+)'/gm)].map((entry) => [entry[1], entry[2]])
+  );
+}
+
+const app = read('app.js');
+const accountGroups = providerMap(app, 'LIMIT_PROVIDER_ACCOUNT_GROUP_IDS');
+const accountStatuses = providerMap(app, 'LIMIT_PROVIDER_ACCOUNT_STATUS_IDS');
+const connectionDetails = providerMap(app, 'LIMIT_PROVIDER_CONNECTION_DETAIL_KEYS');
+
+test('every account group reports its state through a status pill', () => {
+  // limitProviderAccountGroup and limitProviderAccountStatus are looked up
+  // independently, so a group with no status entry renders an expandable panel
+  // that never shows whether the credential took.
+  assert.deepEqual(Object.keys(accountGroups).sort(), Object.keys(accountStatuses).sort());
+});
+
+test('every catalog provider reaches an account group or a connection explainer', () => {
+  // renderLimitProviderCheckboxes gates the whole options block on
+  // `accountGroup || settings || connectionDetailKey`, so a provider in neither
+  // map has nothing to expand into. The two are deliberately not exclusive —
+  // antigravity carries both, an explainer above its account group — so this
+  // asserts the union rather than a partition.
+  const configured = new Set([...Object.keys(accountGroups), ...Object.keys(connectionDetails)]);
+  assert.deepEqual([...configured].sort(), [...LIMIT_PROVIDER_IDS].sort());
+});
+
+test('every mapped settings element exists in index.html', () => {
+  const html = read('index.html');
+  for (const [provider, groupId] of Object.entries(accountGroups)) {
+    assert.match(html, new RegExp(`id="${groupId}"`), `${provider} maps to a missing #${groupId}`);
+  }
+  for (const [provider, statusId] of Object.entries(accountStatuses)) {
+    // Match the tag, then its attributes separately: the pill class is the
+    // contract, the order it is written in is not.
+    const tag = html.match(new RegExp(`<[^>]*\\bid="${statusId}"[^>]*>`));
+    assert.ok(tag, `${provider} maps to a missing #${statusId}`);
+    assert.match(tag[0], /class="[^"]*\bcursor-status-pill\b/, `#${statusId} should render as a status pill`);
+  }
+});
+
+test('every connection explainer resolves to translated copy', () => {
+  // limitProviderConnectionDetail passes the key straight to t(), which echoes
+  // an unknown key back, so a missing entry ships the key itself as body text.
+  // Only English is checked here; i18n.test.js holds the locales to it.
+  for (const [provider, key] of Object.entries(connectionDetails)) {
+    assert.ok(MESSAGES.en[key], `${provider} needs a ${key} entry in i18n.js`);
+  }
+});

--- a/tests/electron/limitProviderCoverage.test.js
+++ b/tests/electron/limitProviderCoverage.test.js
@@ -72,6 +72,23 @@ test('every catalog provider reaches an account group or a connection explainer'
   assert.deepEqual([...configured].sort(), [...LIMIT_PROVIDER_IDS].sort());
 });
 
+test('each mapped element belongs to the provider that points at it', () => {
+  // Existing in index.html is not enough: `cursor: 'claudeAccountGroup'` resolves
+  // to a real element, so the DOM check passes while the settings page drives
+  // Claude's controls from Cursor's row. Every id today is its provider id
+  // followed by a capitalised suffix, and requiring the capital is what keeps
+  // zai from claiming zaiteam's elements.
+  for (const [map, name] of [[accountGroups, 'account group'], [accountStatuses, 'status pill']]) {
+    for (const [provider, elementId] of Object.entries(map)) {
+      assert.match(
+        elementId,
+        new RegExp(`^${provider}[A-Z]`),
+        `${provider} points at a ${name} named for another provider: #${elementId}`
+      );
+    }
+  }
+});
+
 test('every mapped settings element exists in index.html', () => {
   const html = read('index.html');
   // Locate the tag and reject one that falls inside a comment, rather than

--- a/tests/electron/limitProviderCoverage.test.js
+++ b/tests/electron/limitProviderCoverage.test.js
@@ -21,6 +21,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
+const vm = require('node:vm');
 
 const { LIMIT_PROVIDER_IDS } = require('../../src/shared/limitProviders');
 const { MESSAGES } = require('../../src/electron/renderer/i18n');
@@ -33,15 +34,16 @@ const read = (file) => fs.readFileSync(path.join(rendererDir, file), 'utf8');
 // required instead, without any invariant here changing.
 function providerMap(source, name) {
   const start = source.indexOf(`const ${name} = {`);
-  assert.notEqual(start, -1, `${name} should be declared in app.js`);
+  assert.notEqual(start, -1, `${name} should be declared in app.js as a plain object literal`);
   const end = source.indexOf('\n};', start);
   assert.notEqual(end, -1, `${name} should be a closed object literal`);
-  // Strip comments first: a commented-out entry is absent from the runtime map,
-  // so counting it would report coverage the renderer does not have.
-  const body = source.slice(start, end).replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
-  return Object.fromEntries(
-    [...body.matchAll(/^\s+([A-Za-z0-9_]+):\s*'([^']+)'/gm)].map((entry) => [entry[1], entry[2]])
-  );
+  // Evaluate the literal rather than pattern-matching its entries. A parser that
+  // recognises one spelling of an entry drops what it cannot read, and a dropped
+  // entry weakens the checks below without failing any of them: antigravity is in
+  // both the account-group and connection-detail maps, so losing its group would
+  // leave key-equality and the union green while nothing checked its DOM nodes.
+  // Evaluating also lets the JS parser decide what a comment is.
+  return vm.runInNewContext(`(${source.slice(source.indexOf('{', start), end + 2)})`);
 }
 
 const app = read('app.js');

--- a/tests/electron/limitProviderCoverage.test.js
+++ b/tests/electron/limitProviderCoverage.test.js
@@ -71,13 +71,20 @@ test('every catalog provider reaches an account group or a connection explainer'
 });
 
 test('every mapped settings element exists in index.html', () => {
-  // Strip comments first: getElementById cannot see a commented-out element, so
-  // matching inside one would report a surface the settings page has not got.
-  const html = read('index.html').replace(/<!--[\s\S]*?-->/g, '');
+  const html = read('index.html');
+  // Locate the tag and reject one that falls inside a comment, rather than
+  // stripping comments out of the document first: getElementById cannot see a
+  // commented-out element, so counting it would report a surface the settings
+  // page has not got. A comment runs to its first `-->`, which is how the parser
+  // reads it too.
+  const commentSpans = [...html.matchAll(/<!--[\s\S]*?-->/g)]
+    .map((comment) => [comment.index, comment.index + comment[0].length]);
+  const inComment = (index) => commentSpans.some(([start, end]) => index >= start && index < end);
   // Require whitespace before the attribute. A bare `id="x"` also matches
   // data-id="x", and so does `\bid="x"` — the hyphen is a word boundary — and
   // neither is an element the renderer can look up.
-  const tagWithId = (elementId) => html.match(new RegExp(`<[^>]*\\sid="${elementId}"[^>]*>`));
+  const tagWithId = (elementId) => [...html.matchAll(new RegExp(`<[^>]*\\sid="${elementId}"[^>]*>`, 'g'))]
+    .find((match) => !inComment(match.index));
   for (const [provider, groupId] of Object.entries(accountGroups)) {
     assert.ok(tagWithId(groupId), `${provider} maps to a missing #${groupId}`);
   }

--- a/tests/shared/limitProviders.test.js
+++ b/tests/shared/limitProviders.test.js
@@ -12,7 +12,7 @@ const {
   LIMIT_PROVIDER_LABELS,
   limitProvidersForDetectedClients
 } = require('../../src/shared/limitProviders');
-const { parseLimitProviders } = require('../../src/shared/limitCollector');
+const { parseLimitProviders, providerFetchers } = require('../../src/shared/limitCollector');
 
 const rootDir = path.join(__dirname, '..', '..');
 const read = (...parts) => fs.readFileSync(path.join(rootDir, ...parts), 'utf8');
@@ -77,6 +77,20 @@ test('only an omitted provider selection defaults to all providers', () => {
   assert.deepEqual(parseLimitProviders(), LIMIT_PROVIDER_IDS);
   assert.deepEqual(parseLimitProviders(''), []);
   assert.deepEqual(parseLimitProviders([]), []);
+});
+
+// Dispatch coverage. collectLimitsOnce resolves a provider through this table,
+// so a catalog entry with no fetcher is a provider the collector silently skips:
+// it renders in settings, accepts a credential, and never reports a window.
+test('every provider in the catalog has a limits fetcher', () => {
+  // Called with no deps on purpose. deps.providerFetchers spreads over the
+  // defaults as a test seam, so passing anything here would let an injected
+  // stub stand in for a provider that has no real fetcher.
+  const fetchers = providerFetchers();
+  assert.deepEqual(Object.keys(fetchers).sort(), [...LIMIT_PROVIDER_IDS].sort());
+  for (const [id, fetcher] of Object.entries(fetchers)) {
+    assert.equal(typeof fetcher, 'function', `${id} should map to a fetcher function`);
+  }
 });
 
 test('every provider has a display label', () => {


### PR DESCRIPTION
A limits provider needs two things before it works, and each lives in its own hand-maintained table keyed by provider id: a fetcher in `providerFetchers()` (`src/shared/limitCollector.js`) and a settings surface in `app.js` — an account group with a status pill, or a connection explainer for the providers detected without a credential. Nothing checked that a `LIMIT_PROVIDER_CATALOG` entry reached either. A provider with no fetcher renders in settings, accepts a credential and never reports a window; one with no account group or explainer renders a row that expands into nothing.

The existing `AI Tool Limits owns every live account group and its status pill` check starts from a written-out list of 17 providers while the map actually holds 21, so `antigravity`, `zed`, `commandcode` and `alibaba` are unguarded today — and starting from a list cannot see a provider that never reached the map at all. As in #615, the catalog is the direction that catches it, so this adds checks rather than editing that one.

## What the guards assert

`tests/shared/limitProviders.test.js` (+1)

- The dispatch table and the catalog are set-equal in both directions and every value is a function. Called with no deps on purpose: `deps.providerFetchers` spreads over the defaults as a test seam, so passing anything would let an injected stub stand in for a provider that has no real fetcher.

`tests/electron/limitProviderCoverage.test.js` (new, +5)

- The account-group and status-pill maps cover the same providers.
- `union(accountGroups, connectionDetails)` equals the catalog. This is a deliberate contract and is **stricter** than the renderer's own `accountGroup || settings || connectionDetailKey` gate: `LIMIT_PROVIDER_SETTINGS` is that third path, but it holds display toggles (Claude prepaid balance, Codex additional limits, OpenCode local limits), so a provider carrying only a toggle would satisfy the gate while offering no way to connect. The two maps are also **not** required to be exclusive — `antigravity` carries both — so this asserts the union, not a partition.
- Every mapped element id exists in `index.html`, and every status element carries `cursor-status-pill`. A tag inside an HTML comment is rejected and the id attribute requires leading whitespace, so neither a commented-out element nor a `data-id="…"` can satisfy it — `getElementById` resolves none of them. The tag and its attributes are matched separately, so the class is the contract and the order it is written in is not.
- Every mapped element id is its own provider id followed by a capitalised suffix, so `cursor: 'claudeAccountGroup'` fails. That id resolves to a real element, so existence alone would pass while the settings page drove Claude's controls from Cursor's row. Requiring the capital is what stops `zai` from claiming `zaiteam`'s elements.
- Every connection explainer resolves in `MESSAGES.en`; locale parity is already held by `i18n.test.js`, so it is not repeated here.

These prove coverage, not correctness: that every provider resolves to some configurable or explained path, not that the path suits how it authenticates. That limit is recorded in the file header.

## Known transitional debt

`providerMap()` reads the three maps out of `app.js` source because they are declared inside a file that only loads in a browser. It evaluates the literal in a `vm` context, as the renderer guards in `tests/electron` already do, so entry syntax and comments are the JS parser's problem rather than a regex's — the remaining coupling is to the declaration form (`const NAME = {` … `\n};`), which fails loudly rather than quietly reading nothing. That is the same trade-off `clientPresentationCoverage.test.js` made for `clientsWithIcon` in #615, and it is noted in the test: once these maps get a module boundary, the guard should consume the exported metadata instead. Splitting the renderer for it now would inflate this slice.

## Verification

`npm run verify` — 4076 tests, 4075 pass, 0 fail (the 1 skip is unchanged from `main`), lint clean.

Every check was falsified individually against 17 mutations, and each has a break case no other check catches — including "a provider added to the catalog *and* wired to a fetcher but given no settings surface", which only the union check sees, and the three DOM shapes above, which `getElementById` cannot resolve. Reformatting a map entry to double quotes is green, as it should be, while doing that *and* removing the element it points at is not.

`src/shared/limitCollector.js` is not worker-vendored, so exporting `providerFetchers` leaves the Hub build marker untouched; no `sync:worker` or `update:hub-build` is needed. All 24 catalog providers pass today, so there is no production behaviour change beyond the one added export.

Fourth slice of #550.
