### PR TITLE
fix(kiro): fall back for v2 usage summaries

### DIFF
--- a/src/shared/providers/kiro/limits.js
+++ b/src/shared/providers/kiro/limits.js
@@ -7,9 +7,11 @@
 // setup on startup and writes the report to stdout/stderr as ANSI text. Running
 // `kiro-cli chat --no-interactive /usage` with TERM set captures that output
 // without an interactive session (the same approach Win-CodexBar uses, which is
-// what keeps this portable to Windows — no PTY required). We strip ANSI and
-// regex-parse the report. Parsing mirrors CodexBar's KiroStatusProbe so the
-// supported output formats stay aligned with upstream.
+// what keeps this portable to Windows — no PTY required). Kiro CLI 2.x's default
+// v2 engine can collapse that command to a plan-only summary, so we retry through
+// its legacy v1 UI only for that exact shape. We strip ANSI and regex-parse the
+// report. Parsing mirrors CodexBar's KiroStatusProbe so the supported output
+// formats stay aligned with upstream.
 
 const fs = require('node:fs');
 const path = require('node:path');
@@ -263,7 +265,7 @@ function existingKiroCli(env = process.env, platform = process.platform, deps = 
 // formatted report; stdin is ignored so a prompt can never block us. We resolve
 // with stdout (or stderr when stdout is empty) regardless of exit code, because
 // kiro-cli sometimes prints the report and still exits non-zero.
-function runKiroUsageCli(deps = {}) {
+function runKiroUsageCliOnce(args, deps = {}) {
   const spawnFn = deps.spawn || spawn;
   const env = { ...(deps.env || process.env), TERM: 'xterm-256color' };
   const command = deps.kiroCliPath || 'kiro-cli';
@@ -273,7 +275,7 @@ function runKiroUsageCli(deps = {}) {
   return new Promise((resolve, reject) => {
     let child;
     try {
-      child = spawnFn(command, ['chat', '--no-interactive', '/usage'], {
+      child = spawnFn(command, args, {
         env,
         windowsHide: true,
         stdio: ['ignore', 'pipe', 'pipe']
@@ -312,6 +314,25 @@ function runKiroUsageCli(deps = {}) {
     signal?.addEventListener?.('abort', onAbort, { once: true });
     if (signal?.aborted) onAbort();
   });
+}
+
+function isKiroV2UsageSummary(text) {
+  const stripped = stripAnsi(text);
+  return /Plan:[^\n]*\|\s*\d+\s+usage breakdowns?\s*$/im.test(stripped)
+    && !/█+\s*\d+%/.test(stripped)
+    && !/\(\d+\.?\d*\s+of\s+\d+\s+covered/i.test(stripped);
+}
+
+async function runKiroUsageCli(deps = {}) {
+  const output = await runKiroUsageCliOnce(['chat', '--no-interactive', '/usage'], deps);
+  if (!isKiroV2UsageSummary(output)) return output;
+  return runKiroUsageCliOnce([
+    'chat',
+    '--no-interactive',
+    '--agent-engine=v1',
+    '--legacy-ui',
+    '/usage'
+  ], deps);
 }
 
 function statusOnlyProvider(status, updatedAt) {

--- a/tests/shared/kiroLimits.test.js
+++ b/tests/shared/kiroLimits.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
 const test = require('node:test');
 
 const {
@@ -18,6 +19,20 @@ const LEGACY_BASIC = [
   '████████████████████████████████████████████████████ 25%',
   '(12.50 of 50 covered in plan), resets on 01/15'
 ].join('\n');
+
+const V2_USAGE_SUMMARY = 'Plan: KIRO POWER | 1 usage breakdowns';
+
+function completedKiroProcess(output) {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => {};
+  process.nextTick(() => {
+    child.stdout.emit('data', output);
+    child.emit('close', 0);
+  });
+  return child;
+}
 
 const LEGACY_BONUS = [
   '| KIRO PRO                                           |',
@@ -269,7 +284,6 @@ test('the limits collector re-exports fetchKiroLimits', async () => {
 });
 
 test('runKiroUsageCli terminates immediately when the parent probe is aborted', async () => {
-  const { EventEmitter } = require('node:events');
   const controller = new AbortController();
   const child = new EventEmitter();
   child.stdout = new EventEmitter();
@@ -286,4 +300,33 @@ test('runKiroUsageCli terminates immediately when the parent probe is aborted', 
 
   await assert.rejects(pending, /runtime stopped/);
   assert.equal(kills, 1);
+});
+
+test('runKiroUsageCli retries a v2 plan summary through the legacy v1 UI', async () => {
+  const calls = [];
+  const output = await runKiroUsageCli({
+    spawn: (_command, args) => {
+      calls.push(args);
+      return completedKiroProcess(calls.length === 1 ? V2_USAGE_SUMMARY : LEGACY_BASIC);
+    }
+  });
+
+  assert.equal(output, LEGACY_BASIC);
+  assert.deepEqual(calls, [
+    ['chat', '--no-interactive', '/usage'],
+    ['chat', '--no-interactive', '--agent-engine=v1', '--legacy-ui', '/usage']
+  ]);
+});
+
+test('runKiroUsageCli keeps a complete default-engine report without retrying', async () => {
+  const calls = [];
+  const output = await runKiroUsageCli({
+    spawn: (_command, args) => {
+      calls.push(args);
+      return completedKiroProcess(LEGACY_BASIC);
+    }
+  });
+
+  assert.equal(output, LEGACY_BASIC);
+  assert.deepEqual(calls, [['chat', '--no-interactive', '/usage']]);
 });


### PR DESCRIPTION
## Summary

- Retry Kiro `/usage` through the legacy v1 UI only when the default v2 engine returns the plan-only `usage breakdowns` summary.
- Preserve the existing path for complete default-engine reports, managed plans, and authentication failures.
- Add process-level regression coverage for both fallback and no-retry behavior.

Closes #640

## Verification

- `node --test tests/electron/tray.test.js tests/electron/trayIconSizing.test.js tests/shared/kiroLimits.test.js` — 91 passed
- `npm run verify` — 4,117 passed, 0 failed, 1 skipped
- Live Kiro CLI 2.21.1 probe — provider status `ok`, Power plan, finite Credits window (actual usage values omitted)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Summary

- Retries the Kiro `/usage` query through the legacy v1 UI (`--agent-engine=v1 --legacy-ui`) when CLI 2.x's default v2 engine returns only a plan summary.
- Keeps the default-engine result without retrying when the report is complete, the plan is managed, or authentication fails.
- Adds regression tests covering both the fallback and no-retry paths.

| Area | Before | After |
| --- | --- | --- |
| Kiro `/usage` query | A plan-only v2 summary was accepted as the final usage result. | A plan-only v2 summary triggers one retry via the legacy v1 UI; complete reports are used as-is. |

## Tests and validation

- `node --test tests/electron/tray.test.js tests/electron/trayIconSizing.test.js tests/shared/kiroLimits.test.js` — 91 passed.
- `npm run verify` — 4,117 passed, 0 failed, 1 skipped.
- Live probe against Kiro CLI 2.21.1 confirmed provider status `ok`, a Power plan, and a finite Credits window.

Closes #640

<sup>Written for commit cf76877f4849ea4fe7426ca928336370e816ef8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

