### PR TITLE
fix(collector): bound OpenClaw live watcher scope

### DIFF
--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -2417,6 +2417,17 @@ function clientsForWatchPath(filePath, rootsByClient) {
 // never recurses into an ignored dir (so the runaway poll is gone), yet a
 // newly created state.db-wal is still seen on the next top-level readdir.
 const HERMES_DB_FILES = new Set(['state.db', 'state.db-wal', 'state.db-shm']);
+// OpenClaw keeps each agent's usage sources in a small set of lanes under
+// ~/.openclaw/agents/<agentId>: legacy/published JSONL under sessions/, doctor
+// migration archives beside it, the current per-agent SQLite store, and Codex
+// app-server rollouts under agent/codex-home. The rest of an agent directory is
+// runtime/workspace state and can contain dependency trees large enough to make
+// chokidar allocate thousands of directory watches. Keep the official source
+// lanes live; Tokscale's periodic full scan remains the fallback for a
+// non-standard JSONL placed elsewhere under agents/.
+const OPENCLAW_TRANSCRIPT_DIRS = new Set(['sessions', 'session-sqlite-import-archive']);
+const OPENCLAW_AGENT_DB_WATCH_PATTERN = /^openclaw-agent\.sqlite(?:-(?:wal|shm))?$/;
+const OPENCLAW_CODEX_HOME_DIRS = new Set(['sessions', 'archived_sessions']);
 // OpenCode discovers only direct opencode.db / opencode-<channel>.db files.
 // WAL/SHM are not database inputs to tokscale, but they are the live-write
 // signals that must remain watched so a transaction committed before a
@@ -2528,6 +2539,23 @@ function watchPolicyEntries(clientsCsv) {
   // watch root — the home AND every profile dir under it — is kept by the
   // matcher itself, so a profile's own database still reports.
   bound('hermes', candidates.hermes || [], (parts) => !HERMES_DB_FILES.has(parts[parts.length - 1]));
+
+  bound('openclaw', candidates.openclaw || [], (parts) => {
+    // The first level is the dynamic agent id. Keep it so newly created agents
+    // can expose one of the bounded source lanes below.
+    if (parts.length === 1) return false;
+    if (OPENCLAW_TRANSCRIPT_DIRS.has(parts[1])) return false;
+    if (parts[1] !== 'agent') return true;
+
+    // Keep the parent so a fresh SQLite store or codex-home can appear after
+    // startup, then limit its contents to those two sources.
+    if (parts.length === 2) return false;
+    if (parts.length === 3) {
+      return parts[2] !== 'codex-home' && !OPENCLAW_AGENT_DB_WATCH_PATTERN.test(parts[2]);
+    }
+    if (parts[2] !== 'codex-home') return true;
+    return !OPENCLAW_CODEX_HOME_DIRS.has(parts[3]);
+  });
 
   bound('copilot', withBasename('copilot', '.copilot'), (parts) => {
     if (parts[0] === 'otel') return false;

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -172,6 +172,67 @@ test('watchIgnoreMatcher keeps every direct Tokscale MiMo database variant but p
   }
 });
 
+test('watchIgnoreMatcher bounds OpenClaw to its per-agent usage sources', () => {
+  const root = path.join('.openclaw', 'agents');
+  const tmp = withTmpHome([
+    path.join(root, 'main', 'sessions'),
+    path.join(root, 'main', 'session-sqlite-import-archive'),
+    path.join(root, 'main', 'agent', 'codex-home', 'sessions', '2026', '09', '07'),
+    path.join(root, 'main', 'agent', 'codex-home', 'archived_sessions'),
+    path.join(root, 'main', 'workspace', 'node_modules', 'package', 'cache'),
+    path.join(root, 'main', 'logs')
+  ]);
+  const originalHomedir = os.homedir;
+  os.homedir = () => tmp;
+  try {
+    const { watchIgnoreMatcher, watchPathsForClients } = freshCollector();
+    const agents = path.join(tmp, root);
+    const ignored = watchIgnoreMatcher('openclaw');
+
+    assert.deepEqual(watchPathsForClients('openclaw'), [agents]);
+    assert.equal(typeof ignored, 'function');
+
+    const kept = [
+      agents,
+      path.join(agents, 'main'),
+      path.join(agents, 'main', 'sessions'),
+      path.join(agents, 'main', 'sessions', 'session.jsonl'),
+      path.join(agents, 'main', 'sessions', 'session.jsonl.deleted.123'),
+      path.join(agents, 'main', 'session-sqlite-import-archive'),
+      path.join(agents, 'main', 'session-sqlite-import-archive', 'archive-tier.session.jsonl.imported-123'),
+      path.join(agents, 'main', 'agent'),
+      path.join(agents, 'main', 'agent', 'openclaw-agent.sqlite'),
+      path.join(agents, 'main', 'agent', 'openclaw-agent.sqlite-wal'),
+      path.join(agents, 'main', 'agent', 'openclaw-agent.sqlite-shm'),
+      path.join(agents, 'main', 'agent', 'codex-home'),
+      path.join(agents, 'main', 'agent', 'codex-home', 'sessions'),
+      path.join(agents, 'main', 'agent', 'codex-home', 'sessions', '2026', '09', '07', 'rollout.jsonl'),
+      path.join(agents, 'main', 'agent', 'codex-home', 'archived_sessions'),
+      path.join(agents, 'main', 'agent', 'codex-home', 'archived_sessions', 'rollout.jsonl')
+    ];
+    for (const target of kept) assert.equal(ignored(target), false, target);
+
+    const pruned = [
+      path.join(agents, 'main', 'workspace'),
+      path.join(agents, 'main', 'workspace', 'node_modules'),
+      path.join(agents, 'main', 'workspace', 'node_modules', 'package', 'cache'),
+      path.join(agents, 'main', 'logs'),
+      path.join(agents, 'main', 'logs', 'runtime.log'),
+      path.join(agents, 'main', 'agent', 'runtime'),
+      path.join(agents, 'main', 'agent', 'runtime', 'session.jsonl'),
+      path.join(agents, 'main', 'agent', 'incognito-openclaw-agent.sqlite'),
+      path.join(agents, 'main', 'agent', 'codex-home', 'history.jsonl'),
+      path.join(agents, 'main', 'agent', 'codex-home', 'tmp'),
+      path.join(agents, 'main', 'agent', 'codex-home', 'tmp', 'rollout.jsonl')
+    ];
+    for (const target of pruned) assert.equal(ignored(target), true, target);
+  } finally {
+    os.homedir = originalHomedir;
+    delete require.cache[collectorPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test('watchIgnoreMatcher bounds OpenCode to its database family and legacy message source', () => {
   const root = path.join('.local', 'share', 'opencode');
   const tmp = withTmpHome([


### PR DESCRIPTION
## Summary

- keep OpenClaw live watching on its documented per-agent usage sources
- prune unrelated workspace and runtime trees before chokidar allocates directory watches
- retain periodic full Tokscale reconciliation for non-standard JSONL locations

## Why

`~/.openclaw/agents` can contain large runtime and workspace trees. Watching the entire directory recursively causes chokidar to allocate directory watches for paths that do not contain usage data.

We also tested the native macOS watcher approach from #621, but repeated appends to an already-open Codex rollout file were not delivered reliably. This change therefore keeps the existing chokidar backend and narrows only the OpenClaw live-watch surface.

The retained live sources are:

- `<agentId>/sessions/**`
- `<agentId>/session-sqlite-import-archive/**`
- `<agentId>/agent/openclaw-agent.sqlite{,-wal,-shm}`
- `<agentId>/agent/codex-home/{sessions,archived_sessions}/**`

Other paths remain covered by the existing periodic full Tokscale scan, so non-standard layouts may refresh later but are not excluded from final accounting.

## Validation

- `node --test tests/shared/collectorLoadGuards.test.js`
  - 93 passed
- `npm run verify`
  - 4109 passed
  - 0 failed
  - 1 skipped
- synthetic OpenClaw tree with 1,000 nested runtime packages, using the polling fallback:
  - before: 2,012 watched directories, approximately 44.5 MB incremental RSS
  - after: 10 watched directories, approximately 1.4 MB incremental RSS

The synthetic benchmark verifies the pruning boundary. Testing against the original reporter's real OpenClaw tree is still needed to confirm the effect on the reported 2.2 GB case.

Related to #621.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds OpenClaw live watching to its documented per-agent usage sources, so chokidar no longer traverses large runtime and workspace trees under `~/.openclaw/agents`. Periodic full Tokscale scans still reconcile non-standard JSONL placements.

**Before / After**

| Area | Before | After |
| --- | --- | --- |
| OpenClaw watch scope | Entire `~/.openclaw/agents` recursively | Only `sessions/`, `session-sqlite-import-archive/`, `agent/openclaw-agent.sqlite{,-wal,-shm}`, and `agent/codex-home/{sessions,archived_sessions}` |

**Implementation notes**

- Keeps the chokidar backend; the native macOS watcher from #621 didn't deliver appends reliably.
- Added a new watch-ignore matcher test suite (93 passing); full `npm run verify` passes.
- Synthetic benchmark with 1,000 nested runtime packages: watched directories drop from 2,012 to 10, incremental RSS from ~44.5 MB to ~1.4 MB.
- Still needs verification against the original reporter's real 2.2 GB OpenClaw tree.

<sup>Written for commit 6f81788d59408827d93287fd767d441babee827d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

