### PR TITLE
refactor(renderer): test catalog membership before comparing subscription cost

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -3,7 +3,7 @@
 // Client identity — ids, labels and display order — comes from the shared
 // catalog (loaded as a script before this file). Destructured to the bare
 // names the call sites below already use.
-const { CLIENT_LABELS: clientLabels, KNOWN_CLIENT_LIST: KNOWN_CLIENTS } = window.TokenMonitorClientCatalog;
+const { CLIENT_IDS, CLIENT_LABELS: clientLabels, KNOWN_CLIENT_LIST: KNOWN_CLIENTS } = window.TokenMonitorClientCatalog;
 // Limits provider identity comes from its own shared catalog, bound here rather
 // than at its first use below because the icon tables are derived from it.
 const { LIMIT_PROVIDER_CATALOG: LIMIT_PROVIDERS, LIMIT_PROVIDER_IDS } = window.TokenMonitorLimitProviders;
@@ -2520,8 +2520,16 @@ function subscriptionLocalDate(dateString) {
 // (openrouter, deepseek, thirdparty, zai…) simply produce nothing, which is the
 // correct answer: their spend is either pay-as-you-go or spread across clients
 // with no way to attribute it.
+//
+// Membership comes from the catalog rather than from clientLabels. That map is a
+// display lookup and deliberately carries ids that are not tracked clients, so
+// keying off it would let "we can render a name for this" stand in for "this
+// provider names a client we count tokens for". The two happen to agree today
+// only because the one label-only id is not a limits provider.
+const catalogClientIds = new Set(CLIENT_IDS);
+
 function subscriptionUsageCostUsd(providerId) {
-  if (!Object.prototype.hasOwnProperty.call(clientLabels, providerId)) return null;
+  if (!catalogClientIds.has(providerId)) return null;
   const month = state.stats?.periods?.month;
   const cost = Number(month?.clientCosts?.[providerId] || 0);
   return cost > 0 ? cost : null;

--- a/src/shared/clientCatalog.js
+++ b/src/shared/clientCatalog.js
@@ -88,9 +88,9 @@
   // (usageCharts.js), clientsWithIcon (app.js) and VENDOR_LABELS
   // (themePresets.js), and does not depend on this map.
   //
-  // Keep it minimal: subscriptionUsageCostUsd() in app.js reads a key in the
-  // merged CLIENT_LABELS as "this provider id names a client", so every id added
-  // here widens that test too.
+  // Keep it minimal anyway. This is a label lookup, so an id belongs here only
+  // when a row that can actually appear would otherwise render as the bare id —
+  // not as a cheap way to register a client.
   const NON_CATALOG_CLIENT_LABELS = Object.freeze({ gemini: 'Gemini' });
 
   const CLIENT_IDS = Object.freeze(CLIENT_CATALOG.map((client) => client.id));

--- a/tests/electron/clientPresentationCoverage.test.js
+++ b/tests/electron/clientPresentationCoverage.test.js
@@ -18,7 +18,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
 
-const { CLIENT_IDS } = require('../../src/shared/clientCatalog');
+const { CLIENT_IDS, CLIENT_LABELS } = require('../../src/shared/clientCatalog');
 const { VENDOR_ORDER, VENDOR_LABELS } = require('../../src/electron/renderer/themePresets');
 const { clientColors } = require('../../src/electron/renderer/usageCharts');
 
@@ -83,4 +83,29 @@ test('every catalog client resolves to an icon asset through its CSS rule', () =
       `.row-icon-${id} references ${url[1]}, which resolves to a missing file: ${resolved}`
     );
   }
+});
+
+test('the subscription usage comparison tests catalog membership, not label presence', () => {
+  // Same category of mistake as clientsWithIcon above, in the other direction:
+  // CLIENT_LABELS is a display lookup, not a client list. It deliberately
+  // carries ids that are not catalog clients, so a key in it answers "can we
+  // render a name for this" rather than "does this provider name a client we
+  // count tokens for". subscriptionUsageCostUsd needs the second question — it
+  // decides whether a subscription's price is compared against usage cost — and
+  // the two only agree today because the label-only ids happen not to be limits
+  // providers. Read from source for the same reason as clientsWithIcon.
+  const labelOnly = Object.keys(CLIENT_LABELS).filter((id) => !CLIENT_IDS.includes(id));
+  const source = fs.readFileSync(rendererPath, 'utf8');
+  const body = source.match(/function subscriptionUsageCostUsd\([\s\S]*?\n}/);
+  assert.ok(body, 'subscriptionUsageCostUsd should exist in app.js');
+  assert.doesNotMatch(
+    body[0],
+    /clientLabels/,
+    `subscriptionUsageCostUsd must not read clientLabels as a membership test; it carries ${labelOnly.length} non-catalog id(s) (${labelOnly.join(', ') || 'none right now'})`
+  );
+  assert.match(
+    body[0],
+    /catalogClientIds\.has\(/,
+    'subscriptionUsageCostUsd should test membership against the catalog client ids'
+  );
 });


### PR DESCRIPTION
`subscriptionUsageCostUsd()` decides whether a subscription's price is compared against the month's usage cost for the same id. It asked that question of `clientLabels`, which is a display lookup rather than a client list: `CLIENT_LABELS` merges the catalog with `NON_CATALOG_CLIENT_LABELS`, so a key in it means "we can render a name for this", not "this provider names a client we count tokens for". It now tests `CLIENT_IDS`.

```diff
-  if (!Object.prototype.hasOwnProperty.call(clientLabels, providerId)) return null;
+  if (!catalogClientIds.has(providerId)) return null;
```

## No behaviour change

The two tables differ by exactly one id, which is not a limits provider. All three call sites pass either `subscription.provider` or a provider group id, so the difference is unreachable today. This is a latent-correctness change, not a bug fix.

| | before | after |
| --- | ---: | ---: |
| membership read from | `CLIENT_LABELS` (29 keys) | `CLIENT_IDS` (28) |
| ids where the two disagree | 1 | — |
| of those, reachable as a limits provider | 0 | 0 |
| **behaviour difference today** | — | **none** |

## What it buys

`clientCatalog.js` had to carry this warning:

> Keep it minimal: `subscriptionUsageCostUsd()` in app.js reads a key in the merged `CLIENT_LABELS` as "this provider id names a client", so every id added here widens that test too.

That made a display decision quietly carry a second meaning — adding a label so a row renders with a name also widened a money comparison. The caveat is deleted, and the note in its place says what the map is for. `NON_CATALOG_CLIENT_LABELS` can now grow on display grounds alone.

The other five `clientLabels` reads are all `clientLabels[x] || x` display fallbacks or lookups handed to render helpers, so this was the only place the map stood in for a client list.

## Guard

The new test lives in `tests/electron/clientPresentationCoverage.test.js`, beside the one explaining that `clientsWithIcon` is an icon table rather than a client list — the same category of mistake in the other direction. It reads the function from source for the same reason that one does, fails on the previous form, and names the offending ids in the failure message:

```
subscriptionUsageCostUsd must not read clientLabels as a membership test;
it carries 1 non-catalog id(s) (gemini)
```

Without it, the next person reaching for the label map is caught by review or not at all.

## Verification

`npm run verify` — 4,097 tests, 0 failures, 1 skipped (pre-existing); ESLint clean. `main` is at 4,096; the added case is the guard above. `clientCatalog.js` is not in the Worker closure, so the Hub build marker is unchanged. No UI change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `subscriptionUsageCostUsd()` to test membership against the catalog client ids (`CLIENT_IDS`) instead of the display label map (`CLIENT_LABELS`). `CLIENT_LABELS` merges in `NON_CATALOG_CLIENT_LABELS`, so a key there means "we can render a name for this," not "this provider names a client we count tokens for." No behavior changes today — the maps disagree only on `gemini`, which is not a limits provider — but the change decouples a display decision from a money comparison and removes the misleading caveat in `clientCatalog.js`.

| Area | Before | After |
| --- | --- | --- |
| Membership source | `CLIENT_LABELS` (29 keys) | `CLIENT_IDS` (28 keys) |
| Behavior difference today | none | none |

## Verification
- `npm run verify` passes (4,097 tests, 0 failures, 1 pre-existing skip); ESLint clean.
- Added a guard test in `tests/electron/clientPresentationCoverage.test.js` that fails on the old form and names the offending ids.

<sup>Written for commit 49b9a1bbcdce98d1aeea42d39b732b74f0c349ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

