### PR TITLE
feat(limits): animate quota refills after reset

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -142,6 +142,7 @@ const TRAY_ICON_PROVIDERS = [
 const DEFAULT_LIMIT_PROVIDER_ORDER = LIMIT_PROVIDERS.map((provider) => provider.id).join(',');
 const limitProviderOrderApi = window.TokenMonitorLimitProviderOrder;
 const limitProviderPresentationApi = window.TokenMonitorLimitProviderPresentation;
+const limitResetMotionApi = window.TokenMonitorLimitResetMotion;
 const appUpdatePresentationApi = window.TokenMonitorAppUpdatePresentation;
 const accountIdentityApi = window.TokenMonitorAccountIdentity;
 const clientStatusPresentationApi = window.TokenMonitorClientStatusPresentation;
@@ -281,6 +282,9 @@ const serviceStatusProviderPreferencesApi = window.TokenMonitorServiceStatusProv
 const SETTINGS_SECTION_IDS = ['general', 'main', 'window', 'appearance', 'tools', 'limits', 'subscriptions', 'sync'];
 const REFRESH_BUTTON_FEEDBACK_MS = 700;
 const CODEX_PENDING_ACTIVE_GRACE_MS = 30000;
+const LIMIT_RESET_MOTION_EASING = 'cubic-bezier(0.333, 0.667, 0.667, 1)';
+const LIMIT_RESET_GLOW_MS = 700;
+const LIMIT_RESET_GLOW_LEAD_MS = 252;
 const initialFloatingBubble = window.__TOKEN_MONITOR_INITIAL_FLOATING_BUBBLE__ || { collapsed: false, side: null };
 const initialViewState = window.__TOKEN_MONITOR_INITIAL_VIEW_STATE__ || {};
 let initialBreakdownPreferenceApplied = typeof initialViewState.breakdown === 'string';
@@ -1402,6 +1406,7 @@ function animateTotalNumber(el, from, to, duration) {
 
 const rowNumberAnimations = new Map();
 const rowBarAnimations = new Map();
+const limitResetNumberAnimations = new Map();
 const rowRenderFingerprints = new WeakMap();
 const toolDetailData = new WeakMap();
 const largeSessionContainmentScheduler = createAfterLayoutScheduler(
@@ -1449,6 +1454,11 @@ function settleMotionAnimations() {
     delete el.dataset.motionTarget;
   }
   rowNumberAnimations.clear();
+  for (const [el, motion] of limitResetNumberAnimations) {
+    cancelAnimationFrame(motion.handle);
+    el.textContent = `${formatPercent(motion.target)} ${motion.suffix}`;
+  }
+  limitResetNumberAnimations.clear();
   for (const animation of document.getAnimations?.() || []) {
     try { animation.finish(); } catch (_) { animation.cancel(); }
   }
@@ -1574,7 +1584,14 @@ function animateBreakdownFrom(snapshot, { duration = 420 } = {}) {
   }
 }
 
-function animateBarBetween(fill, fromScale, toScale, delay = 0, duration = 420) {
+function animateBarBetween(
+  fill,
+  fromScale,
+  toScale,
+  delay = 0,
+  duration = 420,
+  easing = 'cubic-bezier(0.22, 1, 0.36, 1)'
+) {
   if (!fill?.animate) return;
   const previous = rowBarAnimations.get(fill);
   const previousIsActive = previous?.animation.pending || previous?.animation.playState === 'running';
@@ -1588,7 +1605,7 @@ function animateBarBetween(fill, fromScale, toScale, delay = 0, duration = 420) 
   ], {
     duration,
     delay,
-    easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+    easing,
     fill: 'backwards'
   });
   const motion = { animation, target: toScale };
@@ -1598,6 +1615,55 @@ function animateBarBetween(fill, fromScale, toScale, delay = 0, duration = 420) 
   animation.onfinish = forget;
   animation.oncancel = forget;
   rowBarAnimations.set(fill, motion);
+}
+
+function animateLimitResetPercent(el, from, to, duration) {
+  if (!el) return;
+  const suffix = el.dataset.limitMotionSuffix || '';
+  if (prefersReducedMotion() || !Number.isFinite(from) || !Number.isFinite(to) || from === to) {
+    el.textContent = `${formatPercent(to)} ${suffix}`;
+    return;
+  }
+  const startedAt = performance.now();
+  const delta = to - from;
+  const motion = { handle: 0, target: to, suffix };
+  el.textContent = `${formatPercent(from)} ${suffix}`;
+  function frame(now) {
+    if (prefersReducedMotion()) {
+      el.textContent = `${formatPercent(to)} ${suffix}`;
+      if (limitResetNumberAnimations.get(el) === motion) limitResetNumberAnimations.delete(el);
+      return;
+    }
+    const progress = Math.min(1, (now - startedAt) / duration);
+    const eased = 1 - ((1 - progress) * (1 - progress));
+    el.textContent = `${formatPercent(from + delta * eased)} ${suffix}`;
+    if (progress < 1) {
+      motion.handle = requestAnimationFrame(frame);
+    } else if (limitResetNumberAnimations.get(el) === motion) {
+      limitResetNumberAnimations.delete(el);
+    }
+  }
+  motion.handle = requestAnimationFrame(frame);
+  limitResetNumberAnimations.set(el, motion);
+}
+
+function animateLimitResetCompletion(fill, duration) {
+  if (!fill?.animate || prefersReducedMotion()) return;
+  const restingOpacity = Number(fill.style.opacity);
+  const baseOpacity = Number.isFinite(restingOpacity) ? restingOpacity : 1;
+  fill.animate([
+    { filter: 'brightness(1) saturate(1)', opacity: baseOpacity },
+    {
+      offset: LIMIT_RESET_GLOW_LEAD_MS / LIMIT_RESET_GLOW_MS,
+      filter: 'brightness(1.48) saturate(0.88)',
+      opacity: Math.min(1, baseOpacity + 0.22)
+    },
+    { filter: 'brightness(1) saturate(1)', opacity: baseOpacity }
+  ], {
+    duration: LIMIT_RESET_GLOW_MS,
+    delay: Math.max(0, duration - LIMIT_RESET_GLOW_LEAD_MS),
+    easing: 'linear'
+  });
 }
 
 function captureTrendBarMotion() {
@@ -4414,6 +4480,7 @@ function limitMeterNode(color, percent, tone = 1) {
 function limitWindowNode(label, window, color, tone = 1, valueOverride = null, detailText = '') {
   const remaining = Number(window?.remainingPercent);
   const used = Number(window?.usedPercent);
+  const motionRemaining = limitResetMotionApi.remainingPercent(window);
   const showMeter = window?.showMeter !== false;
   const hasPercent = showMeter && (Number.isFinite(remaining) || Number.isFinite(used));
   // valueOverride windows carry a fixed (money/amount) label — keep their meter
@@ -4423,12 +4490,22 @@ function limitWindowNode(label, window, color, tone = 1, valueOverride = null, d
   const fillPercent = limitFillPercent(remaining, used, showUsed);
   const item = document.createElement('div');
   item.className = 'limit-window';
+  item.dataset.limitMotionKey = limitResetMotionApi.windowKey(label, window);
+  item.dataset.limitRemainingPercent = hasPercent && motionRemaining !== null
+    ? String(Math.max(0, Math.min(100, motionRemaining)))
+    : '';
+  item.dataset.limitDisplayPercent = hasPercent ? String(fillPercent) : '';
+  item.dataset.limitResetAt = window?.resetsAt || '';
   const text = document.createElement('div');
   text.className = 'limit-window-text';
   const name = document.createElement('span');
   name.textContent = window?.label || label;
   const value = document.createElement('span');
   value.textContent = valueOverride != null ? valueOverride : formatLimitWindowValue(window, fillPercent, hasPercent, showUsed);
+  if (valueOverride == null && hasPercent) {
+    value.dataset.limitMotionValue = String(fillPercent);
+    value.dataset.limitMotionSuffix = limitModeSuffix(showUsed);
+  }
   text.append(name, value);
   const meter = limitMeterNode(color, fillPercent, tone);
   const reset = document.createElement('div');
@@ -5544,6 +5621,7 @@ function renderLimitProviderRow(id, label, provider, color, options = {}) {
   if (options.accountRow) classes.push('limit-account-row');
   if (provider.stale) classes.push('stale');
   row.className = classes.join(' ');
+  row.dataset.limitMotionKey = limitResetMotionApi.providerKey(provider);
   row.append(
     renderLimitProviderHead(id, label, provider, color, options),
     renderProviderWindows(provider, color)
@@ -5858,6 +5936,65 @@ function renderVolcengineAccountGroup(label, providers, color) {
   });
 }
 
+function captureLimitResetMotion() {
+  const snapshot = new Map();
+  for (const row of els.limitsPanel?.querySelectorAll('.limit-row[data-limit-motion-key]') || []) {
+    for (const item of row.querySelectorAll('.limit-window[data-limit-motion-key]')) {
+      const key = `${row.dataset.limitMotionKey}\0${item.dataset.limitMotionKey}`;
+      const entry = {
+        remainingPercent: item.dataset.limitRemainingPercent,
+        displayPercent: item.dataset.limitDisplayPercent,
+        resetsAt: item.dataset.limitResetAt
+      };
+      // Ambiguous identities are safer left static than animated on the wrong row.
+      snapshot.set(key, snapshot.has(key) ? null : entry);
+    }
+  }
+  return snapshot;
+}
+
+function animateLimitResets(snapshot) {
+  if (!snapshot?.size || prefersReducedMotion()) return;
+  for (const row of els.limitsPanel?.querySelectorAll('.limit-row[data-limit-motion-key]') || []) {
+    for (const item of row.querySelectorAll('.limit-window[data-limit-motion-key]')) {
+      const key = `${row.dataset.limitMotionKey}\0${item.dataset.limitMotionKey}`;
+      const previous = snapshot.get(key);
+      const current = {
+        remainingPercent: item.dataset.limitRemainingPercent,
+        displayPercent: item.dataset.limitDisplayPercent,
+        resetsAt: item.dataset.limitResetAt
+      };
+      if (!previous || !limitResetMotionApi.shouldAnimateReset(previous, current)) continue;
+      const from = Number(previous.displayPercent);
+      const to = Number(current.displayPercent);
+      const fill = item.querySelector('.limit-meter-fill');
+      if (
+        previous.displayPercent === ''
+        || current.displayPercent === ''
+        || !Number.isFinite(from)
+        || !Number.isFinite(to)
+        || !fill
+      ) continue;
+      const duration = limitResetMotionApi.durationMs(from, to);
+      animateBarBetween(
+        fill,
+        from / 100,
+        to / 100,
+        0,
+        duration,
+        LIMIT_RESET_MOTION_EASING
+      );
+      animateLimitResetCompletion(fill, duration);
+      animateLimitResetPercent(
+        item.querySelector('[data-limit-motion-value]'),
+        from,
+        to,
+        duration
+      );
+    }
+  }
+}
+
 function renderLimits() {
   if (!els.limitsPanel) return;
   const holdLimitDetailTooltipRender = limitDetailTooltipShouldHoldRender();
@@ -5915,6 +6052,7 @@ function renderLimits() {
   ) {
     return;
   }
+  const resetMotionSnapshot = captureLimitResetMotion();
   state.limitPanelRenderSignature = renderSignature;
   const nodes = [];
   const rows = orderedProviders;
@@ -5974,6 +6112,7 @@ function renderLimits() {
     nodes.push(renderLimitProviderRow(id, label, provider, thirdPartyVisual?.color || color, rowOptions));
   }
   els.limitsPanel.replaceChildren(...nodes);
+  animateLimitResets(resetMotionSnapshot);
 }
 
 function serviceStatusLabel(status) {

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -1617,14 +1617,13 @@ function animateBarBetween(
   rowBarAnimations.set(fill, motion);
 }
 
-function animateLimitResetPercent(el, from, to, duration) {
+function animateLimitResetPercent(el, from, to, duration, startedAt = performance.now()) {
   if (!el) return;
   const suffix = el.dataset.limitMotionSuffix || '';
   if (prefersReducedMotion() || !Number.isFinite(from) || !Number.isFinite(to) || from === to) {
     el.textContent = `${formatPercent(to)} ${suffix}`;
     return;
   }
-  const startedAt = performance.now();
   const delta = to - from;
   const motion = { handle: 0, target: to, suffix };
   el.textContent = `${formatPercent(from)} ${suffix}`;
@@ -4487,14 +4486,16 @@ function limitWindowNode(label, window, color, tone = 1, valueOverride = null, d
   // on "remaining" so bar and label stay consistent; only percent-labelled
   // windows honour the used-mode flip.
   const showUsed = Boolean(state.settings?.showLimitUsed) && valueOverride == null;
-  const fillPercent = limitFillPercent(remaining, used, showUsed);
+  const fillPercent = limitResetMotionApi.displayPercent(
+    limitFillPercent(remaining, used, showUsed)
+  );
   const item = document.createElement('div');
   item.className = 'limit-window';
   item.dataset.limitMotionKey = limitResetMotionApi.windowKey(label, window);
   item.dataset.limitRemainingPercent = hasPercent && motionRemaining !== null
     ? String(Math.max(0, Math.min(100, motionRemaining)))
     : '';
-  item.dataset.limitDisplayPercent = hasPercent ? String(fillPercent) : '';
+  item.dataset.limitDisplayPercent = hasPercent && fillPercent !== null ? String(fillPercent) : '';
   item.dataset.limitResetAt = window?.resetsAt || '';
   const text = document.createElement('div');
   text.className = 'limit-window-text';
@@ -4502,7 +4503,7 @@ function limitWindowNode(label, window, color, tone = 1, valueOverride = null, d
   name.textContent = window?.label || label;
   const value = document.createElement('span');
   value.textContent = valueOverride != null ? valueOverride : formatLimitWindowValue(window, fillPercent, hasPercent, showUsed);
-  if (valueOverride == null && hasPercent) {
+  if (valueOverride == null && hasPercent && fillPercent !== null) {
     value.dataset.limitMotionValue = String(fillPercent);
     value.dataset.limitMotionSuffix = limitModeSuffix(showUsed);
   }
@@ -5955,6 +5956,7 @@ function captureLimitResetMotion() {
 
 function animateLimitResets(snapshot) {
   if (!snapshot?.size || prefersReducedMotion()) return;
+  const motions = [];
   for (const row of els.limitsPanel?.querySelectorAll('.limit-row[data-limit-motion-key]') || []) {
     for (const item of row.querySelectorAll('.limit-window[data-limit-motion-key]')) {
       const key = `${row.dataset.limitMotionKey}\0${item.dataset.limitMotionKey}`;
@@ -5976,6 +5978,23 @@ function animateLimitResets(snapshot) {
         || !fill
       ) continue;
       const duration = limitResetMotionApi.durationMs(from, to);
+      motions.push({
+        fill,
+        from,
+        item,
+        to,
+        duration
+      });
+    }
+  }
+  if (!motions.length) return;
+  // Start only after the replacement DOM is paintable. The rest of the refresh render
+  // can delay this first frame; excluding that delay prevents the motion from visibly
+  // catching up by skipping its opening values.
+  requestAnimationFrame((startedAt) => {
+    if (prefersReducedMotion()) return;
+    for (const { fill, from, item, to, duration } of motions) {
+      if (!fill.isConnected || !item.isConnected) continue;
       animateBarBetween(
         fill,
         from / 100,
@@ -5989,10 +6008,11 @@ function animateLimitResets(snapshot) {
         item.querySelector('[data-limit-motion-value]'),
         from,
         to,
-        duration
+        duration,
+        startedAt
       );
     }
-  }
+  });
 }
 
 function renderLimits() {

--- a/src/electron/renderer/index.html
+++ b/src/electron/renderer/index.html
@@ -1764,6 +1764,7 @@
     <script src="appUpdatePresentation.js"></script>
     <script src="limitProviderPresentation.js"></script>
     <script src="limitDisplayMode.js"></script>
+    <script src="limitResetMotion.js"></script>
     <script src="clientStatusPresentation.js"></script>
     <script src="clientHealthPresentation.js"></script>
     <script src="clientSourceCache.js"></script>

--- a/src/electron/renderer/limitResetMotion.js
+++ b/src/electron/renderer/limitResetMotion.js
@@ -1,0 +1,99 @@
+'use strict';
+
+(function init(root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  if (root) root.TokenMonitorLimitResetMotion = api;
+})(typeof window !== 'undefined' ? window : null, function createLimitResetMotionApi() {
+  const FULL_PERCENT = 99.5;
+
+  function clean(value) {
+    return String(value || '').trim();
+  }
+
+  function normalized(value) {
+    return clean(value).toLowerCase();
+  }
+
+  function opaqueKey(parts) {
+    const input = parts.map(clean).join('\0');
+    let hash = 2166136261;
+    for (let index = 0; index < input.length; index += 1) {
+      hash ^= input.charCodeAt(index);
+      hash = Math.imul(hash, 16777619);
+    }
+    return (hash >>> 0).toString(36);
+  }
+
+  function providerKey(provider = {}) {
+    const identity = clean(provider.accountKey)
+      || clean(provider.webAccountKey)
+      || normalized(provider.accountEmail)
+      || clean(provider.accountName)
+      || clean(provider.accountLabel)
+      || clean(provider.profileId)
+      || 'default';
+    return opaqueKey([normalized(provider.provider), identity]);
+  }
+
+  function windowKey(label, window = {}) {
+    const explicitId = clean(window.limitId)
+      || clean(window.id)
+      || clean(window.quotaId)
+      || clean(window.model)
+      || clean(window.group);
+    return opaqueKey([
+      normalized(window.kind),
+      explicitId,
+      normalized(window.label || label),
+      window.additional === true ? 'additional' : 'canonical'
+    ]);
+  }
+
+  function finitePercent(value) {
+    if (value === null || value === undefined || value === '') return null;
+    const number = Number(value);
+    return Number.isFinite(number) ? Math.max(0, Math.min(100, number)) : null;
+  }
+
+  function resetTime(value) {
+    if (!value) return null;
+    const time = new Date(value).getTime();
+    return Number.isFinite(time) ? time : null;
+  }
+
+  function remainingPercent(window = {}) {
+    const remaining = finitePercent(window.remainingPercent);
+    if (remaining !== null) return remaining;
+    const used = finitePercent(window.usedPercent);
+    return used === null ? null : 100 - used;
+  }
+
+  function durationMs(fromPercent, toPercent = 100) {
+    const from = finitePercent(fromPercent);
+    const to = finitePercent(toPercent);
+    if (from === null || to === null) return 1100;
+    return Math.round(900 + (Math.abs(to - from) * 7));
+  }
+
+  function shouldAnimateReset(previous, current) {
+    const from = finitePercent(previous?.remainingPercent);
+    const to = finitePercent(current?.remainingPercent);
+    if (from === null || to === null || from >= FULL_PERCENT || to < FULL_PERCENT) return false;
+
+    const previousReset = resetTime(previous?.resetsAt);
+    const currentReset = resetTime(current?.resetsAt);
+    // When both snapshots expose the cycle boundary, a real reset advances it.
+    // This rejects account/data corrections that happen to refill a meter.
+    if (previousReset !== null && currentReset !== null && currentReset <= previousReset) return false;
+    return true;
+  }
+
+  return {
+    durationMs,
+    providerKey,
+    remainingPercent,
+    shouldAnimateReset,
+    windowKey
+  };
+});

--- a/src/electron/renderer/limitResetMotion.js
+++ b/src/electron/renderer/limitResetMotion.js
@@ -69,6 +69,10 @@
     return used === null ? null : 100 - used;
   }
 
+  function displayPercent(value) {
+    return finitePercent(value);
+  }
+
   function durationMs(fromPercent, toPercent = 100) {
     const from = finitePercent(fromPercent);
     const to = finitePercent(toPercent);
@@ -90,6 +94,7 @@
   }
 
   return {
+    displayPercent,
     durationMs,
     providerKey,
     remainingPercent,

--- a/tests/electron/limitResetMotion.test.js
+++ b/tests/electron/limitResetMotion.test.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 const test = require('node:test');
 
 const {
+  displayPercent,
   durationMs,
   providerKey,
   remainingPercent,
@@ -40,6 +41,13 @@ test('remaining percentage preserves missing values and derives used-only window
   assert.equal(remainingPercent({ usedPercent: 100 }), 0);
   assert.equal(remainingPercent({ usedPercent: 31 }), 69);
   assert.equal(remainingPercent({ remainingPercent: 42, usedPercent: 58 }), 42);
+});
+
+test('display percentage clamps provider overrun values to the meter range', () => {
+  assert.equal(displayPercent(-1), 0);
+  assert.equal(displayPercent(101), 100);
+  assert.equal(displayPercent(42.5), 42.5);
+  assert.equal(displayPercent(null), null);
 });
 
 test('refill duration follows the distance while preserving the approved short refill pace', () => {
@@ -96,6 +104,9 @@ test('renderer wires reset motion before app boot and respects reduced motion', 
   assert.match(app, /LIMIT_RESET_MOTION_EASING/);
   assert.match(app, /const duration = limitResetMotionApi\.durationMs\(from, to\);/);
   assert.match(app, /animateLimitResetCompletion\(fill, duration\);/);
+  assert.match(app, /const fillPercent = limitResetMotionApi\.displayPercent\([\s\S]*limitFillPercent\(remaining, used, showUsed\)[\s\S]*\);/);
+  assert.match(app, /requestAnimationFrame\(\(startedAt\) => \{/);
+  assert.match(app, /duration,\s*startedAt\s*\);/);
   assert.match(app, /delay: Math\.max\(0, duration - LIMIT_RESET_GLOW_LEAD_MS\)/);
   assert.doesNotMatch(css, /limit-window-resetting|limit-reset-shine|limit-reset-brighten|limit-reset-glow/);
   assert.match(css, /@media \(prefers-reduced-motion: reduce\)[\s\S]*\.limit-meter-fill/);

--- a/tests/electron/limitResetMotion.test.js
+++ b/tests/electron/limitResetMotion.test.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  durationMs,
+  providerKey,
+  remainingPercent,
+  shouldAnimateReset,
+  windowKey
+} = require('../../src/electron/renderer/limitResetMotion');
+
+const root = path.join(__dirname, '../..');
+
+test('quota refill motion requires an existing non-full value reaching full', () => {
+  assert.equal(shouldAnimateReset(
+    { remainingPercent: 0 },
+    { remainingPercent: 100 }
+  ), true);
+  assert.equal(shouldAnimateReset(
+    { remainingPercent: 69 },
+    { remainingPercent: 100 }
+  ), true);
+  assert.equal(shouldAnimateReset(null, { remainingPercent: 100 }), false);
+  assert.equal(shouldAnimateReset(
+    { remainingPercent: 70 },
+    { remainingPercent: 85 }
+  ), false);
+  assert.equal(shouldAnimateReset(
+    { remainingPercent: 100 },
+    { remainingPercent: 100 }
+  ), false);
+});
+
+test('remaining percentage preserves missing values and derives used-only windows', () => {
+  assert.equal(remainingPercent({ remainingPercent: null }), null);
+  assert.equal(remainingPercent({ usedPercent: 100 }), 0);
+  assert.equal(remainingPercent({ usedPercent: 31 }), 69);
+  assert.equal(remainingPercent({ remainingPercent: 42, usedPercent: 58 }), 42);
+});
+
+test('refill duration follows the distance while preserving the approved short refill pace', () => {
+  assert.equal(durationMs(0, 100), 1600);
+  assert.equal(durationMs(69, 100), 1117);
+  assert.equal(durationMs(null, 100), 1100);
+});
+
+test('known reset boundaries must advance before a refill animates', () => {
+  const firstReset = '2026-09-09T01:00:00.000Z';
+  const nextReset = '2026-09-09T06:00:00.000Z';
+  assert.equal(shouldAnimateReset(
+    { remainingPercent: 14, resetsAt: firstReset },
+    { remainingPercent: 100, resetsAt: nextReset }
+  ), true);
+  assert.equal(shouldAnimateReset(
+    { remainingPercent: 14, resetsAt: firstReset },
+    { remainingPercent: 100, resetsAt: firstReset }
+  ), false);
+  assert.equal(shouldAnimateReset(
+    { remainingPercent: 14, resetsAt: nextReset },
+    { remainingPercent: 100, resetsAt: firstReset }
+  ), false);
+});
+
+test('used-only snapshots can still identify a refill without changing display mode', () => {
+  assert.equal(shouldAnimateReset(
+    { remainingPercent: remainingPercent({ usedPercent: 86 }) },
+    { remainingPercent: remainingPercent({ usedPercent: 0 }) }
+  ), true);
+});
+
+test('motion keys preserve account and window identity without exposing labels', () => {
+  const firstAccount = providerKey({ provider: 'codex', accountEmail: 'first@example.com' });
+  const secondAccount = providerKey({ provider: 'codex', accountEmail: 'second@example.com' });
+  assert.notEqual(firstAccount, secondAccount);
+  assert.doesNotMatch(firstAccount, /first|example/);
+
+  const session = windowKey('Session', { kind: 'session' });
+  const weekly = windowKey('Weekly', { kind: 'weekly' });
+  assert.notEqual(session, weekly);
+});
+
+test('renderer wires reset motion before app boot and respects reduced motion', () => {
+  const html = fs.readFileSync(path.join(root, 'src/electron/renderer/index.html'), 'utf8');
+  const app = fs.readFileSync(path.join(root, 'src/electron/renderer/app.js'), 'utf8');
+  const css = fs.readFileSync(path.join(root, 'src/electron/renderer/styles.css'), 'utf8');
+
+  assert.ok(html.indexOf('<script src="limitResetMotion.js"></script>') < html.indexOf('<script src="app.js"></script>'));
+  assert.match(app, /const resetMotionSnapshot = captureLimitResetMotion\(\);/);
+  assert.match(app, /els\.limitsPanel\.replaceChildren\(\.\.\.nodes\);\s*animateLimitResets\(resetMotionSnapshot\);/);
+  assert.match(app, /limitResetMotionApi\.shouldAnimateReset\(previous, current\)/);
+  assert.match(app, /previous\.displayPercent === ''/);
+  assert.match(app, /LIMIT_RESET_MOTION_EASING/);
+  assert.match(app, /const duration = limitResetMotionApi\.durationMs\(from, to\);/);
+  assert.match(app, /animateLimitResetCompletion\(fill, duration\);/);
+  assert.match(app, /delay: Math\.max\(0, duration - LIMIT_RESET_GLOW_LEAD_MS\)/);
+  assert.doesNotMatch(css, /limit-window-resetting|limit-reset-shine|limit-reset-brighten|limit-reset-glow/);
+  assert.match(css, /@media \(prefers-reduced-motion: reduce\)[\s\S]*\.limit-meter-fill/);
+});


### PR DESCRIPTION
## Summary

- animate quota meters and percentages from the last visible value to 100% when a reset is detected
- scale the refill duration by distance and finish with a coordinated full-bar glow
- preserve cold-start, account/window identity, repeated-full-state, and reduced-motion safeguards

## Verification

- npm run verify
- node --test tests/electron/limitResetMotion.test.js
- git diff --cached --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Animates quota meters and percentages from their last visible value to 100% when a reset is detected, ending with a coordinated full-bar glow. Scales refill duration by distance and keeps cold-start, account/window identity, repeated-full-state, and reduced-motion safeguards intact.

- Adds `limitResetMotion.js` to centralize reset detection, duration scaling, and stable identity keys.
- Reset detection requires a non-full value reaching full; snapshots with ambiguous identity stay static instead of animating on the wrong row.

| Area | Before | After |
| --- | --- | --- |
| Quota meter on reset | Snaps instantly to 100% | Animates from the last visible value to 100% with a glow |

Reduced-motion users and cold starts render directly at the final state. Verified with `npm run verify` and the new `node --test tests/electron/limitResetMotion.test.js`.

<sup>Written for commit 40162c80c4cc1b5dc6606b4c5cd900ddc1bad135. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

