### PR TITLE
fix(limits): restore smooth bar animations on view entry

### DIFF
--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -1900,6 +1900,17 @@ function applyBarScale(fill, scale) {
   animateBarBetween(fill, 0, safeScale, 0, 420);
 }
 
+function animateCachedLimitBarsFromZero() {
+  if (!state.animateBarsFromZero || prefersReducedMotion()) return;
+  for (const fill of els.limitsPanel?.querySelectorAll('.limit-meter-fill') || []) {
+    const targetScale = Math.max(
+      0,
+      Math.min(1, Number(fill.style.getPropertyValue('--bar-scale')) || 0)
+    );
+    animateBarBetween(fill, 0, targetScale, 0, 420);
+  }
+}
+
 function rowTemplate(rowData) {
   const { key, name, platform, client, subtitle, detail, kind } = rowData;
   const row = document.createElement('div');
@@ -6276,6 +6287,9 @@ function renderLimits() {
     state.limitPanelRenderSignature === renderSignature
     && els.limitsPanel.children.length === orderedProviders.length
   ) {
+    // View changes intentionally reuse the rendered Limits DOM. Replaying the
+    // entrance motion here keeps that cache from swallowing the normal bar fill.
+    animateCachedLimitBarsFromZero();
     return;
   }
   const resetMotionSnapshot = captureLimitResetMotion();

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -1776,7 +1776,8 @@ function animateLimitResetPercent(el, from, to, duration, startedAt = performanc
   }
   const delta = to - from;
   const motion = { handle: 0, target: to, suffix };
-  el.textContent = `${formatPercent(from)} ${suffix}`;
+  let renderedText = `${formatPercent(from)} ${suffix}`;
+  el.textContent = renderedText;
   function frame(now) {
     if (prefersReducedMotion()) {
       el.textContent = `${formatPercent(to)} ${suffix}`;
@@ -1785,7 +1786,13 @@ function animateLimitResetPercent(el, from, to, duration, startedAt = performanc
     }
     const progress = Math.min(1, (now - startedAt) / duration);
     const eased = 1 - ((1 - progress) * (1 - progress));
-    el.textContent = `${formatPercent(from + delta * eased)} ${suffix}`;
+    const nextText = `${formatPercent(from + delta * eased)} ${suffix}`;
+    // The displayed value is integer-rounded, so several animation frames can
+    // resolve to the same string. Avoid invalidating text layout on those frames.
+    if (nextText !== renderedText) {
+      renderedText = nextText;
+      el.textContent = nextText;
+    }
     if (progress < 1) {
       motion.handle = requestAnimationFrame(frame);
     } else if (limitResetNumberAnimations.get(el) === motion) {
@@ -1798,21 +1805,24 @@ function animateLimitResetPercent(el, from, to, duration, startedAt = performanc
 
 function animateLimitResetCompletion(fill, duration) {
   if (!fill?.animate || prefersReducedMotion()) return;
-  const restingOpacity = Number(fill.style.opacity);
-  const baseOpacity = Number.isFinite(restingOpacity) ? restingOpacity : 1;
-  fill.animate([
-    { filter: 'brightness(1) saturate(1)', opacity: baseOpacity },
+  const highlight = document.createElement('span');
+  highlight.className = 'limit-meter-completion';
+  fill.append(highlight);
+  const animation = highlight.animate([
+    { opacity: 0 },
     {
       offset: LIMIT_RESET_GLOW_LEAD_MS / LIMIT_RESET_GLOW_MS,
-      filter: 'brightness(1.48) saturate(0.88)',
-      opacity: Math.min(1, baseOpacity + 0.22)
+      opacity: 0.52
     },
-    { filter: 'brightness(1) saturate(1)', opacity: baseOpacity }
+    { opacity: 0 }
   ], {
     duration: LIMIT_RESET_GLOW_MS,
     delay: Math.max(0, duration - LIMIT_RESET_GLOW_LEAD_MS),
     easing: 'linear'
   });
+  const removeHighlight = () => highlight.remove();
+  animation.onfinish = removeHighlight;
+  animation.oncancel = removeHighlight;
 }
 
 function captureTrendBarMotion() {

--- a/src/electron/renderer/limitResetMotion.js
+++ b/src/electron/renderer/limitResetMotion.js
@@ -26,27 +26,29 @@
   }
 
   function providerKey(provider = {}) {
-    const identity = clean(provider.accountKey)
-      || clean(provider.webAccountKey)
-      || normalized(provider.accountEmail)
-      || clean(provider.accountName)
-      || clean(provider.accountLabel)
-      || clean(provider.profileId)
+    const source = provider || {};
+    const identity = clean(source.accountKey)
+      || clean(source.webAccountKey)
+      || normalized(source.accountEmail)
+      || clean(source.accountName)
+      || clean(source.accountLabel)
+      || clean(source.profileId)
       || 'default';
-    return opaqueKey([normalized(provider.provider), identity]);
+    return opaqueKey([normalized(source.provider), identity]);
   }
 
   function windowKey(label, window = {}) {
-    const explicitId = clean(window.limitId)
-      || clean(window.id)
-      || clean(window.quotaId)
-      || clean(window.model)
-      || clean(window.group);
+    const source = window || {};
+    const explicitId = clean(source.limitId)
+      || clean(source.id)
+      || clean(source.quotaId)
+      || clean(source.model)
+      || clean(source.group);
     return opaqueKey([
-      normalized(window.kind),
+      normalized(source.kind),
       explicitId,
-      normalized(window.label || label),
-      window.additional === true ? 'additional' : 'canonical'
+      normalized(source.label || label),
+      source.additional === true ? 'additional' : 'canonical'
     ]);
   }
 
@@ -63,9 +65,10 @@
   }
 
   function remainingPercent(window = {}) {
-    const remaining = finitePercent(window.remainingPercent);
+    const source = window || {};
+    const remaining = finitePercent(source.remainingPercent);
     if (remaining !== null) return remaining;
-    const used = finitePercent(window.usedPercent);
+    const used = finitePercent(source.usedPercent);
     return used === null ? null : 100 - used;
   }
 

--- a/src/electron/renderer/styles.css
+++ b/src/electron/renderer/styles.css
@@ -4165,12 +4165,21 @@ html.is-windows .limit-live-badge {
   background: rgba(var(--sunken-rgb), 0.44);
 }
 .limit-meter-fill {
+  position: relative;
   width: 100%;
   height: 100%;
   border-radius: 3px;
   transform: scaleX(var(--bar-scale, 0));
   transform-origin: left center;
   transition: transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.limit-meter-completion {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: rgba(255, 255, 255, 0.58);
+  opacity: 0;
+  will-change: opacity;
 }
 @media (prefers-reduced-motion: reduce) {
   :root:not([data-reduce-motion="off"]) .bar-fill,

--- a/tests/electron/limitResetMotion.test.js
+++ b/tests/electron/limitResetMotion.test.js
@@ -37,6 +37,7 @@ test('quota refill motion requires an existing non-full value reaching full', ()
 });
 
 test('remaining percentage preserves missing values and derives used-only windows', () => {
+  assert.equal(remainingPercent(null), null);
   assert.equal(remainingPercent({ remainingPercent: null }), null);
   assert.equal(remainingPercent({ usedPercent: 100 }), 0);
   assert.equal(remainingPercent({ usedPercent: 31 }), 69);
@@ -81,6 +82,8 @@ test('used-only snapshots can still identify a refill without changing display m
 });
 
 test('motion keys preserve account and window identity without exposing labels', () => {
+  assert.equal(providerKey(null), providerKey());
+  assert.equal(windowKey('Weekly', null), windowKey('Weekly'));
   const firstAccount = providerKey({ provider: 'codex', accountEmail: 'first@example.com' });
   const secondAccount = providerKey({ provider: 'codex', accountEmail: 'second@example.com' });
   assert.notEqual(firstAccount, secondAccount);

--- a/tests/electron/limitResetMotion.test.js
+++ b/tests/electron/limitResetMotion.test.js
@@ -111,6 +111,10 @@ test('renderer wires reset motion before app boot and respects reduced motion', 
   assert.match(app, /requestAnimationFrame\(\(startedAt\) => \{/);
   assert.match(app, /duration,\s*startedAt\s*\);/);
   assert.match(app, /delay: Math\.max\(0, duration - LIMIT_RESET_GLOW_LEAD_MS\)/);
+  assert.match(app, /highlight\.className = 'limit-meter-completion'/);
+  assert.doesNotMatch(app, /filter: 'brightness\(/);
+  assert.match(app, /if \(nextText !== renderedText\)/);
+  assert.match(css, /\.limit-meter-completion\s*\{[^}]*position:\s*absolute;[^}]*opacity:\s*0;/s);
   assert.doesNotMatch(css, /limit-window-resetting|limit-reset-shine|limit-reset-brighten|limit-reset-glow/);
   assert.match(css, /@media \(prefers-reduced-motion: reduce\)[\s\S]*\.limit-meter-fill/);
 });

--- a/tests/electron/rendererMotion.test.js
+++ b/tests/electron/rendererMotion.test.js
@@ -40,6 +40,27 @@ test('data bars animate on the compositor instead of changing layout width', () 
   assert.match(applyBarScale, /animateBarBetween\(fill, 0, safeScale, 0, 420\)/);
 });
 
+test('cached Limits bars replay their entrance motion when the view is revisited', () => {
+  const app = read('app.js');
+  const animateCachedLimitBarsFromZero = app.slice(
+    app.indexOf('function animateCachedLimitBarsFromZero('),
+    app.indexOf('function rowWidth(', app.indexOf('function animateCachedLimitBarsFromZero('))
+  );
+  const renderLimits = app.slice(
+    app.indexOf('function renderLimits('),
+    app.indexOf('function serviceStatusLabel(', app.indexOf('function renderLimits('))
+  );
+
+  assert.match(animateCachedLimitBarsFromZero, /if \(!state\.animateBarsFromZero \|\| prefersReducedMotion\(\)\) return;/);
+  assert.match(animateCachedLimitBarsFromZero, /querySelectorAll\('\.limit-meter-fill'\)/);
+  assert.match(animateCachedLimitBarsFromZero, /fill\.style\.getPropertyValue\('--bar-scale'\)/);
+  assert.match(animateCachedLimitBarsFromZero, /animateBarBetween\(fill, 0, targetScale, 0, 420\)/);
+  assert.match(
+    renderLimits,
+    /state\.limitPanelRenderSignature === renderSignature[\s\S]*?animateCachedLimitBarsFromZero\(\);\s*return;/
+  );
+});
+
 test('period changes preserve row identity, animate rank changes, and count from the previous total', () => {
   const app = read('app.js');
   const handler = app.slice(


### PR DESCRIPTION
## Summary

- replay cached Limits meter entrance animations when revisiting the view
- guard quota reset motion helpers against null provider and window records
- move the refill completion highlight to an opacity-only child layer
- avoid redundant percentage text updates during refill animation

## Preview

<img width="356" height="177" alt="CleanShot 2026-09-10 at 8 57 27 AM" src="https://github.com/user-attachments/assets/77e12af4-70fb-49b5-97ae-321b1de6592c" />

## Testing

- `npm run verify` — 4,187 passed, 0 failed, 2 skipped
- manually verified Limits bar animation after switching away from and back to the view
- manually verified a Kiro refill from 3% remaining to 100% through the local Hub


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Limits meter entrance animations when revisiting the view and smooths quota refill motion for cached DOM, including rapid leave-and-return restarts.

- Replays cached Limits bar fill animations from zero when the view is re-entered, so bars no longer appear static.
- Restarts the entrance animation even when a revisit happens before the prior run finishes.
- Moves the refill completion highlight to an opacity-only child layer, dropping the previous brightness/filter animation on the fill.
- Skips percentage text writes during refill when the integer-rounded value hasn't changed.
- Guards reset motion key helpers against null provider and window records.

| Area | Before | After |
| --- | --- | --- |
| Limits view revisit | cached bars render already full with no entrance motion | cached bars replay the fill animation from zero on re-entry |
| Rapid leave-and-return | cached bars stay static while the hidden prior animation still runs | the in-flight animation is cancelled and the entrance motion restarts |
| Refill completion highlight | animates brightness and opacity on the meter fill | animates opacity on a child overlay layer |
| Refill percentage text | `textContent` updated on every animation frame | updates only when the rendered string changes |

**Testing**

- `npm run verify` passes (4,187 passing, 2 skipped); manually verified the revisit animation and a Kiro refill from 3% to 100%.

<sup>Written for commit 77c72b71a02768003325fad3766f419065e2defa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



