### PR TITLE
fix(renderer): generalize hunyuan vendor rule to cover hyN series models

### DIFF
--- a/src/electron/renderer/usageCharts.js
+++ b/src/electron/renderer/usageCharts.js
@@ -392,7 +392,7 @@
     if (/mimo|xiaomi/.test(name)) return 'xiaomi';
     if (/minimax|\babab/.test(name)) return 'minimax';
     if (/doubao|\bseed(?:-|$)/.test(name)) return 'doubao';
-    if (/hy3|hunyuan/.test(name)) return 'hunyuan';
+    if (/hy\d|hunyuan/.test(name)) return 'hunyuan';
     if (/^big-pickle$/.test(name)) return 'opencode'; // OpenCode Zen stealth model — no vendor hint in the name
     return null;
   }

--- a/tests/electron/dashboardCharts.test.js
+++ b/tests/electron/dashboardCharts.test.js
@@ -60,6 +60,7 @@ test('modelVendorFor maps families and modelColor falls back deterministically',
   assert.equal(modelVendorFor('k3-agent-swarm'), 'kimi');
   assert.equal(modelVendorFor('doubao-seed-1.6'), 'doubao');
   assert.equal(modelVendorFor('hy3'), 'hunyuan');
+  assert.equal(modelVendorFor('hy4-preview'), 'hunyuan');
   assert.equal(modelVendorFor('hunyuan-t1'), 'hunyuan');
   assert.equal(modelColor('claude-opus'), clientColors.claude);
   assert.equal(modelColor('hy3'), clientColors.hunyuan);


### PR DESCRIPTION
## Summary

The Hunyuan 4 preview model (`hy4-preview`) renders as a plain colored dot in the model breakdown view, while Hunyuan 3 (`hy3`) shows its brand icon correctly.

Hunyuan support was added in my previous PR, but the vendor rule hardcoded the version number (`hy3`), so it does not generalize to the `hyN` series that followed. For comparison, the GLM rule matches on the brand prefix and is version-agnostic, which is why new GLM models (e.g. `glm-5.3-flash`) pick up their icon automatically without further changes.

## Changes

`src/electron/renderer/usageCharts.js` — `modelVendorFor()`, one line:

```diff
-if (/hy3|hunyuan/.test(name)) return 'hunyuan';
+if (/hy\d|hunyuan/.test(name)) return 'hunyuan';
```

No other changes are needed: the `hunyuan` vendor is already in `clientsWithIcon` / `clientLabels`, and the icon asset + CSS mask rule (`.row-icon-hunyuan`) were added in the previous hy3 PR.

## Verification

- [x] Regex behavior: `hy\d` matches `hy3` / `hy4-preview` (and future `hyN`); `hunyuan` substring matching keeps the previous behavior (incl. image models like `hunyuan-image`); no false positives on other vendor names (`hy` without a digit, `glm-*`, etc.)
- [x] Backward compatible: existing `hy3` rows keep their icon
- [x] `tests/electron/usageCharts.test.js` — 36/36 pass with this change; other test files importing `usageCharts.js` pass as well (one unrelated local-env failure `Cannot find module 'tokscale/bin.js'` reproduces identically on unmodified `main`)
- [ ] Full `npm run verify` (lint + test) — left to CI (local sandbox couldn't install devDependencies); the change is a single regex literal in the same style as the adjacent rules

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Hunyuan vendor rule in `modelVendorFor()` so `hyN` series models (e.g., `hy4-preview`) render with the brand icon instead of a plain colored dot.

- The regex changed from `/hy3|hunyuan/` to `/hy\d|hunyuan/`, matching the GLM rule's version-agnostic approach.
- Added a `hy4-preview` assertion to `dashboardCharts.test.js`.

| Area | Before | After |
| --- | --- | --- |
| Model breakdown icon for Hunyuan models | `hy4-preview` (and future `hyN` series) renders as a plain colored dot | Renders with the Hunyuan brand icon |

- Backward compatible: existing `hy3` rows keep their icon; `hunyuan` substring matching preserves behavior for image models like `hunyuan-image`.
- `usageCharts.test.js` passes 36/36 and `dashboardCharts.test.js` covers the new case; one unrelated local-env failure reproduces on unmodified `main`.

<sup>Written for commit f60fb24a9707453157075ff487d56efec877b690. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

