### PR TITLE
fix(sessions): restore Codex prompt details

### DIFF
--- a/src/shared/sessionDetail.js
+++ b/src/shared/sessionDetail.js
@@ -71,6 +71,24 @@ function codexPromptText(raw) {
   return cleanPromptText(idx >= 0 ? text.slice(idx + marker.length) : text);
 }
 
+function codexResponseItemPrompt(payload) {
+  if (payload?.type !== 'message' || payload.role !== 'user') return null;
+  const content = Array.isArray(payload.content) ? payload.content : [];
+  const kinds = payload.internal_chat_message_metadata_passthrough?.content_item_kinds;
+  const hasKinds = Array.isArray(kinds);
+  const selected = content.filter((part, index) => !hasKinds || String(kinds[index] || '').startsWith('user.'));
+  // Current Codex records injected instructions as role=user too, but gives each content item a
+  // semantic kind. A message with metadata and no user.* items is context, not a prompt boundary.
+  if (hasKinds && selected.length === 0) return null;
+  const text = codexPromptText(selected
+    .filter((part) => part?.type === 'input_text')
+    .map((part) => part.text || '')
+    .join('\n'));
+  const imageCount = selected.filter((part) => part?.type === 'input_image').length;
+  const marker = imageCount > 1 ? `[${imageCount} images]` : (imageCount === 1 ? '[image]' : '');
+  return [marker, text].filter(Boolean).join(' ') || null;
+}
+
 function parseClaudeTranscript(text) {
   const events = [];
   // Claude Code inflates a transcript two ways, both of which would otherwise multiply token counts:
@@ -133,6 +151,7 @@ function codexToolName(payload) {
 function parseCodexTranscript(text) {
   const events = [];
   let pendingTools = [];
+  let responsePromptIndex = -1;
   for (const line of String(text || '').split(/\r?\n/)) {
     const trimmed = line.trim();
     if (!trimmed) continue;
@@ -152,7 +171,21 @@ function parseCodexTranscript(text) {
       const marker = imageCount > 1 ? `[${imageCount} images]` : (imageCount === 1 ? '[image]' : '');
       const label = [marker, text].filter(Boolean).join(' '); // image-bearing prompts keep an [image] marker like Claude
       // empty + no image → degenerate user_message; skip so its turns fold into the real prompt
-      if (label) events.push({ kind: 'prompt', timestamp: obj.timestamp || '', text: label });
+      if (label) {
+        const prompt = { kind: 'prompt', timestamp: obj.timestamp || '', text: label };
+        // One transitional schema writes both the response_item and the older event_msg for the
+        // same prompt. The event_msg is already the renderer-facing text, so let it replace the
+        // immediately preceding response_item boundary instead of showing the turn twice.
+        if (responsePromptIndex >= 0 && responsePromptIndex === events.length - 1) events[responsePromptIndex] = prompt;
+        else events.push(prompt);
+      }
+      responsePromptIndex = -1;
+    } else if (obj.type === 'response_item') {
+      const label = codexResponseItemPrompt(payload);
+      if (label) {
+        events.push({ kind: 'prompt', timestamp: obj.timestamp || '', text: label });
+        responsePromptIndex = events.length - 1;
+      }
     } else if (obj.type === 'event_msg' && payload.type === 'token_count') {
       const u = payload.info && payload.info.last_token_usage;
       if (!u) continue; // session-start / idle tick with no turn usage — not a reply
@@ -171,6 +204,7 @@ function parseCodexTranscript(text) {
       if (tokens.total === 0) { pendingTools = []; continue; } // empty bookkeeping tick — skip
       events.push({ kind: 'turn', timestamp: obj.timestamp || '', tokens, tools: uniqueTools(pendingTools) });
       pendingTools = [];
+      responsePromptIndex = -1;
     }
   }
   return events;

--- a/src/shared/sessionDetail.js
+++ b/src/shared/sessionDetail.js
@@ -85,8 +85,10 @@ function codexResponseItemPrompt(payload) {
     .map((part) => part.text || '')
     .join('\n'));
   const imageCount = selected.filter((part) => part?.type === 'input_image').length;
-  const marker = imageCount > 1 ? `[${imageCount} images]` : (imageCount === 1 ? '[image]' : '');
-  return [marker, text].filter(Boolean).join(' ') || null;
+  const imageMarker = imageCount > 1 ? `[${imageCount} images]` : (imageCount === 1 ? '[image]' : '');
+  const audioCount = selected.filter((part) => part?.type === 'input_audio').length;
+  const audioMarker = audioCount > 1 ? `[${audioCount} audio clips]` : (audioCount === 1 ? '[audio]' : '');
+  return [imageMarker, audioMarker, text].filter(Boolean).join(' ') || null;
 }
 
 function parseClaudeTranscript(text) {
@@ -155,6 +157,11 @@ function parseCodexTranscript(text) {
   for (const line of String(text || '').split(/\r?\n/)) {
     const trimmed = line.trim();
     if (!trimmed) continue;
+    // Transitional logs emit the legacy user_message immediately after its response_item twin.
+    // Snapshot and clear the candidate for every physical JSONL record so an intervening item
+    // cannot make a later, distinct prompt replace an earlier boundary.
+    const adjacentResponsePromptIndex = responsePromptIndex;
+    responsePromptIndex = -1;
     let obj;
     try { obj = JSON.parse(trimmed); } catch (_) { continue; }
     const payload = obj.payload || {};
@@ -176,10 +183,9 @@ function parseCodexTranscript(text) {
         // One transitional schema writes both the response_item and the older event_msg for the
         // same prompt. The event_msg is already the renderer-facing text, so let it replace the
         // immediately preceding response_item boundary instead of showing the turn twice.
-        if (responsePromptIndex >= 0 && responsePromptIndex === events.length - 1) events[responsePromptIndex] = prompt;
+        if (adjacentResponsePromptIndex >= 0 && adjacentResponsePromptIndex === events.length - 1) events[adjacentResponsePromptIndex] = prompt;
         else events.push(prompt);
       }
-      responsePromptIndex = -1;
     } else if (obj.type === 'response_item') {
       const label = codexResponseItemPrompt(payload);
       if (label) {
@@ -204,7 +210,6 @@ function parseCodexTranscript(text) {
       if (tokens.total === 0) { pendingTools = []; continue; } // empty bookkeeping tick — skip
       events.push({ kind: 'turn', timestamp: obj.timestamp || '', tokens, tools: uniqueTools(pendingTools) });
       pendingTools = [];
-      responsePromptIndex = -1;
     }
   }
   return events;

--- a/src/shared/sessionDetail.js
+++ b/src/shared/sessionDetail.js
@@ -153,15 +153,14 @@ function codexToolName(payload) {
 function parseCodexTranscript(text) {
   const events = [];
   let pendingTools = [];
-  let responsePromptIndex = -1;
+  let adjacentPrompt = null;
   for (const line of String(text || '').split(/\r?\n/)) {
     const trimmed = line.trim();
     if (!trimmed) continue;
-    // Transitional logs emit the legacy user_message immediately after its response_item twin.
-    // Snapshot and clear the candidate for every physical JSONL record so an intervening item
-    // cannot make a later, distinct prompt replace an earlier boundary.
-    const adjacentResponsePromptIndex = responsePromptIndex;
-    responsePromptIndex = -1;
+    // Codex can persist the same prompt in either schema order. Snapshot and clear the candidate
+    // for every physical JSONL record so only adjacent, equivalent prompt records are coalesced.
+    const previousPrompt = adjacentPrompt;
+    adjacentPrompt = null;
     let obj;
     try { obj = JSON.parse(trimmed); } catch (_) { continue; }
     const payload = obj.payload || {};
@@ -180,17 +179,27 @@ function parseCodexTranscript(text) {
       // empty + no image → degenerate user_message; skip so its turns fold into the real prompt
       if (label) {
         const prompt = { kind: 'prompt', timestamp: obj.timestamp || '', text: label };
-        // One transitional schema writes both the response_item and the older event_msg for the
-        // same prompt. The event_msg is already the renderer-facing text, so let it replace the
-        // immediately preceding response_item boundary instead of showing the turn twice.
-        if (adjacentResponsePromptIndex >= 0 && adjacentResponsePromptIndex === events.length - 1) events[adjacentResponsePromptIndex] = prompt;
-        else events.push(prompt);
+        // Keep event_msg as the canonical renderer text when it follows its response_item twin.
+        if (previousPrompt?.source === 'response_item'
+          && previousPrompt.index === events.length - 1
+          && previousPrompt.text === label) {
+          events[previousPrompt.index] = prompt;
+        } else {
+          events.push(prompt);
+        }
+        adjacentPrompt = { source: 'event_msg', index: events.length - 1, text: label };
       }
     } else if (obj.type === 'response_item') {
       const label = codexResponseItemPrompt(payload);
       if (label) {
-        events.push({ kind: 'prompt', timestamp: obj.timestamp || '', text: label });
-        responsePromptIndex = events.length - 1;
+        // External-session imports persist event_msg first. Its response_item twin is model
+        // history, not a second user-visible boundary, so retain the canonical event_msg.
+        if (previousPrompt?.source !== 'event_msg'
+          || previousPrompt.index !== events.length - 1
+          || previousPrompt.text !== label) {
+          events.push({ kind: 'prompt', timestamp: obj.timestamp || '', text: label });
+        }
+        adjacentPrompt = { source: 'response_item', index: events.length - 1, text: label };
       }
     } else if (obj.type === 'event_msg' && payload.type === 'token_count') {
       const u = payload.info && payload.info.last_token_usage;

--- a/tests/shared/sessionDetail.test.js
+++ b/tests/shared/sessionDetail.test.js
@@ -3,7 +3,13 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 
-const { parseClaudeTranscript, parseCodexTranscript } = require('../../src/shared/sessionDetail');
+const {
+  distributeCost,
+  filterExchangesByPeriod,
+  groupEvents,
+  parseClaudeTranscript,
+  parseCodexTranscript
+} = require('../../src/shared/sessionDetail');
 
 test('parseClaudeTranscript yields prompts and turns with exact tokens + tools', () => {
   const lines = [
@@ -136,6 +142,40 @@ test('parseCodexTranscript labels response_item images and keeps only user conte
   assert.equal(events[0].text, '[image] 看這個畫面');
 });
 
+test('parseCodexTranscript keeps an audio-only response_item as its own exchange boundary', () => {
+  const lines = [
+    JSON.stringify({
+      type: 'response_item',
+      timestamp: '2026-09-10T02:21:50.000Z',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'first prompt' }],
+        internal_chat_message_metadata_passthrough: { content_item_kinds: ['user.text'] }
+      }
+    }),
+    JSON.stringify({ type: 'event_msg', timestamp: '2026-09-10T02:21:51.000Z', payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 100, cached_input_tokens: 80, output_tokens: 10 } } } }),
+    JSON.stringify({
+      type: 'response_item',
+      timestamp: '2026-09-10T02:22:00.000Z',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_audio', audio_url: 'data:audio/wav;base64,AAAA' }],
+        internal_chat_message_metadata_passthrough: { content_item_kinds: ['user.audio'] }
+      }
+    }),
+    JSON.stringify({ type: 'event_msg', timestamp: '2026-09-10T02:22:01.000Z', payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 200, cached_input_tokens: 150, output_tokens: 20 } } } })
+  ].join('\n');
+
+  const exchanges = groupEvents(parseCodexTranscript(lines));
+  assert.equal(exchanges.length, 2);
+  assert.equal(exchanges[0].promptPreview, 'first prompt');
+  assert.equal(exchanges[0].tokens.total, 110);
+  assert.equal(exchanges[1].promptPreview, '[audio]');
+  assert.equal(exchanges[1].tokens.total, 220);
+});
+
 test('parseCodexTranscript deduplicates transitional response_item and event_msg prompts', () => {
   const lines = [
     JSON.stringify({
@@ -150,6 +190,25 @@ test('parseCodexTranscript deduplicates transitional response_item and event_msg
   const events = parseCodexTranscript(lines);
   assert.equal(events.filter((event) => event.kind === 'prompt').length, 1);
   assert.equal(events[0].text, 'canonical prompt');
+});
+
+test('parseCodexTranscript does not deduplicate prompts across an intervening response_item', () => {
+  const lines = [
+    JSON.stringify({
+      type: 'response_item',
+      timestamp: '2026-09-10T02:21:50.000Z',
+      payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'first prompt' }] }
+    }),
+    JSON.stringify({
+      type: 'response_item',
+      timestamp: '2026-09-10T02:21:50.001Z',
+      payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'intervening response' }] }
+    }),
+    JSON.stringify({ type: 'event_msg', timestamp: '2026-09-10T02:21:51.000Z', payload: { type: 'user_message', message: 'second prompt' } })
+  ].join('\n');
+
+  const prompts = parseCodexTranscript(lines).filter((event) => event.kind === 'prompt');
+  assert.deepEqual(prompts.map((prompt) => prompt.text), ['first prompt', 'second prompt']);
 });
 
 test('parseCodexTranscript reads last_token_usage and attaches preceding tools', () => {
@@ -212,7 +271,6 @@ test('parseClaudeTranscript counts one reply once across content-block splits an
   assert.deepEqual(turns[0].tools, ['exec_command']); // tool_use merged from a later block
 });
 
-const { groupEvents, filterExchangesByPeriod, distributeCost } = require('../../src/shared/sessionDetail');
 const { localDate, localIso } = require('../helpers/localTime');
 
 function turn(ts, total, tools = []) {

--- a/tests/shared/sessionDetail.test.js
+++ b/tests/shared/sessionDetail.test.js
@@ -76,6 +76,82 @@ test('parseCodexTranscript marks a text+image user_message with an [image] prefi
   assert.equal(ev[0].text, '[image] image + test');
 });
 
+test('parseCodexTranscript reads user prompts from response_item messages', () => {
+  const lines = [
+    JSON.stringify({
+      type: 'response_item',
+      timestamp: '2026-09-10T02:21:50.000Z',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: [
+          { type: 'input_text', text: 'plugin context' },
+          { type: 'input_text', text: 'project context' }
+        ],
+        internal_chat_message_metadata_passthrough: {
+          content_item_kinds: ['plugins.recommendations', 'agents_md.instructions']
+        }
+      }
+    }),
+    JSON.stringify({
+      type: 'response_item',
+      timestamp: '2026-09-10T02:21:51.000Z',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: '修復 session detail' }],
+        internal_chat_message_metadata_passthrough: { content_item_kinds: ['user.text'] }
+      }
+    }),
+    JSON.stringify({ type: 'event_msg', timestamp: '2026-09-10T02:21:52.000Z', payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 100, cached_input_tokens: 80, output_tokens: 10 } } } })
+  ].join('\n');
+
+  const events = parseCodexTranscript(lines);
+  assert.equal(events.length, 2);
+  assert.equal(events[0].kind, 'prompt');
+  assert.equal(events[0].text, '修復 session detail');
+  assert.equal(events[1].kind, 'turn');
+});
+
+test('parseCodexTranscript labels response_item images and keeps only user content kinds', () => {
+  const lines = JSON.stringify({
+    type: 'response_item',
+    timestamp: '2026-09-10T02:21:50.000Z',
+    payload: {
+      type: 'message',
+      role: 'user',
+      content: [
+        { type: 'input_text', text: 'hidden instructions' },
+        { type: 'input_image', image_url: 'data:image/png;base64,AAAA' },
+        { type: 'input_text', text: '看這個畫面' }
+      ],
+      internal_chat_message_metadata_passthrough: {
+        content_item_kinds: ['permissions.instructions', 'user.image', 'user.text']
+      }
+    }
+  });
+
+  const events = parseCodexTranscript(lines);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].text, '[image] 看這個畫面');
+});
+
+test('parseCodexTranscript deduplicates transitional response_item and event_msg prompts', () => {
+  const lines = [
+    JSON.stringify({
+      type: 'response_item',
+      timestamp: '2026-09-10T02:21:50.000Z',
+      payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'wrapped prompt' }] }
+    }),
+    JSON.stringify({ type: 'event_msg', timestamp: '2026-09-10T02:21:50.001Z', payload: { type: 'user_message', message: 'canonical prompt' } }),
+    JSON.stringify({ type: 'event_msg', timestamp: '2026-09-10T02:21:52.000Z', payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 100, cached_input_tokens: 80, output_tokens: 10 } } } })
+  ].join('\n');
+
+  const events = parseCodexTranscript(lines);
+  assert.equal(events.filter((event) => event.kind === 'prompt').length, 1);
+  assert.equal(events[0].text, 'canonical prompt');
+});
+
 test('parseCodexTranscript reads last_token_usage and attaches preceding tools', () => {
   // Codex follows OpenAI's convention: input_tokens INCLUDES cached_input_tokens and output_tokens
   // INCLUDES reasoning_output_tokens. The turn total must equal Codex's own total_tokens

--- a/tests/shared/sessionDetail.test.js
+++ b/tests/shared/sessionDetail.test.js
@@ -181,7 +181,7 @@ test('parseCodexTranscript deduplicates transitional response_item and event_msg
     JSON.stringify({
       type: 'response_item',
       timestamp: '2026-09-10T02:21:50.000Z',
-      payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'wrapped prompt' }] }
+      payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'canonical\nprompt' }] }
     }),
     JSON.stringify({ type: 'event_msg', timestamp: '2026-09-10T02:21:50.001Z', payload: { type: 'user_message', message: 'canonical prompt' } }),
     JSON.stringify({ type: 'event_msg', timestamp: '2026-09-10T02:21:52.000Z', payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 100, cached_input_tokens: 80, output_tokens: 10 } } } })
