### PR TITLE
fix(sessions): show persisted DSH titles

### DIFF
--- a/docs/providers/dsh.md
+++ b/docs/providers/dsh.md
@@ -1,18 +1,19 @@
 ---
-summary: "DeepSeek Harness (dsh) provider notes: where the harness stores transcripts, how a versioned transcript name is discovered, and why the usage totals come from tokscale rather than a local reader."
+summary: "DeepSeek Harness (dsh) provider notes: where the harness stores transcripts, how usage, session metadata and Session Detail read them, and why usage totals still come from tokscale."
 read_when:
-  - Changing or debugging DeepSeek Harness (dsh) session discovery or Session Detail
+  - Changing or debugging DeepSeek Harness (dsh) session discovery, titles or Session Detail
   - Investigating DSH usage that is missing from the widget
   - Touching providers/dsh/sessionFiles.js, providers/dsh/sessionDetail.js or paths.js
 ---
 
 # DeepSeek Harness (dsh) provider
 
-DSH has two data planes, and they are deliberately separate:
+DSH has three data planes, and they are deliberately separate:
 
 | Data plane | Read by | Source |
 | --- | --- | --- |
 | Token usage (periods, dashboard, history) | the shared usage collector, through `tokscale` | DSH session transcripts, parsed by tokscale's `dsh.rs` |
+| Local session metadata (timestamps, persisted title) | collector metadata enrichment in `collector.js`, through `providers/dsh/sessionFiles.js` | transcript header, file metadata and the latest `session/title`, parsed locally |
 | Session Detail (per-turn breakdown, prompts) | `providers/dsh/sessionDetail.js`, on demand | the same transcripts, parsed locally |
 
 ## Where the data lives
@@ -41,13 +42,27 @@ versioned file is the live one — the unversioned file stopped being appended t
 upgraded. So `sessionFiles.js` matches the version segment generically
 (`session[.vN].<ext>`, numeric — the harness's own convention) and lists a session's versioned
 transcript before its stale predecessor. Callers that stop at the first match (Session Detail,
-the header index used for session timestamps) therefore read the file the harness is still
+the header index used for session timestamps and titles) therefore read the file the harness is still
 writing, and a session whose only transcript is versioned is found at all.
 
 Token Monitor's pinned tokscale build uses the same canonical generic-version matcher. Keeping
 the two discovery rules aligned means a transcript visible in dashboard usage can also be opened
 in Session Detail. The npm 4.15.1 base predates this support; the vendor override supplies it
 until an official tokscale release includes the fix.
+
+## Local session metadata
+
+The collector enriches local session rows from the preferred transcript without changing token
+accounting. It takes the session start from the transcript header, last activity from the file
+mtime, and folds the latest durable `session/title` event as the conversation title. It never
+derives a title from `user/message` or `session/title-llm-request` content.
+
+Title reads retain complete plain-JSONL or zstd-frame boundaries for incremental refreshes. Before
+reusing an append offset, `sessionFiles.js` verifies the file identity and a bounded head/tail
+fingerprint; a rewrite or generation change resets the fold, while an unfinished tail is replayed
+on the next refresh. DSH validates titles before persistence, so Token Monitor preserves
+`event.data.title` rather than applying a separate display limit. Resolved titles remain local and
+are not added to the device wire record.
 
 ## Session Detail
 

--- a/src/shared/collector.js
+++ b/src/shared/collector.js
@@ -61,6 +61,7 @@ const {
   indexDshSessionHeaders,
   preferredDshSessionFileInDirectory,
   readDshSessionHeader,
+  readDshSessionTitle,
   resolveDshSessionsRoot
 } = require('./providers/dsh/sessionFiles');
 const {
@@ -1155,7 +1156,8 @@ function sessionTimestampMap(periods, home = os.homedir(), deps = {}) {
               filePath: preferredPath,
               createdAt: preferredHeader.createdAt,
               statFingerprint: '',
-              directoryFingerprint
+              directoryFingerprint,
+              titleState: undefined
             };
             dshFileCache.set(key, entry);
           }
