### PR TITLE
fix(tokscale): align with latest upstream and compatibility fixes

### DIFF
--- a/scripts/vendor/tokscale.json
+++ b/scripts/vendor/tokscale.json
@@ -1,60 +1,60 @@
 {
-  "mode": "upstream",
+  "mode": "override",
   "modeNote": "\"override\": ensure-vendored-tokscale.js swaps in the pinned fork build described below, and the two verify-vendored-tokscale*.js gates run against it. \"upstream\": ensure-vendored-tokscale.js no-ops (no download or replacement) and the plain npm-installed tokscale is authoritative — but both verify-vendored-tokscale*.js gates keep running, now against that npm-installed binary, so CI still fails if it doesn't actually cover DEFAULT_CLIENTS or regressed DSH parsing. Flip to this once package.json's tokscale dependency is bumped to an official release that already contains the commit below. The pin fields (commit/releaseTag/platforms) stay in place either way, so flipping back to \"override\" for a future upstream lag is editing this file again rather than re-adding infrastructure; baseVersion is not one of them — it tracks the installed dependency in both modes (see baseVersionNote).",
   "upstream": "junhoyeo/tokscale",
   "fork": "Javis603/tokscale",
-  "commit": "b4abf21f481ea0a58803418f8cdae6733ec68e75",
-  "commitTitle": "feat(sessions): add Oh My Pi (omp) as a local session source (#1161)",
+  "commit": "805e3560fa5510becb6092e1f3e4821b088dea36",
+  "commitTitle": "fix(dsh): discover version-tagged session transcripts",
   "baseVersion": "4.15.1",
   "baseVersionNote": "The npm-installed @tokscale/cli-<platform> package version this manifest is aligned with. It tracks the dependency in BOTH modes, and two gates enforce that: ensure-vendored-tokscale.js refuses to swap under \"override\" when the installed package reports something else, and verify-vendored-tokscale-release.js (plus its real-manifest test, so npm run verify catches it too) rejects any manifest whose baseVersion disagrees with @tokscale/cli optionalDependencies. So a tokscale bump always has to touch this file — either pin a new build or flip the mode — instead of silently leaving a stale override in place.",
   "releaseRepo": "Javis603/tokscale",
-  "releaseTag": "token-monitor-b4abf21f",
-  "reason": "Retired: tokscale 4.14.0 is the first official release containing commit b4abf21f, so the pinned fork build is no longer ahead of npm and the npm-installed binary is authoritative. The commit/commitTitle/releaseTag/platforms block below is the record of that retired pin, kept so the wiring stays in place for a future upstream lag — it is NOT reusable as-is: those SHA-256s are the b4abf21f fork assets, so flipping back to \"override\" means regenerating the whole block (new commit, releaseTag, per-target hashes) against a newly built release, not just changing the mode string.",
+  "releaseTag": "token-monitor-805e3560",
+  "reason": "Tokscale 4.15.1 predates the upstream fixes through d9a45a65 and the downstream DSH version-tagged transcript discovery fix at 805e3560. Token Monitor uses this pinned fork build until an official release contains the required upstream and DSH fixes.",
   "platforms": {
     "android-arm64": {
       "package": "@tokscale/cli-android-arm64",
       "asset": "tokscale-android-arm64",
-      "sha256": "e7286a7e5114ec01936e9384cad2f1dc87afbd3e4daa186573250b4fdaf8cb47"
+      "sha256": "4eb65646015c00106e4e9502d19b5c1aa975851e1f0ca05175e1ea4cac539ad6"
     },
     "darwin-arm64": {
       "package": "@tokscale/cli-darwin-arm64",
       "asset": "tokscale-darwin-arm64",
-      "sha256": "52c5fb2e6c6156496a114d50d6bf0b1c4bf0db1f99c7d57a872557e63e23e2cd"
+      "sha256": "484a914de15ebe91dba4f2d612743294ac5048e34ea56569819d23b9bbfeeb61"
     },
     "darwin-x64": {
       "package": "@tokscale/cli-darwin-x64",
       "asset": "tokscale-darwin-x64",
-      "sha256": "c4fad90b7bb859415657bab77bad1997d44eb0692373b5e043c52ded9763d638"
+      "sha256": "418ccc5ffa8e08dd5a5760f687a9619a496f116d8107eade3e2ab5a8f82dce19"
     },
     "linux-arm64": {
       "package": "@tokscale/cli-linux-arm64-gnu",
       "asset": "tokscale-linux-arm64",
-      "sha256": "65237cdba9eff0eda4fe8d54ba1aa6edb7313776c8fd2821b188efb9413dc1f3"
+      "sha256": "2be1b7348adde5dd0f192726d025937962e91e66b9de09498f31db77c620588c"
     },
     "linux-arm64-musl": {
       "package": "@tokscale/cli-linux-arm64-musl",
       "asset": "tokscale-linux-arm64-musl",
-      "sha256": "8e2d2c6af4c48577275b4af7e67995c63204f4ec209b875d8811b0e0c0354111"
+      "sha256": "bf7e6cb83d23e4000d3d0ad66c6eed29b81da9c42792514d993db39c39b80be5"
     },
     "linux-x64": {
       "package": "@tokscale/cli-linux-x64-gnu",
       "asset": "tokscale-linux-x64",
-      "sha256": "2f153ff53e41a244423e9cba57fcf9c1fabd6fc96f27af68b26f77236b44c0b3"
+      "sha256": "39c851a6a61b81d521e39f8d381bdec14af8c3715cba2dbad66b7910e1dcf6c5"
     },
     "linux-x64-musl": {
       "package": "@tokscale/cli-linux-x64-musl",
       "asset": "tokscale-linux-x64-musl",
-      "sha256": "a1980e920d5152ef7b40e46365ca0a78e9508d36aea6cbe7790838cf34d02ae7"
+      "sha256": "a5bf25da21be11aa94681def7d7ea680c6465d255e4ec8ef4b29a39191618efc"
     },
     "win32-arm64": {
       "package": "@tokscale/cli-win32-arm64-msvc",
       "asset": "tokscale-win32-arm64.exe",
-      "sha256": "5f31304fe46e369f3eed0cbaa7988a52b45086d7f94195c0cfdc20216dae00da"
+      "sha256": "e8effdb104a25a46262be3f53faa977eb15cafc0e8cfbcbcc25852d42bb310bc"
     },
     "win32-x64": {
       "package": "@tokscale/cli-win32-x64-msvc",
       "asset": "tokscale-win32-x64.exe",
-      "sha256": "75e82e00c029b67115de3fac5332b17fec81f73217d5fc481c41011449e87cb0"
+      "sha256": "58bf9b8778cb3c6428dd77dac675e2975729c0aa2dcf402e49a128d4b08cb8d7"
     }
   }
 }

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -2422,13 +2422,17 @@ const HERMES_DB_FILES = new Set(['state.db', 'state.db-wal', 'state.db-shm']);
 // OpenClaw keeps each agent's usage sources in a small set of lanes under
 // ~/.openclaw/agents/<agentId>: legacy/published JSONL under sessions/, doctor
 // migration archives beside it, the current per-agent SQLite store, and Codex
