### PR TITLE
fix(dsh): verify generation promotion on Windows

### DIFF
--- a/src/shared/providers/dsh/sessionMetadata.js
+++ b/src/shared/providers/dsh/sessionMetadata.js
@@ -29,6 +29,13 @@ function resolveSessionMetadata(sessionIds, context) {
   const { deps, home, isoFromDate } = context;
   const result = new Map();
   const fileCache = deps.dshSessionFileCache || sessionFileCache;
+  // Windows directory timestamps can remain unchanged across a create observed
+  // in the same collection window. Verify the preferred generation in
+  // this one already-known session directory instead of trusting that stat as
+  // an invalidation signal. This is still bounded per session and never walks
+  // the whole DSH sessions tree.
+  const directoryFingerprintsReliable = deps.dshDirectoryFingerprintsReliable
+    ?? (process.platform !== 'win32');
   // A scoped home is a WSL distro. Host DSH_HOME must never redirect this
   // lookup away from that distro, matching tokscale's use_env_roots: false.
   const env = deps.scopedHome ? {} : (deps.env || process.env);
@@ -68,7 +75,10 @@ function resolveSessionMetadata(sessionIds, context) {
     let entry = fileCache.get(key);
     if (!entry) continue;
     const directoryFingerprint = directoryStatFingerprint(path.dirname(entry.filePath));
-    if (directoryFingerprint && entry.directoryFingerprint && directoryFingerprint !== entry.directoryFingerprint) {
+    const directoryFingerprintChanged = directoryFingerprint
+      && entry.directoryFingerprint
+      && directoryFingerprint !== entry.directoryFingerprint;
+    if (directoryFingerprintChanged || !directoryFingerprintsReliable) {
       const preferredPath = preferredDshSessionFileInDirectory(path.dirname(entry.filePath));
       if (preferredPath && preferredPath !== entry.filePath) {
         const preferredHeader = readDshSessionHeader(preferredPath);

--- a/tests/shared/collectorSessionTimestamps.test.js
+++ b/tests/shared/collectorSessionTimestamps.test.js
@@ -450,6 +450,9 @@ test('applySessionTimestamps promotes a cached unversioned DSH path when a versi
     const cache = {
       metadataCache: new Map(), resolvedSessionKeys: new Set(), attemptedSessionKeys: new Set(),
       dshSessionFileCache: new Map(), retryMisses: true,
+      // Model Windows/NTFS returning the same directory timestamp around a
+      // rapid create. Promotion must not depend on that timestamp changing.
+      dshDirectoryFingerprintsReliable: false,
       indexDshSessionHeaders(options) {
         indexCalls += 1;
         return indexDshSessionHeaders(options);
@@ -534,13 +537,17 @@ test('collectUsageOnce does not re-walk the DSH sessions tree on a second real t
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(path.join(dir, 'session.jsonl'), `${JSON.stringify({ type: 'session', id: 'session-e2e', createdAt: 1750000000000 })}\n`);
 
-    // dshSessionFiles() walks the tree via fs.readdirSync(dir, {withFileTypes}).
-    // Counting only calls rooted under the DSH sessions dir isolates "the
-    // tree was walked" from every other readdirSync call a full tick makes
-    // (tokscale client discovery, WSL probing, etc).
-    let walks = 0;
+    // dshSessionFiles() walks root -> project -> session. Count only the first
+    // two levels so a Windows fallback that verifies one already-known session
+    // directory is not mistaken for rebuilding the whole tree.
+    let treeWalks = 0;
     fs.readdirSync = (target, ...rest) => {
-      if (typeof target === 'string' && target.startsWith(sessionsRoot)) walks += 1;
+      if (typeof target === 'string') {
+        const relative = path.relative(sessionsRoot, target);
+        if (relative === '' || (!relative.startsWith('..') && relative.split(path.sep).length === 1)) {
+          treeWalks += 1;
+        }
+      }
       return realReaddirSync(target, ...rest);
     };
 
@@ -562,12 +569,12 @@ test('collectUsageOnce does not re-walk the DSH sessions tree on a second real t
 
     const first = await collectUsageOnce(baseOptions);
     assert.equal(first.today.sessions['dsh:session-e2e'].startedAt, new Date(1750000000000).toISOString());
-    const walksAfterFirstTick = walks;
+    const walksAfterFirstTick = treeWalks;
     assert.ok(walksAfterFirstTick > 0, 'the first real tick must discover the session via the tree walk');
 
     const second = await collectUsageOnce(baseOptions);
     assert.equal(second.today.sessions['dsh:session-e2e'].startedAt, new Date(1750000000000).toISOString());
-    assert.equal(walks, walksAfterFirstTick, 'a second collectUsageOnce() call must not rebuild and re-walk the DSH tree');
+    assert.equal(treeWalks, walksAfterFirstTick, 'a second collectUsageOnce() call must not rebuild and re-walk the DSH tree');
   } finally {
     fs.readdirSync = realReaddirSync;
     delete require.cache[collectorPath];


### PR DESCRIPTION
## Summary

- verify the preferred DSH transcript generation inside each cached session directory on Windows, where rapid file creation may leave the directory timestamp unchanged
- keep Linux and macOS on the existing stat-only fast path while avoiding a full DSH tree rescan on Windows
- make the cache-promotion regression deterministic for unreliable directory fingerprints

## Tests

- `node --test tests/shared/collectorSessionTimestamps.test.js tests/shared/dshSessionFiles.test.js` (45 passed)
- `npm run verify` (4,306 passed, 2 skipped)
- `git diff --check origin/main..HEAD`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DSH generation promotion on Windows, where rapid file creation can leave session directory timestamps unchanged and cached sessions stay on the unversioned transcript.

- On Windows, verifies the preferred transcript generation inside each already-known session directory instead of relying only on the directory stat.
- Keeps Linux and macOS on the existing stat-only fast path and avoids a full DSH tree rescan on Windows.
- Adds a `dshDirectoryFingerprintsReliable` dependency flag so tests can force the Windows behavior on any platform.

| Area | Before | After |
| --- | --- | --- |
| DSH cache promotion on Windows | Promotion depended on the session directory timestamp changing, so a versioned transcript could be missed. | Promotion verifies the preferred transcript in the cached session directory, independent of directory timestamp changes. |

**Tests**

- `node --test tests/shared/collectorSessionTimestamps.test.js tests/shared/dshSessionFiles.test.js` (45 passed)
- `npm run verify` (4,306 passed, 2 skipped)
- `git diff --check origin/main..HEAD`

<sup>Written for commit 6e653c69490be3beab09df6355586c6a54ee35c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Javis603/token-monitor/pull/680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