@@ -1187,9 +1189,19 @@ function sessionTimestampMap(periods, home = os.homedir(), deps = {}) {
         }
         dshFileCache.set(key, entry);
       }
+      const readTitle = deps.readDshSessionTitle || readDshSessionTitle;
+      const titleState = readTitle(entry.filePath, entry.titleState);
+      if (titleState !== entry.titleState) {
+        entry = { ...entry, titleState };
+        dshFileCache.set(key, entry);
+      }
       const startedAt = isoFromDate(Number(entry.createdAt));
       if (!startedAt && !lastUsedAt) continue;
-      metadata.set(`dsh:${sessionId}`, { startedAt: startedAt || lastUsedAt, lastUsedAt: lastUsedAt || startedAt });
+      metadata.set(`dsh:${sessionId}`, {
+        startedAt: startedAt || lastUsedAt,
+        lastUsedAt: lastUsedAt || startedAt,
+        ...(titleState?.title ? { title: titleState.title } : {})
+      });
     }
   }
 

--- a/src/shared/providers/dsh/sessionFiles.js
+++ b/src/shared/providers/dsh/sessionFiles.js
@@ -102,6 +102,8 @@ function preferredDshSessionFileInDirectory(dir) {
 }
 const DSH_SESSION_DIR_DEPTH = 2; // <root>/<project>/<session>/<artifact>
 const ZSTD_MAGIC = 0xFD2FB528;
