### PR TITLE
fix(hermes): refresh Desktop usage live from state.db

### DIFF
--- a/docs/providers/hermes.md
+++ b/docs/providers/hermes.md
@@ -1,0 +1,32 @@
+---
+summary: "Hermes Agent usage: SQLite state.db timestamps, compact session ids, and Windows WAL live refresh."
+read_when:
+  - Changing Hermes source detection, watches, or session timestamps
+  - Debugging missing Hermes Desktop usage on Today / live rate
+---
+
+# Hermes Agent
+
+Hermes is a regular Tokscale client (`hermes`). Token counts come from Tokscale reading `state.db`; Token Monitor only dates those rows and keeps the live watch from going silent.
+
+## Source
+
+Default home is `~/.hermes` when `state.db` exists there. On Windows a native Desktop install often uses `%LOCALAPPDATA%\hermes` instead (the two paths may be the same directory via a junction). `HERMES_HOME` wins when set. Profile databases under `profiles/*/state.db` are scanned the same way.
+
+Do not recursively watch the whole Hermes home: the Desktop runtime (`hermes-agent/node_modules`, venv, logs, cache) is large enough to peg CPU (issue #38). The watcher stays on the home directory and ignores everything except `state.db`, `state.db-wal`, and `state.db-shm`.
+
+## Live refresh
+
+SQLite WAL writes on Windows are often mmap updates that never surface as chokidar events, so a Desktop session that started after the last full scan can sit at zero until the hourly full tick. The collector therefore stats the db family every 2s and treats a size/mtime change as a targeted Hermes `--today` watch tick. That poll is bounded to three filenames per Hermes home / profile; it is not a recursive tree poll.
+
+## Session timestamps
+
+Hermes session ids look like `20260911_115516_2cedb0` (local wall time, not ISO). Tokscale JSON for Hermes has no `startedAt` / `lastUsedAt`, so the generic id parser used to leave those fields empty and then freeze the row in `resolvedSessionKeys`.
+
+`providers/hermes/session.js` reads `sessions.started_at` and `sessions.last_activity_at` (Unix epoch seconds) from `state.db`, the same pattern OpenCode uses for `opencode.db`. Compact ids remain a fallback when sqlite is unavailable. Hermes rows are never frozen in `resolvedSessionKeys`, because Desktop keeps `last_activity_at` moving while the chat is open.
+
+This does **not** re-attribute a multi-day session's lifetime tokens onto Today. Tokscale still keys `--today` on session start (`junhoyeo/tokscale#993` / Token Monitor #230). A session that began today, including Hermes Desktop, is what the poll + timestamps are for.
+
+## WSL
+
+As with other SQLite clients, if Windows cannot read a live `state.db` over the WSL share, run the headless agent inside WSL and sync through a hub.

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -28,6 +28,7 @@ const {
 } = require('./usage');
 const { collectWslUsage: collectWslUsageImpl, emptyWslBundle, probeWslState: probeWslStateImpl } = require('./wslUsage');
 const { hermesProfileWatchDirs, resolveHermesHome } = require('./providers/hermes/profiles');
+const hermesSession = require('./providers/hermes/session');
 const { createWatcherHost } = require('./watcherHost');
 const { localDayKey, mergeHistories, parseGraphResult, normalizeHistory } = require('./history');
 const { retainDailyHistory, retainLiveDailyHistory } = require('./dailyHistoryArchive');
@@ -802,8 +803,14 @@ function timestampFromSessionId(id) {
   const isoMatch = raw.match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z/);
   if (isoMatch) return isoFromDate(isoMatch[0]);
   const localMatch = raw.match(/(\d{4})-(\d{2})-(\d{2})T(\d{2})[:-](\d{2})(?:[:-](\d{2}))?/);
-  if (!localMatch) return '';
-  const [, year, month, day, hour, minute, second = '0'] = localMatch;
+  if (localMatch) {
+    const [, year, month, day, hour, minute, second = '0'] = localMatch;
+    return isoFromDate(new Date(Number(year), Number(month) - 1, Number(day), Number(hour), Number(minute), Number(second)));
+  }
+  // Hermes Desktop/CLI: 20260911_115516_2cedb0 (local wall time, not ISO).
+  const hermesMatch = raw.match(/^(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})(?:_[0-9a-f]+)?$/i);
+  if (!hermesMatch) return '';
+  const [, year, month, day, hour, minute, second] = hermesMatch;
   return isoFromDate(new Date(Number(year), Number(month) - 1, Number(day), Number(hour), Number(minute), Number(second)));
 }
 
