### PR TITLE
fix(workbuddy): align personal billing request with desktop client

### DIFF
--- a/src/shared/providers/workbuddy/limits.js
+++ b/src/shared/providers/workbuddy/limits.js
@@ -10,6 +10,7 @@ const WORKBUDDY_DEFAULT_ENDPOINT = 'https://copilot.tencent.com';
 const WORKBUDDY_PERSONAL_PATH = '/v2/billing/meter/get-user-resource';
 const WORKBUDDY_ENTERPRISE_PATH = '/v2/billing/meter/get-enterprise-user-usage';
 const WORKBUDDY_PRODUCT_CODE = 'p_tcaca';
+const WORKBUDDY_PERSONAL_RANGE_MS = 101 * 365 * 24 * 60 * 60 * 1000;
 
 // WorkBuddy is the only provider reading a credential this way: Trae needs the
 // same precedence but its own stricter cleaner, so this stays local rather than
@@ -79,6 +80,15 @@ function toIso(value) {
   return Number.isNaN(date.getTime()) ? null : date.toISOString();
 }
 
+function formatWorkbuddyDateTime(value) {
+  const date = new Date(value);
+  const pad = (part) => String(part).padStart(2, '0');
+  return [
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`,
+    `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
+  ].join(' ');
+}
+
 function pickValue(source, keys) {
   if (!source || typeof source !== 'object') return null;
   for (const key of keys) {
@@ -129,9 +139,8 @@ function parsePersonalUsage(body) {
       continue;
     }
     const status = numberOrNull(pickValue(resource, ['Status', 'status']));
-    // Status 3 is an exhausted/expired resource package. It is returned by
-    // the endpoint even with OnlyValidPeriod=true, but it is not part of the
-    // currently spendable balance shown by WorkBuddy's website.
+    // The official client requests Status 3 packages for its wider UI, but
+    // those historical rows are not part of the currently spendable balance.
     if (status !== null && status !== 0) continue;
     candidateResources += 1;
     const total = numberOrNull(pickValue(resource, ['CycleCapacitySizePrecise', 'cycleCapacitySizePrecise']));
@@ -397,11 +406,12 @@ async function fetchWorkbuddyLimits(options = {}, deps = {}) {
           PageNumber: 1,
           PageSize: 100,
           ProductCode: WORKBUDDY_PRODUCT_CODE,
-          // The endpoint can return exhausted/expired packages even when
-          // OnlyValidPeriod is true. The website's spendable balance is the
-          // active Status=0 set, so avoid downloading the historical rows too.
-          Status: [0],
-          OnlyValidPeriod: true
+          // Match the server-side package selection used by WorkBuddy's
+          // desktop client. parsePersonalUsage still excludes Status 3 rows
+          // from the current spendable aggregate.
+          Status: [0, 3],
+          PackageEndTimeRangeBegin: formatWorkbuddyDateTime(now),
+          PackageEndTimeRangeEnd: formatWorkbuddyDateTime(now + WORKBUDDY_PERSONAL_RANGE_MS)
         })
       }, requestDeps);
     const usage = isEnterprise ? parseEnterpriseUsage(body) : parsePersonalUsage(body);

