### PR TITLE
fix(codex): use never approval for app-server fallback

### DIFF
--- a/src/shared/providers/codex/limits.js
+++ b/src/shared/providers/codex/limits.js
@@ -596,7 +596,7 @@ function existingCodexCommandCandidates(candidates, deps = {}) {
 }
 
 function codexSpawnSpec(command, platform = process.platform) {
-  const args = ['-s', 'read-only', '-a', 'untrusted', 'app-server'];
+  const args = ['-s', 'read-only', '-a', 'never', 'app-server'];
   if (platform !== 'win32' || !/\.(cmd|bat)$/i.test(command)) {
     return { command, args };
   }

--- a/tests/shared/providerProcessCancellation.test.js
+++ b/tests/shared/providerProcessCancellation.test.js
@@ -62,6 +62,37 @@ test('Codex RPC terminates its app-server child when its parent signal aborts', 
   assert.equal(child.kills, 1);
 });
 
+test('Codex RPC starts app-server with an approval policy supported by current CLI', async () => {
+  const child = fakeRpcChild((request, respond) => {
+    if (request.method === 'initialize') respond({});
+    if (request.method === 'account/rateLimits/read') {
+      respond({
+        rateLimits: {
+          primary: { usedPercent: 10, resetsAt: '2026-07-22T12:00:00Z', windowDurationMins: 300 }
+        }
+      });
+    }
+    if (request.method === 'account/read') {
+      respond({ account: { email: 'user@example.com', planType: 'plus' } });
+    }
+  });
+  let spawnSpec;
+
+  await readCodexRpcWithCommand('codex', {
+    spawn: (command, args) => {
+      spawnSpec = { command, args };
+      return child;
+    },
+    platform: 'linux',
+    codexEmptyQuotaRetry: false
+  });
+
+  assert.deepEqual(spawnSpec, {
+    command: 'codex',
+    args: ['-s', 'read-only', '-a', 'never', 'app-server']
+  });
+});
+
 test('Codex RPC rejects a pending request when app-server stdin breaks', async () => {
   const child = fakeChild();
   const pending = readCodexRpcWithCommand('codex', {


### PR DESCRIPTION
## Summary

Codex CLI 0.149.0 removed the `untrusted` approval policy. Token Monitor still passed it when starting the app-server fallback, so Codex quota collection failed before the RPC session could initialize when the OAuth request fell back to app-server.

Use `-a never` with the existing `-s read-only` invocation and add a regression test that asserts the spawned arguments.

Fixes #623

## Validation

- `npm test` — 4,108 passed, 1 skipped
- ESLint on changed files — passed
- `git diff --check` — passed
- Local Codex CLI 0.153.3:
  - `-a untrusted` exits 2 with the invalid-value error
  - `-a never` starts app-server and completes `initialize`
- `npm run verify` remains blocked by existing ESLint errors in `scripts/simulate-limits.js:21`, outside this change


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex quota collection failing in the app-server fallback because the `untrusted` approval policy was removed in Codex CLI 0.149.0. Fixes #623.

- Switches the app-server spawn args from `-a untrusted` to `-a never` alongside the existing `-s read-only`.
- Adds a regression test asserting the exact spawned arguments.

| Area | Before | After |
| --- | --- | --- |
| App-server approval policy | `untrusted` (removed in Codex CLI 0.149.0) | `never` |

**Validation**

- `npm test` — 4,108 passed, 1 skipped.
- Local Codex CLI 0.153.3: `-a untrusted` exits 2 with the invalid-value error; `-a never` starts app-server and completes `initialize`.
- ESLint on changed files and `git diff --check` passed.

<sup>Written for commit 7b9f715f159e962dbc9394fbff3fb9d2a29b4424. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