+const DSH_SESSION_TITLE_MAX_CODE_POINTS = 160;
+const DSH_SESSION_TITLE_READ_BYTES = 256 * 1024;
 
 function resolveDshSessionsRoot(options = {}) {
   const platform = options.platform || process.platform;
@@ -236,8 +238,7 @@ function decodeZstdBuffer(buffer, frames) {
   return { text, decodedEnd, stoppedOnError: false };
 }
 
-function decodeSessionText(filePath, buffer) {
-  if (!filePath.endsWith('.jsonl.zstd')) return buffer.toString('utf8');
+function decodeZstdText(buffer) {
   const frames = scanZstdFrames(buffer);
   const decoded = decodeZstdBuffer(buffer, frames);
   // The first content-corrupt complete frame is the recovery boundary: nothing
@@ -245,7 +246,7 @@ function decodeSessionText(filePath, buffer) {
   // recovery could still read — tokscale's streaming decoder stops at the same
   // first decode error, so records past the corruption must not be resurrected
   // through tail recovery.
-  if (decoded.stoppedOnError) return decoded.text;
+  if (decoded.stoppedOnError) return { text: decoded.text, consumed: decoded.decodedEnd };
   let text = decoded.text;
   // A live transcript is scanned mid-write routinely, so the trailing frame is
   // often torn. dsh's own reader (decompressZstdPrefix with ZSTD_e_flush) and
@@ -253,8 +254,8 @@ function decodeSessionText(filePath, buffer) {
   // managed to write out completely, dropping only the fragment at the cut.
   // zlib's finishFlush reproduces that at block granularity: it emits every
   // fully-decoded block in the torn tail, and the per-line JSON parse
-  // downstream skips the remainder. Scoped to decodeSessionText (not the
-  // header-only decodeFirstFrameText), which already returns '' for a torn
+  // downstream skips the remainder. The header-only decodeFirstFrameText path
+  // deliberately does not use this recovery and still returns '' for a torn
   // first frame.
   const tailStart = decoded.decodedEnd;
   if (tailStart < buffer.length) {
@@ -268,7 +269,119 @@ function decodeSessionText(filePath, buffer) {
       }
     }
   }
-  return text;
+  return { text, consumed: decoded.decodedEnd };
+}
+
+function decodeSessionText(filePath, buffer) {
+  if (!filePath.endsWith('.jsonl.zstd')) return buffer.toString('utf8');
+  return decodeZstdText(buffer).text;
+}
+
+function normalizeDshSessionTitle(value) {
+  if (typeof value !== 'string') return '';
+  return Array.from(value.replace(/\s+/g, ' ').trim())
+    .slice(0, DSH_SESSION_TITLE_MAX_CODE_POINTS)
+    .join('');
+}
+
+function foldDshSessionTitle(text, initialTitle = '') {
+  let title = normalizeDshSessionTitle(initialTitle);
+  for (const line of String(text || '').split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    let event;
+    try { event = JSON.parse(line); } catch (_) { continue; }
+    if (event?.type !== 'session/title') continue;
+    const nextTitle = normalizeDshSessionTitle(event.data?.title);
+    if (nextTitle) title = nextTitle;
+  }
+  return title;
+}
+
+function decodeSessionAppend(filePath, buffer) {
+  if (!filePath.endsWith('.jsonl.zstd')) {
+    // Only advance over newline-complete JSONL records. A final partial record
+    // is re-read after the next append instead of being cached as consumed.
+    const lastNewline = buffer.lastIndexOf(0x0a);
+    const consumed = lastNewline < 0 ? 0 : lastNewline + 1;
+    return { text: buffer.subarray(0, consumed).toString('utf8'), consumed };
+  }
+
+  return decodeZstdText(buffer);
+}
+
+// DSH titles are durable `session/title` events and use latest-wins folding.
+// The log is append-only, so retain the last complete JSONL/zstd boundary and
+// decode only new bytes on later collector ticks. A shrink or same-size rewrite
+// resets the fold, while a torn final record/frame remains eligible for retry.
+function readDshSessionTitle(filePath, previous = {}) {
+  let stat;
+  try { stat = fs.statSync(filePath); } catch (_) { return { title: '', offset: 0, size: 0, mtimeMs: 0 }; }
+  const size = Number(stat.size) || 0;
+  const mtimeMs = Number(stat.mtimeMs) || 0;
+  const previousSize = Number(previous.size) || 0;
+  const previousMtimeMs = Number(previous.mtimeMs) || 0;
+  if (size === previousSize && mtimeMs === previousMtimeMs) return previous;
+
+  const previousOffset = Number(previous.offset);
+  const appendOnly = size > previousSize && Number.isSafeInteger(previousOffset)
+    && previousOffset >= 0 && previousOffset <= previousSize;
+  const start = appendOnly ? previousOffset : 0;
+  let title = normalizeDshSessionTitle(appendOnly ? previous.title : '');
+  let fd;
+  try {
+    fd = fs.openSync(filePath, 'r');
+    const isZstd = filePath.endsWith('.jsonl.zstd');
+    let position = start;
+    let consumed = 0;
+    let pending = Buffer.alloc(0);
+    let stoppedOnError = false;
+    while (position < size && !stoppedOnError) {
+      const length = Math.min(DSH_SESSION_TITLE_READ_BYTES, size - position);
+      const chunk = Buffer.allocUnsafe(length);
+      const bytesRead = fs.readSync(fd, chunk, 0, length, position);
+      if (bytesRead <= 0) break;
+      position += bytesRead;
+      const data = chunk.subarray(0, bytesRead);
+      pending = pending.length > 0 ? Buffer.concat([pending, data]) : data;
+
+      if (isZstd) {
+        const decoded = decodeZstdBuffer(pending, scanZstdFrames(pending));
+        title = foldDshSessionTitle(decoded.text, title);
+        consumed += decoded.decodedEnd;
+        pending = pending.subarray(decoded.decodedEnd);
+        stoppedOnError = decoded.stoppedOnError;
+      } else {
+        const lastNewline = pending.lastIndexOf(0x0a);
+        if (lastNewline >= 0) {
+          const complete = lastNewline + 1;
+          title = foldDshSessionTitle(pending.subarray(0, complete).toString('utf8'), title);
+          consumed += complete;
+          pending = pending.subarray(complete);
+        }
+      }
+    }
+    if (filePath.endsWith('.jsonl.zstd') && !stoppedOnError && pending.length > 0) {
+      // A live final frame may be torn but still contain complete JSONL rows.
+      // Fold those rows now, while retaining the frame boundary for replay.
+      title = foldDshSessionTitle(decodeSessionAppend(filePath, pending).text, title);
+    }
+    return {
+      title,
+      offset: start + consumed,
+      size,
+      mtimeMs
+    };
+  } catch (_) {
+    // Do not cache a failed read as though this file revision were observed;
+    // preserving the older fingerprint makes the next tick retry it.
+    return previous && typeof previous === 'object'
+      ? previous
+      : { title: '', offset: 0, size: 0, mtimeMs: 0 };
+  } finally {
+    if (fd !== undefined) {
+      try { fs.closeSync(fd); } catch (_) {}
+    }
+  }
 }
 
 // DSH appends one zstd frame per flush, and the leading `session` header is
@@ -353,6 +466,7 @@ module.exports = {
   isDshSessionLogName,
   preferredDshSessionFileInDirectory,
   readDshSessionHeader,
+  readDshSessionTitle,
   resolveDshSessionsRoot,
   scanZstdFrames,
   zstdAvailable

--- a/src/shared/providers/dsh/sessionFiles.js
+++ b/src/shared/providers/dsh/sessionFiles.js
@@ -22,6 +22,7 @@
  */
 
 const fs = require('node:fs');
+const crypto = require('node:crypto');
 const os = require('node:os');
 const path = require('node:path');
 const zlib = require('node:zlib');
@@ -102,8 +103,8 @@ function preferredDshSessionFileInDirectory(dir) {
 }
 const DSH_SESSION_DIR_DEPTH = 2; // <root>/<project>/<session>/<artifact>
 const ZSTD_MAGIC = 0xFD2FB528;
-const DSH_SESSION_TITLE_MAX_CODE_POINTS = 160;
 const DSH_SESSION_TITLE_READ_BYTES = 256 * 1024;
+const DSH_SESSION_CONTINUITY_BYTES = 64 * 1024;
 
 function resolveDshSessionsRoot(options = {}) {
   const platform = options.platform || process.platform;
@@ -277,24 +278,55 @@ function decodeSessionText(filePath, buffer) {
   return decodeZstdText(buffer).text;
 }
 
-function normalizeDshSessionTitle(value) {
-  if (typeof value !== 'string') return '';
-  return Array.from(value.replace(/\s+/g, ' ').trim())
-    .slice(0, DSH_SESSION_TITLE_MAX_CODE_POINTS)
-    .join('');
+function persistedDshSessionTitle(value) {
+  return typeof value === 'string' && value.length > 0 ? value : '';
 }
 
 function foldDshSessionTitle(text, initialTitle = '') {
-  let title = normalizeDshSessionTitle(initialTitle);
+  let title = persistedDshSessionTitle(initialTitle);
   for (const line of String(text || '').split(/\r?\n/)) {
     if (!line.trim()) continue;
     let event;
     try { event = JSON.parse(line); } catch (_) { continue; }
     if (event?.type !== 'session/title') continue;
-    const nextTitle = normalizeDshSessionTitle(event.data?.title);
+    const nextTitle = persistedDshSessionTitle(event.data?.title);
     if (nextTitle) title = nextTitle;
   }
   return title;
+}
+
+function dshSessionFileIdentity(stat) {
+  return `${String(stat.dev ?? '')}:${String(stat.ino ?? '')}`;
+}
+
+function hashDshSessionRange(hash, fd, start, length) {
+  const buffer = Buffer.allocUnsafe(length);
+  let offset = 0;
+  while (offset < length) {
+    const bytesRead = fs.readSync(fd, buffer, offset, length - offset, start + offset);
+    if (bytesRead <= 0) throw new Error('DSH transcript changed during continuity read');
+    offset += bytesRead;
+  }
+  hash.update(buffer);
+}
+
+function readDshSessionContinuity(fd, size) {
+  const hash = crypto.createHash('sha256');
+  const headLength = Math.min(size, DSH_SESSION_CONTINUITY_BYTES);
+  hashDshSessionRange(hash, fd, 0, headLength);
+  const tailStart = Math.max(headLength, size - DSH_SESSION_CONTINUITY_BYTES);
+  hashDshSessionRange(hash, fd, tailStart, size - tailStart);
+  return {
+    size,
+    hash: hash.digest('hex')
+  };
+}
+
+function dshSessionContinuityMatches(fd, previous, previousSize) {
+  const continuity = previous?.continuity;
+  if (!continuity || continuity.size !== previousSize
+    || typeof continuity.hash !== 'string') return false;
+  return readDshSessionContinuity(fd, previousSize).hash === continuity.hash;
 }
 
 function decodeSessionAppend(filePath, buffer) {
@@ -310,26 +342,30 @@ function decodeSessionAppend(filePath, buffer) {
 }
 
 // DSH titles are durable `session/title` events and use latest-wins folding.
-// The log is append-only, so retain the last complete JSONL/zstd boundary and
-// decode only new bytes on later collector ticks. A shrink or same-size rewrite
-// resets the fold, while a torn final record/frame remains eligible for retry.
+// Retain the last complete JSONL/zstd boundary and decode only new bytes when
+// the previous file identity and bounded head/tail fingerprint still match. Any
+// replacement or rewrite resets the fold, while a torn final record/frame
+// remains eligible for retry.
 function readDshSessionTitle(filePath, previous = {}) {
   let stat;
   try { stat = fs.statSync(filePath); } catch (_) { return { title: '', offset: 0, size: 0, mtimeMs: 0 }; }
   const size = Number(stat.size) || 0;
   const mtimeMs = Number(stat.mtimeMs) || 0;
+  const identity = dshSessionFileIdentity(stat);
   const previousSize = Number(previous.size) || 0;
   const previousMtimeMs = Number(previous.mtimeMs) || 0;
-  if (size === previousSize && mtimeMs === previousMtimeMs) return previous;
+  if (size === previousSize && mtimeMs === previousMtimeMs
+    && identity === previous.identity && previous.continuity) return previous;
 
   const previousOffset = Number(previous.offset);
-  const appendOnly = size > previousSize && Number.isSafeInteger(previousOffset)
-    && previousOffset >= 0 && previousOffset <= previousSize;
-  const start = appendOnly ? previousOffset : 0;
-  let title = normalizeDshSessionTitle(appendOnly ? previous.title : '');
   let fd;
   try {
     fd = fs.openSync(filePath, 'r');
+    const appendOnly = size > previousSize && identity === previous.identity
+      && Number.isSafeInteger(previousOffset) && previousOffset >= 0 && previousOffset <= previousSize
+      && dshSessionContinuityMatches(fd, previous, previousSize);
+    const start = appendOnly ? previousOffset : 0;
+    let title = persistedDshSessionTitle(appendOnly ? previous.title : '');
     const isZstd = filePath.endsWith('.jsonl.zstd');
     let position = start;
     let consumed = 0;
@@ -369,7 +405,9 @@ function readDshSessionTitle(filePath, previous = {}) {
       title,
       offset: start + consumed,
       size,
-      mtimeMs
+      mtimeMs,
+      identity,
+      continuity: readDshSessionContinuity(fd, size)
     };
   } catch (_) {
     // Do not cache a failed read as though this file revision were observed;

--- a/tests/shared/collectorSessionTimestamps.test.js
+++ b/tests/shared/collectorSessionTimestamps.test.js
@@ -236,7 +236,11 @@ test('applySessionTimestamps fills DSH session start/last from the transcript he
     const dir = path.join(home, '.dsh', 'sessions', 'proj', 'session-abc');
     fs.mkdirSync(dir, { recursive: true });
     const file = path.join(dir, 'session.jsonl');
-    fs.writeFileSync(file, `${JSON.stringify({ type: 'session', id: 'session-abc', createdAt: 1750000000000 })}\n`);
+    fs.writeFileSync(file, [
+      JSON.stringify({ type: 'session', id: 'session-abc', createdAt: 1750000000000 }),
+      JSON.stringify({ type: 'session/title', seq: 1, data: { title: 'DSH session title' } }),
+      ''
+    ].join('\n'));
     const mtime = new Date('2026-07-01T12:00:00.000Z');
     fs.utimesSync(file, mtime, mtime);
 
@@ -251,6 +255,37 @@ test('applySessionTimestamps fills DSH session start/last from the transcript he
     const session = periods.today.sessions['dsh:session-abc'];
     assert.equal(session.startedAt, new Date(1750000000000).toISOString());
     assert.equal(session.lastUsedAt, mtime.toISOString());
+    assert.equal(session.title, 'DSH session title');
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('applySessionTimestamps refreshes a cached DSH title after rename', () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-dsh-title-refresh-'));
+  try {
+    const id = 'session-title-refresh';
+    const dir = path.join(home, '.dsh', 'sessions', 'proj', id);
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'session.jsonl');
+    fs.writeFileSync(file, [
+      JSON.stringify({ type: 'session', id, createdAt: 1750000000000 }),
+      JSON.stringify({ type: 'session/title', seq: 1, data: { title: 'Initial title' } }),
+      ''
+    ].join('\n'));
+    const cache = {
+      metadataCache: new Map(), resolvedSessionKeys: new Set(), attemptedSessionKeys: new Set(),
+      dshSessionFileCache: new Map(), retryMisses: true
+    };
+    const tick = () => {
+      const periods = { today: { sessions: { [`dsh:${id}`]: { client: 'dsh', sessionId: id } } } };
+      applySessionTimestamps(periods, home, cache);
+      return periods.today.sessions[`dsh:${id}`];
+    };
+
+    assert.equal(tick().title, 'Initial title');
+    fs.appendFileSync(file, `${JSON.stringify({ type: 'session/title', seq: 2, data: { title: 'Renamed title' } })}\n`);
+    assert.equal(tick().title, 'Renamed title');
   } finally {
     fs.rmSync(home, { recursive: true, force: true });
   }

--- a/tests/shared/dshSessionFiles.test.js
+++ b/tests/shared/dshSessionFiles.test.js
@@ -16,6 +16,7 @@ const {
   indexDshSessionHeaders,
   isDshSessionLogName,
   readDshSessionHeader,
+  readDshSessionTitle,
   resolveDshSessionsRoot,
   scanZstdFrames,
   zstdAvailable
@@ -239,6 +240,113 @@ test('decodeFirstFrameText reads raw .jsonl without decompression', () => {
 test('decodeSessionText reads raw .jsonl without decompression', () => {
   const text = decodeSessionText('/tmp/session.jsonl', Buffer.from('{"type":"session"}\n', 'utf8'));
   assert.equal(text, '{"type":"session"}\n');
+});
+
+test('readDshSessionTitle folds the latest persisted title and normalizes it', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-title-'));
+  const file = path.join(root, 'session.jsonl');
+  try {
+    fs.writeFileSync(file, [
+      JSON.stringify({ type: 'session', id: 's1' }),
+      JSON.stringify({ type: 'session/title', seq: 1, data: { title: '  First\n title  ' } }),
+      JSON.stringify({ type: 'user/message', seq: 2, data: { content: 'private prompt' } }),
+      JSON.stringify({ type: 'session/title', seq: 3, data: { title: 'Renamed title' } }),
+      ''
+    ].join('\n'));
+
+    const state = readDshSessionTitle(file);
+    assert.equal(state.title, 'Renamed title');
+    assert.equal(state.offset, state.size);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('readDshSessionTitle never derives a title from conversation text', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-title-private-'));
+  const file = path.join(root, 'session.jsonl');
+  try {
+    fs.writeFileSync(file, [
+      JSON.stringify({ type: 'session', id: 's1' }),
+      JSON.stringify({ type: 'user/message', seq: 1, data: { content: [{ type: 'text', text: 'Private prompt' }] } }),
+      JSON.stringify({ type: 'session/title-llm-request', seq: 2, data: { messages: [{ text: 'Private prompt' }] } }),
+      ''
+    ].join('\n'));
+
+    assert.equal(readDshSessionTitle(file).title, '');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('readDshSessionTitle reads only appended plain JSONL after the initial fold', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-title-append-'));
+  const file = path.join(root, 'session.jsonl');
+  const realReadSync = fs.readSync;
+  try {
+    fs.writeFileSync(file, `${JSON.stringify({ type: 'session/title', seq: 1, data: { title: 'Initial' } })}\n`);
+    const first = readDshSessionTitle(file);
+    const appended = `${JSON.stringify({ type: 'session/title', seq: 2, data: { title: 'Updated' } })}\n`;
+    fs.appendFileSync(file, appended);
+
+    const reads = [];
+    fs.readSync = (fd, buffer, offset, length, position) => {
+      reads.push({ length, position });
+      return realReadSync(fd, buffer, offset, length, position);
+    };
+    const second = readDshSessionTitle(file, first);
+
+    assert.equal(second.title, 'Updated');
+    assert.deepEqual(reads, [{ length: Buffer.byteLength(appended), position: first.offset }]);
+  } finally {
+    fs.readSync = realReadSync;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('readDshSessionTitle folds appended zstd frames without re-decoding the prefix', { skip: !hasZstd }, () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-title-zstd-'));
+  const file = path.join(root, 'session.jsonl.zstd');
+  try {
+    const firstFrame = zlib.zstdCompressSync(Buffer.from(
+      `${JSON.stringify({ type: 'session/title', seq: 1, data: { title: 'Initial' } })}\n`,
+      'utf8'
+    ));
+    fs.writeFileSync(file, firstFrame);
+    const first = readDshSessionTitle(file);
+    assert.equal(first.title, 'Initial');
+    assert.equal(first.offset, firstFrame.length);
+
+    const secondFrame = zlib.zstdCompressSync(Buffer.from(
+      `${JSON.stringify({ type: 'session/title', seq: 2, data: { title: 'Updated' } })}\n`,
+      'utf8'
+    ));
+    fs.appendFileSync(file, secondFrame);
+    const second = readDshSessionTitle(file, first);
+    assert.equal(second.title, 'Updated');
+    assert.equal(second.offset, firstFrame.length + secondFrame.length);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('readDshSessionTitle resets latest-wins state after a same-size rewrite', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-title-rewrite-'));
+  const file = path.join(root, 'session.jsonl');
+  try {
+    const event = (title) => `${JSON.stringify({ type: 'session/title', data: { title } })}\n`;
+    fs.writeFileSync(file, event('First title'));
+    const first = readDshSessionTitle(file);
+    fs.writeFileSync(file, event('Other title'));
+    const nextMtime = new Date(first.mtimeMs + 1000);
+    fs.utimesSync(file, nextMtime, nextMtime);
+
+    const second = readDshSessionTitle(file, first);
+    assert.equal(second.title, 'Other title');
+    assert.equal(second.offset, second.size);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 
 // A header's first zstd frame is always tiny in practice (a small JSON

--- a/tests/shared/dshSessionFiles.test.js
+++ b/tests/shared/dshSessionFiles.test.js
@@ -242,20 +242,21 @@ test('decodeSessionText reads raw .jsonl without decompression', () => {
   assert.equal(text, '{"type":"session"}\n');
 });
 
-test('readDshSessionTitle folds the latest persisted title and normalizes it', () => {
+test('readDshSessionTitle folds and preserves the latest persisted title', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-title-'));
   const file = path.join(root, 'session.jsonl');
   try {
+    const persistedTitle = `Renamed title ${'x'.repeat(200)}`;
     fs.writeFileSync(file, [
       JSON.stringify({ type: 'session', id: 's1' }),
       JSON.stringify({ type: 'session/title', seq: 1, data: { title: '  First\n title  ' } }),
       JSON.stringify({ type: 'user/message', seq: 2, data: { content: 'private prompt' } }),
-      JSON.stringify({ type: 'session/title', seq: 3, data: { title: 'Renamed title' } }),
+      JSON.stringify({ type: 'session/title', seq: 3, data: { title: persistedTitle } }),
       ''
     ].join('\n'));
 
     const state = readDshSessionTitle(file);
-    assert.equal(state.title, 'Renamed title');
+    assert.equal(state.title, persistedTitle);
     assert.equal(state.offset, state.size);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
@@ -279,7 +280,7 @@ test('readDshSessionTitle never derives a title from conversation text', () => {
   }
 });
 
-test('readDshSessionTitle reads only appended plain JSONL after the initial fold', () => {
+test('readDshSessionTitle reuses the append boundary after checking content continuity', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-title-append-'));
   const file = path.join(root, 'session.jsonl');
   const realReadSync = fs.readSync;
@@ -297,7 +298,9 @@ test('readDshSessionTitle reads only appended plain JSONL after the initial fold
     const second = readDshSessionTitle(file, first);
 
     assert.equal(second.title, 'Updated');
-    assert.deepEqual(reads, [{ length: Buffer.byteLength(appended), position: first.offset }]);
+    assert.equal(reads.filter(({ length, position }) => (
+      length === Buffer.byteLength(appended) && position === first.offset
+    )).length, 1);
   } finally {
     fs.readSync = realReadSync;
     fs.rmSync(root, { recursive: true, force: true });
@@ -344,6 +347,34 @@ test('readDshSessionTitle resets latest-wins state after a same-size rewrite', (
     const second = readDshSessionTitle(file, first);
     assert.equal(second.title, 'Other title');
     assert.equal(second.offset, second.size);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('readDshSessionTitle refolds a larger in-place rewrite instead of treating it as an append', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-title-larger-rewrite-'));
+  const file = path.join(root, 'session.jsonl');
+  try {
+    const event = (title, paddingBytes) => [
+      JSON.stringify({ type: 'session', id: 's1' }),
+      JSON.stringify({ type: 'session/title', data: { title } }),
+      JSON.stringify({ type: 'assistant/message', data: { content: 'x'.repeat(paddingBytes) } }),
+      '',
+      's'.repeat(64 * 1024)
+    ].join('\n');
+    fs.writeFileSync(file, event('Title A', 160 * 1024));
+    const first = readDshSessionTitle(file);
+    // Keep the old file's final 64 KiB identical: a tail-only check would still
+    // misclassify this as an append and skip the new title near the front.
+    fs.writeFileSync(file, event('Title B', 192 * 1024));
+    const nextMtime = new Date(first.mtimeMs + 1000);
+    fs.utimesSync(file, nextMtime, nextMtime);
+    assert.ok(fs.statSync(file).size > first.size);
+
+    const second = readDshSessionTitle(file, first);
+    assert.equal(second.title, 'Title B');
+    assert.equal(second.offset, second.size - (64 * 1024));
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- resolve persisted DSH session titles from the latest `session/title` event
- update titles incrementally across plain JSONL and multi-frame zstd transcripts
- refresh title state after appends, rewrites, torn tails, and versioned transcript migrations
- ignore prompts and title-generation request payloads so only persisted titles reach local session rows

## Behavior

| Before | After |
| --- | --- |
| DSH session rows fall back to generated labels or session IDs. | DSH session rows show their persisted conversation titles. |
| Title changes are not reflected by Token Monitor. | Appended renames are folded with latest-wins behavior. |
| Reading titles could require rescanning a growing transcript. | Existing files are scanned in bounded chunks and later refreshes read only appended bytes. |

## Testing

- `npm run verify` — 4,264 passed, 2 skipped
- focused DSH and collector tests — 43 passed
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows persisted DSH session titles from `session/title` events instead of falling back to generated labels or session IDs.

- Reads titles from latest-wins `session/title` events across plain JSONL and multi-frame zstd transcripts.
- Refreshes title state after appends, rewrites, torn tails, and versioned transcript migrations.
- Ignores prompt and title-generation payloads so only persisted titles reach local session rows.
- Head/tail fingerprints distinguish in-place rewrites from appends; later refreshes read only appended bytes in bounded chunks.
- Resolved titles stay local and are not added to the device wire record.

| Area | Before | After |
| --- | --- | --- |
| DSH session rows | Fall back to generated labels or session IDs | Show persisted conversation titles |
| Title changes | Not reflected by Token Monitor | Renames and in-place rewrites folded with latest-wins behavior |
| Read performance | Rescanning a growing transcript | Bounded chunk scans; refreshes read only new bytes |

Testing: `npm run verify` passes 4,264 tests (2 skipped), focused DSH and collector tests pass (43), and `git diff --check` is clean.

<sup>Written for commit 8abe6cb44773bc159eeb400ed259b746df8779e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