--- a/tests/shared/workbuddyLimits.test.js
+++ b/tests/shared/workbuddyLimits.test.js
@@ -13,6 +13,28 @@ const {
 const { collectLimitsOnce } = require('../../src/shared/limits/collector');
 
 const NOW = Date.parse('2026-08-09T10:00:00Z');
+const PERSONAL_REQUEST_NOW = new Date(2026, 7, 9, 10, 11, 12).getTime();
+const PERSONAL_RANGE_MS = 101 * 365 * 24 * 60 * 60 * 1000;
+
+function formatLocalDateTime(value) {
+  const date = new Date(value);
+  const pad = (part) => String(part).padStart(2, '0');
+  return [
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`,
+    `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
+  ].join(' ');
+}
+
+function expectedPersonalRequestBody(now) {
+  return {
+    PageNumber: 1,
+    PageSize: 100,
+    ProductCode: 'p_tcaca',
+    Status: [0, 3],
+    PackageEndTimeRangeBegin: formatLocalDateTime(now),
+    PackageEndTimeRangeEnd: formatLocalDateTime(now + PERSONAL_RANGE_MS)
+  };
+}
 
 function response(body, status = 200) {
   return {
@@ -63,7 +85,7 @@ test('parsePersonalUsage aggregates valid WorkBuddy resource packages', () => {
   assert.equal(usage.window.usedPercent, 40);
 });
 
-test('parsePersonalUsage prefers the reported used amount and excludes non-active packages', () => {
+test('parsePersonalUsage prefers reported usage and excludes requested Status 3 history packages', () => {
   const usage = parsePersonalUsage({
     data: { Response: { Data: { Accounts: [
       {
@@ -153,7 +175,7 @@ test('fetchWorkbuddyLimits sends the private personal billing request without ex
     },
     {
       env: {},
-      now: () => NOW,
+      now: () => PERSONAL_REQUEST_NOW,
       fetch: async (url, init) => {
         requests.push({ url: String(url), init });
         return response({
@@ -182,13 +204,7 @@ test('fetchWorkbuddyLimits sends the private personal billing request without ex
   assert.equal(requests[0].init.headers['X-Domain'], 'copilot.tencent.com');
   assert.equal(requests[0].init.headers['X-Department-Info'], 'Engineering');
   assert.equal(requests[0].init.headers['Accept-Language'], 'en');
-  assert.deepEqual(JSON.parse(requests[0].init.body), {
-    PageNumber: 1,
-    PageSize: 100,
-    ProductCode: 'p_tcaca',
-    Status: [0],
-    OnlyValidPeriod: true
-  });
+  assert.deepEqual(JSON.parse(requests[0].init.body), expectedPersonalRequestBody(PERSONAL_REQUEST_NOW));
   assert.equal(provider.provider, 'workbuddy');
   assert.equal(provider.status, 'ok');
   assert.equal(provider.source, 'api');
@@ -247,6 +263,7 @@ test('fetchWorkbuddyLimits uses the WorkBuddy app session without asking users f
   assert.equal(requests[0].init.headers.Authorization, undefined);
   assert.equal(requests[0].init.headers.Cookie, undefined);
   assert.equal(requests[0].init.headers['X-User-Id'], undefined);
+  assert.deepEqual(JSON.parse(requests[0].init.body), expectedPersonalRequestBody(NOW));
   assert.equal(provider.status, 'ok');
   assert.equal(provider.source, 'local');
   assert.equal(provider.sourceDetail, 'app');

--- a/tests/shared/workbuddyLimits.test.js
+++ b/tests/shared/workbuddyLimits.test.js
@@ -14,27 +14,14 @@ const { collectLimitsOnce } = require('../../src/shared/limits/collector');
 
 const NOW = Date.parse('2026-08-09T10:00:00Z');
 const PERSONAL_REQUEST_NOW = new Date(2026, 7, 9, 10, 11, 12).getTime();
-const PERSONAL_RANGE_MS = 101 * 365 * 24 * 60 * 60 * 1000;
-
-function formatLocalDateTime(value) {
-  const date = new Date(value);
-  const pad = (part) => String(part).padStart(2, '0');
-  return [
-    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`,
-    `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
-  ].join(' ');
-}
-
-function expectedPersonalRequestBody(now) {
-  return {
-    PageNumber: 1,
-    PageSize: 100,
-    ProductCode: 'p_tcaca',
-    Status: [0, 3],
-    PackageEndTimeRangeBegin: formatLocalDateTime(now),
-    PackageEndTimeRangeEnd: formatLocalDateTime(now + PERSONAL_RANGE_MS)
-  };
-}
+const EXPECTED_PERSONAL_REQUEST_BODY = {
+  PageNumber: 1,
+  PageSize: 100,
+  ProductCode: 'p_tcaca',
+  Status: [0, 3],
+  PackageEndTimeRangeBegin: '2026-08-09 10:11:12',
+  PackageEndTimeRangeEnd: '2127-07-16 10:11:12'
+};
 
 function response(body, status = 200) {
   return {
@@ -204,7 +191,7 @@ test('fetchWorkbuddyLimits sends the private personal billing request without ex
   assert.equal(requests[0].init.headers['X-Domain'], 'copilot.tencent.com');
   assert.equal(requests[0].init.headers['X-Department-Info'], 'Engineering');
   assert.equal(requests[0].init.headers['Accept-Language'], 'en');
-  assert.deepEqual(JSON.parse(requests[0].init.body), expectedPersonalRequestBody(PERSONAL_REQUEST_NOW));
+  assert.deepEqual(JSON.parse(requests[0].init.body), EXPECTED_PERSONAL_REQUEST_BODY);
   assert.equal(provider.provider, 'workbuddy');
   assert.equal(provider.status, 'ok');
   assert.equal(provider.source, 'api');
@@ -235,7 +222,7 @@ test('fetchWorkbuddyLimits uses the WorkBuddy app session without asking users f
     { workbuddyDesktopSessionEnabled: true },
     {
       env: {},
-      now: () => NOW,
+      now: () => PERSONAL_REQUEST_NOW,
       fetch: async () => { throw new Error('the local app fetch should be used'); },
       workbuddyFetch: async (url, init) => {
         requests.push({ url: String(url), init });
@@ -263,7 +250,7 @@ test('fetchWorkbuddyLimits uses the WorkBuddy app session without asking users f
   assert.equal(requests[0].init.headers.Authorization, undefined);
   assert.equal(requests[0].init.headers.Cookie, undefined);
   assert.equal(requests[0].init.headers['X-User-Id'], undefined);
-  assert.deepEqual(JSON.parse(requests[0].init.body), expectedPersonalRequestBody(NOW));
+  assert.deepEqual(JSON.parse(requests[0].init.body), EXPECTED_PERSONAL_REQUEST_BODY);
   assert.equal(provider.status, 'ok');
   assert.equal(provider.source, 'local');
   assert.equal(provider.sourceDetail, 'app');


### PR DESCRIPTION
## Summary

- align the personal `get-user-resource` request with the current WorkBuddy desktop client
- replace `OnlyValidPeriod` with `PackageEndTimeRangeBegin` and `PackageEndTimeRangeEnd`
- request both `Status=0` and `Status=3` packages while keeping historical `Status=3` rows out of the spendable balance
- avoid a `CapacityType=4` heuristic that would incorrectly hide credits for genuine Experience-plan users
- cover both explicit-token and WorkBuddy desktop-session request paths

## Testing

- `node --test tests/shared/workbuddyLimits.test.js`
- `npm run verify`
- `git diff --check`

Closes #638