@@ -974,6 +981,28 @@ function sessionTimestampMap(periods, home = os.homedir(), deps = {}) {
     if (identity.projectId) resolvedSessionKeys.add(key);
   };
 
+  // Hermes has no transcript file — timestamps live in state.db (started_at /
+  // last_activity_at). Desktop sessions keep last_activity_at moving while the
+  // chat is open, so these rows are never frozen in resolvedSessionKeys.
+  const hermesIds = byClient.get('hermes') || new Set();
+  if (hermesIds.size > 0) {
+    const readHermesMeta = deps.readHermesMeta || ((ids) => hermesSession.readSessionMeta(ids, {
+      homeDir: home,
+      env: deps.scopedHome ? {} : (deps.env || process.env),
+      platform: deps.platform,
+      ...(deps.hermesDeps || {})
+    }));
+    for (const [sessionId, meta] of readHermesMeta(hermesIds)) {
+      const startedAt = meta.startedAt || timestampFromSessionId(sessionId) || '';
+      const lastUsedAt = meta.lastUsedAt || startedAt;
+      const identity = resolveProjects ? projectIdentity(meta.projectPath) : {};
+      const key = `hermes:${sessionId}`;
+      if (startedAt || lastUsedAt || identity.projectId) {
+        metadata.set(key, { startedAt, lastUsedAt, ...identity });
+      }
+    }
+  }
+
   // OpenCode has no transcript file — its timestamps come from the opencode.db `session` table.
   const opencodeIds = byClient.get('opencode') || new Set();
   if (opencodeIds.size > 0) {
@@ -1140,7 +1169,7 @@ function sessionTimestampMap(periods, home = os.homedir(), deps = {}) {
     if (metadata.has(key)) continue;
     const timestamp = timestampFromSessionId(ref.sessionId);
     if (timestamp) metadata.set(key, { startedAt: timestamp, lastUsedAt: timestamp });
-    if (!['claude', 'codex', 'opencode', 'dsh'].includes(ref.client)) resolvedSessionKeys.add(key);
+    if (!['claude', 'codex', 'opencode', 'dsh', 'hermes'].includes(ref.client)) resolvedSessionKeys.add(key);
   }
   for (const ref of refs.values()) attemptedSessionKeys.add(`${ref.client}:${ref.sessionId}`);
 
@@ -3264,6 +3293,8 @@ function startCollector(options) {
   let pendingWaiters = [];
   let debounceTimer = null;
   let intervalTimer = null;
+  let hermesPollTimer = null;
+  let hermesPollFingerprint = '';
   let stopped = false;
   let lastTickAttemptAt = 0;
   let lastTickSuccessAt = 0;
@@ -3852,6 +3883,43 @@ function startCollector(options) {
     });
   }
 
