### PR TITLE
feat(bubble): add live token rate support

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -389,7 +389,6 @@ const CSP_HEADER = [
   "frame-ancestors 'none'"
 ].join('; ');
 const TRAY_CONTENT_VALUES = new Set(['tokens', 'cost', 'both', 'tokensAll', 'costAll', 'bothAll', 'limitsAllSessions', 'liveTokenRate', 'bars', 'barsSession', 'barsWeekly', 'barsAllSessions', 'icon', 'custom']);
-const FLOATING_BUBBLE_CONTENT_VALUES = new Set(['tokens', 'cost', 'both', 'tokensAll', 'costAll', 'bothAll', 'limitsAllSessions', 'bars', 'barsSession', 'barsWeekly', 'barsAllSessions', 'icon', 'custom']);
 const HUB_MODE_VALUES = new Set(['local', 'client', 'host']);
 const LANGUAGE_VALUES = new Set(LANGUAGE_OPTIONS.map((option) => option.value));
 const COLLECTION_MODE_VALUES = new Set(['live', 'smart', 'interval']);
@@ -2528,7 +2527,7 @@ function readSettings() {
     merged.archivedClientUsage = normalizeArchivedClientUsage(merged.archivedClientUsage);
     delete merged.edgeDrawerEnabled;
     merged.floatingBubbleTrigger = merged.floatingBubbleTrigger === 'hover' ? 'hover' : 'click';
-    merged.floatingBubbleContent = normalizeTrayContent(merged.floatingBubbleContent, 'icon', FLOATING_BUBBLE_CONTENT_VALUES);
+    merged.floatingBubbleContent = normalizeTrayContent(merged.floatingBubbleContent, 'icon');
     merged.floatingBubbleCustomLayout = normalizeTrayLayout(merged.floatingBubbleCustomLayout);
     merged.trayCustomLayout = normalizeTrayLayout(merged.trayCustomLayout);
     merged.showTrayProviderBadge = parseBoolean(merged.showTrayProviderBadge, false);
@@ -6791,7 +6790,7 @@ app.whenReady().then(() => {
       trayContent: normalizeTrayContent(patch.trayContent ?? settings.trayContent),
       trayCustomLayout: normalizeTrayLayout(patch.trayCustomLayout ?? settings.trayCustomLayout),
       showTrayProviderBadge: parseBoolean(patch.showTrayProviderBadge ?? settings.showTrayProviderBadge, false),
-      floatingBubbleContent: normalizeTrayContent(patch.floatingBubbleContent ?? settings.floatingBubbleContent, 'icon', FLOATING_BUBBLE_CONTENT_VALUES),
+      floatingBubbleContent: normalizeTrayContent(patch.floatingBubbleContent ?? settings.floatingBubbleContent, 'icon'),
       floatingBubbleCustomLayout: normalizeTrayLayout(patch.floatingBubbleCustomLayout ?? settings.floatingBubbleCustomLayout),
       windowToggleShortcut: normalizeWindowToggleShortcut(patch.windowToggleShortcut ?? settings.windowToggleShortcut),
       currency: normalizedCurrency,

--- a/src/electron/renderer/app.js
+++ b/src/electron/renderer/app.js
@@ -823,9 +823,9 @@ const liveTokenRateTracker = tokenRateApi.createLiveTokenRateGroupTracker({
   activeMs: LIVE_TOKEN_RATE_ACTIVE_MS,
   clearMs: LIVE_TOKEN_RATE_CLEAR_MS
 });
-const trayLiveTokenRateTrackers = new Map();
-const trayLiveTokenRateContexts = new Map();
-let trayLiveTokenRateExpiryTimer = null;
+const displayLiveTokenRateTrackers = new Map();
+const displayLiveTokenRateContexts = new Map();
+let displayLiveTokenRateExpiryTimer = null;
 let liveTokenRateContext = '';
 let liveTokenRateIdleTimer = null;
 let liveTokenRateAnimationTimer = null;
@@ -863,56 +863,61 @@ function resetLiveTokenRateTracking() {
   clearLiveTokenRateTimers();
 }
 
-function trayLiveTokenRateItems() {
-  if (state.settings?.showTrayIcon === false) return [];
-  const customItems = state.settings?.trayContent === 'custom'
-    ? trayLayoutApi.liveTokenRateItems(state.settings?.trayCustomLayout)
-    : [];
-  if (state.settings?.trayContent === 'liveTokenRate') {
-    return [...customItems, { metric: 'liveTokenRate', rateScope: 'all' }];
-  }
-  return customItems;
+function displayLiveTokenRateItems() {
+  return trayLayoutApi.liveTokenRateItemsForSurfaces([
+    {
+      enabled: state.settings?.showTrayIcon !== false,
+      content: state.settings?.trayContent,
+      layout: state.settings?.trayCustomLayout
+    },
+    {
+      enabled: state.settings?.floatingBubbleEnabled === true,
+      content: state.settings?.floatingBubbleContent,
+      layout: state.settings?.floatingBubbleCustomLayout
+    }
+  ]);
 }
 
-function effectiveTrayLiveTokenRateScope(scope) {
+function effectiveDisplayLiveTokenRateScope(scope) {
   const hubMode = state.settings?.hubMode;
   const syncMode = hubMode === 'client' || hubMode === 'host';
   return syncMode && scope === 'all' ? 'all' : 'device';
 }
 
-function clearTrayLiveTokenRateExpiryTimer() {
-  if (trayLiveTokenRateExpiryTimer) clearTimeout(trayLiveTokenRateExpiryTimer);
-  trayLiveTokenRateExpiryTimer = null;
+function clearDisplayLiveTokenRateExpiryTimer() {
+  if (displayLiveTokenRateExpiryTimer) clearTimeout(displayLiveTokenRateExpiryTimer);
+  displayLiveTokenRateExpiryTimer = null;
 }
 
-function scheduleTrayLiveTokenRateExpiry() {
-  clearTrayLiveTokenRateExpiryTimer();
-  const expiries = [...trayLiveTokenRateTrackers.values()]
+function scheduleDisplayLiveTokenRateExpiry() {
+  clearDisplayLiveTokenRateExpiryTimer();
+  const expiries = [...displayLiveTokenRateTrackers.values()]
     .map((tracker) => tracker.nextExpiryAt())
     .filter((value) => Number.isFinite(value));
   if (!expiries.length) return;
-  trayLiveTokenRateExpiryTimer = setTimeout(() => {
-    trayLiveTokenRateExpiryTimer = null;
+  displayLiveTokenRateExpiryTimer = setTimeout(() => {
+    displayLiveTokenRateExpiryTimer = null;
     void maybeUpdateBarsIcon({ refreshComposers: false });
+    renderFloatingBubbleContent();
     if (isSettingsSurfaceVisible()) refreshTrayComposers();
-    scheduleTrayLiveTokenRateExpiry();
+    scheduleDisplayLiveTokenRateExpiry();
   }, Math.max(0, Math.min(...expiries) - Date.now()) + 10);
 }
 
-function resetTrayLiveTokenRateTracking() {
-  trayLiveTokenRateTrackers.clear();
-  trayLiveTokenRateContexts.clear();
-  clearTrayLiveTokenRateExpiryTimer();
+function resetDisplayLiveTokenRateTracking() {
+  displayLiveTokenRateTrackers.clear();
+  displayLiveTokenRateContexts.clear();
+  clearDisplayLiveTokenRateExpiryTimer();
 }
 
-function observeTrayLiveTokenRates(stats) {
-  const items = trayLiveTokenRateItems();
+function observeDisplayLiveTokenRates(stats) {
+  const items = displayLiveTokenRateItems();
   if (!items.length) {
-    resetTrayLiveTokenRateTracking();
+    resetDisplayLiveTokenRateTracking();
     return false;
   }
 
-  const scopes = new Set(items.map((item) => effectiveTrayLiveTokenRateScope(item.rateScope)));
+  const scopes = new Set(items.map((item) => effectiveDisplayLiveTokenRateScope(item.rateScope)));
   let changed = false;
   for (const scope of scopes) {
     const selection = tokenRateApi.selectLiveTokenRatePeriods(
@@ -930,37 +935,37 @@ function observeTrayLiveTokenRates(stats) {
       scope,
       selection.source
     ].join('|');
-    let tracker = trayLiveTokenRateTrackers.get(scope);
+    let tracker = displayLiveTokenRateTrackers.get(scope);
     if (!tracker) {
       tracker = tokenRateApi.createLiveTokenRateGroupTracker({
         now: () => Date.now(),
         activeMs: LIVE_TOKEN_RATE_ACTIVE_MS,
         clearMs: LIVE_TOKEN_RATE_CLEAR_MS
       });
-      trayLiveTokenRateTrackers.set(scope, tracker);
+      displayLiveTokenRateTrackers.set(scope, tracker);
     }
-    if (trayLiveTokenRateContexts.get(scope) !== context) {
-      trayLiveTokenRateContexts.set(scope, context);
+    if (displayLiveTokenRateContexts.get(scope) !== context) {
+      displayLiveTokenRateContexts.set(scope, context);
       tracker.reset(selection.entries);
       changed = true;
     } else {
       changed = tracker.observe(selection.entries).changed || changed;
     }
   }
-  for (const scope of [...trayLiveTokenRateTrackers.keys()]) {
+  for (const scope of [...displayLiveTokenRateTrackers.keys()]) {
     if (scopes.has(scope)) continue;
-    trayLiveTokenRateTrackers.delete(scope);
-    trayLiveTokenRateContexts.delete(scope);
+    displayLiveTokenRateTrackers.delete(scope);
+    displayLiveTokenRateContexts.delete(scope);
     changed = true;
   }
-  scheduleTrayLiveTokenRateExpiry();
+  scheduleDisplayLiveTokenRateExpiry();
   return changed;
 }
 
-function trayLiveTokenRateSamples() {
-  const device = trayLiveTokenRateTrackers.get('device')?.getSample() || null;
-  const all = effectiveTrayLiveTokenRateScope('all') === 'all'
-    ? trayLiveTokenRateTrackers.get('all')?.getSample() || null
+function displayLiveTokenRateSamples() {
+  const device = displayLiveTokenRateTrackers.get('device')?.getSample() || null;
+  const all = effectiveDisplayLiveTokenRateScope('all') === 'all'
+    ? displayLiveTokenRateTrackers.get('all')?.getSample() || null
     : device;
   return { all, device };
 }
@@ -8610,7 +8615,7 @@ async function refreshStats(options = {}) {
     const nextStats = overlayAllTimeSessions(await window.tokenMonitor.getStats(options));
     observeLiveTokenRate(nextStats);
     state.stats = nextStats;
-    observeTrayLiveTokenRates(nextStats);
+    observeDisplayLiveTokenRates(nextStats);
     if (options.forceHistory === true) {
       // A manual history rescan is an explicit retry boundary. Let Home request the
       // corresponding full payload even when its revision is unchanged, and restore
@@ -9223,7 +9228,7 @@ function applyFloatingBubbleState(payload = {}, options = {}) {
   ensureServiceStatusTicker();
 }
 
-const BUBBLE_CONTENT_VALUES = ['icon', 'tokens', 'cost', 'both', 'tokensAll', 'costAll', 'bothAll', 'limitsAllSessions', 'bars', 'barsSession', 'barsWeekly', 'barsAllSessions', 'custom'];
+const BUBBLE_CONTENT_VALUES = ['icon', 'tokens', 'cost', 'both', 'tokensAll', 'costAll', 'bothAll', 'limitsAllSessions', 'liveTokenRate', 'bars', 'barsSession', 'barsWeekly', 'barsAllSessions', 'custom'];
 function normalizeTrayContentValue(value) {
   return BUBBLE_CONTENT_VALUES.includes(value) ? value : 'icon';
 }
@@ -13405,7 +13410,7 @@ window.tokenMonitor.onSettingsPush?.((next) => {
   state.settingsPushRevision += 1;
   state.settings = next;
   applyEffectiveCurrencyRates();
-  observeTrayLiveTokenRates(state.stats);
+  observeDisplayLiveTokenRates(state.stats);
   preserveSettingsPanelScroll(syncSettingsForm);
   if (isSettingsSurfaceVisible()) render(); else statsRenderScheduler.request();
   maybeUpdateBarsIcon();
@@ -13533,7 +13538,7 @@ window.tokenMonitor.onStatsPush?.((payload) => {
     if (payload.data?.mode) state.mode = payload.data.mode;
     state.stats = overlayAllTimeSessions(payload.data.stats);
     observeLiveTokenRate(state.stats);
-    observeTrayLiveTokenRates(state.stats);
+    observeDisplayLiveTokenRates(state.stats);
     applyCodexActiveAccountFromStats();
     // Progressive mid-tick pushes never carry a fresh history scan (see
     // AGENTS.md collector notes), so only the final push can retire the
@@ -14269,7 +14274,7 @@ function renderCustomTrayLayout(stats, layout, height = 44, colors = {}, options
     nowMs: Date.now(),
     activeAccountKeys: activeCodexKey ? { codex: activeCodexKey } : {},
     availableProviderIds: Object.keys(trayProviderImages),
-    liveTokenRates: options.liveTokenRates || trayLiveTokenRateSamples(),
+    liveTokenRates: options.liveTokenRates || displayLiveTokenRateSamples(),
     liveTokenRateFormatter: options.liveTokenRateFormatter || ((value) => formatLiveTokenRate(value))
   });
   const items = resolved.items.map((item) => (
@@ -14620,7 +14625,7 @@ function createTrayComposer(surface) {
     label: t,
     onLayoutChange: (nextLayout, { commit }) => {
       state.settings[layoutKey] = trayLayoutApi.normalizeTrayLayout(nextLayout);
-      if (isTray) observeTrayLiveTokenRates(state.stats);
+      observeDisplayLiveTokenRates(state.stats);
       if (isTray) void maybeUpdateBarsIcon({ refreshComposers: commit });
       else {
         renderFloatingBubbleContent();

--- a/src/electron/renderer/index.html
+++ b/src/electron/renderer/index.html
@@ -313,6 +313,7 @@
                       <option value="costAll" data-i18n="settings.tray.costTotal">Cost Total ($8.28)</option>
                       <option value="bothAll" data-i18n="settings.tray.bothTotal">Tokens + Cost Total</option>
                       <option value="limitsAllSessions" data-i18n="settings.tray.limitsAllSessions">Limits: first two tools' primary quotas (12% · 34%)</option>
+                      <option value="liveTokenRate" data-i18n="settings.tray.liveTokenRate">Live rate (tok/s)</option>
                       <option value="barsSession" data-i18n="settings.tray.barsSession">Limit bars: lowest session remaining</option>
                       <option value="barsWeekly" data-i18n="settings.tray.barsWeekly">Limit bars: lowest weekly remaining</option>
                       <option value="barsAllSessions" data-i18n="settings.tray.barsAllSessions">Limit bars: first two tools' primary quotas</option>

--- a/src/electron/renderer/trayComposer.js
+++ b/src/electron/renderer/trayComposer.js
@@ -336,10 +336,7 @@
         heading.textContent = l(`trayComposer.group.${group.id}`, fallbackGroup);
         const grid = document.createElement('div');
         grid.className = 'tray-composer-gallery-grid';
-        const styles = surface === 'tray'
-          ? group.styles
-          : group.styles.filter((style) => style !== 'liveTokenRate');
-        for (const style of styles) {
+        for (const style of group.styles) {
           const choice = button('tray-composer-gallery-choice', '', () => {
             const next = layoutApi.appendTrayLayoutItem(layout(), style);
             selectedId = next.items.at(-1)?.id || '';
@@ -676,7 +673,7 @@
       );
     }
 
-    function textMetricChoices({ includeLiveTokenRate = surface === 'tray' } = {}) {
+    function textMetricChoices() {
       const choices = [
         { value: 'percent', style: 'percent' },
         { value: 'percentReset', style: 'percentReset' },
@@ -685,9 +682,7 @@
         { value: 'cost', style: 'cost' },
         { value: 'liveTokenRate', style: 'liveTokenRate' }
       ];
-      return choices
-        .filter((entry) => includeLiveTokenRate || entry.value !== 'liveTokenRate')
-        .map((entry) => ({ ...entry, label: styleTitle(entry.style) }));
+      return choices.map((entry) => ({ ...entry, label: styleTitle(entry.style) }));
     }
 
     function liveTokenRateEditor(item, rowIndex = 0) {
@@ -775,7 +770,7 @@
       }
       const metric = options.includeMetric === true ? source.metric : item.metric;
       if (options.includeMetric === true) {
-        const metrics = textMetricChoices({ includeLiveTokenRate: options.includeLiveTokenRate !== false });
+        const metrics = textMetricChoices();
         section.append(picker(
           l('trayComposer.textMetric', 'Text'),
           metrics,
@@ -1117,8 +1112,7 @@
               includeValue: item.type === 'bars'
                 || item.metric === 'percent'
                 || sourceForItem(item, index).metric === 'percent'
-                || sourceForItem(item, index).metric === 'percentReset',
-              includeLiveTokenRate: surface === 'tray'
+                || sourceForItem(item, index).metric === 'percentReset'
             }
           ));
         });

--- a/src/shared/trayLayout.js
+++ b/src/shared/trayLayout.js
@@ -580,6 +580,17 @@
     });
   }
 
+  function liveTokenRateItemsForSurfaces(surfaces) {
+    if (!Array.isArray(surfaces)) return [];
+    return surfaces.flatMap((surface) => {
+      if (surface?.enabled !== true) return [];
+      if (surface.content === 'liveTokenRate') {
+        return [{ metric: 'liveTokenRate', rateMode: 'speed', rateScope: 'all' }];
+      }
+      return surface.content === 'custom' ? liveTokenRateItems(surface.layout) : [];
+    });
+  }
+
   function replaceTrayLayoutItem(layout, itemId, patch) {
     const normalized = normalizeTrayLayout(layout);
     const index = normalized.items.findIndex((item) => item.id === itemId);
@@ -1113,6 +1124,7 @@
     displayPercent,
     formatResetCountdown,
     liveTokenRateItems,
+    liveTokenRateItemsForSurfaces,
     moveTrayLayoutItem,
     normalizeSource,
     normalizeTrayLayout,

--- a/tests/electron/tokenRate.test.js
+++ b/tests/electron/tokenRate.test.js
@@ -629,7 +629,7 @@ test('the live footer rate is opt-in, accessible, and shares the persisted mode'
   assert.match(css, /\.footer\.live-token-rate-obscured \.live-token-rate,[\s\S]*visibility: hidden;/);
 });
 
-test('the custom macOS tray can render live rates independently of the footer setting', () => {
+test('compact display surfaces can render live rates independently of the footer setting', () => {
   assert.match(trayLayout, /'liveTokenRate'/);
   assert.match(trayLayout, /rateMode: 'speed'/);
   assert.match(trayLayout, /rateScope: 'all'/);
@@ -637,29 +637,35 @@ test('the custom macOS tray can render live rates independently of the footer se
   assert.match(trayLayout, /available: Boolean\(sample && sample\.idle !== true\)/);
   assert.match(trayComposer, /styles: \['percent',[\s\S]*'liveTokenRate'/);
   assert.match(trayComposer, /function liveTokenRateEditor\(item, rowIndex = 0\)/);
-  assert.match(trayComposer, /function textMetricChoices\(\{ includeLiveTokenRate = surface === 'tray' \} = \{\}\)/);
-  assert.match(trayComposer, /textMetricChoices\(\{ includeLiveTokenRate: options\.includeLiveTokenRate !== false \}\)/);
-  assert.match(trayComposer, /includeLiveTokenRate: surface === 'tray'/);
+  assert.match(trayComposer, /for \(const style of group\.styles\)/);
+  assert.match(trayComposer, /function textMetricChoices\(\)/);
+  assert.match(trayComposer, /const metrics = textMetricChoices\(\)/);
   assert.match(trayComposer, /if \(metric === 'liveTokenRate'\) \{[\s\S]*liveTokenRateEditor\(item, rowIndex\)/);
   assert.match(trayComposer, /rateMode\.speed/);
   assert.match(trayComposer, /rateScope\.device/);
   assert.match(main, /const TRAY_CONTENT_VALUES = new Set\([\s\S]*'liveTokenRate'/);
-  assert.match(main, /const FLOATING_BUBBLE_CONTENT_VALUES = new Set\([\s\S]*'custom'\]\)/);
-  assert.match(main, /floatingBubbleContent: normalizeTrayContent\([\s\S]*FLOATING_BUBBLE_CONTENT_VALUES/);
+  assert.doesNotMatch(main, /FLOATING_BUBBLE_CONTENT_VALUES/);
+  assert.match(main, /floatingBubbleContent: normalizeTrayContent\([^\n]+, 'icon'\)/);
   assert.match(main, /const trayImageMode = \(mode === 'limitsAllSessions'[\s\S]*mode === 'liveTokenRate'/);
   assert.match(traySource, /\['liveTokenRate', 'trayMenu\.content\.liveTokenRate'\]/);
-  assert.match(app, /const trayLiveTokenRateTrackers = new Map\(\)/);
-  assert.match(app, /function observeTrayLiveTokenRates\(stats\)/);
-  assert.match(app, /trayLayoutApi\.liveTokenRateItems\(state\.settings\?\.trayCustomLayout\)/);
-  assert.match(app, /state\.settings\?\.trayContent === 'liveTokenRate'/);
+  assert.match(app, /const displayLiveTokenRateTrackers = new Map\(\)/);
+  assert.match(app, /const BUBBLE_CONTENT_VALUES = \[[^\n]*'liveTokenRate'/);
+  assert.match(app, /function observeDisplayLiveTokenRates\(stats\)/);
+  assert.match(app, /floatingBubbleEnabled === true/);
+  assert.match(app, /floatingBubbleCustomLayout/);
+  assert.match(app, /trayLayoutApi\.liveTokenRateItemsForSurfaces\(\[/);
   assert.match(app, /function liveTokenRateTrayLayout\(\)/);
   assert.match(app, /if \(mode === 'liveTokenRate'\) \{[\s\S]*liveTokenRateTrayLayout\(\)/);
   assert.match(app, /if \(isSettingsSurfaceVisible\(\)\) refreshTrayComposers\(\)/);
-  assert.match(app, /state\.stats = nextStats;\s*observeTrayLiveTokenRates\(nextStats\)/);
-  assert.match(app, /state\.stats = overlayAllTimeSessions\(payload\.data\.stats\);\s*observeLiveTokenRate\(state\.stats\);\s*observeTrayLiveTokenRates\(state\.stats\)/);
-  assert.match(app, /liveTokenRates: options\.liveTokenRates \|\| trayLiveTokenRateSamples\(\)/);
+  assert.match(app, /state\.stats = nextStats;\s*observeDisplayLiveTokenRates\(nextStats\)/);
+  assert.match(app, /state\.stats = overlayAllTimeSessions\(payload\.data\.stats\);\s*observeLiveTokenRate\(state\.stats\);\s*observeDisplayLiveTokenRates\(state\.stats\)/);
+  assert.match(app, /liveTokenRates: options\.liveTokenRates \|\| displayLiveTokenRateSamples\(\)/);
+  assert.match(app, /renderFloatingBubbleContent\(\);\s*if \(isSettingsSurfaceVisible\(\)\) refreshTrayComposers\(\)/);
   assert.match(app, /trayContentInput\.value = \['tokens',[\s\S]*'liveTokenRate'/);
-  assert.match(html, /<option value="liveTokenRate" data-i18n="settings\.tray\.liveTokenRate">/);
+  const bubbleOptions = html.slice(html.indexOf('id="floatingBubbleContentInput"'), html.indexOf('id="floatingBubbleComposer"'));
+  const trayOptions = html.slice(html.indexOf('id="trayContentInput"'), html.indexOf('id="trayComposer"'));
+  assert.match(bubbleOptions, /<option value="liveTokenRate" data-i18n="settings\.tray\.liveTokenRate">/);
+  assert.match(trayOptions, /<option value="liveTokenRate" data-i18n="settings\.tray\.liveTokenRate">/);
   assert.equal((i18n.match(/'trayComposer\.style\.liveTokenRate'/g) || []).length, 5);
 });
 

--- a/tests/shared/trayLayout.test.js
+++ b/tests/shared/trayLayout.test.js
@@ -11,6 +11,7 @@ const {
   createTrayLayoutItem,
   formatResetCountdown,
   liveTokenRateItems,
+  liveTokenRateItemsForSurfaces,
   moveTrayLayoutItem,
   normalizeTrayLayout,
   preferredRowProvider,
@@ -323,6 +324,23 @@ test('two-line information normalizes, discovers, and resolves live token rates'
   assert.equal(resolved.rows[0].available, true);
   assert.equal(resolved.rows[0].provider, 'app');
   assert.equal(preferredRowProvider(resolved.rows, 0), 'app');
+});
+
+test('live token rate discovery combines enabled compact display surfaces', () => {
+  const single = createTrayLayoutItem('liveTokenRate', { idFactory: () => 'single-rate' });
+  single.rateScope = 'device';
+  const stacked = createTrayLayoutItem('doubleInfo', { idFactory: () => 'stacked-rate' });
+  stacked.rows[1] = { metric: 'liveTokenRate', rateMode: 'burn', rateScope: 'all' };
+
+  assert.deepEqual(liveTokenRateItemsForSurfaces([
+    { enabled: true, content: 'liveTokenRate' },
+    { enabled: true, content: 'custom', layout: { version: 3, items: [single, stacked] } },
+    { enabled: false, content: 'liveTokenRate' }
+  ]), [
+    { metric: 'liveTokenRate', rateMode: 'speed', rateScope: 'all' },
+    normalizeTrayLayout({ version: 3, items: [single] }).items[0],
+    normalizeTrayLayout({ version: 3, items: [stacked] }).items[0].rows[1]
+  ]);
 });
 
 test('custom text items normalize and resolve without quota data', () => {


### PR DESCRIPTION
## Summary

Follow up on #666 by extending live token rate support to the Floating Bubble.

- add Live rate as a direct Floating Bubble content option
- support tok/s and TPM in custom single-line and two-line layouts
- support current-device and all-device rate scopes
- share one tracking lifecycle between the Menu Bar and Floating Bubble, avoiding duplicate observations when both surfaces are enabled

## Before and after

| Area | Before | After |
| --- | --- | --- |
| Floating Bubble preset | Live rate was unavailable | Live rate can be selected directly |
| Custom single-line info | Live rate was excluded | Supports tok/s or TPM for the current device or all devices |
| Custom two-line info | Live rate was excluded | Either row can display tok/s or TPM for the current device or all devices |
| Tracking lifecycle | Only Menu Bar selections activated display tracking | Menu Bar and Floating Bubble share the same trackers, samples, expiry timer, and reset lifecycle |

## Tests

- `npm run verify`
- 4,273 passed
- 0 failed
- 2 skipped

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends live token rate support to the Floating Bubble (follow up on #666).

- Adds live rate as a direct Floating Bubble content option.
- Supports tok/s and TPM in custom single-line and two-line bubble layouts.
- Supports current-device and all-device rate scopes.
- Menu Bar and Floating Bubble now share one tracking lifecycle, avoiding duplicate observations when both surfaces are enabled.

| Area | Before | After |
| --- | --- | --- |
| Floating Bubble preset | Live rate unavailable | Live rate can be selected directly |
| Custom bubble info | Live rate excluded | Supports tok/s or TPM for current or all devices |
| Tracking lifecycle | Only Menu Bar selections activated display tracking | Both surfaces share trackers, samples, expiry timer, and reset lifecycle |

**Tests**

- `npm run verify` — 4,273 passed, 0 failed, 2 skipped.

<sup>Written for commit 432acfead47a6aa7d32c3dd18f2e623df6faf3e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