@@ -190,6 +190,38 @@ test('parseCodexTranscript deduplicates transitional response_item and event_msg
   const events = parseCodexTranscript(lines);
   assert.equal(events.filter((event) => event.kind === 'prompt').length, 1);
   assert.equal(events[0].text, 'canonical prompt');
+});
+
+test('parseCodexTranscript deduplicates external-import event_msg and response_item prompts', () => {
+  const lines = [
+    JSON.stringify({ type: 'event_msg', timestamp: '2026-09-10T02:21:50.000Z', payload: { type: 'user_message', message: 'imported prompt' } }),
+    JSON.stringify({
+      type: 'response_item',
+      timestamp: '2026-09-10T02:21:50.001Z',
+      payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'imported prompt' }] }
+    }),
+    JSON.stringify({ type: 'event_msg', timestamp: '2026-09-10T02:21:52.000Z', payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 100, cached_input_tokens: 80, output_tokens: 10 } } } })
+  ].join('\n');
+
+  const exchanges = groupEvents(parseCodexTranscript(lines));
+  assert.equal(exchanges.length, 1);
+  assert.equal(exchanges[0].promptPreview, 'imported prompt');
+  assert.equal(exchanges[0].turnCount, 1);
+  assert.equal(exchanges[0].tokens.total, 110);
+});
+
+test('parseCodexTranscript preserves distinct adjacent user records', () => {
+  const lines = [
+    JSON.stringify({ type: 'event_msg', timestamp: '2026-09-10T02:21:50.000Z', payload: { type: 'user_message', message: 'copied parent question' } }),
+    JSON.stringify({
+      type: 'response_item',
+      timestamp: '2026-09-10T02:21:50.001Z',
+      payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'child question' }] }
+    })
+  ].join('\n');
+
+  const prompts = parseCodexTranscript(lines).filter((event) => event.kind === 'prompt');
+  assert.deepEqual(prompts.map((prompt) => prompt.text), ['copied parent question', 'child question']);
 });
 
 test('parseCodexTranscript does not deduplicate prompts across an intervening response_item', () => {


### PR DESCRIPTION
## Summary

- restore Codex session prompt boundaries from current `response_item` message records
- filter injected user-role context through `content_item_kinds` while preserving text and image prompts
- deduplicate transitional logs that contain both `response_item` and `event_msg` prompt records

## Testing

- `node --test tests/shared/sessionDetail.test.js`
- `npm run verify`
- validated against 2,125 local Codex sessions containing token turns; promptless sessions dropped from 2,124 to 3, with the remaining three containing no user-message events

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Summary

- Restores Codex session prompt boundaries from current `response_item` message records instead of relying only on legacy `event_msg` records.
- Filters injected user-role context through `content_item_kinds`, keeping only real text, image, and audio prompts, with image and audio markers.
- Deduplicates transitional logs that emit both `response_item` and `event_msg` for the same prompt when adjacent, regardless of which record comes first.

| Area | Before | After |
| --- | --- | --- |
| Codex session prompt extraction | Prompts inside `response_item` messages were ignored, so most sessions appeared promptless | User prompts are read from `response_item` messages; injected context is filtered by `content_item_kinds`, image and audio content gets markers, and duplicate adjacent transitional prompt records collapse into one in either record order |

## Testing

- `node --test tests/shared/sessionDetail.test.js` and `npm run verify` pass.
- Validated against 2,125 local Codex sessions: promptless sessions dropped from 2,124 to 3 (the remaining three contain no user-message events).

<sup>Written for commit 04604e812053df013320a7326ccda2b792de047b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