-// app-server rollouts under agent/codex-home. The rest of an agent directory is
+// app-server rollouts under agent/codex-home and the legacy per-profile CLI
+// homes at agent/cli-auth/codex/<profile>. The rest of an agent directory is
 // runtime/workspace state and can contain dependency trees large enough to make
 // chokidar allocate thousands of directory watches. Keep the official source
 // lanes live; Tokscale's periodic full scan remains the fallback for a
 // non-standard JSONL placed elsewhere under agents/.
 const OPENCLAW_TRANSCRIPT_DIRS = new Set(['sessions', 'session-sqlite-import-archive']);
 const OPENCLAW_AGENT_DB_WATCH_PATTERN = /^openclaw-agent\.sqlite(?:-(?:wal|shm))?$/;
+// Both Codex homes an agent can own — `agent/codex-home` and the legacy
+// `agent/cli-auth/codex/<profile>` — expose their rollouts under the same two
+// directory names, so one set covers both.
 const OPENCLAW_CODEX_HOME_DIRS = new Set(['sessions', 'archived_sessions']);
 // OpenCode discovers only direct opencode.db / opencode-<channel>.db files.
 // WAL/SHM are not database inputs to tokscale, but they are the live-write
@@ -2549,14 +2553,23 @@ function watchPolicyEntries(clientsCsv) {
     if (OPENCLAW_TRANSCRIPT_DIRS.has(parts[1])) return false;
     if (parts[1] !== 'agent') return true;
 
-    // Keep the parent so a fresh SQLite store or codex-home can appear after
-    // startup, then limit its contents to those two sources.
+    // Keep the parent so a fresh SQLite store, codex-home or cli-auth home can
+    // appear after startup, then limit its contents to those sources.
     if (parts.length === 2) return false;
     if (parts.length === 3) {
-      return parts[2] !== 'codex-home' && !OPENCLAW_AGENT_DB_WATCH_PATTERN.test(parts[2]);
+      return parts[2] !== 'codex-home'
+        && parts[2] !== 'cli-auth'
+        && !OPENCLAW_AGENT_DB_WATCH_PATTERN.test(parts[2]);
     }
-    if (parts[2] !== 'codex-home') return true;
-    return !OPENCLAW_CODEX_HOME_DIRS.has(parts[3]);
+    if (parts[2] === 'codex-home') return !OPENCLAW_CODEX_HOME_DIRS.has(parts[3]);
+    if (parts[2] !== 'cli-auth') return true;
+    // Only `cli-auth/codex/<profile>` is a Codex home; `cli-auth/<other>` is an
+    // authentication profile Tokscale never reads. The profile level is kept so
+    // a login added after startup still reports, and `history.jsonl` beside its
+    // session dirs is pruned the same way it is under codex-home.
+    if (parts[3] !== 'codex') return true;
+    if (parts.length <= 5) return false;
+    return !OPENCLAW_CODEX_HOME_DIRS.has(parts[5]);
   });
 
   bound('copilot', withBasename('copilot', '.copilot'), (parts) => {

--- a/tests/shared/collectorLoadGuards.test.js
+++ b/tests/shared/collectorLoadGuards.test.js
@@ -179,6 +179,9 @@ test('watchIgnoreMatcher bounds OpenClaw to its per-agent usage sources', () => 
     path.join(root, 'main', 'session-sqlite-import-archive'),
     path.join(root, 'main', 'agent', 'codex-home', 'sessions', '2026', '09', '07'),
     path.join(root, 'main', 'agent', 'codex-home', 'archived_sessions'),
+    path.join(root, 'main', 'agent', 'cli-auth', 'codex', 'default', 'sessions', '2026', '08', '30'),
+    path.join(root, 'main', 'agent', 'cli-auth', 'codex', 'default', 'archived_sessions'),
+    path.join(root, 'main', 'agent', 'cli-auth', 'other', 'default', 'sessions'),
     path.join(root, 'main', 'workspace', 'node_modules', 'package', 'cache'),
     path.join(root, 'main', 'logs')
   ]);
@@ -208,7 +211,23 @@ test('watchIgnoreMatcher bounds OpenClaw to its per-agent usage sources', () => 
       path.join(agents, 'main', 'agent', 'codex-home', 'sessions'),
       path.join(agents, 'main', 'agent', 'codex-home', 'sessions', '2026', '09', '07', 'rollout.jsonl'),
       path.join(agents, 'main', 'agent', 'codex-home', 'archived_sessions'),
-      path.join(agents, 'main', 'agent', 'codex-home', 'archived_sessions', 'rollout.jsonl')
+      path.join(agents, 'main', 'agent', 'codex-home', 'archived_sessions', 'rollout.jsonl'),
+      // Legacy per-profile CLI homes hold Codex rollouts OpenClaw owns too. The
+      // `codex` and `<profile>` levels are kept so a login added after startup
+      // still reports.
+      path.join(agents, 'main', 'agent', 'cli-auth'),
+      path.join(agents, 'main', 'agent', 'cli-auth', 'codex'),
+      path.join(agents, 'main', 'agent', 'cli-auth', 'codex', 'default'),
+      path.join(agents, 'main', 'agent', 'cli-auth', 'codex', 'default', 'sessions'),
+      path.join(
+        agents, 'main', 'agent', 'cli-auth', 'codex', 'default',
+        'sessions', '2026', '08', '30', 'rollout.jsonl'
+      ),
+      path.join(agents, 'main', 'agent', 'cli-auth', 'codex', 'default', 'archived_sessions'),
+      path.join(
+        agents, 'main', 'agent', 'cli-auth', 'codex', 'default',
+        'archived_sessions', 'rollout.jsonl'
+      )
     ];
     for (const target of kept) assert.equal(ignored(target), false, target);
 
@@ -223,7 +242,15 @@ test('watchIgnoreMatcher bounds OpenClaw to its per-agent usage sources', () => 
       path.join(agents, 'main', 'agent', 'incognito-openclaw-agent.sqlite'),
       path.join(agents, 'main', 'agent', 'codex-home', 'history.jsonl'),
       path.join(agents, 'main', 'agent', 'codex-home', 'tmp'),
-      path.join(agents, 'main', 'agent', 'codex-home', 'tmp', 'rollout.jsonl')
+      path.join(agents, 'main', 'agent', 'codex-home', 'tmp', 'rollout.jsonl'),
+      // `cli-auth/<other>` is an authentication profile, not a Codex home, and
+      // `history.jsonl` beside the session dirs is not a rollout.
+      path.join(agents, 'main', 'agent', 'cli-auth', 'other'),
+      path.join(agents, 'main', 'agent', 'cli-auth', 'other', 'default'),
+      path.join(agents, 'main', 'agent', 'cli-auth', 'other', 'default', 'sessions'),
+      path.join(agents, 'main', 'agent', 'cli-auth', 'codex', 'default', 'history.jsonl'),
+      path.join(agents, 'main', 'agent', 'cli-auth', 'codex', 'default', 'tmp'),
+      path.join(agents, 'main', 'agent', 'cli-auth', 'codex', 'default', 'tmp', 'rollout.jsonl')
     ];
     for (const target of pruned) assert.equal(ignored(target), true, target);
   } finally {


### PR DESCRIPTION
## Summary

Pin Token Monitor to the verified Tokscale vendor build at `805e3560`. This aligns scanner and parser behavior with upstream through `d9a45a65` and adds the downstream DSH filename compatibility fix required by Token Monitor.

## Token Monitor behavior changes

| Area | Before this PR | After this PR |
| --- | --- | --- |
| Antigravity large sessions | Trajectory responses above the previous 16 MiB limit could lose their recovered timestamps and disappear from Today or Month totals. A failed large response could also interrupt timestamp enrichment for later sessions. | The response limit is raised to 128 MiB, failures are isolated per session, and valid cached timestamps are preserved or recovered. |
| DSH usage totals | Recursive scanning already reached nested session directories, but Tokscale recognized only `session.jsonl` and `session.jsonl.zstd`. After a DSH upgrade, historical totals could remain visible while new usage written to files such as `session.v3.jsonl.zstd` was missed. | Version-tagged filenames matching `session.v<N>.jsonl(.zstd)` are recognized generically. If old and re-encoded files coexist, Tokscale’s content-based cross-file deduplication prevents double counting. |
| OpenClaw usage sources | Tokscale 4.15.1 missed newer per-agent SQLite storage, compressed archives, and per-profile Codex rollout locations. Codex-harness turns launched through OpenClaw could remain attributed to Codex. | Tokscale reads per-agent SQLite, compressed and imported archives, and per-profile CLI-auth Codex rollouts. Codex-harness turns owned by OpenClaw are attributed to OpenClaw. |
| OpenClaw live refresh | The new per-profile paths were not admitted by Token Monitor’s bounded watcher, so newly written usage would wait for periodic full reconciliation even after the scanner learned to read it. | The watcher retains only each profile’s relevant `sessions` and `archived_sessions` lanes, allowing new rollout writes to trigger a prompt targeted refresh without watching unrelated profile state. |
| OpenClaw archive correctness | Compaction checkpoint snapshots could be counted as ordinary sessions, and imported archives could surface synthetic archive-tier session IDs. | Checkpoint snapshots are excluded, while imported archives retain their real session identity. |
| Copilot CLI scanning | Large exports were read more than once, increasing peak memory use and allowing trace metadata to come from a separate read. | Exports are processed in one pass with consistent trace attribution and lower peak memory use. |
| Cost estimates | Some supported Zhipu, Xiaomi, Tencent, preview-alias, and large-context models could use older fallback pricing. | Updated first-party tariffs, alias resolution, and large-context pricing may revise historical cost totals without changing token totals. |
| First scan after upgrade | Existing caches use the parser versions shipped with Tokscale 4.15.1. | Affected OpenClaw, Codex, and Pi caches are rebuilt once after the binary switch. The first scan may take longer; subsequent scans return to normal cached behavior. |

## Related work

[PR #657](https://github.com/Javis603/token-monitor/pull/657) updates Token Monitor’s separate Session Detail discovery so it can open and prefer the live version-tagged DSH transcript.

This PR fixes the **usage plane** through Tokscale, while #657 fixes the **Session Detail plane**. They address the same DSH filename transition without duplicating parser ownership.

## Why this is vendored

The official npm release remains at Tokscale 4.15.1 and does not contain all of these upstream changes or the downstream DSH filename fix.

Token Monitor therefore pins a verified cross-platform vendor build while retaining 4.15.1 as the npm fallback and compatibility baseline until an official release contains the required behavior.

## Verification

- published and verified [`token-monitor-805e3560`](https://github.com/Javis603/tokscale/releases/tag/token-monitor-805e3560)
- verified all 9 native assets against the pinned SHA-256 hashes
- verified the DSH parser fixture and all 28 effective Tokscale client ids
- verified production `--json --group-by client,session,model --today` output
- focused tests: 125 passed
- `npm run verify`: 4217 passed, 0 failed, 2 skipped
- `git diff --check`

Refs #602  
Fixes #660  
Related: #657
