### PR TITLE
fix(history): preserve daily archives when reads fail

### DIFF
--- a/src/shared/dailyHistoryArchive.js
+++ b/src/shared/dailyHistoryArchive.js
@@ -3,7 +3,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { isDeepStrictEqual } = require('node:util');
-const { readJson, sharedDataDir, writeJsonAtomic } = require('./config');
+const { sharedDataDir, writeJsonAtomic } = require('./config');
 const {
   normalizeTokscaleClientName, num, sumOutputTokens, sumTokens
 } = require('./history');
@@ -531,9 +531,45 @@ function dailyHistoryArchivePath(options = {}) {
   return options.path || path.join(sharedDataDir(options), 'daily-history-archive.json');
 }
 
+function validateDailyHistoryArchiveDocument(value, filePath) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Could not parse JSON in ${filePath}: archive root must be an object`);
+  }
+  for (const key of ['days', 'liveDays']) {
+    if (Object.prototype.hasOwnProperty.call(value, key)
+      && (!value[key] || typeof value[key] !== 'object' || Array.isArray(value[key]))) {
+      throw new Error(`Could not parse JSON in ${filePath}: ${key} must be an object`);
+    }
+  }
+  return value;
+}
+
 function readDailyHistoryArchive(options = {}) {
-  const read = options.readJson || readJson;
-  return normalizeDailyHistoryArchive(read(dailyHistoryArchivePath(options), {}));
+  const filePath = dailyHistoryArchivePath(options);
+  if (typeof options.readJson === 'function') {
+    return normalizeDailyHistoryArchive(
+      validateDailyHistoryArchiveDocument(options.readJson(filePath, {}), filePath)
+    );
+  }
+  let content;
+  try {
+    content = fs.readFileSync(filePath, 'utf8');
+  } catch (error) {
+    if (error?.code === 'ENOENT') return normalizeDailyHistoryArchive({});
+    throw error;
+  }
+  if (!content.trim()) {
+    throw new Error(`Could not parse JSON in ${filePath}: archive is empty`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    const parseError = new Error(`Could not parse JSON in ${filePath}: ${error.message}`);
+    parseError.cause = error;
+    throw parseError;
+  }
+  return normalizeDailyHistoryArchive(validateDailyHistoryArchiveDocument(parsed, filePath));
 }
 
 function writeDailyHistoryArchive(archive, options = {}) {

--- a/tests/shared/collectorHistory.test.js
+++ b/tests/shared/collectorHistory.test.js
@@ -478,6 +478,35 @@ test('collectHistoryOnce falls back to the current graph when archive persistenc
   assert.match(messages.at(-1), /daily history archive failed: disk full/);
 });
 
+for (const [label, content] of [['blank', ' \n'], ['malformed JSON', '{"days":']]) {
+  test(`collectHistoryOnce falls back safely when the archive is ${label}`, async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'token-monitor-archive-'));
+    const archivePath = path.join(directory, 'daily-history-archive.json');
+    fs.writeFileSync(archivePath, content, 'utf8');
+    const before = fs.readFileSync(archivePath);
+    const messages = [];
+    const statuses = [];
+    try {
+      const history = await collectHistoryOnce({
+        clients: 'claude',
+        todayKey: '2026-06-07',
+        dailyHistoryArchiveEnabled: true,
+        dailyHistoryArchiveOptions: { path: archivePath },
+        logger: (message) => messages.push(message),
+        onHistoryStatus: (status) => statuses.push(status),
+        runGraph: async () => SAMPLE_GRAPH
+      });
+      assert.equal(history.daily[0].tokens, 30);
+      assert.match(messages.at(-1), /daily history archive failed:/);
+      assert.equal(statuses.at(-1).failureCode, 'daily-history-archive-failed');
+      assert.equal(statuses.at(-1).successAt, null);
+      assert.deepEqual(fs.readFileSync(archivePath), before);
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+}
+
 test('collectHistoryOnce preserves a lazy archive ownership guard until write time', async () => {
   let canWrite = true;
   let writes = 0;

--- a/tests/shared/dailyHistoryArchive.test.js
+++ b/tests/shared/dailyHistoryArchive.test.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const test = require('node:test');
 
 const {
@@ -380,6 +383,165 @@ test('live snapshot keeps model-less remainder under its original client', () =>
 
 function dayObservation(archive, date) {
   return Object.values(archive.liveDays[date].observations)[0];
+}
+
+function withArchiveFile(content, callback) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'token-monitor-archive-'));
+  const archivePath = path.join(directory, 'daily-history-archive.json');
+  fs.writeFileSync(archivePath, content, 'utf8');
+  try {
+    return callback(archivePath);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+for (const [name, retain] of [
+  ['retainDailyHistory', (options) => retainDailyHistory(graph('2026-08-05', [
+    client('claude', 'opus', 120, 4.8, 6)
+  ]), options)],
+  ['retainLiveDailyHistory', (options) => retainLiveDailyHistory(livePeriod(120, 1.2), options)]
+]) {
+  test(`${name} treats only a missing archive as empty`, () => {
+    withArchiveFile('   \n', (archivePath) => {
+      assert.throws(
+        () => retain({ path: archivePath, todayKey: '2026-08-05' }),
+        (error) => error.message.includes(archivePath) && error.message.includes('empty')
+      );
+      assert.equal(fs.readFileSync(archivePath, 'utf8'), '   \n');
+    });
+
+    withArchiveFile('{"days":', (archivePath) => {
+      assert.throws(
+        () => retain({ path: archivePath, todayKey: '2026-08-05' }),
+        (error) => error.message.includes(archivePath) && error.cause instanceof SyntaxError
+      );
+      assert.equal(fs.readFileSync(archivePath, 'utf8'), '{"days":');
+    });
+
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'token-monitor-archive-'));
+    const archivePath = path.join(directory, 'missing.json');
+    try {
+      assert.doesNotThrow(() => retain({ path: archivePath, todayKey: '2026-08-05' }));
+      assert.equal(fs.existsSync(archivePath), true);
+      const created = JSON.parse(fs.readFileSync(archivePath, 'utf8'));
+      assert.ok(created.days?.['2026-08-05'] || created.liveDays?.['2026-08-05']);
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+}
+
+for (const [name, retain] of [
+  ['retainDailyHistory', (options) => retainDailyHistory(graph('2026-08-05', [
+    client('claude', 'opus', 120, 4.8, 6)
+  ]), options)],
+  ['retainLiveDailyHistory', (options) => retainLiveDailyHistory(livePeriod(120, 1.2), options)]
+]) {
+  test(`${name} leaves the archive untouched when the prewrite rebase read fails`, () => {
+    const initial = captureDailyHistoryArchive({}, graph('2026-08-04', [
+      client('codex', 'gpt', 50, 2, 3)
+    ]), { todayKey: '2026-08-05' });
+    withArchiveFile(`${JSON.stringify(initial)}\n`, (archivePath) => {
+      const before = fs.readFileSync(archivePath);
+      const beforeMtime = fs.statSync(archivePath).mtimeMs;
+      let writeChecks = 0;
+      let writes = 0;
+      let failedMtime;
+      const options = {
+        path: archivePath,
+        todayKey: '2026-08-05',
+        writeEnabled: () => {
+          writeChecks += 1;
+          if (writeChecks === 1) {
+            fs.writeFileSync(archivePath, '{"days":', 'utf8');
+            failedMtime = fs.statSync(archivePath).mtimeMs;
+          }
+          return true;
+        },
+        writeJsonAtomic: () => { writes += 1; }
+      };
+      assert.throws(() => retain(options), (error) => error.cause instanceof SyntaxError);
+      const failedBytes = fs.readFileSync(archivePath, 'utf8');
+      assert.equal(failedBytes, '{"days":');
+      assert.notEqual(failedBytes, before.toString('utf8'));
+      assert.equal(failedMtime >= beforeMtime, true);
+      assert.equal(writes, 0);
+      assert.equal(fs.readFileSync(archivePath, 'utf8'), failedBytes);
+      assert.equal(fs.statSync(archivePath).mtimeMs, failedMtime);
+
+      const repaired = captureDailyHistoryArchive({}, graph('2026-08-04', [
+        client('codex', 'gpt', 50, 2, 3)
+      ]), { todayKey: '2026-08-05' });
+      fs.writeFileSync(archivePath, `${JSON.stringify(repaired)}\n`, 'utf8');
+      assert.doesNotThrow(() => retain({ path: archivePath, todayKey: '2026-08-05' }));
+      const recovered = JSON.parse(fs.readFileSync(archivePath, 'utf8'));
+      assert.ok(recovered.days['2026-08-04']);
+      assert.ok(recovered.days['2026-08-05'] || recovered.liveDays?.['2026-08-05']);
+    });
+  });
+}
+
+test('strict archive reader rejects invalid container shapes while preserving compatibility', () => {
+  withArchiveFile('null', (archivePath) => {
+    assert.throws(() => retainDailyHistory([], { path: archivePath }), (error) => error.message.includes('root'));
+  });
+  withArchiveFile('{"days":[]}', (archivePath) => {
+    assert.throws(() => retainDailyHistory([], { path: archivePath }), (error) => error.message.includes('days'));
+  });
+  assert.doesNotThrow(() => retainDailyHistory([], { readJson: () => ({}) }));
+});
+
+const ioRetainCases = [
+  ['retainDailyHistory', (options) => retainDailyHistory(graph('2026-08-05', [
+    client('claude', 'opus', 120, 4.8, 6)
+  ]), options)],
+  ['retainLiveDailyHistory', (options) => retainLiveDailyHistory(livePeriod(120, 1.2), options)]
+];
+
+for (const [name, retain] of ioRetainCases) {
+  for (const [phase, failingRead] of [['initial', 1], ['prewrite rebase', 2]]) {
+    for (const code of ['EACCES', 'EBUSY', 'EPERM']) {
+      test(`${name} propagates ${code} from the ${phase} archive read`, (t) => {
+        const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'token-monitor-archive-'));
+        const archivePath = path.join(directory, 'daily-history-archive.json');
+        const initial = captureDailyHistoryArchive({}, graph('2026-08-04', [
+          client('codex', 'gpt', 50, 2, 3)
+        ]), { todayKey: '2026-08-05' });
+        const before = Buffer.from(`${JSON.stringify(initial)}\n`);
+        fs.writeFileSync(archivePath, before);
+        const beforeMtime = fs.statSync(archivePath).mtimeMs;
+        const originalReadFileSync = fs.readFileSync;
+        let reads = 0;
+        let writes = 0;
+        const readError = Object.assign(new Error(code), { code });
+        t.mock.method(fs, 'readFileSync', (filePath, encoding) => {
+          if (filePath === archivePath && ++reads === failingRead) throw readError;
+          return originalReadFileSync(filePath, encoding);
+        });
+        try {
+          assert.throws(
+            () => retain({
+              path: archivePath,
+              todayKey: '2026-08-05',
+              writeJsonAtomic: () => { writes += 1; }
+            }),
+            (error) => error === readError
+          );
+          assert.equal(writes, 0);
+          assert.deepEqual(originalReadFileSync(archivePath), before);
+          assert.equal(fs.statSync(archivePath).mtimeMs, beforeMtime);
+          t.mock.restoreAll();
+          assert.doesNotThrow(() => retain({ path: archivePath, todayKey: '2026-08-05' }));
+          const recovered = JSON.parse(fs.readFileSync(archivePath, 'utf8'));
+          assert.deepEqual(recovered.days['2026-08-04'], initial.days['2026-08-04']);
+          assert.ok(recovered.days?.['2026-08-05'] || recovered.liveDays?.['2026-08-05']);
+        } finally {
+          fs.rmSync(directory, { recursive: true, force: true });
+        }
+      });
+    }
+  }
 }
 
 test('retainLiveDailyHistory persists only a higher live snapshot', () => {


### PR DESCRIPTION
When the daily history archive cannot be read, the existing fallback treats it as empty and can overwrite dates that are no longer present in the current graph. This change gives the archive a strict reader while leaving shared `config.readJson()` behavior unchanged.

Only `ENOENT` initializes an empty archive. Other I/O errors, blank files, malformed JSON, and invalid top-level archive containers propagate through the existing archive error path without writing. Both retention entry points use the strict reader for the initial read and pre-write rebase; the next collection can recover normally. Existing files are preserved without automatic repair.

Validation on Windows / Node v24.16.0:
- `node --test tests/shared/dailyHistoryArchive.test.js tests/shared/collectorHistory.test.js`: 66 passed.
- All 19 added regression cases fail against unchanged main `bda6ffc` (47 existing cases pass), and pass with the fix.
- `npm run verify`: lint passed; 4,140 tests passed, 8 skipped, 1 failed. The same single failure occurs on unchanged main (4,121 passed): `macWidgetLaunchServicesRecovery.test.js` cannot create a symlink on this Windows environment (`EPERM`).
- `git diff --check`: passed.

Tests cover both retention entry points, initial/rebase I/O failures, unchanged archive bytes and timestamps, old-date preservation after recovery, missing-file initialization, and collector error reporting.

Fixes #636

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #636 by hardening daily history archive persistence so failed reads cannot overwrite retained dates.

| Area | Before | After |
| --- | --- | --- |
| Archive reads | Any read failure could fall back to an empty archive. | Only a missing file (`ENOENT`) initializes an empty archive; other I/O, blank-file, malformed-JSON, and invalid-container errors propagate without writing. |
| Recovery | A failed read could discard dates absent from the current graph. | Existing archive contents remain untouched, and the next successful collection can recover normally. |

**Design and validation**

- Both retention entry points use the strict reader for initial reads and pre-write rebases, while shared `config.readJson()` behavior remains unchanged.
- Existing invalid files are not repaired automatically.
- Targeted archive and collector tests pass: 66 passed.
- `npm run verify` passed lint with 4,140 tests passed and 8 skipped; the one symlink failure is unchanged on Windows and reports `EPERM`.
- `git diff --check` passed.

<sup>Written for commit 4ef259d7666e2374863b41cef0961bc25ee379e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