+  function hermesDbFingerprint() {
+    const home = resolveHermesHome({
+      env: options.env || process.env,
+      homeDir: options.homeDir || os.homedir(),
+      platform: options.platform || process.platform
+    });
+    const dirs = [home, ...hermesProfileWatchDirs(home)];
+    let fingerprint = '';
+    for (const dir of dirs) {
+      for (const name of ['state.db', 'state.db-wal', 'state.db-shm']) {
+        try {
+          const st = fs.statSync(path.join(dir, name));
+          fingerprint += `${st.size}:${Math.trunc(st.mtimeMs)};`;
+        } catch (_) { /* file not created yet */ }
+      }
+    }
+    return fingerprint;
+  }
+
+  // SQLite WAL writes on Windows often never surface as chokidar events (mmap).
+  // Stat the db family every 2s and treat a size/mtime change as a Hermes watch
+  // tick so Desktop token counts refresh while the conversation is live.
+  function startHermesDbPoll() {
+    if (hermesPollTimer || stopped) return;
+    if (!watchTriggersCollection || !trackedClients.has('hermes')) return;
+    hermesPollFingerprint = hermesDbFingerprint();
+    hermesPollTimer = setInterval(() => {
+      if (stopped) return;
+      const fingerprint = hermesDbFingerprint();
+      if (!fingerprint || fingerprint === hermesPollFingerprint) return;
+      hermesPollFingerprint = fingerprint;
+      scheduleTick('watch:poll:state.db', ['hermes']);
+    }, 2000);
+    if (typeof hermesPollTimer.unref === 'function') hermesPollTimer.unref();
+    log('Polling Hermes state.db every 2s for live Desktop usage');
+  }
+
   function setupWatchers() {
     if (!watchEnabled) return;
     // Canonicalise before anything derives from these roots, so the paths handed
@@ -4006,6 +4074,7 @@ function startCollector(options) {
     runtimeAbortController.abort(new Error('collector stopped'));
     if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
     if (intervalTimer) { clearTimeout(intervalTimer); intervalTimer = null; }
+    if (hermesPollTimer) { clearInterval(hermesPollTimer); hermesPollTimer = null; }
     clearRolloverHistoryRetry();
     sourceSyncQueue.stop();
     closeWatchers({ skipClose: options.skipCloseWatchers === true });
@@ -4061,6 +4130,7 @@ function startCollector(options) {
   }
 
   setupWatchers();
+  startHermesDbPoll();
   loop();
 
   // A rescan of one tool. Was cursor-only because a Cursor sign-in was the only

--- a/src/shared/providers/hermes/session.js
+++ b/src/shared/providers/hermes/session.js
@@ -1,0 +1,107 @@
+'use strict';
+
+// Read Hermes Agent session timestamps from state.db (SQLite).
+// Tokscale counts the tokens; this file only dates the session rows so Today
+// / live rate can follow a Desktop conversation whose id is YYYYMMDD_HHMMSS_hex
+// (not an ISO timestamp) and whose last_activity_at keeps moving mid-session.
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { resolveHermesHome, discoverHermesProfileScanPaths } = require('./profiles');
+
+let sqlite = null;
+try { sqlite = require('node:sqlite'); } catch (_) { sqlite = null; }
+
+function resolveSqlite(deps) {
+  return deps.sqlite !== undefined ? deps.sqlite : sqlite;
+}
+
+function isoFromUnix(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return '';
+  const ms = n > 1e12 ? n : n * 1000;
+  const date = new Date(ms);
+  return Number.isNaN(date.getTime()) ? '' : date.toISOString();
+}
+
+function openDb(dbPath, sqliteMod) {
+  const db = new sqliteMod.DatabaseSync(dbPath, { readOnly: true });
+  try { db.exec('PRAGMA busy_timeout = 250'); } catch (_) { /* older bindings */ }
+  return db;
+}
+
+function discoverDbPaths(deps = {}) {
+  if (Array.isArray(deps.dbPaths) && deps.dbPaths.length) return deps.dbPaths;
+  const homeDir = deps.homeDir || os.homedir();
+  const hermesHome = resolveHermesHome({
+    env: deps.env || process.env,
+    homeDir,
+    platform: deps.platform || process.platform,
+    existsSync: deps.existsSync || fs.existsSync
+  });
+  const dirs = [hermesHome, ...discoverHermesProfileScanPaths(hermesHome, deps)];
+  const existsSync = deps.existsSync || fs.existsSync;
+  const paths = [];
+  for (const dir of dirs) {
+    const dbPath = path.join(dir, 'state.db');
+    if (existsSync(dbPath)) paths.push(dbPath);
+  }
+  return paths;
+}
+
+function columnSet(db, table) {
+  try {
+    return new Set(db.prepare(`PRAGMA table_info(${table})`).all().map((column) => String(column.name)));
+  } catch (_) {
+    return new Set();
+  }
+}
+
+function readSessionMeta(sessionIds, deps = {}) {
+  const ids = Array.from(sessionIds || []).filter(Boolean).map(String);
+  const out = new Map();
+  if (ids.length === 0) return out;
+  const sqliteMod = resolveSqlite(deps);
+  if (!sqliteMod) return out;
+
+  const placeholders = ids.map(() => '?').join(',');
+  for (const dbPath of discoverDbPaths(deps)) {
+    let db;
+    try {
+      db = openDb(dbPath, sqliteMod);
+      const columns = columnSet(db, 'sessions');
+      if (!columns.has('id') || !columns.has('started_at')) continue;
+      const lastActivity = columns.has('last_activity_at') ? 'last_activity_at' : 'NULL';
+      const cwd = columns.has('cwd') ? "COALESCE(cwd,'')" : "''";
+      const sql = `SELECT id,
+                          started_at AS startedAt,
+                          ${lastActivity} AS lastActivityAt,
+                          ${cwd} AS cwd
+                   FROM sessions WHERE id IN (${placeholders})`;
+      for (const row of db.prepare(sql).all(...ids)) {
+        const id = String(row.id);
+        if (out.has(id)) continue;
+        const startedAt = isoFromUnix(row.startedAt);
+        const lastUsedAt = isoFromUnix(row.lastActivityAt) || startedAt;
+        out.set(id, {
+          startedAt,
+          lastUsedAt,
+          projectPath: String(row.cwd || '').trim()
+        });
+      }
+    } catch (_) {
+      /* live WAL / missing table / node:sqlite unavailable for this file */
+    } finally {
+      try { db?.close(); } catch (_) {}
+    }
+    if (out.size >= ids.length) break;
+  }
+  return out;
+}
+
+module.exports = {
+  discoverDbPaths,
+  isoFromUnix,
+  readSessionMeta
+};

--- a/tests/shared/collectorSessionTimestamps.test.js
+++ b/tests/shared/collectorSessionTimestamps.test.js
@@ -549,3 +549,68 @@ test('applySessionTimestamps retries a progressive miss in the final pass', () =
   assert.equal(reads, 2, 'the final pass should retry a prior miss once');
   assert.equal(periods.today.sessions['opencode:s1'].projectLabel, 'project');
 });
+
+test('applySessionTimestamps fills Hermes session start/last from injected DB meta', () => {
+  const periods = {
+    today: {
+      sessions: {
+        'hermes:20260911_115516_2cedb0': {
+          client: 'hermes',
+          sessionId: '20260911_115516_2cedb0',
+          startedAt: '',
+          lastUsedAt: ''
+        }
+      }
+    }
+  };
+  applySessionTimestamps(periods, '/no/such/home', {
+    readHermesMeta(ids) {
+      assert.ok(ids.has('20260911_115516_2cedb0'));
+      return new Map([['20260911_115516_2cedb0', {
+        startedAt: '2026-09-11T03:56:18.697Z',
+        lastUsedAt: '2026-09-11T04:24:19.108Z',
+        projectPath: '/work/hermes-desktop'
+      }]]);
+    }
+  });
+
+  const session = periods.today.sessions['hermes:20260911_115516_2cedb0'];
+  assert.equal(session.startedAt, '2026-09-11T03:56:18.697Z');
+  assert.equal(session.lastUsedAt, '2026-09-11T04:24:19.108Z');
+  assert.equal(session.projectLabel, 'hermes-desktop');
+});
+
+test('applySessionTimestamps parses Hermes compact session ids when sqlite meta is missing', () => {
+  const periods = { today: { sessions: {
+    'hermes:20260911_115516_2cedb0': { client: 'hermes', sessionId: '20260911_115516_2cedb0', startedAt: '', lastUsedAt: '' }
+  } } };
+  applySessionTimestamps(periods, '/no/such/home', {
+    readHermesMeta: () => new Map(),
+    metadataCache: new Map(),
+    resolvedSessionKeys: new Set(),
+    attemptedSessionKeys: new Set()
+  });
+  const expected = new Date(2026, 8, 11, 11, 55, 16).toISOString();
+  const session = periods.today.sessions['hermes:20260911_115516_2cedb0'];
+  assert.equal(session.startedAt, expected);
+  assert.equal(session.lastUsedAt, expected);
+});
+
+test('applySessionTimestamps does not freeze Hermes rows so lastUsedAt can refresh', () => {
+  const cache = { metadataCache: new Map(), resolvedSessionKeys: new Set(), attemptedSessionKeys: new Set() };
+  let lastUsedAt = '2026-09-11T04:00:00.000Z';
+  const readHermesMeta = () => new Map([['s1', {
+    startedAt: '2026-09-11T03:56:18.697Z',
+    lastUsedAt
+  }]]);
+  const tick = () => {
+    const periods = { today: { sessions: { 'hermes:s1': { client: 'hermes', sessionId: 's1' } } } };
+    applySessionTimestamps(periods, '/no/such/home', { ...cache, readHermesMeta, retryMisses: true });
+    return periods.today.sessions['hermes:s1'];
+  };
+
+  assert.equal(tick().lastUsedAt, '2026-09-11T04:00:00.000Z');
+  lastUsedAt = '2026-09-11T04:25:00.000Z';
+  assert.equal(tick().lastUsedAt, '2026-09-11T04:25:00.000Z');
+  assert.equal(cache.resolvedSessionKeys.has('hermes:s1'), false);
+});

--- a/tests/shared/hermesSession.test.js
+++ b/tests/shared/hermesSession.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+let sqlite = null;
+try { sqlite = require('node:sqlite'); } catch (_) { sqlite = null; }
+
+const hermesSession = require('../../src/shared/providers/hermes/session');
+
+const maybe = sqlite ? test : test.skip;
+const tmpDirs = [];
+test.after(() => {
+  for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function makeDb({ rows }) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-sess-'));
+  tmpDirs.push(tmp);
+  const file = path.join(tmp, 'state.db');
+  const db = new sqlite.DatabaseSync(file);
+  db.exec(`CREATE TABLE sessions (
+    id TEXT PRIMARY KEY,
+    started_at REAL NOT NULL,
+    last_activity_at REAL,
+    cwd TEXT
+  )`);
+  const insert = db.prepare('INSERT INTO sessions (id, started_at, last_activity_at, cwd) VALUES (?,?,?,?)');
+  for (const row of rows) {
+    insert.run(row.id, row.startedAt, row.lastActivityAt ?? null, row.cwd || '');
+  }
+  db.close();
+  return file;
+}
+
+maybe('readSessionMeta converts Hermes epoch-second timestamps and cwd', () => {
+  const started = Date.UTC(2026, 8, 11, 3, 56, 18, 697) / 1000;
+  const last = Date.UTC(2026, 8, 11, 4, 24, 19, 108) / 1000;
+  const file = makeDb({
+    rows: [{
+      id: '20260911_115516_2cedb0',
+      startedAt: started,
+      lastActivityAt: last,
+      cwd: 'D:\\Hermes'
+    }]
+  });
+
+  const meta = hermesSession.readSessionMeta(['20260911_115516_2cedb0', 'missing'], {
+    dbPaths: [file],
+    sqlite
+  });
+  assert.equal(meta.size, 1);
+  assert.deepEqual(meta.get('20260911_115516_2cedb0'), {
+    startedAt: '2026-09-11T03:56:18.697Z',
+    lastUsedAt: '2026-09-11T04:24:19.108Z',
+    projectPath: 'D:\\Hermes'
+  });
+});
+
+maybe('readSessionMeta falls back to started_at when last_activity_at is missing', () => {
+  const started = Date.UTC(2026, 8, 11, 3, 56, 18) / 1000;
+  const file = makeDb({
+    rows: [{ id: 's1', startedAt: started, lastActivityAt: null }]
+  });
+  const meta = hermesSession.readSessionMeta(['s1'], { dbPaths: [file], sqlite });
+  assert.equal(meta.get('s1').startedAt, '2026-09-11T03:56:18.000Z');
+  assert.equal(meta.get('s1').lastUsedAt, '2026-09-11T03:56:18.000Z');
+});
+
+maybe('readSessionMeta returns an empty map when sqlite is unavailable', () => {
+  const file = makeDb({ rows: [{ id: 's1', startedAt: 1, lastActivityAt: 2 }] });
+  const meta = hermesSession.readSessionMeta(['s1'], { dbPaths: [file], sqlite: null });
+  assert.equal(meta.size, 0);
+});
+
+test('isoFromUnix accepts seconds and millisecond timestamps', () => {
+  const ms = Date.UTC(2026, 8, 11, 3, 56, 18, 697);
+  assert.equal(hermesSession.isoFromUnix(ms / 1000), new Date(ms).toISOString());
+  assert.equal(hermesSession.isoFromUnix(ms), new Date(ms).toISOString());
+  assert.equal(hermesSession.isoFromUnix(0), '');
+  assert.equal(hermesSession.isoFromUnix('nope'), '');
+});


### PR DESCRIPTION
## Summary

Hermes Desktop usage on Windows often never appears in Today / live rate until the hourly full scan, even though `tokscale --today -c hermes` already sees the session.

## Root Cause

- Hermes writes tokens through SQLite WAL (`state.db-wal`). On Windows those mmap writes often never surface as chokidar events, so the live watcher never schedules a tick.
- Hermes session ids are `YYYYMMDD_HHMMSS_<hex>`, not ISO. The generic parser left `startedAt` / `lastUsedAt` empty, then froze the row in `resolvedSessionKeys`.
- Tokscale JSON for Hermes has token counts but no time fields, so Token Monitor could not date the row without reading `state.db`.

This is separate from #230 / junhoyeo/tokscale#993 (a session that started on a previous day is still filtered out of `--today` by session start). This PR covers a session that started today, including Hermes Desktop.

## Fix

- Read `sessions.started_at` and `sessions.last_activity_at` from `state.db` (same pattern as OpenCode).
- Parse compact Hermes session ids as a fallback when sqlite is unavailable.
- Never freeze Hermes rows in `resolvedSessionKeys`, so `lastUsedAt` keeps moving while the Desktop chat is open.
- Stat `state.db` / `-wal` / `-shm` every 2s and treat a size/mtime change as a targeted Hermes `--today` watch tick. Still does not recursively watch `~/.hermes` (issue #38).

## Test Plan

- [x] `node --test tests/shared/hermesSession.test.js tests/shared/collectorSessionTimestamps.test.js` (24 pass)
- [x] eslint on the touched files
- [x] Manual: patched 0.55.0 on Windows; session `20260911_115516_2cedb0` appeared in Today within seconds and token counts kept growing (`7583613` → `7673486`)

## Risk Assessment

Low — Hermes-only collector path. Tokscale still owns token totals. The 2s poll is three `stat`s per Hermes home/profile, not a recursive tree watch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Hermes Desktop usage never appearing in Today / live rate on Windows until the hourly full scan.

- Reads `started_at` and `last_activity_at` from `state.db` (same pattern as OpenCode) and parses compact Hermes session ids (`YYYYMMDD_HHMMSS_hex`) when sqlite is unavailable.
- Stops freezing Hermes rows in `resolvedSessionKeys` so `lastUsedAt` keeps moving while the Desktop chat is open.
- Polls `state.db` / `-wal` / `-shm` every 2s and treats a size/mtime change as a targeted Hermes watch tick, since Windows WAL writes often never surface as chokidar events.

| Area | Before | After |
| --- | --- | --- |
| Desktop live usage | Session only appears after the hourly full scan | Appears within seconds; token counts keep growing while the chat is open |
| Session timestamps | Empty `startedAt` / `lastUsedAt` for compact ids; row frozen | Timestamps read from `state.db`, compact id as fallback; row refreshes |

The 2s poll is three `stat`s per Hermes home/profile, not a recursive tree watch. It does not re-attribute multi-day sessions onto Today — Tokscale still owns token totals and `--today` keying. Verified with unit tests plus a manual Windows run on 0.55.0.

<sup>Written for commit 5029946706e7fa49a630378e9cfa3bd0508c548f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

